### PR TITLE
Fix makefile for MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,14 @@ endif
 endif
 #end of engine selection block
 
+# add openssl headers for MacOS
+ifeq ($(shell uname),Darwin)
+	ifeq ($(CRYPTO_ENGINE_PATH),openssl)
+		CFLAGS += -I/usr/local/opt/openssl/include
+		LDFLAGS += -L/usr/local/opt/openssl/lib
+	endif
+endif
+
 CRYPTO_ENGINE = $(SRC_PATH)/soter/$(CRYPTO_ENGINE_PATH)
 CFLAGS += -D$(CRYPTO_ENGINE_DEF) -DCRYPTO_ENGINE_PATH=$(CRYPTO_ENGINE_PATH)
 
@@ -251,11 +259,11 @@ soter_shared: CMD = $(CC) -shared -o $(BIN_PATH)/lib$(SOTER_BIN).$(SHARED_EXT) $
 
 soter_shared: $(SOTER_OBJ)
 	@echo -n "link "
+	@$(BUILD_CMD)
 ifeq ($(shell uname),Darwin)
 	@install_name_tool -id "$(PREFIX)/lib/lib$(SOTER_BIN).$(SHARED_EXT)" $(BIN_PATH)/lib$(SOTER_BIN).$(SHARED_EXT)
 	@install_name_tool -change "$(BIN_PATH)/lib$(SOTER_BIN).$(SHARED_EXT)" "$(PREFIX)/lib/lib(SOTER_BIN).$(SHARED_EXT)" $(BIN_PATH)/lib$(SOTER_BIN).$(SHARED_EXT)
 endif
-	@$(BUILD_CMD)
 
 themis_static: CMD = $(AR) rcs $(BIN_PATH)/lib$(THEMIS_BIN).a $(THEMIS_OBJ)
 
@@ -267,11 +275,11 @@ themis_shared: CMD = $(CC) -shared -o $(BIN_PATH)/lib$(THEMIS_BIN).$(SHARED_EXT)
 
 themis_shared: soter_shared $(THEMIS_OBJ)
 	@echo -n "link "
+	@$(BUILD_CMD)
 ifeq ($(shell uname),Darwin)
 	@install_name_tool -id "$(PREFIX)/lib/lib$(THEMIS_BIN).$(SHARED_EXT)" $(BIN_PATH)/lib$(THEMIS_BIN).$(SHARED_EXT)
 	@install_name_tool -change "$(BIN_PATH)/lib$(THEMIS_BIN).$(SHARED_EXT)" "$(PREFIX)/lib/lib$(THEMIS_BIN).$(SHARED_EXT)" $(BIN_PATH)/lib$(THEMIS_BIN).$(SHARED_EXT)
 endif
-	@$(BUILD_CMD)
 
 themis_jni: CMD = $(CC) -shared -o $(BIN_PATH)/lib$(THEMIS_JNI_BIN).$(SHARED_EXT) $(THEMIS_JNI_OBJ) -L$(BIN_PATH) -l$(THEMIS_BIN) -l$(SOTER_BIN)
 

--- a/Makefile
+++ b/Makefile
@@ -157,8 +157,18 @@ PREFIX = /usr/local
 
 	# add openssl headers for MacOS
 	ifeq ($(CRYPTO_ENGINE_PATH),openssl)
-		CFLAGS += -I$(PREFIX)/opt/openssl/include
-		LDFLAGS += -L$(PREFIX)/opt/openssl/lib
+	
+		# if brew is installed, if openssl is installed
+        PACKAGELIST := $(shell brew list | grep 'openssl')
+		ifeq ($(PACKAGELIST),openssl)
+
+		 	# path to openssl (usually "/usr/local/opt/openssl")
+			OPENSSL_PATH := $(shell brew --prefix openssl)
+			ifneq ($(OPENSSL_PATH),)
+				CFLAGS += -I$(OPENSSL_PATH)/include
+				LDFLAGS += -L$(OPENSSL_PATH)/lib
+			endif
+		endif
 	endif
 
 ifneq ($(SDK),)

--- a/Makefile
+++ b/Makefile
@@ -82,14 +82,6 @@ endif
 endif
 #end of engine selection block
 
-# add openssl headers for MacOS
-ifeq ($(shell uname),Darwin)
-	ifeq ($(CRYPTO_ENGINE_PATH),openssl)
-		CFLAGS += -I/usr/local/opt/openssl/include
-		LDFLAGS += -L/usr/local/opt/openssl/lib
-	endif
-endif
-
 CRYPTO_ENGINE = $(SRC_PATH)/soter/$(CRYPTO_ENGINE_PATH)
 CFLAGS += -D$(CRYPTO_ENGINE_DEF) -DCRYPTO_ENGINE_PATH=$(CRYPTO_ENGINE_PATH)
 
@@ -162,6 +154,13 @@ IS_CLANG_COMPILER = $(shell $(CC) --version 2>&1 | $(EGREP) -i -c "clang version
 ifeq ($(shell uname),Darwin)
 SHARED_EXT = dylib
 PREFIX = /usr/local
+
+	# add openssl headers for MacOS
+	ifeq ($(CRYPTO_ENGINE_PATH),openssl)
+		CFLAGS += -I$(PREFIX)/opt/openssl/include
+		LDFLAGS += -L$(PREFIX)/opt/openssl/lib
+	endif
+
 ifneq ($(SDK),)
 SDK_PLATFORM_VERSION=$(shell xcrun --sdk $(SDK) --show-sdk-platform-version)
 XCODE_BASE=$(shell xcode-select --print-path)

--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ PREFIX = /usr/local
 	ifeq ($(CRYPTO_ENGINE_PATH),openssl)
 	
 		# if brew is installed, if openssl is installed
-        PACKAGELIST := $(shell brew list | grep 'openssl')
+		PACKAGELIST := $(shell brew list | grep 'openssl')
 		ifeq ($(PACKAGELIST),openssl)
 
 		 	# path to openssl (usually "/usr/local/opt/openssl")

--- a/Makefile
+++ b/Makefile
@@ -155,21 +155,21 @@ ifeq ($(shell uname),Darwin)
 SHARED_EXT = dylib
 PREFIX = /usr/local
 
-	# add openssl headers for MacOS
-	ifeq ($(CRYPTO_ENGINE_PATH),openssl)
-	
-		# if brew is installed, if openssl is installed
-		PACKAGELIST := $(shell brew list | grep 'openssl')
-		ifeq ($(PACKAGELIST),openssl)
+# add openssl headers for MacOS
+ifeq ($(CRYPTO_ENGINE_PATH),openssl)
 
-		 	# path to openssl (usually "/usr/local/opt/openssl")
-			OPENSSL_PATH := $(shell brew --prefix openssl)
-			ifneq ($(OPENSSL_PATH),)
-				CFLAGS += -I$(OPENSSL_PATH)/include
-				LDFLAGS += -L$(OPENSSL_PATH)/lib
-			endif
+	# if brew is installed, if openssl is installed
+	PACKAGELIST := $(shell brew list | grep 'openssl')
+	ifeq ($(PACKAGELIST),openssl)
+
+	 	# path to openssl (usually "/usr/local/opt/openssl")
+		OPENSSL_PATH := $(shell brew --prefix openssl)
+		ifneq ($(OPENSSL_PATH),)
+			CFLAGS += -I$(OPENSSL_PATH)/include
+			LDFLAGS += -L$(OPENSSL_PATH)/lib
 		endif
 	endif
+endif
 
 ifneq ($(SDK),)
 SDK_PLATFORM_VERSION=$(shell xcrun --sdk $(SDK) --show-sdk-platform-version)


### PR DESCRIPTION
## 1. Fix missing OpenSSL headers path for MacOS.

**Was:** 
How MacOS users should build themis now:

```
$ brew install openssl
$ export LDFLAGS="-L/usr/local/opt/openssl/lib"
$ export CFLAGS="-I/usr/local/opt/openssl/include"
$ make install
```
I've added path to openssl headers inside Make file, for Darwin core / MacOS only. Now users can build themis more simple:

**Now:**
```
$ brew install openssl
$ make install
```

## 2. Fix dylib building. 

**Was:**

Error while building dylibs (themis, soter):

```
themis_static                  [OK]
-n link 
error: /Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool: can't open file: build/libsoter.dylib (No such file or directory)
make: *** [soter_shared] Error 1
```

This error cause all `make install` command to fail. I swapped lines: first build, then` install_name_tool`.

**Now:**

Themis builds without errors on MacOS:

```
$ make install
....
-n link 
themis_static                  [OK]
-n link 
soter_shared                   [OK]
-n link 
themis_shared                  [OK]
0.9.4-183-g7eaaa17
-n making dirs for install 
[OK]                         
-n install soter headers 
[OK]                         
-n install themis headers 
[OK]                         
-n install static libraries 
[OK]                         
-n install shared libraries 
[OK]
```

If this PR has no breaking changes for other systems, it will help solving issues like https://github.com/cossacklabs/themis/issues/215