### PR TITLE
Makes NSError** argument __autoreleasing; adds check against null

### DIFF
--- a/src/wrappers/themis/Obj-C/objcthemis/scell_seal.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_seal.h
@@ -59,7 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
 * @param [in] error pointer to Error on failure
 * @return Wrapped message as NSData object on success or nil on failure
 */
-- (nullable NSData *)wrapData:(NSData *)message error:(NSError **)error;
+- (nullable NSData *)wrapData:(NSData *)message error:(NSError * __autoreleasing *)error;
 
 /**
 * @brief Unwrap message
@@ -67,7 +67,7 @@ NS_ASSUME_NONNULL_BEGIN
 * @param [in] error pointer to Error on failure
 * @return Unwrapped message as NSData object on success or nil on failure
 */
-- (nullable NSData *)unwrapData:(NSData *)message error:(NSError **)error;
+- (nullable NSData *)unwrapData:(NSData *)message error:(NSError * __autoreleasing *)error;
 
 /**
 * @brief Wrap message with context
@@ -76,7 +76,7 @@ NS_ASSUME_NONNULL_BEGIN
 * @param [in] error pointer to Error on failure
 * @return Wrapped message as NSData object on success or nil on failure
 */
-- (nullable NSData *)wrapData:(NSData *)message context:(nullable NSData *)context error:(NSError **)error;
+- (nullable NSData *)wrapData:(NSData *)message context:(nullable NSData *)context error:(NSError * __autoreleasing *)error;
 
 /**
 * @brief Unwrap message
@@ -84,7 +84,7 @@ NS_ASSUME_NONNULL_BEGIN
 * @param [in] error pointer to Error on failure
 * @return Unwrapped message as NSData object on success or nil on failure
 */
-- (nullable NSData *)unwrapData:(NSData *)message context:(nullable NSData *)context error:(NSError **)error;
+- (nullable NSData *)unwrapData:(NSData *)message context:(nullable NSData *)context error:(NSError * __autoreleasing *)error;
 
 @end
 

--- a/src/wrappers/themis/Obj-C/objcthemis/scell_seal.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_seal.m
@@ -26,17 +26,17 @@
 }
 
 
-- (nullable NSData *)wrapData:(NSData *)message error:(NSError **)error {
+- (nullable NSData *)wrapData:(NSData *)message error:(NSError * __autoreleasing *)error {
     return [self wrapData:message context:nil error:error];
 }
 
 
-- (nullable NSData *)unwrapData:(NSData *)message error:(NSError **)error {
+- (nullable NSData *)unwrapData:(NSData *)message error:(NSError * __autoreleasing *)error {
     return [self unwrapData:message context:nil error:error];
 }
 
 
-- (nullable NSData *)wrapData:(NSData *)message context:(nullable NSData *)context error:(NSError **)error {
+- (nullable NSData *)wrapData:(NSData *)message context:(nullable NSData *)context error:(NSError * __autoreleasing *)error {
     size_t wrappedMessageLength = 0;
 
     const void * contextData = [context bytes];
@@ -46,20 +46,26 @@
         contextData, contextLength, [message bytes], [message length], NULL, &wrappedMessageLength);
 
     if (result != TSErrorTypeBufferTooSmall) {
-        *error = SCERROR(result, @"Secure Cell (Seal) encrypted message length determination failed");
+		if (error) {
+        	*error = SCERROR(result, @"Secure Cell (Seal) encrypted message length determination failed");
+		}
         return nil;
     }
 
     unsigned char * wrappedMessage = malloc(wrappedMessageLength);
     if (!wrappedMessage) {
-        *error = SCERROR(result, @"Secure Cell (Seal) encryption failed, not enough memory");
+		if (error) {
+        	*error = SCERROR(result, @"Secure Cell (Seal) encryption failed, not enough memory");
+		}
         return nil;
     }
     result = (TSErrorType) themis_secure_cell_encrypt_seal([self.key bytes], [self.key length],
         contextData, contextLength, [message bytes], [message length], wrappedMessage, &wrappedMessageLength);
 
     if (result != TSErrorTypeSuccess) {
-        *error = SCERROR(result, @"Secure Cell (Seal) encryption failed");
+		if (error) {
+        	*error = SCERROR(result, @"Secure Cell (Seal) encryption failed");
+		}
         free(wrappedMessage);
         return nil;
     }
@@ -67,7 +73,7 @@
     return [NSData dataWithBytesNoCopy:wrappedMessage length:wrappedMessageLength];
 }
 
-- (nullable NSData *)unwrapData:(NSData *)message context:(nullable NSData *)context error:(NSError **)error {
+- (nullable NSData *)unwrapData:(NSData *)message context:(nullable NSData *)context error:(NSError * __autoreleasing *)error {
     size_t unwrappedMessageLength = 0;
 
     const void * contextData = [context bytes];
@@ -77,13 +83,17 @@
         contextData, contextLength, [message bytes], [message length], NULL, &unwrappedMessageLength);
 
     if (result != TSErrorTypeBufferTooSmall) {
-        *error = SCERROR(result, @"Secure Cell (Seal) decrypted message length determination failed");
+		if (error) {
+        	*error = SCERROR(result, @"Secure Cell (Seal) decrypted message length determination failed");
+		}
         return nil;
     }
 
     unsigned char * unwrappedMessage = malloc(unwrappedMessageLength);
     if (!unwrappedMessage) {
-        *error = SCERROR(result, @"Secure Cell (Seal) decryption failed, not enough memory");
+		if (error) {
+        	*error = SCERROR(result, @"Secure Cell (Seal) decryption failed, not enough memory");
+		}
         return nil;
     }
 
@@ -91,7 +101,9 @@
         contextData, contextLength, [message bytes], [message length], unwrappedMessage, &unwrappedMessageLength);
 
     if (result != TSErrorTypeSuccess) {
-        *error = SCERROR(result, @"Secure Cell (Seal) decryption failed");
+		if (error) {
+        	*error = SCERROR(result, @"Secure Cell (Seal) decryption failed");
+		}
         free(unwrappedMessage);
         return nil;
     }


### PR DESCRIPTION
Makes NSError** argument __autoreleasing; adds check against null deference - NSError** by convension might be null if caller is not interested in error handling.