### PR TITLE
use constant time mem_cmp to compare sensitive data

### DIFF
--- a/src/soter/boringssl/soter_ec_key.c
+++ b/src/soter/boringssl/soter_ec_key.c
@@ -16,6 +16,7 @@
 
 #include <soter/error.h>
 #include <soter/soter_ec_key.h>
+#include <soter/soter_mem_cmp.h>
 
 #include <openssl/evp.h>
 #include <openssl/bn.h>
@@ -373,7 +374,7 @@ soter_status_t soter_ec_priv_key_to_engine_specific(const soter_container_hdr_t 
 	}
 
 	/* Validate tag */
-	if (memcmp(key->tag, EC_PRIV_KEY_PREF, strlen(EC_PRIV_KEY_PREF)))
+	if (cst_time_memcmp(key->tag, EC_PRIV_KEY_PREF, strlen(EC_PRIV_KEY_PREF)))
 	{
 		return SOTER_INVALID_PARAMETER;
 	}

--- a/src/soter/boringssl/soter_rsa_key.c
+++ b/src/soter/boringssl/soter_rsa_key.c
@@ -16,6 +16,7 @@
 
 #include <soter/error.h>
 #include <soter/soter_rsa_key.h>
+#include <soter/soter_mem_cmp.h>
 
 #include <openssl/bn.h>
 #include <openssl/evp.h>
@@ -443,7 +444,7 @@ soter_status_t soter_rsa_priv_key_to_engine_specific(const soter_container_hdr_t
 	}
 
 	/* Validate tag */
-	if (memcmp(key->tag, RSA_PRIV_KEY_PREF, strlen(RSA_PRIV_KEY_PREF)))
+	if (cst_time_memcmp(key->tag, RSA_PRIV_KEY_PREF, strlen(RSA_PRIV_KEY_PREF)))
 	{
 		return SOTER_INVALID_PARAMETER;
 	}

--- a/src/soter/openssl/soter_ec_key.c
+++ b/src/soter/openssl/soter_ec_key.c
@@ -16,6 +16,7 @@
 
 #include <soter/error.h>
 #include <soter/soter_ec_key.h>
+#include <soter/soter_mem_cmp.h>
 
 #include <openssl/evp.h>
 #include <openssl/ec.h>
@@ -372,7 +373,7 @@ soter_status_t soter_ec_priv_key_to_engine_specific(const soter_container_hdr_t 
 	}
 
 	/* Validate tag */
-	if (memcmp(key->tag, EC_PRIV_KEY_PREF, strlen(EC_PRIV_KEY_PREF)))
+	if (cst_time_memcmp(key->tag, EC_PRIV_KEY_PREF, strlen(EC_PRIV_KEY_PREF)))
 	{
 		return SOTER_INVALID_PARAMETER;
 	}

--- a/src/soter/openssl/soter_rsa_key.c
+++ b/src/soter/openssl/soter_rsa_key.c
@@ -16,6 +16,7 @@
 
 #include <soter/error.h>
 #include <soter/soter_rsa_key.h>
+#include <soter/soter_mem_cmp.h>
 
 #include <openssl/evp.h>
 #include <openssl/rsa.h>
@@ -443,7 +444,7 @@ soter_status_t soter_rsa_priv_key_to_engine_specific(const soter_container_hdr_t
 	}
 
 	/* Validate tag */
-	if (memcmp(key->tag, RSA_PRIV_KEY_PREF, strlen(RSA_PRIV_KEY_PREF)))
+	if (cst_time_memcmp(key->tag, RSA_PRIV_KEY_PREF, strlen(RSA_PRIV_KEY_PREF)))
 	{
 		return SOTER_INVALID_PARAMETER;
 	}

--- a/src/soter/soter_mem_cmp.c
+++ b/src/soter/soter_mem_cmp.c
@@ -1,0 +1,34 @@
+/*
+* Copyright (c) 2017 Cossack Labs Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+
+#include <soter/soter_mem_cmp.h>
+
+// https://github.com/chmike/cst_time_memcmp#fastest-implementation-using-subscipt
+
+int cst_time_memcmp(const void *m1, const void *m2, size_t n) {
+    const unsigned char *pm1 = (unsigned char *)m1; 
+    const unsigned char *pm2 = (unsigned char *)m2; 
+    int res = 0, diff;
+    if (n > 0) {
+        do {
+            --n;
+            diff = pm1[n] - pm2[n];
+            res = (res & -!diff) | diff;
+        } while (n != 0);
+    }
+    return (res > 0) - (res < 0);
+}

--- a/src/soter/soter_mem_cmp.h
+++ b/src/soter/soter_mem_cmp.h
@@ -1,0 +1,26 @@
+/*
+* Copyright (c) 2017 Cossack Labs Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+
+#ifndef SOTER_MEM_CMP_H_
+#define SOTER_MEM_CMP_H_
+
+#include <stddef.h>
+
+
+int cst_time_memcmp(const void *m1, const void *m2, size_t n);
+
+#endif /* SOTER_MEM_CMP_H_ */

--- a/src/themis/secure_comparator.c
+++ b/src/themis/secure_comparator.c
@@ -49,6 +49,8 @@
  */
 
 #include "secure_comparator_t.h"
+ 
+#include <soter/soter_mem_cmp.h>
 #include <string.h>
 
 static themis_status_t secure_comparator_alice_step1(secure_comparator_t *comp_ctx, void *output, size_t *output_length);
@@ -169,7 +171,7 @@ static themis_status_t ed_verify(uint8_t pos, const ge_p3 *point, const uint8_t 
 
 	sc_reduce(k);
 
-	if (memcmp(k, signature, ED25519_GE_LENGTH))
+	if (cst_time_memcmp(k, signature, ED25519_GE_LENGTH))
 	{
 		return THEMIS_INVALID_SIGNATURE;
 	}
@@ -302,7 +304,7 @@ static themis_status_t ed_dbl_base_verify(uint8_t pos, const ge_p3 *base1, const
 
 	sc_reduce(k);
 
-	if (memcmp(k, signature, ED25519_GE_LENGTH))
+	if (cst_time_memcmp(k, signature, ED25519_GE_LENGTH))
 	{
 		return THEMIS_INVALID_SIGNATURE;
 	}
@@ -438,7 +440,7 @@ static themis_status_t ed_point_verify(uint8_t pos, const ge_p3 *base2, const ge
 
 	sc_reduce(k);
 
-	if (memcmp(k, signature, ED25519_GE_LENGTH))
+	if (cst_time_memcmp(k, signature, ED25519_GE_LENGTH))
 	{
 		return THEMIS_INVALID_SIGNATURE;
 	}

--- a/src/themis/secure_message_wrapper.c
+++ b/src/themis/secure_message_wrapper.c
@@ -23,6 +23,8 @@
 #include <soter/soter_ec_key.h>
 #include <soter/soter_asym_sign.h>
 #include <soter/soter_asym_ka.h>
+#include <soter/soter_mem_cmp.h>
+
 #include <themis/secure_message_wrapper.h>
 
 
@@ -39,10 +41,10 @@ soter_sign_alg_t get_alg_id(const uint8_t* key, size_t key_length)
   if (key_length < sizeof(soter_container_hdr_t) && key_length < ((const soter_container_hdr_t*)key)->size){
     return (soter_sign_alg_t)(-1);
   }
-  if (memcmp(((const soter_container_hdr_t*)key)->tag,EC_PRIV_KEY_PREF,3)==0 || memcmp(((const soter_container_hdr_t*)key)->tag,EC_PUB_KEY_PREF,3)==0){
+  if (cst_time_memcmp(((const soter_container_hdr_t*)key)->tag,EC_PRIV_KEY_PREF,3)==0 || memcmp(((const soter_container_hdr_t*)key)->tag,EC_PUB_KEY_PREF,3)==0){
       return SOTER_SIGN_ecdsa_none_pkcs8;
   }
-  if (memcmp(((const soter_container_hdr_t*)key)->tag,RSA_PRIV_KEY_PREF,3)==0 || memcmp(((const soter_container_hdr_t*)key)->tag,RSA_PUB_KEY_PREF,3)==0){
+  if (cst_time_memcmp(((const soter_container_hdr_t*)key)->tag,RSA_PRIV_KEY_PREF,3)==0 || memcmp(((const soter_container_hdr_t*)key)->tag,RSA_PUB_KEY_PREF,3)==0){
       return SOTER_SIGN_rsa_pss_pkcs8;
   }
   return SOTER_SIGN_undefined;

--- a/src/themis/secure_session_utils.c
+++ b/src/themis/secure_session_utils.c
@@ -21,6 +21,7 @@
 #include <soter/soter_t.h>
 #include <soter/soter_rsa_key.h>
 #include <soter/soter_ec_key.h>
+#include <soter/soter_mem_cmp.h>
 
 #include <themis/error.h>
 
@@ -37,12 +38,12 @@ soter_sign_alg_t get_key_sign_type(const void *sign_key, size_t sign_key_length)
 			return (soter_sign_alg_t)0xffffffff;
 		}
 
-		if (!memcmp(key->tag, EC_PRIV_KEY_PREF, strlen(EC_PRIV_KEY_PREF)))
+		if (!cst_time_memcmp(key->tag, EC_PRIV_KEY_PREF, strlen(EC_PRIV_KEY_PREF)))
 		{
 			return SOTER_SIGN_ecdsa_none_pkcs8;
 		}
 
-		if (!memcmp(key->tag, RSA_PRIV_KEY_PREF, strlen(RSA_PRIV_KEY_PREF)))
+		if (!cst_time_memcmp(key->tag, RSA_PRIV_KEY_PREF, strlen(RSA_PRIV_KEY_PREF)))
 		{
 			return SOTER_SIGN_rsa_pss_pkcs8;
 		}
@@ -190,7 +191,7 @@ themis_status_t verify_mac(const void *key, size_t key_length, const soter_kdf_c
 		return THEMIS_INVALID_PARAMETER;
 	}
 
-	if (memcmp(mac, computed_mac, mac_length))
+	if (cst_time_memcmp(mac, computed_mac, mac_length))
 	{
 		return THEMIS_INVALID_SIGNATURE;
 	}


### PR DESCRIPTION
when checking private keys and inside secure separator