### PR TITLE
gothemis: make constructors for cell and message

### DIFF
--- a/gothemis/cell/cell.go
+++ b/gothemis/cell/cell.go
@@ -141,6 +141,10 @@ type SecureCell struct {
 	mode int
 }
 
+func New(key []byte, mode int) *SecureCell {
+	return &SecureCell{key, mode}
+}
+
 func (sc *SecureCell) Protect(data []byte, context []byte) ([]byte, []byte, error) {
 	if (sc.mode < CELL_MODE_SEAL) || (sc.mode > CELL_MODE_CONTEXT_IMPRINT) {
 		return nil, nil, errors.New("Invalid mode specified")

--- a/gothemis/cell/cell_test.go
+++ b/gothemis/cell/cell_test.go
@@ -1,10 +1,11 @@
-package cell
+package cell_test
 
 import (
     "testing"
     "crypto/rand"
     "math/big"
     "bytes"
+    "github.com/cossacklabs/themis/gothemis/cell"
 )
 
 func testProtect(mode int, context []byte, t *testing.T) {
@@ -25,7 +26,7 @@ func testProtect(mode int, context []byte, t *testing.T) {
 		t.Error(err)
 	}
 	
-	sc := &SecureCell{key, mode}
+	sc := cell.New(key, mode)
 	encData, addData, err := sc.Protect(data, context)
 	if nil != err {
 		t.Error(err)
@@ -49,12 +50,12 @@ func TestProtect(t *testing.T) {
 		t.Error(err)
 	}
 	
-	testProtect(CELL_MODE_SEAL, nil, t)
-	testProtect(CELL_MODE_SEAL, context, t)
+	testProtect(cell.CELL_MODE_SEAL, nil, t)
+	testProtect(cell.CELL_MODE_SEAL, context, t)
 	
-	testProtect(CELL_MODE_TOKEN_PROTECT, nil, t)
-	testProtect(CELL_MODE_TOKEN_PROTECT, context, t)
+	testProtect(cell.CELL_MODE_TOKEN_PROTECT, nil, t)
+	testProtect(cell.CELL_MODE_TOKEN_PROTECT, context, t)
 	
-	testProtect(CELL_MODE_CONTEXT_IMPRINT, context, t)
+	testProtect(cell.CELL_MODE_CONTEXT_IMPRINT, context, t)
 }
 

--- a/gothemis/message/message.go
+++ b/gothemis/message/message.go
@@ -54,6 +54,10 @@ type SecureMessage struct {
 	peerPublic *keys.PublicKey
 }
 
+func New(private *keys.PrivateKey, peerPublic *keys.PublicKey) *SecureMessage {
+	return &SecureMessage{private, peerPublic}
+}
+
 func messageProcess(private *keys.PrivateKey, peerPublic *keys.PublicKey, message []byte, is_wrap bool) ([]byte, error) {
 	if nil == message {
 		return nil, errors.New("No message was provided")

--- a/gothemis/message/message_test.go
+++ b/gothemis/message/message_test.go
@@ -1,4 +1,4 @@
-package message
+package message_test
 
 import (
     "testing"
@@ -6,6 +6,7 @@ import (
     "math/big"
     "bytes"
     "github.com/cossacklabs/themis/gothemis/keys"
+    sm"github.com/cossacklabs/themis/gothemis/message"
 )
 
 func testWrap(keytype int, t *testing.T) {
@@ -30,7 +31,7 @@ func testWrap(keytype int, t *testing.T) {
 		t.Error(err)
 	}
 	
-	sma := &SecureMessage{kpa.Private, kpb.Public}
+	sma := sm.New(kpa.Private, kpb.Public)
 	wrapped, err := sma.Wrap(message)
 	if nil != err {
 		t.Error(err)
@@ -40,7 +41,7 @@ func testWrap(keytype int, t *testing.T) {
 		t.Error("Original message and wrapped message match")
 	} 
 	
-	smb := &SecureMessage{kpb.Private, kpa.Public}
+	smb := sm.New(kpb.Private, kpa.Public)
 	unwrapped, err := smb.Unwrap(wrapped)
 	if nil != err {
 		t.Error(err)
@@ -64,7 +65,7 @@ func testSign(keytype int, t *testing.T) {
 	
 	message := make([]byte, int(message_length.Int64()))
 	
-	sma := &SecureMessage{kp.Private, nil}
+	sma := sm.New(kp.Private, nil)
 	signed, err := sma.Sign(message)
 	if nil != err {
 		t.Error(err)
@@ -74,7 +75,7 @@ func testSign(keytype int, t *testing.T) {
 		t.Error("Original message and signed message match")
 	} 
 	
-	smb := &SecureMessage{nil, kp.Public}
+	smb := sm.New(nil, kp.Public)
 	verified, err := smb.Verify(signed)
 	if nil != err {
 		t.Error(err)


### PR DESCRIPTION
Some struct members in message and cell are private and not visible outside of package. Constructors provide APIs for external callers to create these objects.