### PR TITLE
add token protect checks for iOS

### DIFF
--- a/tests/objcthemis/Podfile.lock
+++ b/tests/objcthemis/Podfile.lock
@@ -1,12 +1,12 @@
 PODS:
   - GRKOpenSSLFramework (1.0.1.20.4)
-  - themis (0.9.5):
+  - themis (0.9.6):
     - GRKOpenSSLFramework (= 1.0.1.20.4)
-    - themis/core (= 0.9.5)
-    - themis/objcwrapper (= 0.9.5)
-  - themis/core (0.9.5):
+    - themis/core (= 0.9.6)
+    - themis/objcwrapper (= 0.9.6)
+  - themis/core (0.9.6):
     - GRKOpenSSLFramework (= 1.0.1.20.4)
-  - themis/objcwrapper (0.9.5):
+  - themis/objcwrapper (0.9.6):
     - GRKOpenSSLFramework (= 1.0.1.20.4)
     - themis/core
 
@@ -19,12 +19,12 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   themis:
-    :commit: a666818d029290c06140d8bf2a1697f872b6219b
+    :commit: 8090c5067368a29e835cf25538d60ddafd625f31
     :git: https://github.com/cossacklabs/themis.git
 
 SPEC CHECKSUMS:
   GRKOpenSSLFramework: b6172cc34db9b999002483878772a4bf2a1687ba
-  themis: 426fc731cd7be9542bbaaf0a3f3f0f916b5153f5
+  themis: 470fc7b5532b7ff098664185d389fbb1a5ac3603
 
 PODFILE CHECKSUM: 88edddd6333586b5b3690dd262564d9b4bb3c36c
 

--- a/tests/objcthemis/objthemis/SecureCellTests.m
+++ b/tests/objcthemis/objthemis/SecureCellTests.m
@@ -184,11 +184,13 @@
     XCTAssertNil(encryptedMessage, @"encryption without data-to-encrypt, without context should return nil data");
 
     themisError = nil;
-    encryptedMessage = [cellToken wrapData:[message dataUsingEncoding:NSUTF8StringEncoding]
+    NSData * messageData = [message dataUsingEncoding:NSUTF8StringEncoding];
+    encryptedMessage = [cellToken wrapData:messageData
                                    context:[context dataUsingEncoding:NSUTF8StringEncoding]
                                      error:&themisError];
     XCTAssertNil(themisError, @"encryption with data and context should be successful");
     XCTAssertNotNil(encryptedMessage, @"encryption with data and context should be successful");
+    XCTAssertEqual([messageData length], [encryptedMessage.cipherText length], @"encrypted data length should be the same as message length");
 
     themisError = nil;
     NSData *decryptedMessage = [cellToken unwrapData:encryptedMessage
@@ -215,7 +217,7 @@
     NSString *message = @"Roses are grey. Violets are grey.";
     NSString *context = @"I'm a dog";
     NSError *themisError;
-
+    NSData *messageData = [message dataUsingEncoding:NSUTF8StringEncoding];
 
     TSCellTokenEncryptedData *encryptedMessageNoContext = [cellToken
             wrapData:[message dataUsingEncoding:NSUTF8StringEncoding]
@@ -223,6 +225,7 @@
                error:&themisError];
     XCTAssertNil(themisError, @"encryption without data-to-encrypt, without context should be successful");
     XCTAssertNotNil(encryptedMessageNoContext, @"encryption without data-to-encrypt, without context should be successful");
+    XCTAssertEqual([messageData length], [encryptedMessageNoContext.cipherText length], @"encrypted data length should be the same as message length");
 
     themisError = nil;
     NSData *decryptedMessageNoContext = [cellToken unwrapData:encryptedMessageNoContext

--- a/tests/objcthemis/objthemis/SecureCellTestsSwift.swift
+++ b/tests/objcthemis/objthemis/SecureCellTestsSwift.swift
@@ -118,11 +118,12 @@ class SecureCellTestsSwift: XCTestCase {
         let cellToken: TSCellToken = TSCellToken(key: masterKeyData)!
         let message: String = "Roses are grey. Violets are grey."
         let context: String = "I'm a dog"
-        
-        let encryptedMessage = try? cellToken.wrap(message.data(using: .utf8)!,
+        let messageData: Data = message.data(using: .utf8)!
+    
+        let encryptedMessage = try? cellToken.wrap(messageData,
                                               context: context.data(using: .utf8)!)
         XCTAssertNotNil(encryptedMessage, "encryption with data and context should be successful")
-        
+        XCTAssertEqual(encryptedMessage?.cipherText.length, messageData.count)
         
         var decryptedMessage = try? cellToken.unwrapData(encryptedMessage!,
                                                         context: nil)
@@ -140,11 +141,12 @@ class SecureCellTestsSwift: XCTestCase {
         let cellToken: TSCellToken = TSCellToken(key: masterKeyData)!
         let message: String = "Roses are grey. Violets are grey."
         let context: String = "I'm a dog"
+        let messageData: Data = message.data(using: .utf8)!
         
-        let encryptedMessageNoContext = try? cellToken.wrap(message.data(using: .utf8)!,
+        let encryptedMessageNoContext = try? cellToken.wrap(messageData,
                                                context: nil)
         XCTAssertNotNil(encryptedMessageNoContext, "encryption without data-to-encrypt, without context should be successful")
-        
+        XCTAssertEqual(encryptedMessageNoContext?.cipherText.length, messageData.count)
         
         var decryptedMessageNoContext = try? cellToken.unwrapData(encryptedMessageNoContext!,
                                                          context: context.data(using: .utf8))


### PR DESCRIPTION
Add check that encrypted message length is equal to plaintext message length for SecureCell TokenProtect mode.

Similar to #282 but for iOS wrapper.