### PR TITLE
rename subspecs to prevent name colissions

### DIFF
--- a/themis.podspec
+++ b/themis.podspec
@@ -18,17 +18,17 @@ Pod::Spec.new do |s|
     s.xcconfig = { 'OTHER_CFLAGS' => '-DLIBRESSL' } 
 
     
-    s.subspec 'themis' do |ss|
+    s.subspec 'core' do |ss|
         ss.source_files = "src/themis/*.{h,c}", "src/soter/*.{h,c}", "src/soter/openssl/*.{h,c}"
         ss.header_mappings_dir = "src"
         ss.public_header_files = "src/themis/*.h", "src/soter/*.h", "src/soter/openssl/*.h"
     end
     
-    s.subspec 'objcthemis' do |ss|
+    s.subspec 'objcwrapper' do |ss|
         ss.header_mappings_dir = 'src/wrappers/themis/Obj-C/objcthemis'
         ss.source_files = "src/wrappers/themis/Obj-C/objcthemis/*.{h,m}"
         ss.public_header_files = 'src/wrappers/themis/Obj-C/objcthemis/*.h'
         ss.header_dir = 'objcthemis'        
-        ss.dependency 'themis/themis'
+        ss.dependency 'themis/core'
     end
 end


### PR DESCRIPTION
resolve issue #25 

@mnaza take a look
works okay (it's even weird)

pod's folder structure has changed, however, linking & building are successful
![screen shot 2015-06-03 at 23 44 35](https://cloud.githubusercontent.com/assets/2877920/7971019/828f0648-0a4a-11e5-8ad3-1e0867cd69c0.png)

we will push this podspec to public repo on next release
