### PR TITLE
secure cell x32-x64 compatibility fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,6 +224,12 @@ CFLAGS += -Werror -Wno-switch
 # strict checks for docs
 #CFLAGS += -Wdocumentation -Wno-error=documentation
 
+# fixing compatibility between x64 0.9.6 and x64 0.9.7
+# https://github.com/cossacklabs/themis/pull/279
+ifeq ($(NO_SCELL_COMPAT),)
+	CFLAGS += -DSCELL_COMPAT
+endif
+
 ifndef ERROR
 include src/soter/soter.mk
 include src/themis/themis.mk

--- a/src/soter/soter_error.h
+++ b/src/soter/soter_error.h
@@ -27,7 +27,7 @@
 #include <stdint.h>
 
 /** @brief return type */
-typedef int soter_status_t;
+typedef int32_t soter_status_t;
 
 /**
  * @addtogroup SOTER
@@ -127,7 +127,7 @@ typedef int soter_status_t;
     }
 
 #define SOTER_STATUS_CHECK(x,y){		\
-  int res=x;					\
+  soter_status_t res=x;					\
   if(res!=y){					\
      SOTER_ERROR_OUT(#x);				\
      return res;					\
@@ -135,7 +135,7 @@ typedef int soter_status_t;
   }
 
 #define SOTER_STATUS_CHECK_FREE(x,y,z){		\
-  int res=x;					\
+  soter_status_t res=x;					\
   if(res!=y){					\
      SOTER_ERROR_OUT(#x);				\
      free(z);						\

--- a/src/themis/secure_cell.h
+++ b/src/themis/secure_cell.h
@@ -38,6 +38,13 @@ extern "C"{
  * @{
  */
 
+
+// before 0.9.7 Secure Cell context_size was defined by sizeof(size_t), therefore it was different for x86 and x64
+// since 0.9.7 Secure Cell context size is equal sizeof(uint32_t) for both platforms,
+// causing compatibility issues on x64
+// this define makes SecureCell
+#define THEMIS_097_SECURE_CELL_X64_COMPATIBILITY_FIX
+
 /**
  * @brief encrypt
  * @param [in] master_key master key

--- a/src/themis/secure_cell.h
+++ b/src/themis/secure_cell.h
@@ -39,12 +39,6 @@ extern "C"{
  */
 
 
-// before 0.9.7 Secure Cell context_size was defined by sizeof(size_t), therefore it was different for x86 and x64
-// since 0.9.7 Secure Cell context size is equal sizeof(uint32_t) for both platforms,
-// causing compatibility issues on x64
-// this define makes SecureCell
-#define THEMIS_097_SECURE_CELL_X64_COMPATIBILITY_FIX
-
 /**
  * @brief encrypt
  * @param [in] master_key master key

--- a/src/themis/sym_enc_message.c
+++ b/src/themis/sym_enc_message.c
@@ -181,7 +181,7 @@ themis_status_t themis_auth_sym_encrypt_message(const uint8_t* key,
 						 size_t* encrypted_message_length){
   uint8_t key_[THEMIS_AUTH_SYM_KEY_LENGTH/8];
   THEMIS_CHECK_PARAM(message!=NULL && message_length!=0);
-  THEMIS_STATUS_CHECK(themis_sym_kdf(key,key_length, THEMIS_SYM_KDF_KEY_LABEL, (uint8_t*)(&message_length), sizeof(message_length), in_context, in_context_length, key_, sizeof(key_)),THEMIS_SUCCESS);
+  THEMIS_STATUS_CHECK(themis_sym_kdf(key,key_length, THEMIS_SYM_KDF_KEY_LABEL, (uint8_t*)(&message_length), sizeof(uint32_t), in_context, in_context_length, key_, sizeof(key_)),THEMIS_SUCCESS);
   return themis_auth_sym_encrypt_message_(key_, sizeof(key_), message, message_length, in_context, in_context_length, out_context, out_context_length, encrypted_message, encrypted_message_length);
 }
 themis_status_t themis_auth_sym_decrypt_message_(const uint8_t* key,
@@ -221,8 +221,23 @@ themis_status_t themis_auth_sym_decrypt_message(const uint8_t* key,
 						size_t* message_length){
   uint8_t key_[THEMIS_AUTH_SYM_KEY_LENGTH/8];
   THEMIS_CHECK_PARAM(context!=NULL && context_length!=0);
-  THEMIS_STATUS_CHECK(themis_sym_kdf(key,key_length, THEMIS_SYM_KDF_KEY_LABEL, (uint8_t*)(&encrypted_message_length), sizeof(encrypted_message_length), in_context, in_context_length, key_, sizeof(key_)),THEMIS_SUCCESS);
-  return themis_auth_sym_decrypt_message_(key_, sizeof(key_), in_context, in_context_length, context, context_length, encrypted_message, encrypted_message_length, message, message_length);
+  THEMIS_STATUS_CHECK(themis_sym_kdf(key,key_length, THEMIS_SYM_KDF_KEY_LABEL, (uint8_t*)(&encrypted_message_length), sizeof(uint32_t), in_context, in_context_length, key_, sizeof(key_)),THEMIS_SUCCESS);
+  themis_status_t decryption_result = themis_auth_sym_decrypt_message_(key_, sizeof(key_), in_context, in_context_length, context, context_length, encrypted_message, encrypted_message_length, message, message_length);
+
+#ifdef THEMIS_097_SECURE_CELL_X64_COMPATIBILITY_FIX
+
+  if (decryption_result != THEMIS_SUCCESS && decryption_result != THEMIS_BUFFER_TOO_SMALL) {
+
+    // we are on x64, should sizeof(uin64_t) for backwards compatibility with themis 0.9.6 x64
+    if (sizeof(size_t) == sizeof(uint64_t)) {
+      THEMIS_STATUS_CHECK(themis_sym_kdf(key,key_length, THEMIS_SYM_KDF_KEY_LABEL, (uint8_t*)(&encrypted_message_length), sizeof(uint64_t), in_context, in_context_length, key_, sizeof(key_)),THEMIS_SUCCESS);
+      decryption_result = themis_auth_sym_decrypt_message_(key_, sizeof(key_), in_context, in_context_length, context, context_length, encrypted_message, encrypted_message_length, message, message_length);
+    }
+  }
+
+#endif
+
+  return decryption_result;
 }
 
 
@@ -262,7 +277,7 @@ themis_status_t themis_sym_encrypt_message_u(const uint8_t* key,
 					     uint8_t* encrypted_message,
 					     size_t* encrypted_message_length){
   uint8_t key_[THEMIS_SYM_KEY_LENGTH/8];
-  THEMIS_STATUS_CHECK(themis_sym_kdf(key,key_length, THEMIS_SYM_KDF_KEY_LABEL, (uint8_t*)(&message_length), sizeof(message_length), NULL, 0, key_, sizeof(key_)),THEMIS_SUCCESS);  
+  THEMIS_STATUS_CHECK(themis_sym_kdf(key,key_length, THEMIS_SYM_KDF_KEY_LABEL, (uint8_t*)(&message_length), sizeof(uint32_t), NULL, 0, key_, sizeof(key_)),THEMIS_SUCCESS);
   return themis_sym_encrypt_message_u_(key_, sizeof(key_), message,message_length,context,context_length,encrypted_message,encrypted_message_length);
 }
 
@@ -296,6 +311,6 @@ themis_status_t themis_sym_decrypt_message_u(const uint8_t* key,
 					     uint8_t* message,
 					     size_t* message_length){
   uint8_t key_[THEMIS_SYM_KEY_LENGTH/8];
-  THEMIS_STATUS_CHECK(themis_sym_kdf(key,key_length, THEMIS_SYM_KDF_KEY_LABEL, (uint8_t*)(&encrypted_message_length), sizeof(encrypted_message_length), NULL, 0, key_, sizeof(key_)),THEMIS_SUCCESS);
+  THEMIS_STATUS_CHECK(themis_sym_kdf(key,key_length, THEMIS_SYM_KDF_KEY_LABEL, (uint8_t*)(&encrypted_message_length), sizeof(uint32_t), NULL, 0, key_, sizeof(key_)),THEMIS_SUCCESS);
   return themis_sym_decrypt_message_u_(key_,sizeof(key_),context,context_length,encrypted_message,encrypted_message_length,message,message_length);
 }

--- a/src/themis/sym_enc_message.c
+++ b/src/themis/sym_enc_message.c
@@ -181,7 +181,9 @@ themis_status_t themis_auth_sym_encrypt_message(const uint8_t* key,
 						 size_t* encrypted_message_length){
   uint8_t key_[THEMIS_AUTH_SYM_KEY_LENGTH/8];
   THEMIS_CHECK_PARAM(message!=NULL && message_length!=0);
-  THEMIS_STATUS_CHECK(themis_sym_kdf(key,key_length, THEMIS_SYM_KDF_KEY_LABEL, (uint8_t*)(&message_length), sizeof(uint32_t), in_context, in_context_length, key_, sizeof(key_)),THEMIS_SUCCESS);
+
+  // TODO: TYPE WARNING Should update `sizeof(uint32_t)` to `sizeof(message_length)` after changing encrypted_message_length type to uint32_t
+  THEMIS_STATUS_CHECK(themis_sym_kdf(key,key_length, THEMIS_SYM_KDF_KEY_LABEL, (uint8_t*)(&message_length), sizeof((uint32_t)(encrypted_message_length)), in_context, in_context_length, key_, sizeof(key_)),THEMIS_SUCCESS);
   return themis_auth_sym_encrypt_message_(key_, sizeof(key_), message, message_length, in_context, in_context_length, out_context, out_context_length, encrypted_message, encrypted_message_length);
 }
 themis_status_t themis_auth_sym_decrypt_message_(const uint8_t* key,
@@ -221,6 +223,8 @@ themis_status_t themis_auth_sym_decrypt_message(const uint8_t* key,
 						size_t* message_length){
   uint8_t key_[THEMIS_AUTH_SYM_KEY_LENGTH/8];
   THEMIS_CHECK_PARAM(context!=NULL && context_length!=0);
+
+  // TODO: TYPE WARNING Should update `sizeof(uint32_t)` to `sizeof(encrypted_message_length)` after changing encrypted_message_length type to uint32_t
   THEMIS_STATUS_CHECK(themis_sym_kdf(key,key_length, THEMIS_SYM_KDF_KEY_LABEL, (uint8_t*)(&encrypted_message_length), sizeof(uint32_t), in_context, in_context_length, key_, sizeof(key_)),THEMIS_SUCCESS);
   themis_status_t decryption_result = themis_auth_sym_decrypt_message_(key_, sizeof(key_), in_context, in_context_length, context, context_length, encrypted_message, encrypted_message_length, message, message_length);
 
@@ -229,8 +233,9 @@ themis_status_t themis_auth_sym_decrypt_message(const uint8_t* key,
   // we are on x64, should sizeof(uin64_t) for backwards compatibility with themis 0.9.6 x64
   if (sizeof(size_t) == sizeof(uint64_t)) {
     if (decryption_result != THEMIS_SUCCESS && decryption_result != THEMIS_BUFFER_TOO_SMALL) {
-        THEMIS_STATUS_CHECK(themis_sym_kdf(key,key_length, THEMIS_SYM_KDF_KEY_LABEL, (uint8_t*)(&encrypted_message_length), sizeof(uint64_t), in_context, in_context_length, key_, sizeof(key_)),THEMIS_SUCCESS);
-        decryption_result = themis_auth_sym_decrypt_message_(key_, sizeof(key_), in_context, in_context_length, context, context_length, encrypted_message, encrypted_message_length, message, message_length);
+      // TODO: TYPE WARNING `sizeof(uint64_t)`. Fix that on next versions
+      THEMIS_STATUS_CHECK(themis_sym_kdf(key,key_length, THEMIS_SYM_KDF_KEY_LABEL, (uint8_t*)(&encrypted_message_length), sizeof(uint64_t), in_context, in_context_length, key_, sizeof(key_)),THEMIS_SUCCESS);
+      decryption_result = themis_auth_sym_decrypt_message_(key_, sizeof(key_), in_context, in_context_length, context, context_length, encrypted_message, encrypted_message_length, message, message_length);
     }
   }
 
@@ -276,6 +281,8 @@ themis_status_t themis_sym_encrypt_message_u(const uint8_t* key,
 					     uint8_t* encrypted_message,
 					     size_t* encrypted_message_length){
   uint8_t key_[THEMIS_SYM_KEY_LENGTH/8];
+
+  // TODO: TYPE WARNING Should update `sizeof(uint32_t)` to `sizeof(message_length)` after changing encrypted_message_length type to uint32_t
   THEMIS_STATUS_CHECK(themis_sym_kdf(key,key_length, THEMIS_SYM_KDF_KEY_LABEL, (uint8_t*)(&message_length), sizeof(uint32_t), NULL, 0, key_, sizeof(key_)),THEMIS_SUCCESS);
   return themis_sym_encrypt_message_u_(key_, sizeof(key_), message,message_length,context,context_length,encrypted_message,encrypted_message_length);
 }
@@ -310,6 +317,8 @@ themis_status_t themis_sym_decrypt_message_u(const uint8_t* key,
 					     uint8_t* message,
 					     size_t* message_length){
   uint8_t key_[THEMIS_SYM_KEY_LENGTH/8];
+
+  // TODO: TYPE WARNING Should update `sizeof(uint32_t)` to `sizeof(encrypted_message_length)` after changing encrypted_message_length type to uint32_t
   THEMIS_STATUS_CHECK(themis_sym_kdf(key,key_length, THEMIS_SYM_KDF_KEY_LABEL, (uint8_t*)(&encrypted_message_length), sizeof(uint32_t), NULL, 0, key_, sizeof(key_)),THEMIS_SUCCESS);
   themis_status_t decryption_result = themis_sym_decrypt_message_u_(key_,sizeof(key_),context,context_length,encrypted_message,encrypted_message_length,message,message_length);
 
@@ -318,8 +327,9 @@ themis_status_t themis_sym_decrypt_message_u(const uint8_t* key,
   // we are on x64, should sizeof(uin64_t) for backwards compatibility with themis 0.9.6 x64
   if (sizeof(size_t) == sizeof(uint64_t)) {
     if (decryption_result != THEMIS_SUCCESS && decryption_result != THEMIS_BUFFER_TOO_SMALL) {
-        THEMIS_STATUS_CHECK(themis_sym_kdf(key,key_length, THEMIS_SYM_KDF_KEY_LABEL, (uint8_t*)(&encrypted_message_length), sizeof(uint64_t), NULL, 0, key_, sizeof(key_)),THEMIS_SUCCESS);
-        decryption_result = themis_sym_decrypt_message_u_(key_,sizeof(key_),context,context_length,encrypted_message,encrypted_message_length,message,message_length);
+      // TODO: TYPE WARNING `sizeof(uint64_t)`. Fix that on next versions
+      THEMIS_STATUS_CHECK(themis_sym_kdf(key,key_length, THEMIS_SYM_KDF_KEY_LABEL, (uint8_t*)(&encrypted_message_length), sizeof(uint64_t), NULL, 0, key_, sizeof(key_)),THEMIS_SUCCESS);
+      decryption_result = themis_sym_decrypt_message_u_(key_,sizeof(key_),context,context_length,encrypted_message,encrypted_message_length,message,message_length);
     }
   }
 #endif

--- a/src/themis/sym_enc_message.c
+++ b/src/themis/sym_enc_message.c
@@ -224,14 +224,13 @@ themis_status_t themis_auth_sym_decrypt_message(const uint8_t* key,
   THEMIS_STATUS_CHECK(themis_sym_kdf(key,key_length, THEMIS_SYM_KDF_KEY_LABEL, (uint8_t*)(&encrypted_message_length), sizeof(uint32_t), in_context, in_context_length, key_, sizeof(key_)),THEMIS_SUCCESS);
   themis_status_t decryption_result = themis_auth_sym_decrypt_message_(key_, sizeof(key_), in_context, in_context_length, context, context_length, encrypted_message, encrypted_message_length, message, message_length);
 
-#ifdef THEMIS_097_SECURE_CELL_X64_COMPATIBILITY_FIX
+#ifdef SCELL_COMPAT
 
-  if (decryption_result != THEMIS_SUCCESS && decryption_result != THEMIS_BUFFER_TOO_SMALL) {
-
-    // we are on x64, should sizeof(uin64_t) for backwards compatibility with themis 0.9.6 x64
-    if (sizeof(size_t) == sizeof(uint64_t)) {
-      THEMIS_STATUS_CHECK(themis_sym_kdf(key,key_length, THEMIS_SYM_KDF_KEY_LABEL, (uint8_t*)(&encrypted_message_length), sizeof(uint64_t), in_context, in_context_length, key_, sizeof(key_)),THEMIS_SUCCESS);
-      decryption_result = themis_auth_sym_decrypt_message_(key_, sizeof(key_), in_context, in_context_length, context, context_length, encrypted_message, encrypted_message_length, message, message_length);
+  // we are on x64, should sizeof(uin64_t) for backwards compatibility with themis 0.9.6 x64
+  if (sizeof(size_t) == sizeof(uint64_t)) {
+    if (decryption_result != THEMIS_SUCCESS && decryption_result != THEMIS_BUFFER_TOO_SMALL) {
+        THEMIS_STATUS_CHECK(themis_sym_kdf(key,key_length, THEMIS_SYM_KDF_KEY_LABEL, (uint8_t*)(&encrypted_message_length), sizeof(uint64_t), in_context, in_context_length, key_, sizeof(key_)),THEMIS_SUCCESS);
+        decryption_result = themis_auth_sym_decrypt_message_(key_, sizeof(key_), in_context, in_context_length, context, context_length, encrypted_message, encrypted_message_length, message, message_length);
     }
   }
 
@@ -314,17 +313,15 @@ themis_status_t themis_sym_decrypt_message_u(const uint8_t* key,
   THEMIS_STATUS_CHECK(themis_sym_kdf(key,key_length, THEMIS_SYM_KDF_KEY_LABEL, (uint8_t*)(&encrypted_message_length), sizeof(uint32_t), NULL, 0, key_, sizeof(key_)),THEMIS_SUCCESS);
   themis_status_t decryption_result = themis_sym_decrypt_message_u_(key_,sizeof(key_),context,context_length,encrypted_message,encrypted_message_length,message,message_length);
 
-#ifdef THEMIS_097_SECURE_CELL_X64_COMPATIBILITY_FIX
+#ifdef SCELL_COMPAT
 
-  if (decryption_result != THEMIS_SUCCESS && decryption_result != THEMIS_BUFFER_TOO_SMALL) {
-
-    // we are on x64, should sizeof(uin64_t) for backwards compatibility with themis 0.9.6 x64
-    if (sizeof(size_t) == sizeof(uint64_t)) {
-      THEMIS_STATUS_CHECK(themis_sym_kdf(key,key_length, THEMIS_SYM_KDF_KEY_LABEL, (uint8_t*)(&encrypted_message_length), sizeof(uint64_t), NULL, 0, key_, sizeof(key_)),THEMIS_SUCCESS);
-      decryption_result = themis_sym_decrypt_message_u_(key_,sizeof(key_),context,context_length,encrypted_message,encrypted_message_length,message,message_length);
+  // we are on x64, should sizeof(uin64_t) for backwards compatibility with themis 0.9.6 x64
+  if (sizeof(size_t) == sizeof(uint64_t)) {
+    if (decryption_result != THEMIS_SUCCESS && decryption_result != THEMIS_BUFFER_TOO_SMALL) {
+        THEMIS_STATUS_CHECK(themis_sym_kdf(key,key_length, THEMIS_SYM_KDF_KEY_LABEL, (uint8_t*)(&encrypted_message_length), sizeof(uint64_t), NULL, 0, key_, sizeof(key_)),THEMIS_SUCCESS);
+        decryption_result = themis_sym_decrypt_message_u_(key_,sizeof(key_),context,context_length,encrypted_message,encrypted_message_length,message,message_length);
     }
   }
-
 #endif
 
   return decryption_result;

--- a/src/themis/sym_enc_message.c
+++ b/src/themis/sym_enc_message.c
@@ -183,7 +183,7 @@ themis_status_t themis_auth_sym_encrypt_message(const uint8_t* key,
   THEMIS_CHECK_PARAM(message!=NULL && message_length!=0);
 
   // TODO: TYPE WARNING Should update `sizeof(uint32_t)` to `sizeof(message_length)` after changing encrypted_message_length type to uint32_t
-  THEMIS_STATUS_CHECK(themis_sym_kdf(key,key_length, THEMIS_SYM_KDF_KEY_LABEL, (uint8_t*)(&message_length), sizeof((uint32_t)(encrypted_message_length)), in_context, in_context_length, key_, sizeof(key_)),THEMIS_SUCCESS);
+  THEMIS_STATUS_CHECK(themis_sym_kdf(key,key_length, THEMIS_SYM_KDF_KEY_LABEL, (uint8_t*)(&message_length), sizeof(uint32_t), in_context, in_context_length, key_, sizeof(key_)),THEMIS_SUCCESS);
   return themis_auth_sym_encrypt_message_(key_, sizeof(key_), message, message_length, in_context, in_context_length, out_context, out_context_length, encrypted_message, encrypted_message_length);
 }
 themis_status_t themis_auth_sym_decrypt_message_(const uint8_t* key,

--- a/tests/_integration/decrypt_folder.sh
+++ b/tests/_integration/decrypt_folder.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+
+TEST_IN=$1
+
+echo ".. decrypting data from $TEST_IN"
+
+ruby ./tests/_integration/scell_seal_string_echo.rb "dec" "pass" `cat $TEST_IN/scell_seal.txt`
+ruby ./tests/_integration/scell_seal_string_echo.rb "dec" "pass" `cat $TEST_IN/scell_seal_context.txt` "somecontext"
+ruby ./tests/_integration/scell_context_string_echo.rb "dec" "pass" `cat $TEST_IN/scell_context_impr.txt` "somecontext"
+ruby ./tests/_integration/scell_token_string_echo.rb "dec" "pass" `cat $TEST_IN/scell_token.txt`
+ruby ./tests/_integration/scell_token_string_echo.rb "dec" "pass" `cat $TEST_IN/scell_token_context.txt` "somecontext"
+ruby ./tests/_integration/scell_token_string_echo.rb "dec" "pass" `cat $TEST_IN/scell_token_context.txt` "somecontext"

--- a/tests/_integration/encrypt_folder.sh
+++ b/tests/_integration/encrypt_folder.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+
+HOST_NAME=$1
+
+TEST_OUT=./tests/out/$HOST_NAME
+mkdir -p $TEST_OUT
+
+echo ".. encrypting data from $HOST_NAME in folder $TEST_OUT"
+
+ruby ./tests/_integration/scell_seal_string_echo.rb "enc" "pass" "test seal: pass" > $TEST_OUT/scell_seal.txt
+ruby ./tests/_integration/scell_seal_string_echo.rb "enc" "pass" "test seal context: pass" "somecontext" > $TEST_OUT/scell_seal_context.txt
+ruby ./tests/_integration/scell_context_string_echo.rb "enc" "pass" "test context imprint: pass" "somecontext" > $TEST_OUT/scell_context_impr.txt
+ruby ./tests/_integration/scell_token_string_echo.rb "enc" "pass" "test token: pass" > $TEST_OUT/scell_token.txt
+ruby ./tests/_integration/scell_token_string_echo.rb "enc" "pass" "test token: pass" "somecontext" > $TEST_OUT/scell_token_context.txt


### PR DESCRIPTION
The problem described in #220 appears to be SecureCell incompatibility between x32 and x64 platforms. SecureCell is working correctly on both platforms, however, ciphertext calculations are platform-dependent.

**Where is the problem**
Message length and context length are used in encryption and decryption in every mode of SecureCell, and they are defined as `size_t` types ([secure_cell.c#L47](https://github.com/cossacklabs/themis/blob/master/src/themis/secure_cell.c#L47), [secure_cell.c#L29](https://github.com/cossacklabs/themis/blob/master/src/themis/secure_cell.c#L29) and below).

During encryption-decryption process `sizeof(message_length)` is calculated ([sym_enc_message.c#L184](https://github.com/cossacklabs/themis/blob/master/src/themis/sym_enc_message.c#L184)) which is equal to `sizeof(size_t)`.

Result of `sizeof(size_t)` is platform dependent: 4 bytes on x32 platforms, 8 bytes on x64 platforms. 

This value is used inside [`soter_kdf` function](https://github.com/cossacklabs/themis/blob/master/src/soter/soter_kdf.c#L86) for calculating hmac.

Therefore, resulting ciphertext uses different amount of bytes on different platforms.

**Fix**
Real fix is to use platform-independent types, like `uint32_t`, instead of `size_t`. `uint32_t` variables are already used among many data structures [`themis_auth_sym_message_hdr_type`](https://github.com/cossacklabs/themis/blob/master/src/themis/sym_enc_message.c#L135) and [`themis_sym_message_hdr_type`](https://github.com/cossacklabs/themis/blob/master/src/themis/sym_enc_message.c#L229)

Changing `sizeof(message_length)` to `sizeof(uint32_t)` results in using 4 bytes on every platform, making encryption-decryption compatible among x32 and x64.

**Compatibility fix**
Unfortunately using 4 bytes for x64 leads to unability to decrypt messages encrypted by themis 0.9.6 x64. 

Therefore on x64 platform if decrypting fails first time, we try to re-decrypt message using 8 bytes as context length for the second time.

**Testing**
I made manual integration testing among x32 and x64 Ubuntu 17.04 for themis 0.9.6 and 0.9.7. I encrypt data in every Secure Cell mode, write it to the files, and encrypt on another platform.

**Results**

- *fully compatible* (can be encrypted and decrypted both ways)
0.9.7 х64 <-> 0.9.7 х32
0.9.7 х64 <-> 0.9.6 х32
0.9.7 х32 <-> 0.9.6 х32 

- *almost fully compatible*
0.9.7 x64 <-> 0.9.6 x64 (messages encrypted with `context imprint` mode can't be decrypted on 0.9.7)

- *not compatible*
0.9.6 x64 can't decrypt messages encrypted by 0.9.7 x64/x32. Users should update to 0.9.7.
0.9.7 x32 can't decrypt messages encrypted by 0.9.6 x64. Users should update to 0.9.7.