### PR TITLE
Fix Circle CI build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,8 +5,6 @@ machine:
     GOTHEMIS_IMPORT: github.com/cossacklabs/themis/gothemis
     GOPATH: $HOME/gopath
     JAVA_HOME: /usr/lib/jvm/default-java
-  java:
-    version: openjdk8
 
 ## Customize dependencies
 dependencies:

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,6 @@ machine:
     GOROOT: $HOME/go
     GOTHEMIS_IMPORT: github.com/cossacklabs/themis/gothemis
     GOPATH: $HOME/gopath
-    JAVA_HOME: /usr/lib/jvm/default-java
 
 ## Customize dependencies
 dependencies:
@@ -14,7 +13,7 @@ dependencies:
 
   override:
     - make SECURE_COMPARATOR=enable
-    - make SECURE_COMPARATOR=enable themis_jni
+    - make SECURE_COMPARATOR=enable JAVA_HOME=/usr/lib/jvm/default-java themis_jni
     - sudo make SECURE_COMPARATOR=enable install
     - sudo make SECURE_COMPARATOR=enable themispp_install
     - sudo make SECURE_COMPARATOR=enable pythemis_install


### PR DESCRIPTION
Circle CI has weird config: if you use Java there as advertised to compile JNI code, it fails by not finding some specific headers (related to incorrect JAVA_HOME environment). However, if you override it globally, Android fails to run. So we override it only for on JNI library compile.