### PR TITLE
unify name of make command to fetch version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -338,7 +338,7 @@ install_shared_libs: err all make_install_dirs
 
 install: install_soter_headers install_themis_headers install_static_libs install_shared_libs
 
-get_themis_version:
+get_version:
 	@echo $(THEMIS_VERSION)
 
 THEMIS_DIST_FILENAME = $(THEMIS_VERSION).tar.gz


### PR DESCRIPTION
it will simplify writing scripts for other our repos if all of them will use the same name of commands (make get_version dist test etc) and don't use project names in command names