### PR TITLE
WIP: small integration test scripts

### DIFF
--- a/tests/_integration/integration_checks.sh
+++ b/tests/_integration/integration_checks.sh
@@ -1,0 +1,41 @@
+#!/bin/bash -e
+
+echo ".. testing secure cell, ruby <--> ruby"
+ruby ./tests/_integration/scell_seal_string_echo.rb "dec" "passr" `ruby ./tests/_integration/scell_seal_string_echo.rb "enc" "passr" "ruby seal test"`
+ruby ./tests/_integration/scell_seal_string_echo.rb "dec" "passr" `ruby ./tests/_integration/scell_seal_string_echo.rb "enc" "passr" "ruby seal with context" "somecontext"` "somecontext"
+
+ruby ./tests/_integration/scell_context_string_echo.rb "dec" "passw2" `ruby ./tests/_integration/scell_context_string_echo.rb "enc" "passw2" "ruby context with context" "somecontext"` "somecontext"
+
+ruby ./tests/_integration/scell_token_string_echo.rb "dec" "passw1" `ruby ./tests/_integration/scell_token_string_echo.rb "enc" "passw1" "ruby token test"`
+ruby ./tests/_integration/scell_token_string_echo.rb "dec" "passw2" `ruby ./tests/_integration/scell_token_string_echo.rb "enc" "passw2" "ruby token with context" "somecontext"` "somecontext"
+
+echo ".. testing secure cell, go <--> go"
+go run ./tests/_integration/scell_seal_string_echo.go "dec" "passg" `go run ./tests/_integration/scell_seal_string_echo.go "enc" "passg" "go seal test"`
+go run ./tests/_integration/scell_seal_string_echo.go "dec" "passg" `go run ./tests/_integration/scell_seal_string_echo.go "enc" "passg" "go seal with context" "somecontext"` "somecontext"
+
+go run ./tests/_integration/scell_context_string_echo.go "dec" "passg" `go run ./tests/_integration/scell_context_string_echo.go "enc" "passg" "go context with context" "somecontext"` "somecontext"
+
+go run ./tests/_integration/scell_token_string_echo.go "dec" "passg" `go run ./tests/_integration/scell_token_string_echo.go "enc" "passg" "go token test"`
+go run ./tests/_integration/scell_token_string_echo.go "dec" "passg" `go run ./tests/_integration/scell_token_string_echo.go "enc" "passg" "go token with context" "somecontext"` "somecontext"
+
+
+echo ".. testing SECURE CELL, SEAL MODE, go <--> ruby"
+ruby ./tests/_integration/scell_seal_string_echo.rb "dec" "passw1" `go run ./tests/_integration/scell_seal_string_echo.go "enc" "passw1" "go-ruby test"`
+ruby ./tests/_integration/scell_seal_string_echo.rb "dec" "passw2" `go run ./tests/_integration/scell_seal_string_echo.go "enc" "passw2" "go-ruby with context" "somecontext"` "somecontext"
+
+go run ./tests/_integration/scell_seal_string_echo.go "dec" "passw3" `ruby ./tests/_integration/scell_seal_string_echo.rb "enc" "passw3" "ruby-go test"`
+go run ./tests/_integration/scell_seal_string_echo.go "dec" "passw4" `ruby ./tests/_integration/scell_seal_string_echo.rb "enc" "passw4" "ruby-go with context" "somecontext"` "somecontext"
+
+
+echo ".. testing SECURE CELL, CONTEXT IMPRINT MODE, go <--> ruby"
+ruby ./tests/_integration/scell_context_string_echo.rb "dec" "passw2" `go run ./tests/_integration/scell_context_string_echo.go "enc" "passw2" "go-ruby with context" "somecontext"` "somecontext"
+go run ./tests/_integration/scell_context_string_echo.go "dec" "passw4" `ruby ./tests/_integration/scell_context_string_echo.rb "enc" "passw4" "ruby-go with context" "somecontext"` "somecontext"
+
+
+echo ".. testing SECURE CELL, TOKEN PROTECT MODE, go <--> ruby"
+ruby ./tests/_integration/scell_token_string_echo.rb "dec" "passw1" `go run ./tests/_integration/scell_token_string_echo.go "enc" "passw1" "go-ruby test"`
+ruby ./tests/_integration/scell_token_string_echo.rb "dec" "passw2" `go run ./tests/_integration/scell_token_string_echo.go "enc" "passw2" "go-ruby with context" "somecontext"` "somecontext"
+
+go run ./tests/_integration/scell_token_string_echo.go "dec" "passw3" `ruby ./tests/_integration/scell_token_string_echo.rb "enc" "passw3" "ruby-go test"`
+go run ./tests/_integration/scell_token_string_echo.go "dec" "passw4" `ruby ./tests/_integration/scell_token_string_echo.rb "enc" "passw4" "ruby-go with context" "somecontext"` "somecontext"
+

--- a/tests/_integration/scell_context_string_echo.go
+++ b/tests/_integration/scell_context_string_echo.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"github.com/cossacklabs/themis/gothemis/cell"
+	"os"
+)
+
+func main() {
+	args := os.Args
+
+	if len(args) != 5 {
+		fmt.Printf("usage %s <command: enc | dec > <key> <message> <context>\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	command := args[1]
+	key := args[2]
+	message := args[3]
+	context := []byte(args[4])
+
+	sc := cell.New([]byte(key), cell.CELL_MODE_CONTEXT_IMPRINT)
+
+	if "enc" == command {
+		encData, _, err := sc.Protect([]byte(message), context)
+		if nil != err {
+			fmt.Println(os.Stderr, "Error encrypting message")
+			os.Exit(1)
+		}
+		fmt.Println(base64.StdEncoding.EncodeToString(encData))
+
+	} else if "dec" == command {
+		decoded_message, err := base64.StdEncoding.DecodeString(message)
+		if nil != err {
+			fmt.Println(os.Stderr, "Error decoding message")
+			os.Exit(1)
+		}
+		decData, err := sc.Unprotect(decoded_message, nil, context)
+		if nil != err {
+			fmt.Println(os.Stderr, "Error decrypting message")
+			os.Exit(1)
+		}
+		fmt.Println(string(decData[:]))
+
+	} else {
+		fmt.Println(os.Stderr, "Wrong command, use \"enc\" or \"dec\"")
+		os.Exit(1)
+	}
+}

--- a/tests/_integration/scell_context_string_echo.rb
+++ b/tests/_integration/scell_context_string_echo.rb
@@ -1,0 +1,46 @@
+#
+# Copyright (c) 2017 Cossack Labs Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#!/usr/bin/env ruby
+
+require 'rubygems'
+require 'rubythemis'
+require 'base64'
+
+input_args = ARGV
+
+if input_args.length != 4 
+	STDERR.puts "Usage: <command: enc | dec > <key> <message> <context>\n"
+	exit 1
+end
+
+command = input_args[0]
+key = input_args[1].dup
+message = input_args[2].dup
+context = input_args[3].dup
+
+scell = Themis::Scell.new(key, Themis::Scell::CONTEXT_IMPRINT_MODE)
+
+if command == "enc"
+	encr_message = scell.encrypt(message, context)
+	puts Base64.strict_encode64(encr_message)
+elsif command == "dec"
+	decr_message = scell.decrypt(Base64.decode64(message), context)
+	puts decr_message
+else
+	STDERR.puts "Wrong command, use \"enc\" or \"dec\""
+	exit 1
+end

--- a/tests/_integration/scell_seal_string_echo.go
+++ b/tests/_integration/scell_seal_string_echo.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"github.com/cossacklabs/themis/gothemis/cell"
+	"os"
+)
+
+func main() {
+	args := os.Args
+
+	if len(args) < 4 || len(args) > 5 {
+		fmt.Printf("usage %s <command: enc | dec > <key> <message> <context>\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	command := args[1]
+	key := args[2]
+	message := args[3]
+	var context []byte
+
+	if len(args) == 5 {
+		context = []byte(args[4])
+	}
+
+	sc := cell.New([]byte(key), cell.CELL_MODE_SEAL)
+
+	if "enc" == command {
+		encData, _, err := sc.Protect([]byte(message), context)
+		if nil != err {
+			fmt.Println(os.Stderr, "Error encrypting message")
+			os.Exit(1)
+		}
+		fmt.Println(base64.StdEncoding.EncodeToString(encData))
+
+	} else if "dec" == command {
+		decoded_message, err := base64.StdEncoding.DecodeString(message)
+		if nil != err {
+			fmt.Println(os.Stderr, "Error decoding message")
+			os.Exit(1)
+		}
+		decData, err := sc.Unprotect(decoded_message, nil, context)
+		if nil != err {
+			fmt.Println(os.Stderr, "Error decrypting message")
+			os.Exit(1)
+		}
+		fmt.Println(string(decData[:]))
+
+	} else {
+		fmt.Println(os.Stderr, "Wrong command, use \"enc\" or \"dec\"")
+		os.Exit(1)
+	}
+}

--- a/tests/_integration/scell_seal_string_echo.rb
+++ b/tests/_integration/scell_seal_string_echo.rb
@@ -1,0 +1,50 @@
+#
+# Copyright (c) 2017 Cossack Labs Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#!/usr/bin/env ruby
+
+require 'rubygems'
+require 'rubythemis'
+require 'base64'
+
+input_args = ARGV
+
+if input_args.length < 3 || input_args.length > 4 
+	STDERR.puts "Usage: <command: enc | dec > <key> <message> <context (optional)>\n"
+	exit 1
+end
+
+command = input_args[0]
+key = input_args[1].dup
+message = input_args[2].dup
+context = nil
+
+if input_args.length == 4
+	context = input_args[3].dup
+end
+
+scell = Themis::Scell.new(key, Themis::Scell::SEAL_MODE)
+
+if command == "enc"
+	encr_message = scell.encrypt(message, context)
+	puts Base64.strict_encode64(encr_message)
+elsif command == "dec"
+	decr_message = scell.decrypt(Base64.decode64(message), context)
+	puts decr_message
+else
+	STDERR.puts "Wrong command, use \"enc\" or \"dec\""
+	exit 1
+end

--- a/tests/_integration/scell_token_string_echo.go
+++ b/tests/_integration/scell_token_string_echo.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"github.com/cossacklabs/themis/gothemis/cell"
+	"os"
+	"strings"
+)
+
+func main() {
+	args := os.Args
+
+	if len(args) < 4 || len(args) > 5 {
+		fmt.Printf("usage %s <command: enc | dec > <key> <message,token> <context (optional)>\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	command := args[1]
+	key := args[2]
+
+	message_and_token := strings.Split(args[3], ",")
+	message := message_and_token[0]
+
+	var token string
+	if len(message_and_token) == 2 {
+		token = message_and_token[1] 
+	}
+
+	var context []byte
+
+	if len(args) == 5 {
+		context = []byte(args[4])
+	}
+
+	sc := cell.New([]byte(key), cell.CELL_MODE_TOKEN_PROTECT)
+
+	if "enc" == command {
+		encData, encToken, err := sc.Protect([]byte(message), context)
+		if nil != err {
+			fmt.Println(os.Stderr, "Error encrypting message")
+			os.Exit(1)
+		}
+		fmt.Println(base64.StdEncoding.EncodeToString(encData) + "," + base64.StdEncoding.EncodeToString(encToken))
+
+	} else if "dec" == command {
+		decoded_message, err := base64.StdEncoding.DecodeString(message)
+		if nil != err {
+			fmt.Println(os.Stderr, "Error decoding message")
+			os.Exit(1)
+		}
+		decoded_token, err := base64.StdEncoding.DecodeString(token)
+		if nil != err {
+			fmt.Println("Error decoding token")
+			os.Exit(1)
+		}
+		decData, err := sc.Unprotect(decoded_message, decoded_token, context)
+		if nil != err {
+			fmt.Println(os.Stderr, "Error decrypting message")
+			os.Exit(1)
+		}
+		fmt.Println(string(decData[:]))
+
+	} else {
+		fmt.Println(os.Stderr, "Wrong command, use \"enc\" or \"dec\"")
+		os.Exit(1)
+	}
+}

--- a/tests/_integration/scell_token_string_echo.rb
+++ b/tests/_integration/scell_token_string_echo.rb
@@ -1,0 +1,50 @@
+#
+# Copyright (c) 2017 Cossack Labs Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#!/usr/bin/env ruby
+
+require 'rubygems'
+require 'rubythemis'
+require 'base64'
+
+input_args = ARGV
+
+if input_args.length < 3 || input_args.length > 4 
+	STDERR.puts "Usage: <command: enc | dec > <key> <message,token> <context (optional)> \n"
+	exit 1
+end
+
+command = input_args[0]
+key = input_args[1].dup
+message, token = input_args[2].split(",")
+context = nil
+
+if input_args.length == 4
+	context = input_args[3].dup
+end
+
+scell = Themis::Scell.new(key, Themis::Scell::TOKEN_PROTECT_MODE)
+
+if command == "enc"
+	encr_message, token = scell.encrypt(message, context)
+	puts Base64.strict_encode64(encr_message) + "," + Base64.strict_encode64(token)
+elsif command == "dec"
+	decr_message = scell.decrypt([Base64.decode64(message), Base64.decode64(token)], context)
+	puts decr_message
+else
+	STDERR.puts "Wrong command, use \"enc\" or \"dec\""
+	exit 1
+end


### PR DESCRIPTION
I believe we should test how different Themis wrappers work with each other.

This is a simple example of testing Secure Cell, ruby and go.

Fun thing is that I found that results of Secure Cell in `token protect` mode is incompatible between ruby and go (however, it might be my own mistake).

Current state:

```
$ tests/_integration/integration_checks.sh
.. testing secure cell, ruby <--> ruby
ruby seal test
ruby seal with context
ruby context with context
ruby token test
ruby token with context
.. testing secure cell, go <--> go
go seal test
go seal with context
go context with context
go token test
go token with context
.. testing SECURE CELL, SEAL MODE, go <--> ruby
go-ruby test
go-ruby with context
ruby-go test
ruby-go with context
.. testing SECURE CELL, CONTEXT IMPRINT MODE, go <--> ruby
go-ruby with context
ruby-go with context
.. testing SECURE CELL, TOKEN PROTECT MODE, go <--> ruby
/Users/hdf/.rvm/gems/ruby-2.2.5/gems/rubythemis-0.9.5/lib/rubythemis.rb:332:in `decrypt': Secure Cell (Token Protect) failed decrypting: 11 (Themis::ThemisError)
	from ./tests/_integration/scell_token_string_echo.rb:45:in `<main>'
```