### PR TITLE
NaN ’NewInstance’ API fix

### DIFF
--- a/src/wrappers/themis/jsthemis/secure_cell_context_imprint.cpp
+++ b/src/wrappers/themis/jsthemis/secure_cell_context_imprint.cpp
@@ -50,7 +50,7 @@ namespace jsthemis {
       const int argc = 1;
       v8::Local<v8::Value> argv[argc] = { args[0]};
       v8::Local<v8::Function> cons = Nan::New<v8::Function>(constructor);
-      args.GetReturnValue().Set(cons->NewInstance(argc, argv));
+      args.GetReturnValue().Set(Nan::NewInstance(cons, argc, argv).ToLocalChecked());
     }
   }
 

--- a/src/wrappers/themis/jsthemis/secure_cell_seal.cpp
+++ b/src/wrappers/themis/jsthemis/secure_cell_seal.cpp
@@ -50,7 +50,7 @@ namespace jsthemis {
       const int argc = 1;
       v8::Local<v8::Value> argv[argc] = { args[0]};
       v8::Local<v8::Function> cons = Nan::New<v8::Function>(constructor);
-      args.GetReturnValue().Set(cons->NewInstance(argc, argv));
+      args.GetReturnValue().Set(Nan::NewInstance(cons, argc, argv).ToLocalChecked());
     }
   }
 

--- a/src/wrappers/themis/jsthemis/secure_cell_token_protect.cpp
+++ b/src/wrappers/themis/jsthemis/secure_cell_token_protect.cpp
@@ -50,7 +50,7 @@ namespace jsthemis {
       const int argc = 1;
       v8::Local<v8::Value> argv[argc] = { args[0]};
       v8::Local<v8::Function> cons = Nan::New<v8::Function>(constructor);
-      args.GetReturnValue().Set(cons->NewInstance(argc, argv));
+      args.GetReturnValue().Set(Nan::NewInstance(cons, argc, argv).ToLocalChecked());
     }
   }
 

--- a/src/wrappers/themis/jsthemis/secure_comparator.cpp
+++ b/src/wrappers/themis/jsthemis/secure_comparator.cpp
@@ -68,7 +68,7 @@ namespace jsthemis {
       const int argc = 3;
       v8::Local<v8::Value> argv[argc] = { args[0], args[1], args[2]};
       v8::Local<v8::Function> cons = Nan::New<v8::Function>(constructor);
-      args.GetReturnValue().Set(cons->NewInstance(argc, argv));
+      args.GetReturnValue().Set(Nan::NewInstance(cons, argc, argv).ToLocalChecked());
     }
   }
 

--- a/src/wrappers/themis/jsthemis/secure_keygen.cpp
+++ b/src/wrappers/themis/jsthemis/secure_keygen.cpp
@@ -73,7 +73,7 @@ namespace jsthemis {
       const int argc = 2;
       v8::Local<v8::Value> argv[argc] = { args[0], args[1] };
       v8::Local<v8::Function> cons = Nan::New<v8::Function>(constructor);
-      args.GetReturnValue().Set(cons->NewInstance(argc, argv));
+      args.GetReturnValue().Set(Nan::NewInstance(cons, argc, argv).ToLocalChecked());
     }
   }
 

--- a/src/wrappers/themis/jsthemis/secure_message.cpp
+++ b/src/wrappers/themis/jsthemis/secure_message.cpp
@@ -55,7 +55,7 @@ namespace jsthemis {
       const int argc = 2;
       v8::Local<v8::Value> argv[argc] = { args[0], args[1] };
       v8::Local<v8::Function> cons = Nan::New<v8::Function>(constructor);
-      args.GetReturnValue().Set(cons->NewInstance(argc, argv));
+      args.GetReturnValue().Set(Nan::NewInstance(cons, argc, argv).ToLocalChecked());
     }
   }
 

--- a/src/wrappers/themis/jsthemis/secure_session.cpp
+++ b/src/wrappers/themis/jsthemis/secure_session.cpp
@@ -76,7 +76,7 @@ namespace jsthemis {
       const int argc = 3;
       v8::Local<v8::Value> argv[argc] = { args[0], args[1], args[2]};
       v8::Local<v8::Function> cons = Nan::New<v8::Function>(constructor);
-      args.GetReturnValue().Set(cons->NewInstance(argc, argv));
+      args.GetReturnValue().Set(Nan::NewInstance(cons, argc, argv).ToLocalChecked());
     }
   }
 


### PR DESCRIPTION
`NewInstance` method in NaN seems to lack version with only two arguments (argc and argv). Maybe it was removed at some time. Only three versions exist for now: [Source](https://github.com/nodejs/nan/blob/77d0fcaba3305d05176a9ad95d8e5101e8f2a283/nan_maybe_pre_43_inl.h#L115) 
I've changed js wrapper to use correct version.