### PR TITLE
refresh objcthemis build files, and fix doc typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,11 +32,14 @@ xcuserdata
 *~.nib
 *.swp
 
+docs/examples/objc/Pods
 
 # additional rules
 DerivedData/
 .idea/
 build
+.gradle
+
 
 # python rules
 # Byte-compiled / optimized / DLL files
@@ -48,3 +51,5 @@ tests/phpthemis/vendor
 tests/phpthemis/composer.json
 tests/phpthemis/composer.phar
 tests/phpthemis/composer.lock
+
+third_party/boringssl/.externalNativeBuild

--- a/docs/examples/objc/Podfile.lock
+++ b/docs/examples/objc/Podfile.lock
@@ -13,10 +13,15 @@ PODS:
 DEPENDENCIES:
   - themis (= 0.10.0)
 
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - GRKOpenSSLFramework
+    - themis
+
 SPEC CHECKSUMS:
   GRKOpenSSLFramework: b6172cc34db9b999002483878772a4bf2a1687ba
   themis: f06f5690dbb18276e98f3c8d7c9ba90e8100bd09
 
 PODFILE CHECKSUM: 1e963e072c7246908b254b958a140d32c5bd6993
 
-COCOAPODS: 1.3.1
+COCOAPODS: 1.5.3

--- a/docs/examples/objc/ThemisTest.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/docs/examples/objc/ThemisTest.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/docs/examples/objc/ThemisTest/ThemisTest.xcodeproj/project.pbxproj
+++ b/docs/examples/objc/ThemisTest/ThemisTest.xcodeproj/project.pbxproj
@@ -192,8 +192,7 @@
 				7316248E1ADB174200972A7A /* Sources */,
 				7316248F1ADB174200972A7A /* Frameworks */,
 				731624901ADB174200972A7A /* Resources */,
-				1FFD9858FC7E8062F22FDBB1 /* [CP] Embed Pods Frameworks */,
-				89E8FFF06454B0B7A4490BF6 /* [CP] Copy Pods Resources */,
+				C0B21AE78F6B25EA73FA9E6E /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -286,7 +285,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		1FFD9858FC7E8062F22FDBB1 /* [CP] Embed Pods Frameworks */ = {
+		C0B21AE78F6B25EA73FA9E6E /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -304,21 +303,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-ThemisTest/Pods-ThemisTest-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		89E8FFF06454B0B7A4490BF6 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-ThemisTest/Pods-ThemisTest-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		CBE2965EA2BC2CF591D82F10 /* [CP] Check Pods Manifest.lock */ = {

--- a/src/wrappers/themis/Obj-C/objcthemis/skeygen.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/skeygen.h
@@ -50,7 +50,7 @@ typedef NS_ENUM(NSInteger, TSKeyGenAsymmetricAlgorithm) {
 
 /**
 * @brief initialise key pair generator, generates privateKey and publicKey
-* @param [in] algorithm, RSA or EC. @see TSKeyGenAsymmetricAlgorithm
+* @param [in] algorithm RSA or EC. @see TSKeyGenAsymmetricAlgorithm
 */
 - (nullable instancetype)initWithAlgorithm:(TSKeyGenAsymmetricAlgorithm)algorithm;
 


### PR DESCRIPTION
I was annoyed by clang doc check:

```
- WARN  | [acrawriter] xcodebuild:  Headers/Private/themis/objcthemis/skeygen.h:53:15: warning: parameter 'algorithm,' not found in the function declaration [-Wdocumentation]
- NOTE  | [acrawriter] xcodebuild:  Headers/Private/themis/objcthemis/skeygen.h:53:15: note: did you mean 'algorithm'?
```