### PR TITLE
Minor improvements to scell_seal.m

### DIFF
--- a/src/wrappers/themis/Obj-C/objcthemis/scell_seal.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_seal.m
@@ -51,6 +51,10 @@
     }
 
     unsigned char * wrappedMessage = malloc(wrappedMessageLength);
+    if (!wrappedMessage) {
+        *error = SCERROR(result, @"Secure Cell (Seal) encryption failed, not enough memory");
+        return nil;
+    }
     result = (TSErrorType) themis_secure_cell_encrypt_seal([self.key bytes], [self.key length],
         contextData, contextLength, [message bytes], [message length], wrappedMessage, &wrappedMessageLength);
 
@@ -60,10 +64,7 @@
         return nil;
     }
 
-    NSData * wrappedData = [[NSData alloc] initWithBytes:wrappedMessage length:wrappedMessageLength];
-    free(wrappedMessage);
-    return wrappedData;
-
+    return [NSData dataWithBytesNoCopy:wrappedMessage length:wrappedMessageLength];
 }
 
 
@@ -82,6 +83,11 @@
     }
 
     unsigned char * unwrappedMessage = malloc(unwrappedMessageLength);
+    if (!unwrappedMessage) {
+        *error = SCERROR(result, @"Secure Cell (Seal) decryption failed, not enough memory");
+        return nil;
+    }
+
     result = (TSErrorType) themis_secure_cell_decrypt_seal([self.key bytes], [self.key length],
         contextData, contextLength, [message bytes], [message length], unwrappedMessage, &unwrappedMessageLength);
 
@@ -91,9 +97,7 @@
         return nil;
     }
 
-    NSData * unwrappedData = [[NSData alloc] initWithBytes:unwrappedMessage length:unwrappedMessageLength];
-    free(unwrappedMessage);
-    return unwrappedData;
+    return [NSData dataWithBytesNoCopy:unwrappedMessage length:unwrappedMessageLength];
 }
 
 @end

--- a/src/wrappers/themis/Obj-C/objcthemis/scell_seal.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_seal.m
@@ -39,8 +39,8 @@
 - (NSData *)wrapData:(NSData *)message context:(NSData *)context error:(NSError **)error {
     size_t wrappedMessageLength = 0;
 
-    const void * contextData = (context != nil) ? [context bytes] : NULL;
-    size_t contextLength = (context != nil) ? [context length] : 0;
+    const void * contextData = [context bytes];
+    size_t contextLength = [context length];
 
     TSErrorType result = (TSErrorType) themis_secure_cell_encrypt_seal([self.key bytes], [self.key length],
         contextData, contextLength, [message bytes], [message length], NULL, &wrappedMessageLength);
@@ -71,8 +71,8 @@
 - (NSData *)unwrapData:(NSData *)message context:(NSData *)context error:(NSError **)error {
     size_t unwrappedMessageLength = 0;
 
-    const void * contextData = (context != nil) ? [context bytes] : nil;
-    size_t contextLength = (context != Nil) ? [context length] : 0;
+    const void * contextData = [context bytes];
+    size_t contextLength = [context length];
 
     TSErrorType result = (TSErrorType) themis_secure_cell_decrypt_seal([self.key bytes], [self.key length],
         contextData, contextLength, [message bytes], [message length], NULL, &unwrappedMessageLength);


### PR DESCRIPTION
Adds check for malloc result. Removes excessive malloc inside of NSData and bytes copying.
Removes usless code which only makes illusion it's doing something usefull.