### PR TITLE
Move symmetric algorythms definitions to separate file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,13 @@ endif
 ifneq ($(ENGINE_LIB_PATH),)
 	CRYPTO_ENGINE_LIB_PATH = $(ENGINE_LIB_PATH)
 endif
+ifneq ($(AUTH_SYM_ALG),)
+	CFLAGS += -D$(AUTH_SYM_ALG)
+endif
+ifneq ($(SYM_ALG),)
+	CFLAGS += -D$(SYM_ALG)
+endif
+
 
 PHP_VERSION := $(shell php --version 2>/dev/null)
 RUBY_GEM_VERSION := $(shell gem --version 2>/dev/null)

--- a/src/soter/openssl/soter_sym.c
+++ b/src/soter/openssl/soter_sym.c
@@ -28,7 +28,7 @@ soter_status_t soter_pbkdf2(const uint8_t* password, const size_t password_lengt
   if(!PKCS5_PBKDF2_HMAC((const char*)password, password_length, salt, salt_length, 0, EVP_sha256(), (*key_length), key)){
       return SOTER_FAIL;
     }
-  return SOTER_SUCCESS;			
+  return SOTER_SUCCESS;
 }
 
 soter_status_t soter_nokdf(const uint8_t* password, const size_t password_length, uint8_t* key, size_t* key_length){
@@ -292,13 +292,3 @@ soter_status_t soter_sym_aead_decrypt_final(soter_sym_ctx_t *ctx, const void* au
 soter_status_t soter_sym_aead_decrypt_destroy(soter_sym_ctx_t *ctx){
   return soter_sym_ctx_destroy(ctx);
 }
-
-
-
-
-
-
-
-
-
-

--- a/src/themis/secure_cell_alg.h
+++ b/src/themis/secure_cell_alg.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2015 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _SECURE_CELL_ALG_H_
+#define _SECURE_CELL_ALG_H_
+
+#ifdef THEMIS_AUTH_SYM_ALG_AES_256_GCM
+#define THEMIS_AUTH_SYM_KEY_LENGTH SOTER_SYM_256_KEY_LENGTH
+#define THEMIS_AUTH_SYM_ALG (SOTER_SYM_AES_GCM|THEMIS_AUTH_SYM_KEY_LENGTH)
+#define THEMIS_AUTH_SYM_IV_LENGTH 12
+#define THEMIS_AUTH_SYM_AUTH_TAG_LENGTH 16
+#endif
+
+#ifdef THEMIS_AUTH_SYM_ALG_AES_128_GCM
+#define THEMIS_AUTH_SYM_KEY_LENGTH SOTER_SYM_128_KEY_LENGTH
+#define THEMIS_AUTH_SYM_ALG (SOTER_SYM_AES_GCM|THEMIS_AUTH_SYM_KEY_LENGTH)
+#define THEMIS_AUTH_SYM_IV_LENGTH 12
+#define THEMIS_AUTH_SYM_AUTH_TAG_LENGTH 16
+#endif
+
+#ifdef THEMIS_AUTH_SYM_ALG_AES_192_GCM
+#define THEMIS_AUTH_SYM_KEY_LENGTH SOTER_SYM_192_KEY_LENGTH
+#define THEMIS_AUTH_SYM_ALG (SOTER_SYM_AES_GCM|THEMIS_AUTH_SYM_KEY_LENGTH)
+#define THEMIS_AUTH_SYM_IV_LENGTH 12
+#define THEMIS_AUTH_SYM_AUTH_TAG_LENGTH 16
+#endif
+
+/*default values*/
+#ifndef THEMIS_AUTH_SYM_ALG
+#define THEMIS_AUTH_SYM_KEY_LENGTH SOTER_SYM_256_KEY_LENGTH
+#define THEMIS_AUTH_SYM_ALG (SOTER_SYM_AES_GCM|THEMIS_AUTH_SYM_KEY_LENGTH)
+#define THEMIS_AUTH_SYM_IV_LENGTH 12
+#define THEMIS_AUTH_SYM_AUTH_TAG_LENGTH 16
+#endif
+
+#ifdef THEMIS_SYM_ALG_AES_256_CTR
+#define THEMIS_SYM_KEY_LENGTH SOTER_SYM_256_KEY_LENGTH
+#define THEMIS_SYM_ALG (SOTER_SYM_AES_CTR|THEMIS_SYM_KEY_LENGTH)
+#define THEMIS_SYM_IV_LENGTH 16
+#endif
+
+#ifdef THEMIS_SYM_ALG_AES_192_CTR
+#define THEMIS_SYM_KEY_LENGTH SOTER_SYM_192_KEY_LENGTH
+#define THEMIS_SYM_ALG (SOTER_SYM_AES_CTR|THEMIS_SYM_KEY_LENGTH)
+#define THEMIS_SYM_IV_LENGTH 16
+#endif
+
+#ifdef THEMIS_SYM_ALG_AES_128_CTR
+#define THEMIS_SYM_KEY_LENGTH SOTER_SYM_128_KEY_LENGTH
+#define THEMIS_SYM_ALG (SOTER_SYM_AES_CTR|THEMIS_SYM_KEY_LENGTH)
+#define THEMIS_SYM_IV_LENGTH 16
+#endif
+
+/*default values*/
+#ifndef THEMIS_SYM_ALG
+
+#define THEMIS_SYM_KEY_LENGTH SOTER_SYM_256_KEY_LENGTH
+#define THEMIS_SYM_ALG (SOTER_SYM_AES_CTR|THEMIS_SYM_KEY_LENGTH)
+#define THEMIS_SYM_IV_LENGTH 16
+#endif
+
+
+#endif /* _SECURE_CELL_ALG_H_ */

--- a/src/themis/sym_enc_message.c
+++ b/src/themis/sym_enc_message.c
@@ -18,12 +18,7 @@
 #include <themis/sym_enc_message.h>
 #include <soter/soter.h>
 #include <string.h>
-
-
-#define THEMIS_SYM_KEY_LENGTH SOTER_SYM_256_KEY_LENGTH
-#define THEMIS_AUTH_SYM_ALG (SOTER_SYM_AES_GCM|THEMIS_SYM_KEY_LENGTH)
-#define THEMIS_AUTH_SYM_IV_LENGTH 12
-#define THEMIS_AUTH_SYM_AUTH_TAG_LENGTH 16
+#include <themis/secure_cell_alg.h>
 
 #define THEMIS_SYM_KDF_KEY_LABEL "Themis secure cell message key"
 #define THEMIS_SYM_KDF_IV_LABEL "Themis secure cell message iv"
@@ -160,15 +155,7 @@ themis_status_t themis_auth_sym_encrypt_message_(const uint8_t* key,
   themis_auth_sym_message_hdr_t* hdr=(themis_auth_sym_message_hdr_t*)out_context;
   uint8_t* iv=out_context+sizeof(themis_auth_sym_message_hdr_t);
   uint8_t* auth_tag=iv+THEMIS_AUTH_SYM_IV_LENGTH;
-  //uint8_t aad[20];
-  //size_t aad_length=0;
   THEMIS_CHECK(soter_rand(iv, THEMIS_AUTH_SYM_IV_LENGTH)==THEMIS_SUCCESS);
-  //if(in_context!=NULL && in_context_length!=0){
-  //  aad_length=20;
-  //  THEMIS_STATUS_CHECK(themis_sym_kdf(key,key_length, THEMIS_SYM_KDF_IV_LABEL, in_context, in_context_length, aad, aad_length),THEMIS_SUCCESS);
-    //    memcpy(iv, in_context, THEMIS_AUTH_SYM_IV_LENGTH);
-    //    memcpy(aad,in_context+THEMIS_AUTH_SYM_IV_LENGTH, THEMIS_AUTH_SYM_AAD_LENGTH);    
-  //}
   hdr->alg=THEMIS_AUTH_SYM_ALG;
   hdr->iv_length=THEMIS_AUTH_SYM_IV_LENGTH;
   hdr->auth_tag_length=THEMIS_AUTH_SYM_AUTH_TAG_LENGTH;
@@ -188,7 +175,7 @@ themis_status_t themis_auth_sym_encrypt_message(const uint8_t* key,
 						 size_t* out_context_length,
 						 uint8_t* encrypted_message,
 						 size_t* encrypted_message_length){
-  uint8_t key_[THEMIS_SYM_KEY_LENGTH/8];
+  uint8_t key_[THEMIS_AUTH_SYM_KEY_LENGTH/8];
   THEMIS_CHECK_PARAM(message!=NULL && message_length!=0);
   THEMIS_STATUS_CHECK(themis_sym_kdf(key,key_length, THEMIS_SYM_KDF_KEY_LABEL, (uint8_t*)(&message_length), sizeof(message_length), in_context, in_context_length, key_, sizeof(key_)),THEMIS_SUCCESS);
   return themis_auth_sym_encrypt_message_(key_, sizeof(key_), message, message_length, in_context, in_context_length, out_context, out_context_length, encrypted_message, encrypted_message_length);
@@ -228,13 +215,12 @@ themis_status_t themis_auth_sym_decrypt_message(const uint8_t* key,
 						const size_t encrypted_message_length,
 						uint8_t* message,
 						size_t* message_length){
-  uint8_t key_[THEMIS_SYM_KEY_LENGTH/8];
+  uint8_t key_[THEMIS_AUTH_SYM_KEY_LENGTH/8];
   THEMIS_CHECK_PARAM(context!=NULL && context_length!=0);
   THEMIS_STATUS_CHECK(themis_sym_kdf(key,key_length, THEMIS_SYM_KDF_KEY_LABEL, (uint8_t*)(&encrypted_message_length), sizeof(encrypted_message_length), in_context, in_context_length, key_, sizeof(key_)),THEMIS_SUCCESS);
   return themis_auth_sym_decrypt_message_(key_, sizeof(key_), in_context, in_context_length, context, context_length, encrypted_message, encrypted_message_length, message, message_length);
 }
-#define THEMIS_SYM_ALG (SOTER_SYM_AES_CTR|THEMIS_SYM_KEY_LENGTH)
-#define THEMIS_SYM_IV_LENGTH 16
+
 
 typedef struct themis_sym_message_hdr_type{
   uint32_t alg;


### PR DESCRIPTION
for #8 
Move symmetric algorythms definitions to separate file secure_cell_alg.h.
Add makefile parameters to change default symmetric algorithm to use. For available algorithms see src/themis/secure_cell_alg.h