### PR TITLE
check sources with -Wdocumentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ endif
 CFLAGS += -Werror -Wno-switch
 
 # strict checks for docs
-#CFLAGS += -Wdocumentation -ferror-limit=200
+#CFLAGS += -Wdocumentation -Wno-error=documentation
 
 ifndef ERROR
 include src/soter/soter.mk

--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,9 @@ endif
 # Should pay attention to warnings (some may be critical for crypto-enabled code (ex. signed-unsigned mismatch)
 CFLAGS += -Werror -Wno-switch
 
+# strict checks for docs
+#CFLAGS += -Wdocumentation -ferror-limit=200
+
 ifndef ERROR
 include src/soter/soter.mk
 include src/themis/themis.mk

--- a/src/soter/soter_asym_cipher.h
+++ b/src/soter/soter_asym_cipher.h
@@ -61,8 +61,8 @@ soter_asym_cipher_t* soter_asym_cipher_create(const void* key, const size_t key_
  * @param [in] plain_data data to encrypt
  * @param [in] plain_data_length length of plain_data
  * @param [out] cipher_data buffer for cipher data store. May be set to NULL for cipher data length determination
- * @param [in, out] length of cipher_data
- * @return  SOTER_SUCESS on success or SOTER_FAIL on failure
+ * @param [in, out] cipher_data_length length of cipher_data
+ * @return result of operation, @ref SOTER_SUCESS on success or @ref SOTER_FAIL on failure
  * @note If cipher_data==NULL or cipher_data_length less then need to store cipher data, @ref SOTER_BUFFER_TOO_SMALL will return and cipher_data_length will contain length of buffer thet need to store cipher data.
  */
 soter_status_t soter_asym_cipher_encrypt(soter_asym_cipher_t* asym_cipher_ctx, const void* plain_data, size_t plain_data_length, void* cipher_data, size_t* cipher_data_length);
@@ -73,8 +73,8 @@ soter_status_t soter_asym_cipher_encrypt(soter_asym_cipher_t* asym_cipher_ctx, c
  * @param [in] cipher_data data to decrypt
  * @param [in] cipher_data_length length of cipher_data
  * @param [out] plain_data buffer for plain data store. May be set to NULL for plain data length determination
- * @param [in, out] length of plain_data
- * @return  SOTER_SUCESS on success or SOTER_FAIL on failure
+ * @param [in, out] plain_data_length length of plain_data
+ * @return result of operation, @ref SOTER_SUCESS on success or @ref SOTER_FAIL on failure
  * @note If plain_data==NULL or plain_data_length less then need to store plain data, @ref SOTER_BUFFER_TOO_SMALL will return and plain_data_length will contain length of buffer thet need to store plain data.
  */
 soter_status_t soter_asym_cipher_decrypt(soter_asym_cipher_t* asym_cipher_ctx, const void* cipher_data, size_t cipher_data_length, void* plain_data, size_t* plain_data_length);
@@ -84,14 +84,14 @@ soter_status_t soter_asym_cipher_decrypt(soter_asym_cipher_t* asym_cipher_ctx, c
  * @param [in] asym_cipher_ctx pointer to asymmetric encription/decription context previously created by soter_asym_cipher_create
  * @param [in] key buffer with stored key
  * @param [in] key_length length of key
- * @return  SOTER_SUCESS on success or SOTER_FAIL on failure
+ * @return result of operation, @ref SOTER_SUCESS on success or @ref SOTER_FAIL on failure
  */
 //soter_status_t soter_asym_cipher_import_key(soter_asym_cipher_t* asym_cipher_ctx, const void* key, size_t key_length);
 
 /**
  * @brief destroy asymmetric encription/decription context
  * @param [in] asym_cipher_ctx pointer to asymmetric encription/decription context previously created by soter_asym_cipher_create
- * @return  SOTER_SUCESS on success or SOTER_FAIL on failure
+ * @return result of operation, @ref SOTER_SUCESS on success or @ref SOTER_FAIL on failure
  */
 soter_status_t soter_asym_cipher_destroy(soter_asym_cipher_t* asym_cipher_ctx);
 

--- a/src/soter/soter_asym_ka.h
+++ b/src/soter/soter_asym_ka.h
@@ -52,7 +52,7 @@ soter_asym_ka_t* soter_asym_ka_create(soter_asym_ka_alg_t alg);
 /**
  * @brief asymmetric keys pair generation for key agreement context
  * @param [in] asym_ka_ctx pointer to key agreement context previously created by soter_asym_ka_create
- * @return SOTER_SUCESS on success or SOTER_FAIL on failure
+ * @return result of operation, @ref SOTER_SUCESS on success or @ref SOTER_FAIL on failure
  */
 soter_status_t soter_asym_ka_gen_key(soter_asym_ka_t* asym_ka_ctx);
 
@@ -62,7 +62,7 @@ soter_status_t soter_asym_ka_gen_key(soter_asym_ka_t* asym_ka_ctx);
  * @param [out] key buffer to store exported key
  * @param [in,out] key_length length of key. May be set to NULL for key length determination
  * @param [in] isprivate if set private key will be exported. If not set public key will be exported
- * @return  SOTER_SUCESS on success or SOTER_FAIL on failure
+ * @return result of operation, @ref  SOTER_SUCESS on success or @ref SOTER_FAIL on failure
  * @note If key==NULL or key_length less then need to store key, @ref SOTER_BUFFER_TOO_SMALL will return and key_length will contain length of buffer thet need to store key.
  */
 soter_status_t soter_asym_ka_export_key(soter_asym_ka_t* asym_ka_ctx, void* key, size_t* key_length, bool isprivate);
@@ -72,7 +72,7 @@ soter_status_t soter_asym_ka_export_key(soter_asym_ka_t* asym_ka_ctx, void* key,
  * @param [in] asym_ka_ctx pointer to key agreement context previously created by soter_asym_ka_create
  * @param [in] key buffer with stored key
  * @param [in] key_length length of key
- * @return  SOTER_SUCESS on success or SOTER_FAIL on failure
+ * @return result of operation, @ref SOTER_SUCESS on success or @ref SOTER_FAIL on failure
  */
 soter_status_t soter_asym_ka_import_key(soter_asym_ka_t* asym_ka_ctx, const void* key, size_t key_length);
 
@@ -83,15 +83,15 @@ soter_status_t soter_asym_ka_import_key(soter_asym_ka_t* asym_ka_ctx, const void
  * @param [in] peer_key_length length of peer_key
  * @param [out] shared_secret buffer to store shared secret. May be set to NULL for shared secret length determination
  * @param [in,out] shared_secret_length length of shared secret
- * @return  SOTER_SUCESS on success or SOTER_FAIL on failure
+ * @return result of operation, @ref SOTER_SUCESS on success or @ref SOTER_FAIL on failure
  * @note If shared_secret==NULL or shared_secret_length less then need to store shared secret, @ref SOTER_BUFFER_TOO_SMALL will return and shared_secret_length will contain length of buffer thet need to store shared secret.
  */
 soter_status_t soter_asym_ka_derive(soter_asym_ka_t* asym_ka_ctx, const void* peer_key, size_t peer_key_length, void *shared_secret, size_t* shared_secret_length);
 
 /**
  * @brief destroy key agreement context
- * @param [in] asym_cipher_ctx pointer to key agreement context previously created by soter_asym_ka_create
- * @return  SOTER_SUCESS on success or SOTER_FAIL on failure
+ * @param [in] asym_ka_ctx pointer to key agreement context previously created by soter_asym_ka_create
+ * @return result of operation, @ref SOTER_SUCESS on success or @ref SOTER_FAIL on failure
  */
 soter_status_t soter_asym_ka_destroy(soter_asym_ka_t* asym_ka_ctx);
 

--- a/src/soter/soter_asym_sign.h
+++ b/src/soter/soter_asym_sign.h
@@ -55,7 +55,7 @@ typedef struct soter_sign_ctx_type soter_sign_ctx_t;
  * @param [in] private_key_length length of private_key
  * @param [in] public_key buffer with public key
  * @param [in] public_key_length length of public_key
- * @return SOTER_SUCCESS on success or SOTER_FAIL on failure
+ * @return result of operation, @ref SOTER_SUCCESS on success or SOTER_FAIL on failure
  * @note If private_key==NULL and public_key==NULL with creating of sign context will be generated new key pair.
  */ 
 soter_sign_ctx_t* soter_sign_create(soter_sign_alg_t alg, const void* private_key, const size_t private_key_length, const void* public_key, const size_t public_key_length);
@@ -64,7 +64,7 @@ soter_sign_ctx_t* soter_sign_create(soter_sign_alg_t alg, const void* private_ke
  * @param [in] ctx pointer to sign context previously created by soter_sign_create
  * @param [in] data data to sign
  * @param [in] data_length length of data
- * @return SOTER_SUCCESS on success or SOTER_FAIL on failure
+ * @return result of operation, @ref SOTER_SUCCESS on success or SOTER_FAIL on failure
  */ 
 soter_status_t soter_sign_update(soter_sign_ctx_t* ctx, const void* data, const size_t data_length);
 
@@ -72,31 +72,30 @@ soter_status_t soter_sign_update(soter_sign_ctx_t* ctx, const void* data, const 
  * @param [in] ctx pointer to sign context previously created by soter_sign_create
  * @param [out] signature buffer to store signature. May be set to NULL for signature length determination
  * @param [in, out] signature_length length of signature 
- * @return SOTER_SUCCESS on success or SOTER_FAIL on failure
+ * @return result of operation, @ref SOTER_SUCCESS on success or SOTER_FAIL on failure
  * @note If signature==NULL or signature_length less then need to store signature, @ref SOTER_BUFFER_TOO_SMALL will return and signature_length will contain length of buffer thet need to store signature.
  */ 
 soter_status_t soter_sign_final(soter_sign_ctx_t* ctx, void* signature, size_t* signature_length);
 
 /** @brief export key from sign context
  * @param [in] ctx pointer to sign context previously created by soter_sign_create
- * @param [in] asym_cipher_ctx pointer to asymmetric encription/decription context previously created by soter_asym_cipher_create
  * @param [out] key buffer to store exported key
  * @param [in,out] key_length length of key. May be set to NULL for key length determination
  * @param [in] isprivate if set private key will be exported. If not set public key will be exported
- * @return  SOTER_SUCESS on success or SOTER_FAIL on failure
+ * @return result of operation, @ref SOTER_SUCESS on success or @ref SOTER_FAIL on failure
  * @note If key==NULL or key_length less then need to store key, @ref SOTER_BUFFER_TOO_SMALL will return and key_length will contain length of buffer thet need to store key.
  */
 soter_status_t soter_sign_export_key(soter_sign_ctx_t* ctx, void* key, size_t* key_length, bool isprivate);
 
 /** @brief destroy sign context
  * @param [in] ctx pointer to sign context previously created by soter_sign_create
- * @return SOTER_SUCCESS on success or SOTER_FAIL on failure
+ * @return result of operation, @ref SOTER_SUCCESS on success or @ref SOTER_FAIL on failure
  */ 
 soter_status_t soter_sign_destroy(soter_sign_ctx_t* ctx);
 
 /** @brief get used algorithm id from sign context
  * @param [in] ctx pointer to sign context previously created by soter_sign_create
- * @return used algorithm id (see @ref soter_sign_alg_type) on success or SOTER_SIGN_undefined on failure
+ * @return used algorithm id (see @ref soter_sign_alg_type) on success or @ref SOTER_SIGN_undefined on failure
  */
 soter_sign_alg_t soter_sign_get_alg_id(soter_sign_ctx_t* ctx);
 /** @}*/
@@ -115,7 +114,7 @@ typedef struct soter_sign_ctx_type soter_verify_ctx_t;
  * @param [in] private_key_length length of private_key
  * @param [in] public_key buffer with public key
  * @param [in] public_key_length length of public_key
- * @return SOTER_SUCCESS on success or SOTER_FAIL on failure
+ * @return result of operation, @ref SOTER_SUCCESS on success or @ref SOTER_FAIL on failure
  */ 
 soter_verify_ctx_t* soter_verify_create(soter_sign_alg_t alg, const void* private_key, const size_t private_key_length, const void* public_key, const size_t public_key_length);
 
@@ -123,7 +122,7 @@ soter_verify_ctx_t* soter_verify_create(soter_sign_alg_t alg, const void* privat
  * @param [in] ctx pointer to verify context previously created by soter_verify_create
  * @param [in] data data to verify
  * @param [in] data_length length of data
- * @return SOTER_SUCCESS on success or SOTER_FAIL on failure
+ * @return result of operation, @ref SOTER_SUCCESS on success or @ref SOTER_FAIL on failure
  */ 
 soter_status_t soter_verify_update(soter_verify_ctx_t* ctx, const void* data, const size_t data_length);
 
@@ -131,19 +130,19 @@ soter_status_t soter_verify_update(soter_verify_ctx_t* ctx, const void* data, co
  * @param [in] ctx pointer to verify context previously created by soter_verify_create
  * @param [in] signature signature to verify.
  * @param [in] signature_length length of signature 
- * @return SOTER_SUCCESS on success or SOTER_INVALID_SIGNATURE on incorrect signature or SOTER_FAIL on other failure
+ * @return result of operation, @ref SOTER_SUCCESS on success or @ref SOTER_INVALID_SIGNATURE on incorrect signature or @ref SOTER_FAIL on other failure
  */ 
 soter_status_t soter_verify_final(soter_verify_ctx_t* ctx, const void* signature, const size_t signature_length);
 
 /** @brief destroy verify context
  * @param [in] ctx pointer to verify context previously created by soter_verify_create
- * @return SOTER_SUCCESS on success or SOTER_FAIL on failure
+ * @return result of operation, @ref SOTER_SUCCESS on success or @ref SOTER_FAIL on failure
  */ 
 soter_status_t soter_verify_destroy(soter_verify_ctx_t* ctx);
 
 /** @brief get used algorithm id from verify context
  * @param [in] ctx pointer to verify context previously created by soter_verify_create
- * @return used algorithm id (see @ref soter_sign_alg_type) on success or SOTER_SIGN_undefined on failure
+ * @return used algorithm id (see @ref soter_sign_alg_type) on success or @ref SOTER_SIGN_undefined on failure
  */
 soter_sign_alg_t soter_verify_get_alg_id(soter_verify_ctx_t* ctx);
 

--- a/src/soter/soter_hash.h
+++ b/src/soter/soter_hash.h
@@ -90,7 +90,7 @@ soter_hash_ctx_t* soter_hash_create(soter_hash_algo_t algo);
 /**
  * @brief destroy hash context
  * @param [in] hash_ctx pointer to hash context previosly created by @ref soter_hash_create
- * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure
+ * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure
  */
 soter_status_t soter_hash_destroy(soter_hash_ctx_t *hash_ctx);
 soter_status_t soter_hash_cleanup(soter_hash_ctx_t *hash_ctx);
@@ -100,7 +100,7 @@ soter_status_t soter_hash_cleanup(soter_hash_ctx_t *hash_ctx);
  * @param [in] hash_ctx pointer to hash context previosly created by @ref soter_hash_create
  * @param [in] data pointer to buffer with data to hash update
  * @param [in] length of data buffer
- * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure
+ * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure
  */
 soter_status_t soter_hash_update(soter_hash_ctx_t *hash_ctx, const void *data, size_t length);
 
@@ -109,7 +109,7 @@ soter_status_t soter_hash_update(soter_hash_ctx_t *hash_ctx, const void *data, s
  * @param [in] hash_ctx pointer to hash context previosly created by @ref soter_hash_create
  * @param [out] hash_value pointer to buffer for hash value retrieve, may be set to NULL for hash value length determination
  * @param [in, out] hash_length length of hash_value buffer
- * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
+ * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
  * @note If hash_value==NULL or hash_length less then need to store hash value, @ref SOTER_BUFFER_TOO_SMALL will return and hash_length will contain length of buffer thet need to store hash value.
  */
 soter_status_t soter_hash_final(soter_hash_ctx_t *hash_ctx, uint8_t* hash_value, size_t* hash_length);

--- a/src/soter/soter_hmac.h
+++ b/src/soter/soter_hmac.h
@@ -74,7 +74,7 @@ soter_hmac_ctx_t* soter_hmac_create(soter_hash_algo_t algo, const uint8_t* key, 
 /**
  * @brief destroy HMAC context
  * @param [in] hmac_ctx pointer to HMAC context previosly created by @ref soter_hmac_create
- * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure
+ * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure
  */
 soter_status_t soter_hmac_destroy(soter_hmac_ctx_t *hmac_ctx);
 
@@ -83,7 +83,7 @@ soter_status_t soter_hmac_destroy(soter_hmac_ctx_t *hmac_ctx);
  * @param [in] hmac_ctx pointer to HMAC context previosly created by @ref soter_hmac_create
  * @param [in] data pointer to buffer with data to HMAC update
  * @param [in] length of data buffer
- * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure
+ * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure
  */
 soter_status_t soter_hmac_update(soter_hmac_ctx_t *hmac_ctx, const void *data, size_t length);
 
@@ -92,7 +92,7 @@ soter_status_t soter_hmac_update(soter_hmac_ctx_t *hmac_ctx, const void *data, s
  * @param [in] hmac_ctx pointer to hash context previosly created by @ref soter_hmac_create
  * @param [out] hmac_value pointer to buffer for HMAC value retrieve, may be set to NULL for HMAC value length determination
  * @param [in, out] hmac_length length of hmac_value buffer
- * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
+ * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
  * @note If hmac_value==NULL or hmac_length less then need to store HMAC value, @ref SOTER_BUFFER_TOO_SMALL will return and hmac_length will contain length of buffer thet need to store HMAC value.
  */
 soter_status_t soter_hmac_final(soter_hmac_ctx_t *hmac_ctx, uint8_t* hmac_value, size_t* hmac_length);

--- a/src/soter/soter_sym.h
+++ b/src/soter/soter_sym.h
@@ -137,7 +137,7 @@ soter_sym_ctx_t* soter_sym_encrypt_create(const uint32_t alg, const void* key, c
  * @param [in] data_length length of plain_data
  * @param [out] cipher_data pointer to buffer to cipher data store, may be set to NULL for cipher data length determination
  * @param [in, out] cipher_data_length length of cipher_data
- * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
+ * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
  * @note If cipher_data==NULL or cipher_data_length less then need to store cipher data, @ref SOTER_BUFFER_TOO_SMALL will return and cipher_data_length will contain length of buffer thet need to store cipher data.
  */
 soter_status_t soter_sym_encrypt_update(soter_sym_ctx_t *ctx, const void* plain_data,  const size_t data_length, void* cipher_data, size_t* cipher_data_length);
@@ -147,7 +147,7 @@ soter_status_t soter_sym_encrypt_update(soter_sym_ctx_t *ctx, const void* plain_
  * @param [in] ctx pointer to symmetric encryption context prerviosly created by soter_sym_encrypt_create
  * @param [out] cipher_data pointer to buffer to cipher data store, may be set to NULL for cipher data length determination
  * @param [in, out] cipher_data_length length of cipher_data
- * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
+ * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
  * @note If cipher_data==NULL or cipher_data_length less then need to store cipher data, @ref SOTER_BUFFER_TOO_SMALL will return and cipher_data_length will contain length of buffer thet need to store cipher data.
  */
 soter_status_t soter_sym_encrypt_final(soter_sym_ctx_t *ctx, void* cipher_data, size_t* cipher_data_length);
@@ -155,7 +155,7 @@ soter_status_t soter_sym_encrypt_final(soter_sym_ctx_t *ctx, void* cipher_data, 
 /**
  * @brief destroy symmetric encryption context
  * @param [in] ctx pointer to symmetric encryption context prerviosly created by soter_sym_encrypt_create
- * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
+ * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
  */
 soter_status_t soter_sym_encrypt_destroy(soter_sym_ctx_t *ctx);
 /** @} */
@@ -185,8 +185,8 @@ soter_sym_ctx_t* soter_sym_decrypt_create(const uint32_t alg, const void* key, c
  * @param [in] cipher_data pointer to data buffer to decrypt
  * @param [in] data_length length of cipher_data
  * @param [out] plain_data pointer to buffer to plain data store, may be set to NULL for plain data length determination
- * @param [in, out] plain_data_length 
- * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
+ * @param [in, out] plain_data_length length of plaintext data
+ * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
  * @note If plain_data==NULL or plain_data_length less then need to store plain data, @ref SOTER_BUFFER_TOO_SMALL will return and plain_data_length will contain length of buffer thet need to store plain data.
  */
 soter_status_t soter_sym_decrypt_update(soter_sym_ctx_t *ctx, const void* cipher_data,  const size_t data_length, void* plain_data, size_t* plain_data_length);
@@ -195,8 +195,8 @@ soter_status_t soter_sym_decrypt_update(soter_sym_ctx_t *ctx, const void* cipher
  * @brief final symmetric decryption context
  * @param [in] ctx pointer to symmetric decryption context prerviosly created by soter_sym_decrypt_create
  * @param [out] plain_data pointer to buffer to plain data store, may be set to NULL for plain data length determination
- * @param [in, out] plain_data_length 
- * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
+ * @param [in, out] plain_data_length length of plaintext data
+ * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
  * @note If plain_data==NULL or plain_data_length less then need to store plain data, @ref SOTER_BUFFER_TOO_SMALL will return and plain_data_length will contain length of buffer thet need to store plain data.
  */
 soter_status_t soter_sym_decrypt_final(soter_sym_ctx_t *ctx, void* plain_data, size_t* plain_data_length);
@@ -204,7 +204,7 @@ soter_status_t soter_sym_decrypt_final(soter_sym_ctx_t *ctx, void* plain_data, s
 /**
  * @brief destroy symmetric decryption context
  * @param [in] ctx pointer to symmetric decryption context prerviosly created by soter_sym_decrypt_create
- * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure.
+ * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure.
  */
 soter_status_t soter_sym_decrypt_destroy(soter_sym_ctx_t *ctx);
 /** @} */
@@ -238,11 +238,11 @@ soter_sym_ctx_t* soter_sym_aead_encrypt_create(const uint32_t alg, const void* k
 /**
  * @brief Add AAD data to symmetric encryption context
  * @param [in] ctx pointer to symmetric encryption context prerviosly created by soter_sym_encrypt_create
- * @param [in] aad_data pointer to buffer with AAD data
- * @param [in] aad_length length of AAD data
- * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
+ * @param [in] plain_data pointer to buffer with AAD data
+ * @param [in] data_length length of AAD data
+ * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
  */
-soter_status_t soter_sym_aead_encrypt_aad(soter_sym_ctx_t *ctx, const void* plain_data,  const size_t data_length);
+soter_status_t soter_sym_aead_encrypt_aad(soter_sym_ctx_t *ctx, const void* plain_data, const size_t data_length);
 
 /**
  * @brief update symmetric encryption context
@@ -251,7 +251,7 @@ soter_status_t soter_sym_aead_encrypt_aad(soter_sym_ctx_t *ctx, const void* plai
  * @param [in] data_length length of plain_data
  * @param [out] cipher_data pointer to buffer to cipher data store, may be set to NULL for cipher data length determination
  * @param [in, out] cipher_data_length  length of cipher data
- * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
+ * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
  * @note If cipher_data==NULL or cipher_data_length less then need to store cipher data, @ref SOTER_BUFFER_TOO_SMALL will return and cipher_data_length will contain length of buffer thet need to store cipher data.
  */
 soter_status_t soter_sym_aead_encrypt_update(soter_sym_ctx_t *ctx, const void* plain_data,  const size_t data_length, void* cipher_data, size_t* cipher_data_length);
@@ -261,7 +261,7 @@ soter_status_t soter_sym_aead_encrypt_update(soter_sym_ctx_t *ctx, const void* p
  * @param [in] ctx pointer to symmetric encryption context prerviosly created by soter_sym_encrypt_create
  * @param [out] auth_tag pointer to buffer for auth tag store, may be set to NULL for auth tag length determination
  * @param [in, out] auth_tag_length length of auth_tag
- * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
+ * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
  * @note If auth_tag==NULL or auth_tag_length less then need to store auth tag, @ref SOTER_BUFFER_TOO_SMALL will return and auth_tag_length will contain length of buffer thet need to store auth_tag.
  */
 soter_status_t soter_sym_aead_encrypt_final(soter_sym_ctx_t *ctx, void* auth_tag, size_t* auth_tag_length);
@@ -269,7 +269,7 @@ soter_status_t soter_sym_aead_encrypt_final(soter_sym_ctx_t *ctx, void* auth_tag
 /**
  * @brief destroy symmetric encryption context
  * @param [in] ctx pointer to symmetric encryption context prerviosly created by soter_sym_encrypt_create
- * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
+ * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
  */
 soter_status_t soter_sym_aead_encrypt_destroy(soter_sym_ctx_t *ctx);
 /** @} */
@@ -296,37 +296,37 @@ soter_sym_ctx_t* soter_sym_aead_decrypt_create(const uint32_t alg, const void* k
 /**
  * @brief Add AAD data to symmetric decryption context
  * @param [in] ctx pointer to symmetric decryption context prerviosly created by soter_sym_decrypt_create
- * @param [in] aad_data pointer to buffer with AAD data
- * @param [in] aad_length length of AAD data
- * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
+ * @param [in] plain_data pointer to buffer with AAD data
+ * @param [in] data_length length of AAD data
+ * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
  */
-soter_status_t soter_sym_aead_decrypt_aad(soter_sym_ctx_t *ctx, const void* plain_data,  const size_t data_length);
+soter_status_t soter_sym_aead_decrypt_aad(soter_sym_ctx_t *ctx, const void* plain_data, const size_t data_length);
 
 /**
  * @brief update symmetric decryption context
  * @param [in] ctx pointer to symmetric decryption context prerviosly created by soter_sym_decrypt_create
  * @param [in] cipher_data pointer to data buffer to decrypt
- * @param [in] data_length length of cipher_data
+ * @param [in] cipher_data_length length of cipher_data
  * @param [out] plain_data pointer to buffer to plain data store, may be set to NULL for plain data length determination
- * @param [in, out] plain_data_length 
- * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
+ * @param [in, out] data_length length of plain_data 
+ * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
  * @note If plain_data==NULL or plain_data_length less then need to store plain data, @ref SOTER_BUFFER_TOO_SMALL will return and plain_data_length will contain length of buffer thet need to store plain data.
  */
-soter_status_t soter_sym_aead_decrypt_update(soter_sym_ctx_t *ctx, const void* plain_data,  const size_t data_length, void* chiper_data, size_t* chipher_data_length);
+soter_status_t soter_sym_aead_decrypt_update(soter_sym_ctx_t *ctx, const void* plain_data, const size_t data_length, void* cipher_data, size_t* cipher_data_length);
 
 /** 
  * @brief final symmetric decryption context
  * @param [in] ctx pointer to symmetric decryption context prerviosly created by soter_sym_decrypt_create
  * @param [in] auth_tag pointer to buffer of auth tag
  * @param [in] auth_tag_length length of auth_tag
- * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
+ * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
  */
 soter_status_t soter_sym_aead_decrypt_final(soter_sym_ctx_t *ctx, const void* auth_tag, const size_t auth_tag_length);
 
 /**
  * @brief destroy symmetric decryption context
  * @param [in] ctx pointer to symmetric decryption context prerviosly created by soter_sym_decrypt_create
- * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure.
+ * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure.
  */
 soter_status_t soter_sym_aead_decrypt_destroy(soter_sym_ctx_t *ctx);
 /** @} */

--- a/src/themis/secure_cell.h
+++ b/src/themis/secure_cell.h
@@ -66,7 +66,7 @@ themis_status_t themis_secure_cell_encrypt_seal(const uint8_t* master_key,
  * @param [in] master_key_length length of master_key
  * @param [in] user_context user defined context. May be set to NULL
  * @param [in] user_context_length length of user_context
- * @param [in] encrypted message to decrypt
+ * @param [in] encrypted_message message to decrypt
  * @param [in] encrypted_message_length length of encrypted_message
  * @param [out] plain_message buffer for plain message store. May be set to NULL for plain message length determination
  * @param [in, out] plain_message_length length of plain_message
@@ -99,7 +99,7 @@ themis_status_t themis_secure_cell_decrypt_seal(const uint8_t* master_key,
  * @param [in] message message to encrypt
  * @param [in] message_length length of message
  * @param [out] token additional authentication info. May be set to NULL for additional authentication info length determination
- * @param [in, out] length of additional authentication info
+ * @param [in, out] token_length length of additional authentication info
  * @param [out] encrypted_message buffer for encrypted message store. May be set to NULL for encrypted message length determination
  * @param [in, out] encrypted_message_length length of encrypted_message
  * @return THEMIS_SUCCESS on success or THEMIS_FAIL on failure
@@ -122,10 +122,10 @@ themis_status_t themis_secure_cell_encrypt_token_protect(const uint8_t* master_k
  * @param [in] master_key_length length of master_key
  * @param [in] user_context user defined context. May be set to NULL
  * @param [in] user_context_length length of user_context
- * @param [in] encrypted message to decrypt
+ * @param [in] encrypted_message message to decrypt
  * @param [in] encrypted_message_length length of encrypted_message
  * @param [in] token additional authentication info
- * @param [in] context_length length of additional authentication info
+ * @param [in] token_length length of additional authentication info
  * @param [out] plain_message buffer for plain message store. May be set to NULL for plain message length determination
  * @param [in, out] plain_message_length length of plain_message
  * @return THEMIS_SUCCESS on success or THEMIS_FAIL on failure
@@ -176,7 +176,7 @@ themis_status_t themis_secure_cell_encrypt_context_imprint(const uint8_t* master
  * @brief decrypt
  * @param [in] master_key master key
  * @param [in] master_key_length length of master_key
- * @param [in] encrypted message to decrypt
+ * @param [in] encrypted_message message to decrypt
  * @param [in] encrypted_message_length length of encrypted_message
  * @param [in] context user defined context. May be set to NULL
  * @param [in] context_length length of user_context

--- a/src/themis/secure_message.h
+++ b/src/themis/secure_message.h
@@ -67,7 +67,7 @@ themis_status_t themis_gen_ec_key_pair(uint8_t* private_key,
 /** 
  * @brief wrap message to secure message
  * @param [in] private_key private key
- * @param [in] pribate_key_length length of private_key
+ * @param [in] private_key_length length of private_key
  * @param [in] public_key peer public key
  * @param [in] public_key_length length of public_key
  * @param [in] message message to wrap
@@ -89,7 +89,7 @@ themis_status_t themis_secure_message_wrap(const uint8_t* private_key,
 /** 
  * @brief unwrap secure message to plain message
  * @param [in] private_key private key
- * @param [in] pribate_key_length length of private_key
+ * @param [in] private_key_length length of private_key
  * @param [in] public_key peer public key
  * @param [in] public_key_length length of public_key
  * @param [in] wrapped_message wrapped message to unwrap

--- a/src/wrappers/themis/Obj-C/objcthemis/skeygen.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/skeygen.h
@@ -50,7 +50,7 @@ typedef NS_ENUM(NSInteger, TSKeyGenAsymmetricAlgorithm) {
 
 /**
 * @brief initialise key pair generator, generates privateKey and publicKey
-* @param [in] alg algorithm. @see TSKeyGenAsymmetricAlgorithm
+* @param [in] algorithm, RSA or EC. @see TSKeyGenAsymmetricAlgorithm
 */
 - (nullable instancetype)initWithAlgorithm:(TSKeyGenAsymmetricAlgorithm)algorithm;
 

--- a/src/wrappers/themis/Obj-C/objcthemis/smessage.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/smessage.h
@@ -87,14 +87,14 @@ typedef NS_ENUM(NSInteger, TSMessageMode) {
 /**
 * @brief Initialize Secure message object in encrypt/decrypt mode
 * @param [in] privateKey Private key
-* @param [in] peer_public_key Peer public key
+* @param [in] peerPublicKey Peer public key
 */
 - (nullable instancetype)initInEncryptModeWithPrivateKey:(NSData *)privateKey peerPublicKey:(NSData *)peerPublicKey;
 
 /**
 * @brief Initialize Secure message object in sign/verify mode
 * @param [in] privateKey Private key
-* @param [in] peer_public_key Peer public key
+* @param [in] peerPublicKey Peer public key
 */
 - (nullable instancetype)initInSignVerifyModeWithPrivateKey:(NSData *)privateKey peerPublicKey:(NSData *)peerPublicKey;
 

--- a/src/wrappers/themis/Obj-C/objcthemis/ssession.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/ssession.h
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
 * @brief Initialise Secure session object
-* @param [in] id User id
+* @param [in] userId User id
 * @param [in] privateKey User private key
 * @param [in] callbacks Reference to TSSessionTransportInterface object
 */
@@ -106,7 +106,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** @brief Unwrap received from peer by \b receive method from callbacks object message.
 * @see TSSessionTransportInterface.
-* @param [in] length
+* @param [in] length of data to receive
 * @param [in] error pointer to Error on failure
 * @return Plain message in NSData object on success or nil on failure.
 */

--- a/src/wrappers/themis/Obj-C/objcthemis/ssession_transport_interface.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/ssession_transport_interface.h
@@ -44,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 
 /** @brief Return public key associated with binaryId as NSData object or nil on failure
-* @param [in] binaryId
+* @param [in] binaryId usually server id
 * @param [in] error pointer to Error on failure
 * @return binary public key associated with binaryId or nil on failure
 */


### PR DESCRIPTION
While pushing new CocoaPod, I've noticed that we have many warnings due to inconsistency of doxygen doc.

I've checked and updated some docs.

Example of warnings we had before

```
cc -Isrc -Isrc/wrappers/themis/ -I/usr/local/include -fPIC -DLIBRESSL -DCRYPTO_ENGINE_PATH=openssl -Werror -Wno-switch -Wdocumentation -ferror-limit=200 -I/usr/local/opt/openssl/include -c src/soter/soter_container.c -o build/obj/soter/soter_container.o
In file included from src/soter/soter_container.c:18:
In file included from src/soter/soter.h:42:
src/soter/soter_hmac.h:77:11: error: empty paragraph passed to '@return' command [-Werror,-Wdocumentation]
 * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure
   ~~~~~~~^
src/soter/soter_hmac.h:86:11: error: empty paragraph passed to '@return' command [-Werror,-Wdocumentation]
 * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure
   ~~~~~~~^
src/soter/soter_hmac.h:95:11: error: empty paragraph passed to '@return' command [-Werror,-Wdocumentation]
 * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
   ~~~~~~~^
In file included from src/soter/soter_container.c:18:
In file included from src/soter/soter.h:43:
src/soter/soter_sym.h:140:11: error: empty paragraph passed to '@return' command [-Werror,-Wdocumentation]
 * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
   ~~~~~~~^
src/soter/soter_sym.h:150:11: error: empty paragraph passed to '@return' command [-Werror,-Wdocumentation]
 * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
   ~~~~~~~^
src/soter/soter_sym.h:158:11: error: empty paragraph passed to '@return' command [-Werror,-Wdocumentation]
 * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
   ~~~~~~~^
src/soter/soter_sym.h:188:37: error: empty paragraph passed to '@param' command [-Werror,-Wdocumentation]
 * @param [in, out] plain_data_length 
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
src/soter/soter_sym.h:189:11: error: empty paragraph passed to '@return' command [-Werror,-Wdocumentation]
 * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
   ~~~~~~~^
src/soter/soter_sym.h:198:37: error: empty paragraph passed to '@param' command [-Werror,-Wdocumentation]
 * @param [in, out] plain_data_length 
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
src/soter/soter_sym.h:199:11: error: empty paragraph passed to '@return' command [-Werror,-Wdocumentation]
 * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
   ~~~~~~~^
src/soter/soter_sym.h:207:11: error: empty paragraph passed to '@return' command [-Werror,-Wdocumentation]
 * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure.
   ~~~~~~~^
src/soter/soter_sym.h:243:11: error: empty paragraph passed to '@return' command [-Werror,-Wdocumentation]
 * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
   ~~~~~~~^
src/soter/soter_sym.h:241:16: error: parameter 'aad_data' not found in the function declaration [-Werror,-Wdocumentation]
 * @param [in] aad_data pointer to buffer with AAD data
               ^~~~~~~~
src/soter/soter_sym.h:242:16: error: parameter 'aad_length' not found in the function declaration [-Werror,-Wdocumentation]
 * @param [in] aad_length length of AAD data
               ^~~~~~~~~~
src/soter/soter_sym.h:242:16: note: did you mean 'data_length'?
 * @param [in] aad_length length of AAD data
               ^~~~~~~~~~
               data_length
src/soter/soter_sym.h:254:11: error: empty paragraph passed to '@return' command [-Werror,-Wdocumentation]
 * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
   ~~~~~~~^
src/soter/soter_sym.h:264:11: error: empty paragraph passed to '@return' command [-Werror,-Wdocumentation]
 * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
   ~~~~~~~^
src/soter/soter_sym.h:272:11: error: empty paragraph passed to '@return' command [-Werror,-Wdocumentation]
 * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
   ~~~~~~~^
src/soter/soter_sym.h:301:11: error: empty paragraph passed to '@return' command [-Werror,-Wdocumentation]
 * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
   ~~~~~~~^
src/soter/soter_sym.h:299:16: error: parameter 'aad_data' not found in the function declaration [-Werror,-Wdocumentation]
 * @param [in] aad_data pointer to buffer with AAD data
               ^~~~~~~~
src/soter/soter_sym.h:300:16: error: parameter 'aad_length' not found in the function declaration [-Werror,-Wdocumentation]
 * @param [in] aad_length length of AAD data
               ^~~~~~~~~~
src/soter/soter_sym.h:300:16: note: did you mean 'data_length'?
 * @param [in] aad_length length of AAD data
               ^~~~~~~~~~
               data_length
src/soter/soter_sym.h:311:37: error: empty paragraph passed to '@param' command [-Werror,-Wdocumentation]
 * @param [in, out] plain_data_length 
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
src/soter/soter_sym.h:312:11: error: empty paragraph passed to '@return' command [-Werror,-Wdocumentation]
 * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
   ~~~~~~~^
src/soter/soter_sym.h:308:16: error: parameter 'cipher_data' not found in the function declaration [-Werror,-Wdocumentation]
 * @param [in] cipher_data pointer to data buffer to decrypt
               ^~~~~~~~~~~
src/soter/soter_sym.h:308:16: note: did you mean 'chiper_data'?
 * @param [in] cipher_data pointer to data buffer to decrypt
               ^~~~~~~~~~~
               chiper_data
src/soter/soter_sym.h:311:21: error: parameter 'plain_data_length' not found in the function declaration [-Werror,-Wdocumentation]
 * @param [in, out] plain_data_length 
                    ^~~~~~~~~~~~~~~~~
src/soter/soter_sym.h:322:11: error: empty paragraph passed to '@return' command [-Werror,-Wdocumentation]
 * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure. 
   ~~~~~~~^
src/soter/soter_sym.h:329:11: error: empty paragraph passed to '@return' command [-Werror,-Wdocumentation]
 * @return @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure.
   ~~~~~~~^
In file included from src/soter/soter_container.c:18:
In file included from src/soter/soter.h:45:
src/soter/soter_asym_cipher.h:64:21: error: parameter 'length' not found in the function declaration [-Werror,-Wdocumentation]
 * @param [in, out] length of cipher_data
                    ^~~~~~
src/soter/soter_asym_cipher.h:64:21: note: did you mean 'cipher_data_length'?
 * @param [in, out] length of cipher_data
                    ^~~~~~
                    cipher_data_length
src/soter/soter_asym_cipher.h:76:21: error: parameter 'length' not found in the function declaration [-Werror,-Wdocumentation]
 * @param [in, out] length of plain_data
                    ^~~~~~
src/soter/soter_asym_cipher.h:76:21: note: did you mean 'plain_data_length'?
 * @param [in, out] length of plain_data
                    ^~~~~~
                    plain_data_length
In file included from src/soter/soter_container.c:18:
In file included from src/soter/soter.h:46:
src/soter/soter_asym_ka.h:93:16: error: parameter 'asym_cipher_ctx' not found in the function declaration [-Werror,-Wdocumentation]
 * @param [in] asym_cipher_ctx pointer to key agreement context previously created by soter_asym_ka_create
               ^~~~~~~~~~~~~~~
src/soter/soter_asym_ka.h:93:16: note: did you mean 'asym_ka_ctx'?
 * @param [in] asym_cipher_ctx pointer to key agreement context previously created by soter_asym_ka_create
               ^~~~~~~~~~~~~~~
               asym_ka_ctx
In file included from src/soter/soter_container.c:18:
In file included from src/soter/soter.h:47:
src/soter/soter_asym_sign.h:82:16: error: parameter 'asym_cipher_ctx' not found in the function declaration [-Werror,-Wdocumentation]
 * @param [in] asym_cipher_ctx pointer to asymmetric encription/decription context previously created by soter_asym_cipher_create
               ^~~~~~~~~~~~~~~
30 errors generated.

```