### PR TITLE
correct Obj-C wrapper calls with renamed secure cell modes

### DIFF
--- a/src/wrappers/themis/Obj-C/objcthemis/scell_context_imprint.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_context_imprint.m
@@ -30,7 +30,7 @@
 - (NSData *)wrapData:(NSData *)message context:(NSData *)context error:(NSError **)error {
     size_t wrappedMessageLength = 0;
 
-    TSErrorType encryptionResult = (TSErrorType) themis_secure_cell_encrypt_user_split([self.key bytes], [self.key length],
+    TSErrorType encryptionResult = (TSErrorType) themis_secure_cell_encrypt_context_imprint([self.key bytes], [self.key length],
             [message bytes], [message length], [context bytes], [context length], NULL, &wrappedMessageLength);
 
     if (encryptionResult != TSErrorTypeBufferTooSmall) {
@@ -40,7 +40,7 @@
 
     unsigned char * wrappedMessage = malloc(wrappedMessageLength);
 
-    encryptionResult = (TSErrorType) themis_secure_cell_encrypt_user_split([self.key bytes], [self.key length],
+    encryptionResult = (TSErrorType) themis_secure_cell_encrypt_context_imprint([self.key bytes], [self.key length],
             [message bytes], [message length], [context bytes], [context length], wrappedMessage, &wrappedMessageLength);
 
     if (encryptionResult != TSErrorTypeSuccess) {
@@ -58,7 +58,7 @@
 - (NSData *)unwrapData:(NSData *)message context:(NSData *)context error:(NSError **)error {
     size_t unwrappedMessageLength = 0;
 
-    int decryptionResult = themis_secure_cell_decrypt_user_split([self.key bytes], [self.key length],
+    int decryptionResult = themis_secure_cell_decrypt_context_imprint([self.key bytes], [self.key length],
         [message bytes], [message length], [context bytes], [context length], NULL, &unwrappedMessageLength);
 
     if (decryptionResult != TSErrorTypeBufferTooSmall) {
@@ -68,7 +68,7 @@
 
     unsigned char * unwrappedMessage = malloc(unwrappedMessageLength);
 
-    decryptionResult = themis_secure_cell_decrypt_user_split([self.key bytes], [self.key length],
+    decryptionResult = themis_secure_cell_decrypt_context_imprint([self.key bytes], [self.key length],
         [message bytes], [message length], [context bytes], [context length], unwrappedMessage, &unwrappedMessageLength);
 
     if (decryptionResult != TSErrorTypeSuccess) {

--- a/src/wrappers/themis/Obj-C/objcthemis/scell_seal.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_seal.m
@@ -42,20 +42,20 @@
     const void * contextData = (context != nil) ? [context bytes] : NULL;
     size_t contextLength = (context != nil) ? [context length] : 0;
 
-    TSErrorType result = (TSErrorType) themis_secure_cell_encrypt_full([self.key bytes], [self.key length],
+    TSErrorType result = (TSErrorType) themis_secure_cell_encrypt_seal([self.key bytes], [self.key length],
         contextData, contextLength, [message bytes], [message length], NULL, &wrappedMessageLength);
 
     if (result != TSErrorTypeBufferTooSmall) {
-        *error = SCERROR(result, @"themis_secure_cell_encrypt_full (length determination) fail");
+        *error = SCERROR(result, @"themis_secure_cell_encrypt_seal (length determination) fail");
         return nil;
     }
 
     unsigned char * wrappedMessage = malloc(wrappedMessageLength);
-    result = (TSErrorType) themis_secure_cell_encrypt_full([self.key bytes], [self.key length],
+    result = (TSErrorType) themis_secure_cell_encrypt_seal([self.key bytes], [self.key length],
         contextData, contextLength, [message bytes], [message length], wrappedMessage, &wrappedMessageLength);
 
     if (result != TSErrorTypeSuccess) {
-        *error = SCERROR(result, @"themis_secure_cell_encrypt_full fail");
+        *error = SCERROR(result, @"themis_secure_cell_encrypt_seal fail");
         free(wrappedMessage);
         return nil;
     }
@@ -73,20 +73,20 @@
     const void * contextData = (context != nil) ? [context bytes] : nil;
     size_t contextLength = (context != Nil) ? [context length] : 0;
 
-    TSErrorType result = (TSErrorType) themis_secure_cell_decrypt_full([self.key bytes], [self.key length],
+    TSErrorType result = (TSErrorType) themis_secure_cell_decrypt_seal([self.key bytes], [self.key length],
         contextData, contextLength, [message bytes], [message length], NULL, &unwrappedMessageLength);
 
     if (result != TSErrorTypeBufferTooSmall) {
-        *error = SCERROR(result, @"themis_secure_cell_decrypt_full (length determination) fail");
+        *error = SCERROR(result, @"themis_secure_cell_decrypt_seal (length determination) fail");
         return nil;
     }
 
     unsigned char * unwrappedMessage = malloc(unwrappedMessageLength);
-    result = (TSErrorType) themis_secure_cell_decrypt_full([self.key bytes], [self.key length],
+    result = (TSErrorType) themis_secure_cell_decrypt_seal([self.key bytes], [self.key length],
         contextData, contextLength, [message bytes], [message length], unwrappedMessage, &unwrappedMessageLength);
 
     if (result != TSErrorTypeSuccess) {
-        *error = SCERROR(result, @"themis_secure_cell_decrypt_full fail");
+        *error = SCERROR(result, @"themis_secure_cell_decrypt_seal fail");
         free(unwrappedMessage);
         return nil;
     }

--- a/src/wrappers/themis/Obj-C/objcthemis/scell_token.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_token.m
@@ -49,7 +49,7 @@
     size_t contextLength = (context != nil) ? [context length] : 0;
 
     TSCellTokenEncryptedData * encryptedMessage = [[TSCellTokenEncryptedData alloc] init];
-    TSErrorType result = (TSErrorType) themis_secure_cell_encrypt_auto_split([self.key bytes], [self.key length],
+    TSErrorType result = (TSErrorType) themis_secure_cell_encrypt_token_protect([self.key bytes], [self.key length],
             contextData, contextLength, [message bytes], [message length], NULL, &tokenLength,
             NULL, &wrappedMessageLength);
 
@@ -61,7 +61,7 @@
     encryptedMessage.cipherText = [[NSMutableData alloc] initWithLength:wrappedMessageLength];
     encryptedMessage.token = [[NSMutableData alloc] initWithLength:tokenLength];
 
-    result = (TSErrorType) themis_secure_cell_encrypt_auto_split([self.key bytes], [self.key length], contextData, contextLength,
+    result = (TSErrorType) themis_secure_cell_encrypt_token_protect([self.key bytes], [self.key length], contextData, contextLength,
             [message bytes], [message length], [encryptedMessage.token mutableBytes], &tokenLength,
             [encryptedMessage.cipherText mutableBytes], &wrappedMessageLength);
 
@@ -78,7 +78,7 @@
     const void * contextData = (context != nil) ? [context bytes] : NULL;
     size_t contextLength = (context != nil) ? [context length] : 0;
 
-    TSErrorType result = (TSErrorType) themis_secure_cell_decrypt_auto_split([self.key bytes], [self.key length], contextData, contextLength,
+    TSErrorType result = (TSErrorType) themis_secure_cell_decrypt_token_protect([self.key bytes], [self.key length], contextData, contextLength,
             [message.cipherText bytes], [message.cipherText length], [message.token bytes], [message.token length],
             NULL, &unwrappedMessageLength);
 
@@ -88,7 +88,7 @@
     }
 
     NSMutableData * unwrapped_message = [[NSMutableData alloc] initWithLength:unwrappedMessageLength];
-    result = (TSErrorType) themis_secure_cell_decrypt_auto_split([self.key bytes], [self.key length], contextData, contextLength,
+    result = (TSErrorType) themis_secure_cell_decrypt_token_protect([self.key bytes], [self.key length], contextData, contextLength,
             [message.cipherText bytes], [message.cipherText length], [message.token bytes], [message.token length],
             [unwrapped_message mutableBytes], &unwrappedMessageLength);
 


### PR DESCRIPTION
need to review by @vixentael 