### PR TITLE
Allow to disable reference of AES-256-XTS for Themis iOS

### DIFF
--- a/src/soter/boringssl/soter_sym.c
+++ b/src/soter/boringssl/soter_sym.c
@@ -65,8 +65,13 @@ const EVP_CIPHER* algid_to_evp(uint32_t alg){
       return EVP_aes_192_ctr();
     case SOTER_SYM_AES_CTR|SOTER_SYM_128_KEY_LENGTH:
       return EVP_aes_128_ctr();
+// Workaround for using BoringSSL on iOS, because XTS is not included in BoringSSL pod implementation.
+// see https://github.com/CocoaPods/Specs/blob/master/Specs/0/8/a/BoringSSL/10.0.6/BoringSSL.podspec.json#L44
+// see https://github.com/cossacklabs/themis/issues/223#issuecomment-432720576
+#ifndef SOTER_BORINGSSL_DISABLE_XTS
     case SOTER_SYM_AES_XTS|SOTER_SYM_256_KEY_LENGTH:
       return EVP_aes_256_xts();
+#endif
   }
   return NULL;
 }

--- a/src/soter/boringssl/soter_sym.c
+++ b/src/soter/boringssl/soter_sym.c
@@ -65,9 +65,11 @@ const EVP_CIPHER* algid_to_evp(uint32_t alg){
       return EVP_aes_192_ctr();
     case SOTER_SYM_AES_CTR|SOTER_SYM_128_KEY_LENGTH:
       return EVP_aes_128_ctr();
-// Workaround for using BoringSSL on iOS, because XTS is not included in BoringSSL pod implementation.
-// see https://github.com/CocoaPods/Specs/blob/master/Specs/0/8/a/BoringSSL/10.0.6/BoringSSL.podspec.json#L44
-// see https://github.com/cossacklabs/themis/issues/223#issuecomment-432720576
+/* 
+* Workaround for using BoringSSL on iOS, because XTS is not included in BoringSSL pod implementation.
+* see https://github.com/CocoaPods/Specs/blob/master/Specs/0/8/a/BoringSSL/10.0.6/BoringSSL.podspec.json#L44
+* see https://github.com/cossacklabs/themis/issues/223#issuecomment-432720576
+*/
 #ifndef SOTER_BORINGSSL_DISABLE_XTS
     case SOTER_SYM_AES_XTS|SOTER_SYM_256_KEY_LENGTH:
       return EVP_aes_256_xts();

--- a/src/wrappers/themis/Obj-C/objcthemis/objcthemis.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/objcthemis.h
@@ -7,8 +7,8 @@
 	#import <objcthemis/skeygen.h>
 	#import <objcthemis/smessage.h>
 	#import <objcthemis/scomparator.h>
-    #import <objcthemis/ssession.h>
-    #import <objcthemis/serror.h>
+	#import <objcthemis/ssession.h>
+	#import <objcthemis/serror.h>
 
 #endif /* _OBJCTHEMIS_ */
 


### PR DESCRIPTION
Currently building Themis iOS with BoringSSL as backend leads to error:

```
Undefined symbols for architecture x86_64:
  "_EVP_aes_256_xts", referenced from:
      _algid_to_evp in libthemis.a(soter_sym.o)
ld: symbol(s) not found for architecture x86_64
```


AES-256-XTS implementation is missing in [BoringSSL CocoaPod](https://github.com/CocoaPods/Specs/blob/master/Specs/0/8/a/BoringSSL/10.0.6/BoringSSL.podspec.json#L44). BoringSSL CocoaPod is rather popular and used in thousands apps, and probably they had a reason to exclude XTS, so I won't suggest them to change their podspec.

However, Themis is not really using XTS mode (see [search results](https://github.com/cossacklabs/themis/search?utf8=%E2%9C%93&q=SOTER_SYM_AES_XTS&type=)), but `soter_sym` has two references on it (see [soter/openssl/soter_sym](https://github.com/cossacklabs/themis/blob/master/src/soter/openssl/soter_sym.c#L68) and [soter/boringssl/soter_sym](https://github.com/cossacklabs/themis/blob/master/src/soter/boringssl/soter_sym.c#L68)).


I suggest to have a way to exclude references to `EVP_aes_256_xts` for Themis iOS using  `#define SOTER_BORINGSSL_DISABLE_XTS`.

This change won't affect other platforms, but will be used only in `themis.podspec` for iOS.