### PR TITLE
Fix PHP tests by updating SHA of installer

### DIFF
--- a/tests/phpthemis/composer-setup.sh
+++ b/tests/phpthemis/composer-setup.sh
@@ -1,6 +1,14 @@
 #!/bin/bash -e
 
 php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-php -r "if (hash_file('SHA384', 'composer-setup.php') === '544e09ee996cdf60ece3804abc52599c22b1f40f4323403c44d44fdfdd586475ca9813a858088ffbc1f233e9b180f061') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+
+php -r "if (hash_file('SHA384', 'composer-setup.php') === '93b54496392c062774670ac18b134c3b3a95e5a5e5c8f1a9f115f203b75bf9a129d5daa8ba6a13e2cc8a1da0806388a8') 
+  { echo 'Valid signature, continue installation'; } 
+else 
+  { echo 'ERROR: Invalid installer signature, probably installer was updated'; unlink('composer-setup.php'); exit(1); } 
+echo PHP_EOL;"
+
+echo "If installation fails, means installer signature is invalid"
 php composer-setup.php
+RESULT=$?
 php -r "unlink('composer-setup.php');"


### PR DESCRIPTION
Composer installer was updated at some point, I've updated signature of installer and refactor installation code a bit.

Should see more user-friendly messages if installer will be updated again.