### PR TITLE
fix installing dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,12 @@ include src/themis/themis.mk
 include jni/themis_jni.mk
 endif
 
+JSTHEMIS_PACKAGE_VERSION=$(shell cat src/wrappers/themis/jsthemis/package.json \
+  | grep version \
+  | head -1 \
+  | awk -F: '{ print $$2 }' \
+  | sed 's/[",]//g' \
+  | tr -d '[[:space:]]')
 
 all: err themis_static themis_shared
 	@echo $(VERSION)
@@ -263,10 +269,10 @@ endif
 	echo "cd ./tests/jsthemis/" > ./$(BIN_PATH)/tests/node.sh
 	echo "wget https://nodejs.org/dist/v4.6.0/node-v4.6.0-linux-x64.tar.gz" >> ./$(BIN_PATH)/tests/node.sh
 	echo "tar -xvf node-v4.6.0-linux-x64.tar.gz" >> ./$(BIN_PATH)/tests/node.sh
-	echo "cd ../../src/wrappers/themis/jsthemis && PATH=`pwd`/tests/jsthemis/node-v4.6.0-linux-x64/bin:$(PATH) npm pack && mv jsthemis-0.9.5.tgz ../../../../build && cd -" >> ./$(BIN_PATH)/tests/node.sh
+	echo "cd ../../src/wrappers/themis/jsthemis && PATH=`pwd`/tests/jsthemis/node-v4.6.0-linux-x64/bin:$(PATH) npm pack && mv jsthemis-$(JSTHEMIS_PACKAGE_VERSION).tgz ../../../../build && cd -" >> ./$(BIN_PATH)/tests/node.sh
 	echo "PATH=`pwd`/tests/jsthemis/node-v4.6.0-linux-x64/bin:$(PATH) npm install mocha" >> ./$(BIN_PATH)/tests/node.sh
 	echo "PATH=`pwd`/tests/jsthemis/node-v4.6.0-linux-x64/bin:$(PATH) npm install nan" >> ./$(BIN_PATH)/tests/node.sh
-	echo "PATH=`pwd`/tests/jsthemis/node-v4.6.0-linux-x64/bin:$(PATH) npm install ../../build/jsthemis-0.9.5.tgz" >> ./$(BIN_PATH)/tests/node.sh
+	echo "PATH=`pwd`/tests/jsthemis/node-v4.6.0-linux-x64/bin:$(PATH) npm install ../../build/jsthemis-$(JSTHEMIS_PACKAGE_VERSION).tgz" >> ./$(BIN_PATH)/tests/node.sh
 	echo "PATH=`pwd`/tests/jsthemis/node-v4.6.0-linux-x64/bin:$(PATH) ./node_modules/mocha/bin/mocha" >> ./$(BIN_PATH)/tests/node.sh
 	chmod a+x ./$(BIN_PATH)/tests/node.sh
 

--- a/src/wrappers/themis/jsthemis/binding.gyp
+++ b/src/wrappers/themis/jsthemis/binding.gyp
@@ -6,9 +6,6 @@
       "libraries": ["-L/usr/local/lib/", "-L/usr/lib/", "-lsoter", "-lthemis"],
       "include_dirs": [
          "<!(node -e \"require('nan')\")"
-      ],
-      "defines": [
-	"SECURE_COMPARATOR_ENABLED"
       ]
     }
   ]

--- a/src/wrappers/themis/jsthemis/package.json
+++ b/src/wrappers/themis/jsthemis/package.json
@@ -1,16 +1,16 @@
 {
   "name": "jsthemis",
-  "version": "0.9.5",
+  "version": "0.9.6-1",
   "description": "Themis is a data security library, providing users with high-quality security services for secure messaging of any kinds and flexible data storage. Themis is aimed at modern developers, with high level OOP wrappers for Ruby, Python, PHP, Java / Android and iOS / OSX. It is designed with ease of use in mind, high security and cross-platform availability.",
   "main": "build/Release/jsthemis.node",
   "scripts": {
-    "preinstall": "node-gyp configure && node-gyp build",
+    "preinstall": "npm install && node-gyp configure && node-gyp build",
     "preuninstall": "rm -rf build/*"
   },
   "author": {
     "name": "Cossack Labs",
     "email": "dev@cossacklabs.com",
-    "url": "http://cossacklabs.com/"
+    "url": "https://www.cossacklabs.com/"
   },
   "dependencies": {
     "nan": "^2.4.0"

--- a/src/wrappers/themis/jsthemis/package.json
+++ b/src/wrappers/themis/jsthemis/package.json
@@ -4,7 +4,6 @@
   "description": "Themis is a data security library, providing users with high-quality security services for secure messaging of any kinds and flexible data storage. Themis is aimed at modern developers, with high level OOP wrappers for Ruby, Python, PHP, Java / Android and iOS / OSX. It is designed with ease of use in mind, high security and cross-platform availability.",
   "main": "build/Release/jsthemis.node",
   "scripts": {
-    "preinstall": "npm install && node-gyp configure && node-gyp build",
     "preuninstall": "rm -rf build/*"
   },
   "author": {


### PR DESCRIPTION
drop redundant "define" option
up to 0.9.6-**1** because published 0.9.6-**0** without adding `npm install &&` command (just with fixed library search paths) in preinstall script that fixes installing `nan` before building jsthemis