### PR TITLE
jsthemis update (support new versions of NaN and Nodejs)

### DIFF
--- a/docs/examples/js/secure_cell.js
+++ b/docs/examples/js/secure_cell.js
@@ -3,13 +3,13 @@ var addon = require('jsthemis');
 
 if(process.argv.length==5){
     command=process.argv[2];
-    password=new Buffer(process.argv[3]);
+    password=new Buffer.from(process.argv[3]);
 
     seal = new addon.SecureCellSeal(password);
     if(command=="enc"){
-	console.log(seal.encrypt(new Buffer(process.argv[4])).toString("base64"));
+	console.log(seal.encrypt(new Buffer.from(process.argv[4])).toString("base64"));
     }else if(command=="dec"){
-	console.log(seal.decrypt(new Buffer(process.argv[4], "base64")).toString());
+	console.log(seal.decrypt(new Buffer.from(process.argv[4], "base64")).toString());
     }else{
 	console.log("usage node secure_cell.js <enc/dec> <password> <message>");
     }

--- a/docs/examples/js/secure_comparator_client.js
+++ b/docs/examples/js/secure_comparator_client.js
@@ -1,7 +1,7 @@
 var net = require('net');
 var themis = require('jsthemis');
 
-comparator = new themis.SecureComparator(new Buffer("secret"));
+comparator = new themis.SecureComparator(new Buffer.from("secret"));
 
 var client = new net.Socket();
 client.connect(1337, '127.0.0.1', function() {

--- a/docs/examples/js/secure_comparator_server.js
+++ b/docs/examples/js/secure_comparator_server.js
@@ -3,7 +3,7 @@ var themis = require('jsthemis');
 
 var server = net.createServer(function(socket) {
 
-    comparator = new themis.SecureComparator(new Buffer("secret"));
+    comparator = new themis.SecureComparator(new Buffer.from("secret"));
   
     socket.on('data', function (data) {
 	d=comparator.proceedCompare(data);

--- a/docs/examples/js/secure_message.js
+++ b/docs/examples/js/secure_message.js
@@ -5,11 +5,11 @@ if(process.argv.length==6){
     private_key=process.argv[3];
     peer_public_key=process.argv[4];
 
-    sm = new addon.SecureMessage(new Buffer(private_key, "base64"), new Buffer(peer_public_key, "base64"));
+    sm = new addon.SecureMessage(new Buffer.from(private_key, "base64"), new Buffer.from(peer_public_key, "base64"));
     if(command=="enc"){
-        console.log(sm.encrypt(new Buffer(process.argv[5])).toString("base64"));
+        console.log(sm.encrypt(new Buffer.from(process.argv[5])).toString("base64"));
     }else if(command=="dec"){
-	console.log(sm.decrypt(new Buffer(process.argv[5], "base64")).toString());
+	console.log(sm.decrypt(new Buffer.from(process.argv[5], "base64")).toString());
     }else{
         console.log("usage node secure_message.js <enc/dec> <private key> <peer public key> <message>");
     }

--- a/docs/examples/js/secure_session_client.js
+++ b/docs/examples/js/secure_session_client.js
@@ -1,12 +1,12 @@
 var net = require('net');
 var themis = require('jsthemis');
 
-session = new themis.SecureSession(new Buffer("client"), new Buffer("UkVDMgAAAC3DZR2qAEbvO092R/IKXBttnf9dVSU65R+Fb4eNoyxxlzn2n4GR","base64"), function(id){
+session = new themis.SecureSession(new Buffer.from("client"), new Buffer.from("UkVDMgAAAC3DZR2qAEbvO092R/IKXBttnf9dVSU65R+Fb4eNoyxxlzn2n4GR","base64"), function(id){
     if(id.toString()=="server".toString()){
-	return new Buffer("VUVDMgAAAC30/vs+AwciK6egi82A9TkTydVuOzMFsJ9AkA0gMGyNH0tSu5Bk", "base64");
+	return new Buffer.from("VUVDMgAAAC30/vs+AwciK6egi82A9TkTydVuOzMFsJ9AkA0gMGyNH0tSu5Bk", "base64");
     }
     else if(id.toString()=="client".toString())
-	return new Buffer("VUVDMgAAAC15KNjgAr1DQEw+So1oztUarO4Jw/CGgyehBRCbOxbpHrPBKO7s", "base64");
+	return new Buffer.from("VUVDMgAAAC15KNjgAr1DQEw+So1oztUarO4Jw/CGgyehBRCbOxbpHrPBKO7s", "base64");
 });
 
 retry_count=5;
@@ -25,7 +25,7 @@ client.on('data', function(data) {
 	if(d != undefined)
 	    console.log(d.toString());
 	if(retry_count--)
-	    client.write(session.wrap(new Buffer("Hello server!!!")));
+	    client.write(session.wrap(new Buffer.from("Hello server!!!")));
 	else
 	    client.destroy();
     }

--- a/docs/examples/js/secure_session_server.js
+++ b/docs/examples/js/secure_session_server.js
@@ -3,11 +3,11 @@ var themis = require('jsthemis');
 
 var server = net.createServer(function(socket) {
 
-    session = new themis.SecureSession(new Buffer("server"), new Buffer("UkVDMgAAAC0U6AK7AAm6ha0cgHmovSTpZax01+icg9xwFlZAqqGWeGTqbHUt","base64"), function(id){
+    session = new themis.SecureSession(new Buffer.from("server"), new Buffer.from("UkVDMgAAAC0U6AK7AAm6ha0cgHmovSTpZax01+icg9xwFlZAqqGWeGTqbHUt","base64"), function(id){
 	if(id.toString()=="server".toString())
-	    return new Buffer("VUVDMgAAAC30/vs+AwciK6egi82A9TkTydVuOzMFsJ9AkA0gMGyNH0tSu5Bk", "base64");
+	    return new Buffer.from("VUVDMgAAAC30/vs+AwciK6egi82A9TkTydVuOzMFsJ9AkA0gMGyNH0tSu5Bk", "base64");
 	else if(id.toString()=="client".toString()){
-	    return new Buffer("VUVDMgAAAC15KNjgAr1DQEw+So1oztUarO4Jw/CGgyehBRCbOxbpHrPBKO7s","base64");
+	    return new Buffer.from("VUVDMgAAAC15KNjgAr1DQEw+So1oztUarO4Jw/CGgyehBRCbOxbpHrPBKO7s","base64");
 	}
     });
   

--- a/src/wrappers/themis/jsthemis/package.json
+++ b/src/wrappers/themis/jsthemis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsthemis",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Themis is a data security library, providing users with high-quality security services for secure messaging of any kinds and flexible data storage. Themis is aimed at modern developers, with high level OOP wrappers for Ruby, Python, PHP, Java / Android and iOS / OSX. It is designed with ease of use in mind, high security and cross-platform availability.",
   "main": "build/Release/jsthemis.node",
   "scripts": {
@@ -12,7 +12,7 @@
     "url": "https://www.cossacklabs.com/"
   },
   "dependencies": {
-    "nan": "^2.4.0"
+    "nan": "^2.8.0"
   },
   "license": " Apache-2.0",
   "gypfile": true

--- a/src/wrappers/themis/jsthemis/secure_cell_context_imprint.cpp
+++ b/src/wrappers/themis/jsthemis/secure_cell_context_imprint.cpp
@@ -50,7 +50,7 @@ namespace jsthemis {
       const int argc = 1;
       v8::Local<v8::Value> argv[argc] = { args[0]};
       v8::Local<v8::Function> cons = Nan::New<v8::Function>(constructor);
-      args.GetReturnValue().Set(cons->NewInstance(argc, argv));
+      args.GetReturnValue().Set(Nan::NewInstance(cons, argc, argv).ToLocalChecked());
     }
   }
 

--- a/src/wrappers/themis/jsthemis/secure_cell_seal.cpp
+++ b/src/wrappers/themis/jsthemis/secure_cell_seal.cpp
@@ -50,7 +50,7 @@ namespace jsthemis {
       const int argc = 1;
       v8::Local<v8::Value> argv[argc] = { args[0]};
       v8::Local<v8::Function> cons = Nan::New<v8::Function>(constructor);
-      args.GetReturnValue().Set(cons->NewInstance(argc, argv));
+      args.GetReturnValue().Set(Nan::NewInstance(cons, argc, argv).ToLocalChecked());
     }
   }
 

--- a/src/wrappers/themis/jsthemis/secure_cell_token_protect.cpp
+++ b/src/wrappers/themis/jsthemis/secure_cell_token_protect.cpp
@@ -50,7 +50,7 @@ namespace jsthemis {
       const int argc = 1;
       v8::Local<v8::Value> argv[argc] = { args[0]};
       v8::Local<v8::Function> cons = Nan::New<v8::Function>(constructor);
-      args.GetReturnValue().Set(cons->NewInstance(argc, argv));
+      args.GetReturnValue().Set(Nan::NewInstance(cons, argc, argv).ToLocalChecked());
     }
   }
 

--- a/src/wrappers/themis/jsthemis/secure_comparator.cpp
+++ b/src/wrappers/themis/jsthemis/secure_comparator.cpp
@@ -68,7 +68,7 @@ namespace jsthemis {
       const int argc = 3;
       v8::Local<v8::Value> argv[argc] = { args[0], args[1], args[2]};
       v8::Local<v8::Function> cons = Nan::New<v8::Function>(constructor);
-      args.GetReturnValue().Set(cons->NewInstance(argc, argv));
+      args.GetReturnValue().Set(Nan::NewInstance(cons, argc, argv).ToLocalChecked());
     }
   }
 

--- a/src/wrappers/themis/jsthemis/secure_keygen.cpp
+++ b/src/wrappers/themis/jsthemis/secure_keygen.cpp
@@ -73,7 +73,7 @@ namespace jsthemis {
       const int argc = 2;
       v8::Local<v8::Value> argv[argc] = { args[0], args[1] };
       v8::Local<v8::Function> cons = Nan::New<v8::Function>(constructor);
-      args.GetReturnValue().Set(cons->NewInstance(argc, argv));
+      args.GetReturnValue().Set(Nan::NewInstance(cons, argc, argv).ToLocalChecked());
     }
   }
 

--- a/src/wrappers/themis/jsthemis/secure_message.cpp
+++ b/src/wrappers/themis/jsthemis/secure_message.cpp
@@ -55,7 +55,7 @@ namespace jsthemis {
       const int argc = 2;
       v8::Local<v8::Value> argv[argc] = { args[0], args[1] };
       v8::Local<v8::Function> cons = Nan::New<v8::Function>(constructor);
-      args.GetReturnValue().Set(cons->NewInstance(argc, argv));
+      args.GetReturnValue().Set(Nan::NewInstance(cons, argc, argv).ToLocalChecked());
     }
   }
 

--- a/src/wrappers/themis/jsthemis/secure_session.cpp
+++ b/src/wrappers/themis/jsthemis/secure_session.cpp
@@ -76,7 +76,7 @@ namespace jsthemis {
       const int argc = 3;
       v8::Local<v8::Value> argv[argc] = { args[0], args[1], args[2]};
       v8::Local<v8::Function> cons = Nan::New<v8::Function>(constructor);
-      args.GetReturnValue().Set(cons->NewInstance(argc, argv));
+      args.GetReturnValue().Set(Nan::NewInstance(cons, argc, argv).ToLocalChecked());
     }
   }
 


### PR DESCRIPTION
1. Merge @deszip update for `jsthemis` wrapper #326  (using new NaN API for `NewInstance` call).
2. Update js examples.
3. Test on Node v8, Node v9, Node v10.10 and NaN versions 2.8 - 2.11.
4. Update `package.json` and publish new version of `jsthemis`.
5. Update [Nodejs docs](https://github.com/cossacklabs/themis/wiki/NodeJS-Howto).

Should fix #325 