### PR TITLE
Refactoring if (!pkey) in 'soter_sign_ecdsa.c' for OpenSSL/BoringSSL

### DIFF
--- a/src/soter/boringssl/soter_sign_ecdsa.c
+++ b/src/soter/boringssl/soter_sign_ecdsa.c
@@ -93,7 +93,7 @@ soter_status_t soter_sign_final_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx, void* si
   if (!pkey) {
     return SOTER_INVALID_PARAMETER;
   }
-  if (EVP_PKEY_base_id(pkey)!=EVP_PKEY_EC) {
+  if (EVP_PKEY_type(pkey->type)!=EVP_PKEY_EC) {
     return SOTER_INVALID_PARAMETER;
   }
   /* TODO: need review */

--- a/tests/soter/soter_sign_test.c
+++ b/tests/soter/soter_sign_test.c
@@ -211,7 +211,7 @@ static void soter_sign_api_test()
 		soter_sign_destroy(sign_ctx);
 		return;
 	}
- 
+
 	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_sign_final(NULL, signature, &signature_length), "soter_sign_final: invalid context");
 	testsuite_fail_unless(SOTER_BUFFER_TOO_SMALL == soter_sign_final(sign_ctx, NULL, &signature_length), "soter_sign_final: get output size (NULL out buffer)");
 	signature_length--;

--- a/tests/soter/soter_sign_test.c
+++ b/tests/soter/soter_sign_test.c
@@ -211,7 +211,7 @@ static void soter_sign_api_test()
 		soter_sign_destroy(sign_ctx);
 		return;
 	}
-  
+ 
 	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_sign_final(NULL, signature, &signature_length), "soter_sign_final: invalid context");
 	testsuite_fail_unless(SOTER_BUFFER_TOO_SMALL == soter_sign_final(sign_ctx, NULL, &signature_length), "soter_sign_final: get output size (NULL out buffer)");
 	signature_length--;


### PR DESCRIPTION
Based on #314 

We've added similar check into BoringSSL-related code.

Unfortunately we didn't find any ways to simulate NULL pKey using OpenSSL API.

Thank you @movie-travel-code!