### PR TITLE
fix license name in rubythemis.gemspec

### DIFF
--- a/src/wrappers/themis/ruby/rubythemis.gemspec
+++ b/src/wrappers/themis/ruby/rubythemis.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.email       = 'dev@cossacklabs.com'
   s.files       = ["lib/rubythemis.rb"]
   s.homepage    = 'http://cossacklabs.com/'
-  s.license     = 'Apache 2.0'
+  s.license     = 'Apache-2.0'
   s.add_runtime_dependency 'ffi', '~> 1.9', '>= 1.9.8'
   s.requirements << 'libthemis, v0.9.5'
 end


### PR DESCRIPTION
now rubythemis builds with warning:
```
WARNING:  license value 'Apache 2.0' is invalid.  Use a license identifier from
http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
Did you mean 'Apache-2.0'?
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
```
so this commit set correct license name according to http://guides.rubygems.org/specification-reference/ and https://spdx.org/licenses/