### PR TITLE
fix type consistency in jni wrapper code

### DIFF
--- a/jni/themis_cell.c
+++ b/jni/themis_cell.c
@@ -74,10 +74,10 @@ JNIEXPORT jobjectArray JNICALL Java_com_cossacklabs_themis_SecureCell_encrypt(JN
 	switch (mode)
 	{
 	case MODE_SEAL:
-		res = themis_secure_cell_encrypt_seal(key_buf, key_length, context_buf, context_length, data_buf, data_length, NULL, &encrypted_data_length);
+		res = themis_secure_cell_encrypt_seal((uint8_t *)key_buf, key_length, (uint8_t *)context_buf, context_length, (uint8_t *)data_buf, data_length, NULL, &encrypted_data_length);
 		break;
 	case MODE_TOKEN_PROTECT:
-		res = themis_secure_cell_encrypt_token_protect(key_buf, key_length, context_buf, context_length, data_buf, data_length, NULL, &additional_data_length, NULL, &encrypted_data_length);
+		res = themis_secure_cell_encrypt_token_protect((uint8_t *)key_buf, key_length, (uint8_t *)context_buf, context_length, (uint8_t *)data_buf, data_length, NULL, &additional_data_length, NULL, &encrypted_data_length);
 		break;
 	case MODE_CONTEXT_IMPRINT:
 		if (!context)
@@ -86,7 +86,7 @@ JNIEXPORT jobjectArray JNICALL Java_com_cossacklabs_themis_SecureCell_encrypt(JN
 			goto err;
 		}
 
-		res = themis_secure_cell_encrypt_context_imprint(key_buf, key_length, data_buf, data_length, context_buf, context_length, NULL, &encrypted_data_length);
+		res = themis_secure_cell_encrypt_context_imprint((uint8_t *)key_buf, key_length, (uint8_t *)data_buf, data_length, (uint8_t *)context_buf, context_length, NULL, &encrypted_data_length);
 		break;
 	default:
 		goto err;
@@ -129,10 +129,10 @@ JNIEXPORT jobjectArray JNICALL Java_com_cossacklabs_themis_SecureCell_encrypt(JN
 	switch (mode)
 	{
 	case MODE_SEAL:
-		res = themis_secure_cell_encrypt_seal(key_buf, key_length, context_buf, context_length, data_buf, data_length, encrypted_data_buf, &encrypted_data_length);
+		res = themis_secure_cell_encrypt_seal((uint8_t *)key_buf, key_length, (uint8_t *)context_buf, context_length, (uint8_t *)data_buf, data_length, (uint8_t *)encrypted_data_buf, &encrypted_data_length);
 		break;
 	case MODE_TOKEN_PROTECT:
-		res = themis_secure_cell_encrypt_token_protect(key_buf, key_length, context_buf, context_length, data_buf, data_length, additional_data_buf, &additional_data_length, encrypted_data_buf, &encrypted_data_length);
+		res = themis_secure_cell_encrypt_token_protect((uint8_t *)key_buf, key_length, (uint8_t *)context_buf, context_length, (uint8_t *)data_buf, data_length, (uint8_t *)additional_data_buf, &additional_data_length, (uint8_t *)encrypted_data_buf, &encrypted_data_length);
 		break;
 	case MODE_CONTEXT_IMPRINT:
 		if (!context)
@@ -141,7 +141,7 @@ JNIEXPORT jobjectArray JNICALL Java_com_cossacklabs_themis_SecureCell_encrypt(JN
 			goto err;
 		}
 
-		res = themis_secure_cell_encrypt_context_imprint(key_buf, key_length, data_buf, data_length, context_buf, context_length, encrypted_data_buf, &encrypted_data_length);
+		res = themis_secure_cell_encrypt_context_imprint((uint8_t *)key_buf, key_length, (uint8_t *)data_buf, data_length, (uint8_t *)context_buf, context_length, (uint8_t *)encrypted_data_buf, &encrypted_data_length);
 		break;
 	default:
 		goto err;
@@ -269,7 +269,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureCell_decrypt(JNIE
 	switch (mode)
 	{
 	case MODE_SEAL:
-		res = themis_secure_cell_decrypt_seal(key_buf, key_length, context_buf, context_length, encrypted_data_buf, encrypted_data_length, NULL, &data_length);
+		res = themis_secure_cell_decrypt_seal((uint8_t *)key_buf, key_length, (uint8_t *)context_buf, context_length, (uint8_t *)encrypted_data_buf, encrypted_data_length, NULL, &data_length);
 		break;
 	case MODE_TOKEN_PROTECT:
 		if (!additional_data_buf)
@@ -278,7 +278,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureCell_decrypt(JNIE
 			goto err;
 		}
 
-		res = themis_secure_cell_decrypt_token_protect(key_buf, key_length, context_buf, context_length, encrypted_data_buf, encrypted_data_length, additional_data_buf, additional_data_length, NULL, &data_length);
+		res = themis_secure_cell_decrypt_token_protect((uint8_t *)key_buf, key_length, (uint8_t *)context_buf, context_length, (uint8_t *)encrypted_data_buf, encrypted_data_length, (uint8_t *)additional_data_buf, additional_data_length, NULL, &data_length);
 		break;
 	case MODE_CONTEXT_IMPRINT:
 		if (!context)
@@ -287,7 +287,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureCell_decrypt(JNIE
 			goto err;
 		}
 
-		res = themis_secure_cell_encrypt_context_imprint(key_buf, key_length, encrypted_data_buf, encrypted_data_length, context_buf, context_length, NULL, &data_length);
+		res = themis_secure_cell_encrypt_context_imprint((uint8_t *)key_buf, key_length, (uint8_t *)encrypted_data_buf, encrypted_data_length, (uint8_t *)context_buf, context_length, NULL, &data_length);
 		break;
 	default:
 		goto err;
@@ -313,7 +313,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureCell_decrypt(JNIE
 	switch (mode)
 	{
 	case MODE_SEAL:
-		res = themis_secure_cell_decrypt_seal(key_buf, key_length, context_buf, context_length, encrypted_data_buf, encrypted_data_length, data_buf, &data_length);
+		res = themis_secure_cell_decrypt_seal((uint8_t *)key_buf, key_length, (uint8_t *)context_buf, context_length, (uint8_t *)encrypted_data_buf, encrypted_data_length, (uint8_t *)data_buf, &data_length);
 		break;
 	case MODE_TOKEN_PROTECT:
 		if (!additional_data_buf)
@@ -322,7 +322,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureCell_decrypt(JNIE
 			goto err;
 		}
 
-		res = themis_secure_cell_decrypt_token_protect(key_buf, key_length, context_buf, context_length, encrypted_data_buf, encrypted_data_length, additional_data_buf, additional_data_length, data_buf, &data_length);
+		res = themis_secure_cell_decrypt_token_protect((uint8_t *)key_buf, key_length, (uint8_t *)context_buf, context_length, (uint8_t *)encrypted_data_buf, encrypted_data_length, (uint8_t *)additional_data_buf, additional_data_length, (uint8_t *)data_buf, &data_length);
 		break;
 	case MODE_CONTEXT_IMPRINT:
 		if (!context)
@@ -331,7 +331,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureCell_decrypt(JNIE
 			goto err;
 		}
 
-		res = themis_secure_cell_encrypt_context_imprint(key_buf, key_length, encrypted_data_buf, encrypted_data_length, context_buf, context_length, data_buf, &data_length);
+		res = themis_secure_cell_encrypt_context_imprint((uint8_t *)key_buf, key_length, (uint8_t *)encrypted_data_buf, encrypted_data_length, (uint8_t *)context_buf, context_length, (uint8_t *)data_buf, &data_length);
 		break;
 	default:
 		goto err;

--- a/jni/themis_keygen.c
+++ b/jni/themis_keygen.c
@@ -82,10 +82,10 @@ JNIEXPORT jobjectArray JNICALL Java_com_cossacklabs_themis_KeypairGenerator_gene
 	switch (key_type)
 	{
 	case KEYTYPE_EC:
-		res = themis_gen_ec_key_pair(priv_buf, &private_length, pub_buf, &public_length);
+		res = themis_gen_ec_key_pair((uint8_t *)priv_buf, &private_length, (uint8_t *)pub_buf, &public_length);
 		break;
 	case KEYTYPE_RSA:
-		res = themis_gen_rsa_key_pair(priv_buf, &private_length, pub_buf, &public_length);
+		res = themis_gen_rsa_key_pair((uint8_t *)priv_buf, &private_length, (uint8_t *)pub_buf, &public_length);
 		break;
 	default:
 		(*env)->ReleaseByteArrayElements(env, public, pub_buf, 0);

--- a/jni/themis_message.c
+++ b/jni/themis_message.c
@@ -69,11 +69,11 @@ JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureMessage_process(J
 
 	if (is_wrap)
 	{
-		res = themis_secure_message_wrap(priv_buf, private_length, pub_buf, public_length, message_buf, message_length, NULL, &output_length);
+		res = themis_secure_message_wrap((uint8_t *)priv_buf, private_length, (uint8_t *)pub_buf, public_length, (uint8_t *)message_buf, message_length, NULL, &output_length);
 	}
 	else
 	{
-		res = themis_secure_message_unwrap(priv_buf, private_length, pub_buf, public_length, message_buf, message_length, NULL, &output_length);
+		res = themis_secure_message_unwrap((uint8_t *)priv_buf, private_length, (uint8_t *)pub_buf, public_length, (uint8_t *)message_buf, message_length, NULL, &output_length);
 	}
 
 	if (THEMIS_BUFFER_TOO_SMALL != res)
@@ -95,11 +95,11 @@ JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureMessage_process(J
 
 	if (is_wrap)
 	{
-		res = themis_secure_message_wrap(priv_buf, private_length, pub_buf, public_length, message_buf, message_length, output_buf, &output_length);
+		res = themis_secure_message_wrap((uint8_t *)priv_buf, private_length, (uint8_t *)pub_buf, public_length, (uint8_t *)message_buf, message_length, (uint8_t *)output_buf, &output_length);
 	}
 	else
 	{
-		res = themis_secure_message_unwrap(priv_buf, private_length, pub_buf, public_length, message_buf, message_length, output_buf, &output_length);
+		res = themis_secure_message_unwrap((uint8_t *)priv_buf, private_length, (uint8_t *)pub_buf, public_length, (uint8_t *)message_buf, message_length, (uint8_t *)output_buf, &output_length);
 	}
 
 err:


### PR DESCRIPTION
fix warnings from `jni` wrapper casting types.

This is small enhancement that I felt necessary to fix during investigation of #220 