### PR TITLE
Fix the misusage of short-circuit evaluation in 'soter_sign_ecdsa.c'

### DIFF
--- a/src/soter/openssl/soter_sign_ecdsa.c
+++ b/src/soter/openssl/soter_sign_ecdsa.c
@@ -102,7 +102,7 @@ soter_status_t soter_sign_update_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx, const v
 soter_status_t soter_sign_final_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx, void* signature, size_t *signature_length)
 {
   EVP_PKEY *pkey = EVP_PKEY_CTX_get0_pkey(ctx->pkey_ctx);
-  if (!pkey && EVP_PKEY_base_id(pkey)!=EVP_PKEY_EC){
+  if (!pkey || EVP_PKEY_base_id(pkey)!=EVP_PKEY_EC){
     return SOTER_INVALID_PARAMETER;
   } /* TODO: need review */
   soter_status_t res = SOTER_SUCCESS;


### PR DESCRIPTION
I'm henry wong, from Qihoo360 CodeSafe Team. We found a possible null
pointer deference caused by the misusage of short-circuit evaluation. If
`pkey` is null, the program will continue execute `EVP_PKEY_base_id(pkey)`,
and this will cause a null pointer dereference.

Since I'm unfamiliar with `themis`,  please forgive me if there is anything 
wrong with my description.

Henry Wong
Qihoo360 CodeSafe Team