### PR TITLE
Rename error.h files

### DIFF
--- a/gothemis/cell/cell.go
+++ b/gothemis/cell/cell.go
@@ -6,7 +6,7 @@ package cell
 #include <string.h>
 #include <stdint.h>
 #include <stdbool.h>
-#include <themis/error.h>
+#include <themis/themis_error.h>
 #include <themis/secure_cell.h>
 
 #define MODE_SEAL 0

--- a/gothemis/compare/compare.go
+++ b/gothemis/compare/compare.go
@@ -6,7 +6,7 @@ package compare
 #include <string.h>
 #include <stdint.h>
 #include <stdbool.h>
-#include <themis/error.h>
+#include <themis/themis_error.h>
 #include <themis/secure_comparator.h>
 
 static void* compare_init(void)

--- a/gothemis/keys/keypair.go
+++ b/gothemis/keys/keypair.go
@@ -6,7 +6,7 @@ package keys
 #include <string.h>
 #include <stdint.h>
 #include <stdbool.h>
-#include <themis/error.h>
+#include <themis/themis_error.h>
 #include <themis/secure_message.h>
 
 #define KEYTYPE_EC 0

--- a/gothemis/message/message.go
+++ b/gothemis/message/message.go
@@ -6,7 +6,7 @@ package message
 #include <string.h>
 #include <stdint.h>
 #include <stdbool.h>
-#include <themis/error.h>
+#include <themis/themis_error.h>
 #include <themis/secure_message.h>
 
 static bool get_message_size(const void *priv, size_t priv_len, const void *public, size_t pub_len, const void *message, size_t message_len, bool is_wrap, size_t *out_len)

--- a/gothemis/session/session.h
+++ b/gothemis/session/session.h
@@ -6,7 +6,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#include <themis/error.h>
+#include <themis/themis_error.h>
 #include <themis/secure_session.h>
 
 struct session_with_callbacks_type

--- a/jni/themis_cell.c
+++ b/jni/themis_cell.c
@@ -15,7 +15,7 @@
 */
 
 #include <jni.h>
-#include <themis/error.h>
+#include <themis/themis_error.h>
 #include <themis/secure_cell.h>
 
 /* These definitions should correspond to the ones in SecureCell.java */

--- a/jni/themis_compare.c
+++ b/jni/themis_compare.c
@@ -15,7 +15,7 @@
 */
 
 #include <jni.h>
-#include <themis/error.h>
+#include <themis/themis_error.h>
 #include <themis/secure_comparator.h>
 
 #define COMPARE_CTX_FIELD_NAME "nativeCtx"

--- a/jni/themis_keygen.c
+++ b/jni/themis_keygen.c
@@ -15,7 +15,7 @@
 */
 
 #include <jni.h>
-#include <themis/error.h>
+#include <themis/themis_error.h>
 #include <themis/secure_message.h>
 
 /* Should be same as in AsymmetricKey.java */

--- a/jni/themis_message.c
+++ b/jni/themis_message.c
@@ -15,7 +15,7 @@
 */
 
 #include <jni.h>
-#include <themis/error.h>
+#include <themis/themis_error.h>
 #include <themis/secure_message.h>
 
 JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureMessage_process(JNIEnv *env, jobject thiz, jbyteArray private, jbyteArray public, jbyteArray message, jboolean is_wrap)

--- a/jni/themis_session.c
+++ b/jni/themis_session.c
@@ -16,7 +16,7 @@
 
 #include <jni.h>
 #include <string.h>
-#include <themis/error.h>
+#include <themis/themis_error.h>
 #include <themis/secure_session.h>
 #include <themis/secure_session_t.h>
 /*extern JavaVM *g_vm;*/

--- a/src/soter/boringssl/soter_asym_cipher.c
+++ b/src/soter/boringssl/soter_asym_cipher.c
@@ -14,7 +14,6 @@
 * limitations under the License.
 */
 
-#include <soter/error.h>
 #include <soter/soter.h>
 #include <soter/soter_rsa_key.h>
 #include "soter_engine.h"

--- a/src/soter/boringssl/soter_asym_ka.c
+++ b/src/soter/boringssl/soter_asym_ka.c
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-#include <soter/error.h>
+#include <soter/soter_error.h>
 #include "soter_engine.h"
 #include <soter/soter_ec_key.h>
 #include <openssl/ec.h>

--- a/src/soter/boringssl/soter_ec_key.c
+++ b/src/soter/boringssl/soter_ec_key.c
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-#include <soter/error.h>
+#include <soter/soter_error.h>
 #include <soter/soter_ec_key.h>
 
 #include <openssl/evp.h>

--- a/src/soter/boringssl/soter_ecdsa_common.c
+++ b/src/soter/boringssl/soter_ecdsa_common.c
@@ -14,7 +14,6 @@
 * limitations under the License.
 */
 
-#include <soter/error.h>
 #include <soter/soter.h>
 #include <soter/soter_ec_key.h>
 #include "soter_engine.h"

--- a/src/soter/boringssl/soter_hash.c
+++ b/src/soter/boringssl/soter_hash.c
@@ -14,7 +14,6 @@
 * limitations under the License.
 */
 
-#include "soter/error.h"
 #include "soter/soter.h"
 #include "soter_engine.h"
 #include <openssl/evp.h>

--- a/src/soter/boringssl/soter_rand.c
+++ b/src/soter/boringssl/soter_rand.c
@@ -14,7 +14,6 @@
 * limitations under the License.
 */
 
-#include "soter/error.h"
 #include "soter/soter.h"
 #include <openssl/rand.h>
 

--- a/src/soter/boringssl/soter_rsa_common.c
+++ b/src/soter/boringssl/soter_rsa_common.c
@@ -14,9 +14,7 @@
 * limitations under the License.
 */
 
-#include <soter/error.h>
 #include <soter/soter.h>
-#include <soter/error.h>
 #include <soter/soter_rsa_key.h>
 #include "soter_engine.h"
 #include <openssl/evp.h>

--- a/src/soter/boringssl/soter_rsa_key.c
+++ b/src/soter/boringssl/soter_rsa_key.c
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-#include <soter/error.h>
+#include <soter/soter_error.h>
 #include <soter/soter_rsa_key.h>
 
 #include <openssl/bn.h>

--- a/src/soter/boringssl/soter_rsa_key_pair_gen.c
+++ b/src/soter/boringssl/soter_rsa_key_pair_gen.c
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-#include <soter/error.h>
+#include <soter/soter_error.h>
 #include "soter_engine.h"
 #include "soter_rsa_common.h"
 #include <soter/soter_rsa_key_pair_gen.h>

--- a/src/soter/boringssl/soter_sign_ecdsa.c
+++ b/src/soter/boringssl/soter_sign_ecdsa.c
@@ -15,7 +15,6 @@
 */
 
 #include <soter/soter_sign_ecdsa.h>
-#include <soter/error.h>
 #include <soter/soter.h>
 #include <soter/soter_ec_key.h>
 #include "soter_engine.h"

--- a/src/soter/boringssl/soter_sign_rsa.c
+++ b/src/soter/boringssl/soter_sign_rsa.c
@@ -15,7 +15,6 @@
 */
 
 #include <soter/soter_sign_rsa.h>
-#include <soter/error.h>
 #include <soter/soter.h>
 #include <soter/soter_rsa_key.h>
 #include "soter_engine.h"

--- a/src/soter/boringssl/soter_sym.c
+++ b/src/soter/boringssl/soter_sym.c
@@ -15,7 +15,6 @@
 */
 
 #include <string.h>
-#include "soter/error.h"
 #include "soter/soter.h"
 #include "soter_engine.h"
 #include <openssl/err.h>

--- a/src/soter/boringssl/soter_verify_ecdsa.c
+++ b/src/soter/boringssl/soter_verify_ecdsa.c
@@ -15,7 +15,6 @@
 */
 
 #include <soter/soter_sign_ecdsa.h>
-#include <soter/error.h>
 #include <soter/soter.h>
 #include <soter/soter_ec_key.h>
 #include "soter_engine.h"

--- a/src/soter/boringssl/soter_verify_rsa.c
+++ b/src/soter/boringssl/soter_verify_rsa.c
@@ -15,7 +15,6 @@
 */
 
 #include <soter/soter_sign_rsa.h>
-#include <soter/error.h>
 #include <soter/soter.h>
 #include <soter/soter_rsa_key.h>
 #include "soter_engine.h"

--- a/src/soter/openssl/soter_asym_cipher.c
+++ b/src/soter/openssl/soter_asym_cipher.c
@@ -14,7 +14,6 @@
 * limitations under the License.
 */
 
-#include <soter/error.h>
 #include <soter/soter.h>
 #include <soter/soter_rsa_key.h>
 #include "soter_engine.h"

--- a/src/soter/openssl/soter_asym_ka.c
+++ b/src/soter/openssl/soter_asym_ka.c
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-#include <soter/error.h>
+#include <soter/soter_error.h>
 #include "soter_engine.h"
 #include <soter/soter_ec_key.h>
 #include <openssl/ec.h>

--- a/src/soter/openssl/soter_ec_key.c
+++ b/src/soter/openssl/soter_ec_key.c
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-#include <soter/error.h>
+#include <soter/soter_error.h>
 #include <soter/soter_ec_key.h>
 
 #include <openssl/evp.h>

--- a/src/soter/openssl/soter_ecdsa_common.c
+++ b/src/soter/openssl/soter_ecdsa_common.c
@@ -14,7 +14,6 @@
 * limitations under the License.
 */
 
-#include <soter/error.h>
 #include <soter/soter.h>
 #include <soter/soter_ec_key.h>
 #include "soter_engine.h"

--- a/src/soter/openssl/soter_hash.c
+++ b/src/soter/openssl/soter_hash.c
@@ -14,7 +14,6 @@
 * limitations under the License.
 */
 
-#include "soter/error.h"
 #include "soter/soter.h"
 #include "soter_engine.h"
 #include <openssl/evp.h>

--- a/src/soter/openssl/soter_rand.c
+++ b/src/soter/openssl/soter_rand.c
@@ -14,7 +14,6 @@
 * limitations under the License.
 */
 
-#include "soter/error.h"
 #include "soter/soter.h"
 #include <openssl/rand.h>
 

--- a/src/soter/openssl/soter_rsa_common.c
+++ b/src/soter/openssl/soter_rsa_common.c
@@ -14,7 +14,6 @@
 * limitations under the License.
 */
 
-#include <soter/error.h>
 #include <soter/soter.h>
 #include <soter/soter_rsa_key.h>
 #include "soter_engine.h"

--- a/src/soter/openssl/soter_rsa_key.c
+++ b/src/soter/openssl/soter_rsa_key.c
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-#include <soter/error.h>
+#include <soter/soter_error.h>
 #include <soter/soter_rsa_key.h>
 
 #include <openssl/evp.h>

--- a/src/soter/openssl/soter_rsa_key_pair_gen.c
+++ b/src/soter/openssl/soter_rsa_key_pair_gen.c
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-#include <soter/error.h>
+#include <soter/soter_error.h>
 #include "soter_engine.h"
 #include <soter/soter_rsa_key_pair_gen.h>
 

--- a/src/soter/openssl/soter_sign_ecdsa.c
+++ b/src/soter/openssl/soter_sign_ecdsa.c
@@ -15,7 +15,6 @@
 */
 
 #include <soter/soter_sign_ecdsa.h>
-#include <soter/error.h>
 #include <soter/soter.h>
 #include <soter/soter_ec_key.h>
 #include "soter_engine.h"

--- a/src/soter/openssl/soter_sign_rsa.c
+++ b/src/soter/openssl/soter_sign_rsa.c
@@ -15,7 +15,6 @@
 */
 
 #include <soter/soter_sign_rsa.h>
-#include <soter/error.h>
 #include <soter/soter.h>
 #include <soter/soter_rsa_key.h>
 #include "soter_engine.h"

--- a/src/soter/openssl/soter_sym.c
+++ b/src/soter/openssl/soter_sym.c
@@ -15,7 +15,6 @@
 */
 
 #include <string.h>
-#include "soter/error.h"
 #include "soter/soter.h"
 #include "soter_engine.h"
 #include <openssl/err.h>

--- a/src/soter/openssl/soter_verify_ecdsa.c
+++ b/src/soter/openssl/soter_verify_ecdsa.c
@@ -15,7 +15,6 @@
 */
 
 #include <soter/soter_sign_ecdsa.h>
-#include <soter/error.h>
 #include <soter/soter.h>
 #include <soter/soter_ec_key.h>
 #include "soter_engine.h"

--- a/src/soter/openssl/soter_verify_rsa.c
+++ b/src/soter/openssl/soter_verify_rsa.c
@@ -15,7 +15,6 @@
 */
 
 #include <soter/soter_sign_rsa.h>
-#include <soter/error.h>
 #include <soter/soter.h>
 #include <soter/soter_rsa_key.h>
 #include "soter_engine.h"

--- a/src/soter/soter.h
+++ b/src/soter/soter.h
@@ -36,7 +36,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
-#include <soter/error.h>
+#include <soter/soter_error.h>
 #include <soter/soter_rand.h>
 #include <soter/soter_hash.h>
 #include <soter/soter_hmac.h>

--- a/src/soter/soter_container.c
+++ b/src/soter/soter_container.c
@@ -16,7 +16,7 @@
 
 #include <soter/soter_container.h>
 #include <soter/soter.h>
-#include <soter/error.h>
+#include <soter/soter_error.h>
 #include <soter/soter_crc32.h>
 #include <arpa/inet.h>
 soter_status_t soter_update_container_checksum(soter_container_hdr_t *hdr)

--- a/src/soter/soter_container.h
+++ b/src/soter/soter_container.h
@@ -18,7 +18,7 @@
 #define SOTER_CONTAINER_H
 
 #include <stdint.h>
-#include <soter/error.h>
+#include <soter/soter_error.h>
 
 #define SOTER_CONTAINER_TAG_LENGTH 4
 

--- a/src/soter/soter_error.h
+++ b/src/soter/soter_error.h
@@ -15,7 +15,7 @@
 */
 
 /**
- * @file soter/error.h
+ * @file soter/soter_error.h
  * @brief Soter return type, return codes and check macros
  *
  */

--- a/src/soter/soter_hmac.c
+++ b/src/soter/soter_hmac.c
@@ -15,7 +15,7 @@
 */
 
 #include <soter/soter_t.h>
-#include <soter/error.h>
+#include <soter/soter_error.h>
 
 #include <string.h>
 

--- a/src/soter/soter_kdf.c
+++ b/src/soter/soter_kdf.c
@@ -16,7 +16,7 @@
 
 #include <soter/soter_kdf.h>
 #include <soter/soter_t.h>
-#include <soter/error.h>
+#include <soter/soter_error.h>
 
 #include <string.h>
 

--- a/src/soter/soter_sign.c
+++ b/src/soter/soter_sign.c
@@ -14,7 +14,6 @@
 * limitations under the License.
 */
 
-#include <soter/error.h>
 #include <soter/soter.h>
 
 #ifdef CRYPTO_ENGINE_PATH

--- a/src/themis/error.h
+++ b/src/themis/error.h
@@ -25,7 +25,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <soter/error.h>
+#include <soter/soter_error.h>
 
 /** @brief return type */
 typedef int32_t themis_status_t;

--- a/src/themis/message.c
+++ b/src/themis/message.c
@@ -15,7 +15,7 @@
 */
 
 #include <string.h>
-#include <themis/error.h>
+#include <themis/themis_error.h>
 #include <themis/message.h>
 
 themis_message_t* themis_message_init(const uint8_t* message, const size_t message_length){

--- a/src/themis/secure_cell.c
+++ b/src/themis/secure_cell.c
@@ -15,7 +15,7 @@
 */
 
 #include <themis/secure_cell.h>
-#include <themis/error.h>
+#include <themis/themis_error.h>
 #include "sym_enc_message.h"
 
 themis_status_t themis_secure_cell_encrypt_seal(const uint8_t* master_key,

--- a/src/themis/secure_message.c
+++ b/src/themis/secure_message.c
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-#include <themis/error.h>
+#include <themis/themis_error.h>
 #include <themis/secure_message.h>
 #include <themis/secure_message_wrapper.h>
 #include <soter/soter_t.h>

--- a/src/themis/secure_message_wrapper.c
+++ b/src/themis/secure_message_wrapper.c
@@ -17,7 +17,7 @@
 #include <string.h>
 
 
-#include <themis/error.h>
+#include <themis/themis_error.h>
 #include <soter/soter.h>
 #include <soter/soter_rsa_key.h>
 #include <soter/soter_ec_key.h>

--- a/src/themis/secure_session.c
+++ b/src/themis/secure_session.c
@@ -16,7 +16,7 @@
 
 #include <themis/secure_session.h>
 #include <themis/secure_session_t.h>
-#include <themis/error.h>
+#include <themis/themis_error.h>
 #include <soter/soter_rsa_key.h>
 #include <soter/soter_ec_key.h>
 

--- a/src/themis/secure_session_message.c
+++ b/src/themis/secure_session_message.c
@@ -17,7 +17,7 @@
 #include <themis/secure_session.h>
 #include <themis/secure_session_t.h>
 #include <themis/secure_session_utils.h>
-#include <themis/error.h>
+#include <themis/themis_error.h>
 
 #include <soter/soter_container.h>
 

--- a/src/themis/secure_session_peer.c
+++ b/src/themis/secure_session_peer.c
@@ -15,7 +15,7 @@
 */
 
 #include <themis/secure_session_peer.h>
-#include <themis/error.h>
+#include <themis/themis_error.h>
 
 #include <string.h>
 

--- a/src/themis/secure_session_serialize.c
+++ b/src/themis/secure_session_serialize.c
@@ -16,7 +16,7 @@
 
 #include <themis/secure_session_utils.h>
 #include <themis/secure_session_t.h>
-#include <themis/error.h>
+#include <themis/themis_error.h>
 
 #include <soter/soter_container.h>
 

--- a/src/themis/secure_session_utils.c
+++ b/src/themis/secure_session_utils.c
@@ -22,7 +22,7 @@
 #include <soter/soter_rsa_key.h>
 #include <soter/soter_ec_key.h>
 
-#include <themis/error.h>
+#include <themis/themis_error.h>
 
 #define MAX_HMAC_SIZE 64 /* For HMAC-SHA512 */
 

--- a/src/themis/sym_enc_message.c
+++ b/src/themis/sym_enc_message.c
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-#include <themis/error.h>
+#include <themis/themis_error.h>
 #include <themis/sym_enc_message.h>
 #include <soter/soter.h>
 #include <string.h>

--- a/src/themis/themis.h
+++ b/src/themis/themis.h
@@ -32,7 +32,7 @@
 
 #define THEMIS_VERSION_TEXT "themis 0.9: "
 
-#include <themis/error.h>
+#include <themis/themis_error.h>
 #include <themis/secure_message.h>
 #include <themis/secure_cell.h>
 #include <themis/secure_session.h>

--- a/src/themis/themis_error.h
+++ b/src/themis/themis_error.h
@@ -15,7 +15,7 @@
 */
 
 /**
- * @file themis/error.h
+ * @file themis/themis_error.h
  * @brief return type, return codes and check macros
  */
 

--- a/src/wrappers/themis/Obj-C/objcthemis/objcthemis.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/objcthemis.h
@@ -8,6 +8,7 @@
 	#import <objcthemis/smessage.h>
 	#import <objcthemis/scomparator.h>
     #import <objcthemis/ssession.h>
+    #import <objcthemis/serror.h>
 
 #endif /* _OBJCTHEMIS_ */
 

--- a/src/wrappers/themis/Obj-C/objcthemis/scell_context_imprint.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_context_imprint.m
@@ -15,8 +15,7 @@
 */
 
 #import <objcthemis/scell_context_imprint.h>
-#import <objcthemis/error.h>
-#import "error.h"
+#import <objcthemis/serror.h>
 
 
 @implementation TSCellContextImprint

--- a/src/wrappers/themis/Obj-C/objcthemis/scell_seal.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_seal.m
@@ -15,7 +15,7 @@
 */
 
 #import <objcthemis/scell_seal.h>
-#import <objcthemis/error.h>
+#import <objcthemis/serror.h>
 
 
 @implementation TSCellSeal

--- a/src/wrappers/themis/Obj-C/objcthemis/scell_token.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_token.m
@@ -15,7 +15,7 @@
 */
 
 #import <objcthemis/scell_token.h>
-#import <objcthemis/error.h>
+#import <objcthemis/serror.h>
 
 
 @implementation TSCellTokenEncryptedData

--- a/src/wrappers/themis/Obj-C/objcthemis/scomparator.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/scomparator.m
@@ -15,7 +15,7 @@
 */
 
 #import <objcthemis/scomparator.h>
-#import <objcthemis/error.h>
+#import <objcthemis/serror.h>
 
 
 @interface TSComparator ()

--- a/src/wrappers/themis/Obj-C/objcthemis/serror.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/serror.h
@@ -14,11 +14,11 @@
 * limitations under the License.
 */
 
-#ifndef OBJCTHEMIS_ERROR_H
-#define OBJCTHEMIS_ERROR_H
+#ifndef OBJCTHEMIS_S_ERROR_H
+#define OBJCTHEMIS_S_ERROR_H
 
 /**
- * @file objthemis/error.h
+ * @file objthemis/serror.h
  * @brief Status codes defenitions for Obj-C wrapper for themis
  */
 
@@ -55,4 +55,4 @@ typedef NS_ENUM(NSInteger, TSErrorType) {
 /** @} */
 /** @} */
 
-#endif
+#endif //OBJCTHEMIS_S_ERROR_H

--- a/src/wrappers/themis/Obj-C/objcthemis/skeygen.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/skeygen.m
@@ -15,7 +15,7 @@
 */
 
 #import <objcthemis/skeygen.h>
-#import <objcthemis/error.h>
+#import <objcthemis/serror.h>
 
 
 @interface TSKeyGen ()

--- a/src/wrappers/themis/Obj-C/objcthemis/smessage.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/smessage.m
@@ -15,7 +15,7 @@
 */
 
 #import <objcthemis/smessage.h>
-#import <objcthemis/error.h>
+#import <objcthemis/serror.h>
 
 
 @interface TSMessage ()

--- a/src/wrappers/themis/Obj-C/objcthemis/ssession.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/ssession.m
@@ -15,7 +15,7 @@
 */
 
 #import <objcthemis/ssession.h>
-#import <objcthemis/error.h>
+#import <objcthemis/serror.h>
 
 
 @interface TSSession ()

--- a/src/wrappers/themis/Obj-C/objcthemis/ssession_transport_interface.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/ssession_transport_interface.m
@@ -15,7 +15,7 @@
 */
 
 #import <objcthemis/ssession_transport_interface.h>
-#import <objcthemis/error.h>
+#import <objcthemis/serror.h>
 
 
 ssize_t on_send_callback(const uint8_t * data, size_t data_length, void * user_data) {

--- a/src/wrappers/themis/php/php_themis.c
+++ b/src/wrappers/themis/php/php_themis.c
@@ -17,7 +17,7 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include <themis/error.h>
+#include <themis/themis_error.h>
 
 #include "php.h"
 #include "php_themis.h"

--- a/tests/common/test_utils.h
+++ b/tests/common/test_utils.h
@@ -17,7 +17,7 @@
 #ifndef TEST_UTILS_H
 #define TEST_UTILS_H
 
-#include <themis/error.h>
+#include <themis/themis_error.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/tests/soter/soter_test.h
+++ b/tests/soter/soter_test.h
@@ -17,7 +17,7 @@
 #ifndef SOTER_TEST_H
 #define SOTER_TEST_H
 
-#include <soter/error.h>
+#include <soter/soter_error.h>
 #include <common/test_utils.h>
 #include <soter/soter_t.h>
 

--- a/tests/themis/themis_test.h
+++ b/tests/themis/themis_test.h
@@ -17,7 +17,7 @@
 #ifndef _THEMIS_TEST_H_
 #define _THEMIS_TEST_H_
 
-#include <themis/error.h>
+#include <themis/themis_error.h>
 #include <common/test_utils.h>
 #include <themis/themis.h>
 void run_secure_message_test(void);


### PR DESCRIPTION
Currently core has two `error.h` files: inside `soter` and inside `themis` folders. It might cause compiler warnings due to same names.

Moreover, objc wrapper has `error.h` file inside too, this cause warning while building iOS (ObjC/Swift) examples.  

Previously mentioned:

- #63 
- https://github.com/cossacklabs/themis/issues/219#issuecomment-327501161


# Changes:

- rename `soter/error.h` to `soter/soter_error.h`
- remove extra includes inside soter and themis
- rename `objcthemis/serror.h` to `objcthemis/serror.h