### PR TITLE
separate pythemis install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ RUBY_GEM_VERSION := $(shell gem --version 2>/dev/null)
 GO_VERSION := $(shell go version 2>&1)
 NPM_VERSION := $(shell npm --version 2>/dev/null)
 PIP_VERSION := $(shell pip --version 2>/dev/null)
-PYTHON_VERSION := $(shell python --version 2>&1)
+PYTHON2_VERSION := $(shell python2 --version 2>&1)
 PYTHON3_VERSION := $(shell python3 --version 2>/dev/null)
 ifdef PIP_VERSION
 PIP_THEMIS_INSTALL := $(shell pip freeze |grep themis)
@@ -432,19 +432,15 @@ else
 	@exit 1
 endif
 
-pythemis_install: CMD = cd src/wrappers/themis/python/ && python2 setup.py install --record files.txt
-
+pythemis_install: CMD = cd src/wrappers/themis/python/ && python2 setup.py install --record files.txt;  python3 setup.py install --record files3.txt
 pythemis_install:
-ifdef PYTHON_VERSION
-	@echo -n "pythemis install "
-	@$(BUILD_CMD_)
-else
-	@echo "Error: python not found"
+ifeq ($(or $(PYTHON2_VERSION),$(PYTHON3_VERSION)),)
+	@echo "python2 or python3 not found"
 	@exit 1
 endif
-ifdef PYTHON3_VERSION
-	@cd src/wrappers/themis/python/ && python3 setup.py install --record files3.txt
-endif
+	@echo -n "pythemis install "
+	@$(BUILD_CMD_)
+
 
 themispp_install: CMD = install $(SRC_PATH)/wrappers/themis/themispp/*.hpp $(PREFIX)/include/themispp
 

--- a/tests/phpthemis/php.ini
+++ b/tests/phpthemis/php.ini
@@ -860,7 +860,7 @@ default_socket_timeout = 60
 ;
 ; ... or under UNIX:
 ;
-extension=./phpthemis.so
+extension=phpthemis.so
 ;
 ; ... or with a path:
 ;

--- a/tests/test.mk
+++ b/tests/test.mk
@@ -26,6 +26,8 @@ include tests/tools/tools.mk
 include tests/themis/themis.mk
 include tests/themispp/themispp.mk
 
+PYTHON2_TEST_SCRIPT=$(BIN_PATH)/tests/pythemis2_test.sh
+PYTHON3_TEST_SCRIPT=$(BIN_PATH)/tests/pythemis3_test.sh
 
 nist_rng_test_suite: CMD = $(MAKE) -C $(NIST_STS_DIR)
 
@@ -62,13 +64,9 @@ prepare_tests_all: err prepare_tests_basic themispp_test
 ifdef PHP_VERSION
 	@echo -n "make tests for phpthemis "
 	@echo "#!/bin/bash -e" > ./$(BIN_PATH)/tests/phpthemis_test.sh
-	# @echo "php -c tests/phpthemis/php.ini ./tests/tools/phpunit.phar ./tests/phpthemis/scell_test.php" >> ./$(BIN_PATH)/tests/phpthemis_test.sh
-	# @echo "php -c tests/phpthemis/php.ini ./tests/tools/phpunit.phar ./tests/phpthemis/smessage_test.php" >> ./$(BIN_PATH)/tests/phpthemis_test.sh
-	# @echo "php -c tests/phpthemis/php.ini ./tests/tools/phpunit.phar ./tests/phpthemis/ssession_test.php" >> ./$(BIN_PATH)/tests/phpthemis_test.sh
-	# @cp ./src/wrappers/themis/$(PHP_FOLDER)/.libs/phpthemis.so ./tests/phpthemis/phpthemis.so
 	@echo "cd tests/phpthemis; bash ./run_tests.sh" >> ./$(BIN_PATH)/tests/phpthemis_test.sh
 	@chmod a+x ./$(BIN_PATH)/tests/phpthemis_test.sh
-	@cd ./tests/phpthemis; ln -s ../../src/wrappers/themis/$(PHP_FOLDER)/.libs/phpthemis.so ./phpthemis.so
+	#@cd ./tests/phpthemis; ln -s ../../src/wrappers/themis/$(PHP_FOLDER)/.libs/phpthemis.so ./phpthemis.so
 	@$(PRINT_OK_)
 endif
 ifdef RUBY_GEM_VERSION
@@ -81,15 +79,17 @@ ifdef RUBY_GEM_VERSION
 	@chmod a+x ./$(BIN_PATH)/tests/rubythemis_test.sh
 	@$(PRINT_OK_)
 endif
-ifdef PYTHON_VERSION
-	@echo -n "make tests for pythemis "
-	@echo "#!/bin/bash -e" > ./$(BIN_PATH)/tests/pythemis_test.sh
-	@echo "python -m unittest discover -s tests/pythemis" >> ./$(BIN_PATH)/tests/pythemis_test.sh
-ifdef PYTHON3_VERSION
-	@echo "echo Python3 $(PYTHON3_VERSION) tests" >> ./$(BIN_PATH)/tests/pythemis_test.sh
-	@echo "python3 -m unittest discover -s tests/pythemis" >> ./$(BIN_PATH)/tests/pythemis_test.sh
+ifdef PYTHON2_VERSION
+	@echo -n "make tests for pythemis with python 2 "
+	@echo "#!/bin/bash -e" > ./$(PYTHON2_TEST_SCRIPT)
+	@echo "python2 -m unittest discover -s tests/pythemis" >> ./$(PYTHON2_TEST_SCRIPT)
+	@chmod a+x ./$(PYTHON2_TEST_SCRIPT)
 endif
-	@chmod a+x ./$(BIN_PATH)/tests/pythemis_test.sh
+ifdef PYTHON3_VERSION
+	@echo -n "make tests for pythemis with python3 "
+	@echo "#!/bin/bash -e" > ./$(PYTHON3_TEST_SCRIPT)
+	@echo "python3 -m unittest discover -s tests/pythemis" >> ./$(PYTHON3_TEST_SCRIPT)
+	@chmod a+x ./$(PYTHON3_TEST_SCRIPT)
 	@$(PRINT_OK_)
 endif
 ifdef NPM_VERSION
@@ -137,13 +137,22 @@ ifdef PHP_VERSION
 endif
 
 test_python:
-ifdef PYTHON_VERSION
+# run test if any of python version available
+ifneq ($(or $(PYTHON2_VERSION),$(PYTHON3_VERSION)),)
 	@echo "------------------------------------------------------------"
 	@echo "Running pythemis tests."
 	@echo "If any error, check https://github.com/cossacklabs/themis/wiki/Python-Howto"
 	@echo "------------------------------------------------------------"
-	$(TEST_BIN_PATH)/pythemis_test.sh
+ifneq ($(PYTHON2_VERSION),)
+	$(PYTHON2_TEST_SCRIPT)
+endif
+ifneq ($(PYTHON3_VERSION),)
+	$(PYTHON3_TEST_SCRIPT)
+endif
 	@echo "------------------------------------------------------------"
+else
+	@echo "python2 or python3 not found"
+	@exit 1
 endif
 
 test_ruby:


### PR DESCRIPTION
* explicitly use python2 and python3
* install python X version if exists, don't fail if one not exists (before installing come down when python2 not exists)
* same with tests, test all versions that exists (2, 3, 2+3)
* plus dropped linking phpthemis.so + fixed php.ini (because has a failure when tested locally and found that it is overhead)