### PR TITLE
iOS example fix

### DIFF
--- a/docs/examples/objc/Podfile
+++ b/docs/examples/objc/Podfile
@@ -22,7 +22,7 @@ inhibit_all_warnings!
 
 target :"ThemisTest" do
 
-  # it's temporary solution until we will have always stable code in master :)
-  pod 'themis', :git => 'https://github.com/cossacklabs/themis.git', :commit => '33e0697d722c85ec999c0f18019ed6c30e6bdb25'
+  # example should work with head
+  pod 'themis', :git => 'https://github.com/cossacklabs/themis.git'
 
 end

--- a/docs/examples/objc/Podfile
+++ b/docs/examples/objc/Podfile
@@ -22,6 +22,7 @@ inhibit_all_warnings!
 
 target :"ThemisTest" do
 
-  pod 'themis'
+  # it's temporary solution until we will have always stable code in master :)
+  pod 'themis', :git => 'https://github.com/cossacklabs/themis.git', :commit => '33e0697d722c85ec999c0f18019ed6c30e6bdb25'
 
 end


### PR DESCRIPTION
@mnaza 

currently iOS example fails to build, because it is linked to last stable Themis release (0.9).

But since then, we have changed `objcwrapper` sources, and updated example to correspond these changes. However, it's still linked to 0.9 version which doesn't contain newest changes.

I believe that better solution is to work in `develop` branch and push to `master` only public releases (and hotfixes).

But quick-fix is linking example to current `:head` of `master` branch.