### PR TITLE
Reorganize secure comparator parameter validation

### DIFF
--- a/src/themis/secure_comparator.c
+++ b/src/themis/secure_comparator.c
@@ -743,11 +743,6 @@ static themis_status_t secure_comparator_alice_step3(secure_comparator_t *comp_c
 	ge_double_scalarmult_vartime((ge_p2 *)&(comp_ctx->Q), comp_ctx->secret, &(comp_ctx->g2), comp_ctx->rand);
 	ge_p2_to_p3(&(comp_ctx->Q), (const ge_p2 *)&(comp_ctx->Q));
 
-	if (!ge_cmp(&Qb, &(comp_ctx->Q)))
-	{
-		comp_ctx->result = THEMIS_SCOMPARE_NO_MATCH;
-	}
-
 	ge_p3_sub(&(comp_ctx->Qa_Qb), &(comp_ctx->Q), &Qb);
 	ge_scalarmult_blinded(&R, comp_ctx->rand3, &(comp_ctx->Qa_Qb));
 
@@ -800,15 +795,6 @@ static themis_status_t secure_comparator_bob_step4(secure_comparator_t *comp_ctx
 	if (ge_frombytes_vartime(&Ra, ((const unsigned char *)input) + (5 * ED25519_GE_LENGTH)))
 	{
 		return THEMIS_INVALID_PARAMETER;
-	}
-
-	if (!ge_cmp(&Qa, &(comp_ctx->Q)))
-	{
-		comp_ctx->result = THEMIS_SCOMPARE_NO_MATCH;
-	}
-	if (!ge_cmp(&Pa, &(comp_ctx->P)))
-	{
-		comp_ctx->result = THEMIS_SCOMPARE_NO_MATCH;
 	}
 
 	/* Output will contain 1 group element and 2 ZK-proofs */
@@ -885,11 +871,6 @@ static themis_status_t secure_comparator_alice_step5(secure_comparator_t *comp_c
 	if (ge_frombytes_vartime(&Rb, (const unsigned char *)input))
 	{
 		return THEMIS_INVALID_PARAMETER;
-	}
-
-	if (!ge_cmp(&(comp_ctx->Pp), &(comp_ctx->P)))
-	{
-		comp_ctx->result = THEMIS_SCOMPARE_NO_MATCH;
 	}
 
 	/* No output */

--- a/src/wrappers/themis/go/src/gothemis/keypair.go
+++ b/src/wrappers/themis/go/src/gothemis/keypair.go
@@ -1,0 +1,99 @@
+package gothemis
+
+/*
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <themis/error.h>
+#include <themis/secure_message.h>
+
+#define KEYTYPE_EC 0
+#define KEYTYPE_RSA 1
+
+static bool get_key_size(int key_type, size_t *priv_len, size_t *pub_len)
+{
+	themis_status_t res = THEMIS_FAIL;
+
+	switch (key_type)
+	{
+	case KEYTYPE_EC:
+		res = themis_gen_ec_key_pair(NULL, priv_len, NULL, pub_len);
+		break;
+	case KEYTYPE_RSA:
+		res = themis_gen_rsa_key_pair(NULL, priv_len, NULL, pub_len);
+		break;
+	default:
+		return;
+	}
+	
+	return THEMIS_BUFFER_TOO_SMALL == res;
+}
+
+static bool gen_keys(int key_type, void *private, size_t priv_len, void *public, size_t pub_len)
+{
+	themis_status_t res = THEMIS_FAIL;
+
+	switch (key_type)
+	{
+	case KEYTYPE_EC:
+		res = themis_gen_ec_key_pair((uint8_t *)private, &priv_len, (uint8_t *)public, &pub_len);
+		break;
+	case KEYTYPE_RSA:
+		res = themis_gen_rsa_key_pair((uint8_t *)private, &priv_len, (uint8_t *)public, &pub_len);
+		break;
+	default:
+		return;
+	}
+	
+	return THEMIS_SUCCESS == res;
+}
+
+*/
+import "C"
+
+import (
+	"errors"
+	"unsafe"
+)
+
+const (
+	KEYTYPE_EC = 0
+	KEYTYPE_RSA = 1
+)
+
+type PrivateKey struct {
+	value []byte
+}
+
+type PublicKey struct {
+	value []byte
+}
+
+type Keypair struct {
+	private *PrivateKey
+	public *PublicKey
+}
+
+func NewKeypair(keytype int) (*Keypair, error) {
+	if (keytype != KEYTYPE_EC) && (keytype != KEYTYPE_RSA) {
+		return nil, errors.New("Incorrect key type")
+	}
+	
+	var privLen, pubLen C.size_t
+	if ! bool(C.get_key_size(C.int(keytype), &privLen, &pubLen)) {
+		return nil, errors.New("Failed to get needed key sizes");
+	}
+	
+	priv := make([]byte, int(privLen), int(privLen))
+	pub := make([]byte, int(pubLen), int(pubLen))
+	
+	if ! bool(C.gen_keys(C.int(keytype), unsafe.Pointer(&priv[0]), privLen, unsafe.Pointer(&pub[0]), pubLen)) {
+		return nil, errors.New("Failed to generate keypair");
+	}
+	
+	return &Keypair {
+		private: &PrivateKey {value: priv},
+		public: &PublicKey {value: pub},
+	}, nil
+}

--- a/src/wrappers/themis/go/src/gothemis/keypair.go
+++ b/src/wrappers/themis/go/src/gothemis/keypair.go
@@ -37,10 +37,10 @@ static bool gen_keys(int key_type, void *private, size_t priv_len, void *public,
 	switch (key_type)
 	{
 	case KEYTYPE_EC:
-		res = themis_gen_ec_key_pair((uint8_t *)private, &priv_len, (uint8_t *)public, &pub_len);
+		res = themis_gen_ec_key_pair(private, &priv_len, public, &pub_len);
 		break;
 	case KEYTYPE_RSA:
-		res = themis_gen_rsa_key_pair((uint8_t *)private, &priv_len, (uint8_t *)public, &pub_len);
+		res = themis_gen_rsa_key_pair(private, &priv_len, public, &pub_len);
 		break;
 	default:
 		return;

--- a/src/wrappers/themis/go/src/gothemis/keypair_test.go
+++ b/src/wrappers/themis/go/src/gothemis/keypair_test.go
@@ -1,0 +1,18 @@
+package gothemis
+
+import (
+    "testing"
+)
+
+func TestNewKeypair(t *testing.T) {
+	_, err := NewKeypair(KEYTYPE_EC)
+	if nil != err {
+		t.Error(err)
+	}
+	
+	_, err = NewKeypair(KEYTYPE_RSA)
+	if nil != err {
+		t.Error(err)
+	}
+}
+

--- a/src/wrappers/themis/go/src/gothemis/message_test.go
+++ b/src/wrappers/themis/go/src/gothemis/message_test.go
@@ -1,0 +1,91 @@
+package gothemis
+
+import (
+    "testing"
+    "crypto/rand"
+    "math/big"
+    "bytes"
+)
+
+func testWrap(keytype int, t *testing.T) {
+	kpa, err := NewKeypair(keytype)
+	if nil != err {
+		t.Error(err)
+	}
+	
+	kpb, err := NewKeypair(keytype)
+	if nil != err {
+		t.Error(err)
+	}
+	
+	message_length, err := rand.Int(rand.Reader, big.NewInt(2048))
+	if nil != err {
+		t.Error(err)
+	}
+	
+	message := make([]byte, int(message_length.Int64()))
+	
+	sma := &SecureMessage{kpa.private, kpb.public}
+	wrapped, err := sma.Wrap(message)
+	if nil != err {
+		t.Error(err)
+	}
+	
+	if 0 == bytes.Compare(message, wrapped) {
+		t.Error("Original message and wrapped message match")
+	} 
+	
+	smb := &SecureMessage{kpb.private, kpa.public}
+	unwrapped, err := smb.Unwrap(wrapped)
+	if nil != err {
+		t.Error(err)
+	}
+	
+	if 0 != bytes.Compare(message, unwrapped) {
+		t.Error("Original message and unwrapped message do not match")
+	} 
+}
+
+func testSign(keytype int, t *testing.T) {
+	kp, err := NewKeypair(keytype)
+	if nil != err {
+		t.Error(err)
+	}
+	
+	message_length, err := rand.Int(rand.Reader, big.NewInt(2048))
+	if nil != err {
+		t.Error(err)
+	}
+	
+	message := make([]byte, int(message_length.Int64()))
+	
+	sma := &SecureMessage{kp.private, nil}
+	signed, err := sma.Sign(message)
+	if nil != err {
+		t.Error(err)
+	}
+	
+	if 0 == bytes.Compare(message, signed) {
+		t.Error("Original message and signed message match")
+	} 
+	
+	smb := &SecureMessage{nil, kp.public}
+	verified, err := smb.Verify(signed)
+	if nil != err {
+		t.Error(err)
+	}
+	
+	if 0 != bytes.Compare(message, verified) {
+		t.Error("Original message and verified message do not match")
+	} 
+}
+
+func TestMessageWrap(t *testing.T) {
+	testWrap(KEYTYPE_EC, t)
+	testWrap(KEYTYPE_RSA, t)
+}
+
+func TestMessageSign(t *testing.T) {
+	testSign(KEYTYPE_EC, t)
+	testSign(KEYTYPE_RSA, t)
+}

--- a/tests/themis/themis_secure_comparator.c
+++ b/tests/themis/themis_secure_comparator.c
@@ -22,6 +22,9 @@
 #include <string.h>
 #include "themis_test.h"
 
+/* Implemented in themis_secure_comparator_security.c */
+void secure_comparator_security_test(void);
+
 /* Fuzz parameters */
 #define MAX_SECRET_SIZE 2048
 
@@ -234,137 +237,6 @@ static void secure_comparator_api_test(void)
 
 	bob = NULL;
 	alice = NULL;
-}
-
-static void corrupt_alice_step1(secure_comparator_t *alice, void *output)
-{
-	/* Let's assume alice is malicious and uses zeroes instead of random numbers */
-
-	ge_p3 g2a;
-	ge_p3 g3a;
-
-	memset(alice->rand2, 0, sizeof(alice->rand2));
-	memset(alice->rand3, 0, sizeof(alice->rand3));
-
-	ge_scalarmult_base(&g2a, alice->rand2);
-	ge_scalarmult_base(&g3a, alice->rand3);
-
-	ge_p3_tobytes((unsigned char *)output, &g2a);
-	ge_p3_tobytes(((unsigned char *)output) + ED25519_GE_LENGTH, &g3a);
-}
-
-static void corrupt_bob_step2(secure_comparator_t *bob, const void *input, size_t input_length, void *output, size_t *output_length)
-{
-	/* Let's assume bob is malicious and uses zeroes instead of random numbers */
-
-	ge_p3 g2a;
-	ge_p3 g3a;
-
-	ge_p3 g2b;
-	ge_p3 g3b;
-
-	ge_frombytes_vartime(&g2a, (const unsigned char *)input);
-	ge_frombytes_vartime(&g3a, ((const unsigned char *)input) + ED25519_GE_LENGTH);
-
-	if (THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER != secure_comparator_proceed_compare(bob, input, input_length, output, output_length))
-	{
-		testsuite_fail_if(true, "secure_comparator_proceed_compare failed");
-		return;
-	}
-
-	memset(bob->rand2, 0, sizeof(bob->rand2));
-	memset(bob->rand3, 0, sizeof(bob->rand3));
-
-	ge_scalarmult_base(&g2b, bob->rand2);
-	ge_scalarmult_base(&g3b, bob->rand3);
-
-	ge_scalarmult_blinded(&(bob->g2), bob->rand2, &g2a);
-	ge_scalarmult_blinded(&(bob->g3), bob->rand3, &g3a);
-
-	memset(bob->rand, 0, sizeof(bob->rand));
-
-	ge_scalarmult_blinded(&(bob->P), bob->rand, &(bob->g3));
-	ge_double_scalarmult_vartime((ge_p2 *)&(bob->Q), bob->secret, &(bob->g2), bob->rand);
-	ge_p2_to_p3(&(bob->Q), (const ge_p2 *)&(bob->Q));
-
-	ge_p3_tobytes((unsigned char *)output, &g2b);
-	ge_p3_tobytes(((unsigned char *)output) + ED25519_GE_LENGTH, &g3b);
-	ge_p3_tobytes(((unsigned char *)output) + ED25519_GE_LENGTH + ED25519_GE_LENGTH, &(bob->Q));
-}
-
-static void secure_comparator_security_test(void)
-{
-	const char alice_secret[] = "alice secret";
-	const char bob_secret[] = "bob secret";
-
-	size_t output_length = sizeof(shared_mem);
-
-	secure_comparator_t alice, bob;
-
-	if (THEMIS_SUCCESS != secure_comparator_init(&alice))
-	{
-		testsuite_fail_if(true, "secure_comparator_init failed");
-		return;
-	}
-
-	if (THEMIS_SUCCESS != secure_comparator_init(&bob))
-	{
-		testsuite_fail_if(true, "secure_comparator_init failed");
-		return;
-	}
-
-	if (THEMIS_SUCCESS != secure_comparator_append_secret(&alice, alice_secret, sizeof(alice_secret)))
-	{
-		testsuite_fail_if(true, "secure_comparator_append_secret failed");
-		return;
-	}
-
-	if (THEMIS_SUCCESS != secure_comparator_append_secret(&bob, bob_secret, sizeof(bob_secret)))
-	{
-		testsuite_fail_if(true, "secure_comparator_append_secret failed");
-		return;
-	}
-
-	current_length = sizeof(shared_mem);
-
-	if (THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER != secure_comparator_begin_compare(&alice, shared_mem, &current_length))
-	{
-		testsuite_fail_if(true, "secure_comparator_begin_compare failed");
-		return;
-	}
-
-	corrupt_alice_step1(&alice, shared_mem);
-
-	corrupt_bob_step2(&bob, shared_mem, current_length, shared_mem, &output_length);
-
-	current_length = output_length;
-	output_length = sizeof(shared_mem);
-
-	if (THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER != secure_comparator_proceed_compare(&alice, shared_mem, current_length, shared_mem, &output_length))
-	{
-		testsuite_fail_if(true, "secure_comparator_proceed_compare failed");
-		return;
-	}
-
-	current_length = output_length;
-	output_length = sizeof(shared_mem);
-
-	if (THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER != secure_comparator_proceed_compare(&bob, shared_mem, current_length, shared_mem, &output_length))
-	{
-		testsuite_fail_if(true, "secure_comparator_proceed_compare failed");
-		return;
-	}
-
-	current_length = output_length;
-	output_length = sizeof(shared_mem);
-
-	if (THEMIS_SUCCESS != secure_comparator_proceed_compare(&alice, shared_mem, current_length, shared_mem, &output_length))
-	{
-		testsuite_fail_if(true, "secure_comparator_proceed_compare failed");
-		return;
-	}
-
-	testsuite_fail_unless((THEMIS_SCOMPARE_NO_MATCH == secure_comparator_get_result(&alice)) && (THEMIS_SCOMPARE_NO_MATCH == secure_comparator_get_result(&bob)), "compare result no match");
 }
 
 void run_secure_comparator_test(void)

--- a/tests/themis/themis_secure_comparator_security.c
+++ b/tests/themis/themis_secure_comparator_security.c
@@ -1,0 +1,342 @@
+/*
+ * themis_secure_comparator_security.c
+ *
+ *  Created on: 14 Jan 2016
+ *      Author: ignat
+ */
+
+#ifdef SECURE_COMPARATOR_ENABLED
+
+#include <themis/secure_comparator.h>
+#include <themis/secure_comparator_t.h>
+#include <stdio.h>
+#include <string.h>
+#include "themis_test.h"
+
+/* Peers will communicate using shared memory */
+static uint8_t shared_mem[512];
+static size_t current_length = 0;
+
+/* below functions are copied from secure_comparator.c */
+/* Having duplicate code in tests is better than making them public in real code */
+static bool ge_is_zero(const ge_p3 *ge)
+{
+	uint8_t y[ED25519_GE_LENGTH];
+	uint8_t z[ED25519_GE_LENGTH];
+
+	fe_tobytes(y, ge->Y);
+	fe_tobytes(z, ge->Z);
+
+	return (!fe_isnonzero(ge->X)) && (!crypto_verify_32(y, z));
+}
+
+static themis_status_t ed_sign(uint8_t pos, const uint8_t *scalar, uint8_t *signature)
+{
+	uint8_t r[ED25519_GE_LENGTH];
+	ge_p3 R;
+	uint8_t k[64];
+
+	soter_hash_ctx_t hash_ctx;
+	size_t hash_length = 64;
+	themis_status_t res;
+
+	generate_random_32(r);
+	ge_scalarmult_base(&R, r);
+	ge_p3_tobytes(k, &R);
+
+	res = soter_hash_init(&hash_ctx, SOTER_HASH_SHA512);
+	if (THEMIS_SUCCESS != res)
+	{
+		return res;
+	}
+
+	res = soter_hash_update(&hash_ctx, k, ED25519_GE_LENGTH);
+	if (THEMIS_SUCCESS != res)
+	{
+		soter_hash_final(&hash_ctx, k, &hash_length);
+		return res;
+	}
+
+	res = soter_hash_update(&hash_ctx, &pos, sizeof(pos));
+	if (THEMIS_SUCCESS != res)
+	{
+		soter_hash_final(&hash_ctx, k, &hash_length);
+		return res;
+	}
+
+	res = soter_hash_final(&hash_ctx, k, &hash_length);
+
+	if (THEMIS_SUCCESS == res)
+	{
+		sc_reduce(k);
+
+		memcpy(signature, k, ED25519_GE_LENGTH);
+		sc_muladd(signature + ED25519_GE_LENGTH, k, scalar, r);
+	}
+
+	return res;
+}
+
+static themis_status_t ed_dbl_base_sign(uint8_t pos, const uint8_t *scalar1, const uint8_t *scalar2, const ge_p3 *base1, const ge_p3 *base2, uint8_t *signature)
+{
+	uint8_t r1[ED25519_GE_LENGTH];
+	uint8_t r2[ED25519_GE_LENGTH];
+	ge_p3 R1;
+	ge_p2 R2;
+	uint8_t k[64];
+
+	soter_hash_ctx_t hash_ctx;
+	size_t hash_length = 64;
+
+	themis_status_t res;
+
+	generate_random_32(r1);
+	generate_random_32(r2);
+	ge_scalarmult_blinded(&R1, r1, base2);
+	ge_double_scalarmult_vartime(&R2, r2, base1, r1);
+
+	res = soter_hash_init(&hash_ctx, SOTER_HASH_SHA512);
+	if (THEMIS_SUCCESS != res)
+	{
+		return res;
+	}
+
+	ge_p3_tobytes(k, &R1);
+	res = soter_hash_update(&hash_ctx, k, ED25519_GE_LENGTH);
+	if (THEMIS_SUCCESS != res)
+	{
+		soter_hash_final(&hash_ctx, k, &hash_length);
+		return res;
+	}
+
+	ge_tobytes(k, &R2);
+	res = soter_hash_update(&hash_ctx, k, ED25519_GE_LENGTH);
+	if (THEMIS_SUCCESS != res)
+	{
+		soter_hash_final(&hash_ctx, k, &hash_length);
+		return res;
+	}
+
+	res = soter_hash_update(&hash_ctx, &pos, sizeof(pos));
+	if (THEMIS_SUCCESS != res)
+	{
+		soter_hash_final(&hash_ctx, k, &hash_length);
+		return res;
+	}
+
+	res = soter_hash_final(&hash_ctx, k, &hash_length);
+
+	if (THEMIS_SUCCESS == res)
+	{
+		sc_reduce(k);
+		memcpy(signature, k, ED25519_GE_LENGTH);
+		sc_muladd(signature + ED25519_GE_LENGTH, k, scalar1, r1);
+		sc_muladd(signature + (2 * ED25519_GE_LENGTH), k, scalar2, r2);
+	}
+
+	return res;
+}
+
+static themis_status_t ed_point_sign(uint8_t pos, const uint8_t *scalar, const ge_p3 *point, uint8_t *signature)
+{
+	uint8_t r[ED25519_GE_LENGTH];
+	ge_p3 R;
+	uint8_t k[64];
+
+	soter_hash_ctx_t hash_ctx;
+	size_t hash_length = 64;
+
+	themis_status_t res;
+
+	generate_random_32(r);
+	ge_scalarmult_base(&R, r);
+	ge_p3_tobytes(k, &R);
+
+	res = soter_hash_init(&hash_ctx, SOTER_HASH_SHA512);
+	if (THEMIS_SUCCESS != res)
+	{
+		return res;
+	}
+
+	res = soter_hash_update(&hash_ctx, k, ED25519_GE_LENGTH);
+	if (THEMIS_SUCCESS != res)
+	{
+		soter_hash_final(&hash_ctx, k, &hash_length);
+		return res;
+	}
+
+	ge_scalarmult_blinded(&R, r, point);
+	ge_p3_tobytes(k, &R);
+
+	res = soter_hash_update(&hash_ctx, k, ED25519_GE_LENGTH);
+	if (THEMIS_SUCCESS != res)
+	{
+		soter_hash_final(&hash_ctx, k, &hash_length);
+		return res;
+	}
+
+	res = soter_hash_update(&hash_ctx, &pos, sizeof(pos));
+	if (THEMIS_SUCCESS != res)
+	{
+		soter_hash_final(&hash_ctx, k, &hash_length);
+		return res;
+	}
+
+	res = soter_hash_final(&hash_ctx, k, &hash_length);
+	if (THEMIS_SUCCESS != res)
+	{
+		return res;
+	}
+
+	if (THEMIS_SUCCESS == res)
+	{
+		sc_reduce(k);
+		memcpy(signature, k, ED25519_GE_LENGTH);
+		sc_muladd(signature + ED25519_GE_LENGTH, k, scalar, r);
+	}
+
+	return res;
+}
+
+static void corrupt_alice_step1(secure_comparator_t *alice, void *output)
+{
+	/* Let's assume alice is malicious and uses zeroes instead of random numbers */
+
+	ge_p3 g2a;
+	ge_p3 g3a;
+
+	memset(alice->rand2, 0, sizeof(alice->rand2));
+	memset(alice->rand3, 0, sizeof(alice->rand3));
+
+	ge_scalarmult_base(&g2a, alice->rand2);
+	ge_scalarmult_base(&g3a, alice->rand3);
+
+	ge_p3_tobytes((unsigned char *)output, &g2a);
+	ed_sign(1, alice->rand2, ((unsigned char *)output) + ED25519_GE_LENGTH);
+
+	ge_p3_tobytes(((unsigned char *)output) + (3 * ED25519_GE_LENGTH), &g3a);
+	ed_sign(2, alice->rand3, ((unsigned char *)output) + (4 * ED25519_GE_LENGTH));
+}
+
+static void corrupt_bob_step2(secure_comparator_t *bob, const void *input, size_t input_length, void *output, size_t *output_length)
+{
+	/* Let's assume bob is malicious and uses zeroes instead of random numbers */
+
+	ge_p3 g2a;
+	ge_p3 g3a;
+
+	ge_p3 g2b;
+	ge_p3 g3b;
+
+	ge_frombytes_vartime(&g2a, (const unsigned char *)input);
+	ge_frombytes_vartime(&g3a, ((const unsigned char *)input) + (3 * ED25519_GE_LENGTH));
+
+	if (THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER != secure_comparator_proceed_compare(bob, input, input_length, output, output_length))
+	{
+		testsuite_fail_if(true, "secure_comparator_proceed_compare failed");
+		return;
+	}
+
+	memset(bob->rand2, 0, sizeof(bob->rand2));
+	memset(bob->rand3, 0, sizeof(bob->rand3));
+
+	ge_scalarmult_base(&g2b, bob->rand2);
+	ge_scalarmult_base(&g3b, bob->rand3);
+
+	ge_scalarmult_blinded(&(bob->g2), bob->rand2, &g2a);
+	ge_scalarmult_blinded(&(bob->g3), bob->rand3, &g3a);
+
+	memset(bob->rand, 0, sizeof(bob->rand));
+
+	ge_scalarmult_blinded(&(bob->P), bob->rand, &(bob->g3));
+	ge_double_scalarmult_vartime((ge_p2 *)&(bob->Q), bob->secret, &(bob->g2), bob->rand);
+	ge_p2_to_p3(&(bob->Q), (const ge_p2 *)&(bob->Q));
+
+	ge_p3_tobytes((unsigned char *)output, &g2b);
+	ed_sign(3, bob->rand2, ((unsigned char *)output) + ED25519_GE_LENGTH);
+
+	ge_p3_tobytes(((unsigned char *)output) + (3 * ED25519_GE_LENGTH), &g3b);
+	ed_sign(4, bob->rand3, ((unsigned char *)output) + (4 * ED25519_GE_LENGTH));
+
+	ge_p3_tobytes(((unsigned char *)output) + (6 * ED25519_GE_LENGTH), &(bob->P));
+	ge_p3_tobytes(((unsigned char *)output) + (7 * ED25519_GE_LENGTH), &(bob->Q));
+	ed_dbl_base_sign(5, bob->rand, bob->secret, &(bob->g2), &(bob->g3), ((unsigned char *)output) + (8 * ED25519_GE_LENGTH));
+}
+
+void secure_comparator_security_test(void)
+{
+	const char alice_secret[] = "alice secret";
+	const char bob_secret[] = "bob secret";
+
+	size_t output_length = sizeof(shared_mem);
+
+	secure_comparator_t alice, bob;
+
+	if (THEMIS_SUCCESS != secure_comparator_init(&alice))
+	{
+		testsuite_fail_if(true, "secure_comparator_init failed");
+		return;
+	}
+
+	if (THEMIS_SUCCESS != secure_comparator_init(&bob))
+	{
+		testsuite_fail_if(true, "secure_comparator_init failed");
+		return;
+	}
+
+	if (THEMIS_SUCCESS != secure_comparator_append_secret(&alice, alice_secret, sizeof(alice_secret)))
+	{
+		testsuite_fail_if(true, "secure_comparator_append_secret failed");
+		return;
+	}
+
+	if (THEMIS_SUCCESS != secure_comparator_append_secret(&bob, bob_secret, sizeof(bob_secret)))
+	{
+		testsuite_fail_if(true, "secure_comparator_append_secret failed");
+		return;
+	}
+
+	current_length = sizeof(shared_mem);
+
+	if (THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER != secure_comparator_begin_compare(&alice, shared_mem, &current_length))
+	{
+		testsuite_fail_if(true, "secure_comparator_begin_compare failed");
+		return;
+	}
+
+	corrupt_alice_step1(&alice, shared_mem);
+
+	corrupt_bob_step2(&bob, shared_mem, current_length, shared_mem, &output_length);
+
+	current_length = output_length;
+	output_length = sizeof(shared_mem);
+
+	if (THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER != secure_comparator_proceed_compare(&alice, shared_mem, current_length, shared_mem, &output_length))
+	{
+		testsuite_fail_if(true, "secure_comparator_proceed_compare failed");
+		return;
+	}
+
+	current_length = output_length;
+	output_length = sizeof(shared_mem);
+
+	if (THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER != secure_comparator_proceed_compare(&bob, shared_mem, current_length, shared_mem, &output_length))
+	{
+		testsuite_fail_if(true, "secure_comparator_proceed_compare failed");
+		return;
+	}
+
+	current_length = output_length;
+	output_length = sizeof(shared_mem);
+
+	if (THEMIS_SUCCESS != secure_comparator_proceed_compare(&alice, shared_mem, current_length, shared_mem, &output_length))
+	{
+		testsuite_fail_if(true, "secure_comparator_proceed_compare failed");
+		return;
+	}
+
+	testsuite_fail_unless((THEMIS_SCOMPARE_NO_MATCH == secure_comparator_get_result(&alice)) && (THEMIS_SCOMPARE_NO_MATCH == secure_comparator_get_result(&bob)), "compare result no match");
+}
+
+#endif
+


### PR DESCRIPTION
- removes seem to be unneeded checks
- moves security test to separate file for easier expansion later