### PR TITLE
Fix android secure cell wrapper in token protect mode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ android {
     
     defaultConfig {
     	minSdkVersion 16
+        targetSdkVersion 16
     }
     
     sourceSets {

--- a/docs/examples/python/scell_test.py
+++ b/docs/examples/python/scell_test.py
@@ -1,9 +1,15 @@
 import base64
 
+from pythemis.scell import SCellTokenProtect
 from pythemis.scell import SCellSeal
+from pythemis.scell import SCellContextImprint
 
-message = 'message to encrypt'
+message = "i'm plain text message"
 passwrd = b"pass"
+context = b"somecontext"
+
+
+print("running secure cell in seal mode...")
 
 scell = SCellSeal(passwrd)
 
@@ -12,14 +18,45 @@ encrypted_message = scell.encrypt(message.encode('utf-8'))
 encrypted_message_string = base64.b64encode(encrypted_message)
 print(encrypted_message_string)
 
-print("decrypting from binary...")
+print("decrypting from binary... --> ")
 decrypted_message = scell.decrypt(encrypted_message).decode('utf-8')
 print(decrypted_message)
 
 
-print("decrypting from string...")
+print("decrypting from string... --> ")
 # check https://themis.cossacklabs.com/data-simulator/cell/
 encrypted_message_string = "AAEBQAwAAAAQAAAADQAAACoEM9MbJzEu2RDuRoGzcQgN4jchys0q+LLcsbfUDV3M2eg/FhygH1ns"
 decrypted_message_from_string = base64.b64decode(encrypted_message_string)
 decrypted_message = scell.decrypt(decrypted_message_from_string).decode('utf-8')
+print(decrypted_message)
+
+
+print("----------------------")
+print("running secure cell in token protect mode...")
+
+scellTP = SCellTokenProtect(passwrd)
+
+print("encrypting...")
+encrypted_message, additional_auth_data = scellTP.encrypt(message.encode('utf-8'))
+encrypted_message_string = base64.b64encode(encrypted_message)
+print(encrypted_message_string)
+
+print("decrypting from binary... --> ")
+decrypted_message = scellTP.decrypt(encrypted_message, additional_auth_data).decode('utf-8')
+print(decrypted_message)
+
+
+print("----------------------")
+print("running secure cell in context imprint mode...")
+
+
+scellCI = SCellContextImprint(passwrd)
+
+print("encrypting...")
+encrypted_message = scellCI.encrypt(message.encode('utf-8'), context)
+encrypted_message_string = base64.b64encode(encrypted_message)
+print(encrypted_message_string)
+
+print("decrypting from binary... --> ")
+decrypted_message = scellCI.decrypt(encrypted_message, context).decode('utf-8')
 print(decrypted_message)

--- a/jni/themis_cell.c
+++ b/jni/themis_cell.c
@@ -121,6 +121,7 @@ JNIEXPORT jobjectArray JNICALL Java_com_cossacklabs_themis_SecureCell_encrypt(JN
 	if (additional_data_length)
 	{
 		additional_data_buf = (*env)->GetByteArrayElements(env, additional_data, NULL);
+		if (!additional_data_buf) 
 		{
 			goto err;
 		}

--- a/src/themis/secure_session_message.c
+++ b/src/themis/secure_session_message.c
@@ -22,6 +22,7 @@
 #include <soter/soter_container.h>
 
 #include <string.h>
+#include <time.h>
 
 #include <arpa/inet.h>
 #include "portable_endian.h"

--- a/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellTest.java
+++ b/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellTest.java
@@ -45,9 +45,9 @@ public class SecureCellTest extends AndroidTestCase {
 	@Override
 	public void runTest() {
 		try {
-//			testSeal();
-//			testTokenProtect();
-//			testContextImprint();
+			testSeal();
+			testTokenProtect();
+			testContextImprint();
 		} catch (Exception e) {
 			String failMessage = e.getClass().getCanonicalName();
 			
@@ -65,6 +65,8 @@ public class SecureCellTest extends AndroidTestCase {
 		byte[] data = generateTestData();
 		
 		SecureCell cell = new SecureCell(key);
+		assertNotNull(cell);
+
 		SecureCellData protectedData = cell.protect(context, data);
 		
 		assertNotNull(protectedData);
@@ -85,7 +87,9 @@ public class SecureCellTest extends AndroidTestCase {
 		byte[] data = generateTestData();
 		
 		SecureCell cell = new SecureCell(key, SecureCell.MODE_TOKEN_PROTECT);
-		SecureCellData protectedData = cell.protect(context, data);
+		assertNotNull(cell);
+
+		SecureCellData protectedData = cell.protect(key, context, data);
 		
 		assertNotNull(protectedData);
 		assertNotNull(protectedData.getProtectedData());
@@ -105,6 +109,8 @@ public class SecureCellTest extends AndroidTestCase {
 		byte[] data = generateTestData();
 		
 		SecureCell cell = new SecureCell(key, SecureCell.MODE_CONTEXT_IMPRINT);
+		assertNotNull(cell);
+
 		SecureCellData protectedData = cell.protect(context, data);
 		
 		assertNotNull(protectedData);


### PR DESCRIPTION
bits and pieces while fixing android secure cell :)

- uncomment tests for Secure Cell (facepalm.jpg)
- see that tests are failing for token protect mode
- fix themis_jni for token protect

extra points:
- update python secure cell example (well, i just use it as reference code)