### PR TITLE
Soter fixes

### DIFF
--- a/src/soter/boringssl/soter_sign_ecdsa.c
+++ b/src/soter/boringssl/soter_sign_ecdsa.c
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 
+#include <soter/soter_sign_ecdsa.h>
 #include <soter/error.h>
 #include <soter/soter.h>
 #include <soter/soter_ec_key.h>

--- a/src/soter/boringssl/soter_sign_rsa.c
+++ b/src/soter/boringssl/soter_sign_rsa.c
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 
+#include <soter/soter_sign_rsa.h>
 #include <soter/error.h>
 #include <soter/soter.h>
 #include <soter/soter_rsa_key.h>

--- a/src/soter/boringssl/soter_verify_ecdsa.c
+++ b/src/soter/boringssl/soter_verify_ecdsa.c
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 
+#include <soter/soter_sign_ecdsa.h>
 #include <soter/error.h>
 #include <soter/soter.h>
 #include <soter/soter_ec_key.h>

--- a/src/soter/boringssl/soter_verify_rsa.c
+++ b/src/soter/boringssl/soter_verify_rsa.c
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 
+#include <soter/soter_sign_rsa.h>
 #include <soter/error.h>
 #include <soter/soter.h>
 #include <soter/soter_rsa_key.h>

--- a/src/soter/openssl/soter_sign_ecdsa.c
+++ b/src/soter/openssl/soter_sign_ecdsa.c
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 
+#include <soter/soter_sign_ecdsa.h>
 #include <soter/error.h>
 #include <soter/soter.h>
 #include <soter/soter_ec_key.h>

--- a/src/soter/openssl/soter_sign_rsa.c
+++ b/src/soter/openssl/soter_sign_rsa.c
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 
+#include <soter/soter_sign_rsa.h>
 #include <soter/error.h>
 #include <soter/soter.h>
 #include <soter/soter_rsa_key.h>

--- a/src/soter/openssl/soter_verify_ecdsa.c
+++ b/src/soter/openssl/soter_verify_ecdsa.c
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 
+#include <soter/soter_sign_ecdsa.h>
 #include <soter/error.h>
 #include <soter/soter.h>
 #include <soter/soter_ec_key.h>

--- a/src/soter/openssl/soter_verify_rsa.c
+++ b/src/soter/openssl/soter_verify_rsa.c
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 
+#include <soter/soter_sign_rsa.h>
 #include <soter/error.h>
 #include <soter/soter.h>
 #include <soter/soter_rsa_key.h>

--- a/src/soter/soter_sign_ecdsa.h
+++ b/src/soter/soter_sign_ecdsa.h
@@ -23,9 +23,11 @@ soter_status_t soter_sign_init_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx, const voi
 soter_status_t soter_sign_update_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx, const void* data, const size_t data_length);
 soter_status_t soter_sign_final_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx, void* signature, size_t* signature_length);
 soter_status_t soter_sign_export_key_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx, void* key, size_t* key_length, bool isprivate);
+soter_status_t soter_sign_cleanup_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx);
 
 soter_status_t soter_verify_init_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx, const void* private_key, const size_t private_key_length, const void* public_key, const size_t public_key_length);
 soter_status_t soter_verify_update_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx, const void* data, const size_t data_length);
 soter_status_t soter_verify_final_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx, const void* signature, const size_t signature_length);
+soter_status_t soter_verify_cleanup_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx);
 
 #endif /*SOTER_SIGN_ECDSA_H*/

--- a/src/soter/soter_sign_rsa.h
+++ b/src/soter/soter_sign_rsa.h
@@ -23,9 +23,11 @@ soter_status_t soter_sign_init_rsa_pss_pkcs8(soter_sign_ctx_t* ctx, const void* 
 soter_status_t soter_sign_update_rsa_pss_pkcs8(soter_sign_ctx_t* ctx, const void* data, const size_t data_length);
 soter_status_t soter_sign_final_rsa_pss_pkcs8(soter_sign_ctx_t* ctx, void* signature, size_t* signature_length);
 soter_status_t soter_sign_export_key_rsa_pss_pkcs8(soter_sign_ctx_t* ctx, void* key, size_t* key_length, bool isprivate);
+soter_status_t soter_sign_cleanup_rsa_pss_pkcs8(soter_sign_ctx_t* ctx);
 
 soter_status_t soter_verify_init_rsa_pss_pkcs8(soter_sign_ctx_t* ctx, const void* private_key, const size_t private_key_length, const void* public_key, const size_t public_key_length);
 soter_status_t soter_verify_update_rsa_pss_pkcs8(soter_sign_ctx_t* ctx, const void* data, const size_t data_length);
 soter_status_t soter_verify_final_rsa_pss_pkcs8(soter_sign_ctx_t* ctx, const void* signature, const size_t signature_length);
+soter_status_t soter_verify_cleanup_rsa_pss_pkcs8(soter_sign_ctx_t* ctx);
 
 #endif /*SOTER_SIGN_RSA_H*/


### PR DESCRIPTION
Add more imports inside soter files. Because otherwise iOS wrapper can't be built.