### PR TITLE
Returning immutable object

### DIFF
--- a/src/wrappers/themis/Obj-C/objcthemis/scell_token.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_token.m
@@ -96,7 +96,7 @@
         *error = SCERROR(result, @"Secure Cell (Token Protect) decryption failed");
         return nil;
     }
-    return unwrapped_message;
+    return [unwrapped_message copy];
 }
 
 @end


### PR DESCRIPTION
In Objective-C where we too often branch by conditions similar to `if [someData isKindOfClass:[NSMutableData class]]` it's always does make sense from method declaring returning immutable object return not its mutable subclass but exact immutable instance as declared.