### PR TITLE
Update Themis iOS tests to use fresh Themis podspec from master

### DIFF
--- a/tests/objcthemis/Podfile
+++ b/tests/objcthemis/Podfile
@@ -22,18 +22,14 @@ inhibit_all_warnings!
 target "objthemis" do
 
   # example should work with head
-  #pod 'themis', :git => "https://github.com/cossacklabs/themis.git"
-
-  pod 'themis', :git => 'https://github.com/cossacklabs/themis', :branch => 'vixentael/ios-boringssl'
+  pod 'themis', :git => "https://github.com/cossacklabs/themis.git"
 
 end
 
 target "objthemis_boring" do
 
   # example should work with head
-  #pod 'themis/themis-boringssl', :git => "https://github.com/cossacklabs/themis.git"
-
-  pod 'themis/themis-boringssl', :git => 'https://github.com/cossacklabs/themis', :branch => 'vixentael/ios-boringssl'
+  pod 'themis/themis-boringssl', :git => "https://github.com/cossacklabs/themis.git"
 
 end
 

--- a/tests/objcthemis/Podfile.lock
+++ b/tests/objcthemis/Podfile.lock
@@ -10,18 +10,26 @@ PODS:
     - themis/themis-openssl (= 0.10.1)
   - themis/themis-boringssl (0.10.1):
     - BoringSSL (~> 10.0)
+    - themis/themis-boringssl/core (= 0.10.1)
     - themis/themis-boringssl/objcwrapper (= 0.10.1)
+  - themis/themis-boringssl/core (0.10.1):
+    - BoringSSL (~> 10.0)
   - themis/themis-boringssl/objcwrapper (0.10.1):
     - BoringSSL (~> 10.0)
+    - themis/themis-boringssl/core
   - themis/themis-openssl (0.10.1):
     - GRKOpenSSLFramework (~> 1.0.1)
+    - themis/themis-openssl/core (= 0.10.1)
     - themis/themis-openssl/objcwrapper (= 0.10.1)
+  - themis/themis-openssl/core (0.10.1):
+    - GRKOpenSSLFramework (~> 1.0.1)
   - themis/themis-openssl/objcwrapper (0.10.1):
     - GRKOpenSSLFramework (~> 1.0.1)
+    - themis/themis-openssl/core
 
 DEPENDENCIES:
-  - themis (from `https://github.com/cossacklabs/themis`, branch `vixentael/ios-boringssl`)
-  - themis/themis-boringssl (from `https://github.com/cossacklabs/themis`, branch `vixentael/ios-boringssl`)
+  - themis (from `https://github.com/cossacklabs/themis.git`)
+  - themis/themis-boringssl (from `https://github.com/cossacklabs/themis.git`)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -30,19 +38,18 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   themis:
-    :branch: vixentael/ios-boringssl
-    :git: https://github.com/cossacklabs/themis
+    :git: https://github.com/cossacklabs/themis.git
 
 CHECKOUT OPTIONS:
   themis:
-    :commit: a9934c2303908e426348c3cc805fc3fecc0943d8
-    :git: https://github.com/cossacklabs/themis
+    :commit: 911bcaf7ebe79afc6606de184492f30976bc2bf8
+    :git: https://github.com/cossacklabs/themis.git
 
 SPEC CHECKSUMS:
   BoringSSL: e10f92a27043805c01071fe815a5cd98ae8212e7
   GRKOpenSSLFramework: 845532a41bd75c6f5b99c9d95b25858357268a78
-  themis: e5ce8f4d78aa46741b7d3100cebfb67d8a1ca3a6
+  themis: c80f35d57e92089078299c3a6f8f4b859206534c
 
-PODFILE CHECKSUM: d9fd0d0456eb117173cc0eb2bc45d8872b6d49f1
+PODFILE CHECKSUM: 75777382b765353e199301afe97759406a56f7a0
 
 COCOAPODS: 1.5.3

--- a/tests/objcthemis/objcthemis.xcodeproj/project.pbxproj
+++ b/tests/objcthemis/objcthemis.xcodeproj/project.pbxproj
@@ -7,8 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0A59E174F159E9266860B285 /* libPods-objthemis_boring.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 40C7BF22CEC5F2B349A2EF03 /* libPods-objthemis_boring.a */; };
 		7308F54F1F717C4500AE0411 /* SecureMessageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7308F54D1F717BF300AE0411 /* SecureMessageTests.m */; };
 		7308F5531F717D2D00AE0411 /* SecureCellTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7308F5521F717D2D00AE0411 /* SecureCellTests.m */; };
+		735D9F866F353EEC816BC9EA /* libPods-objthemis.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B9266FCF4D3BDFBDCEAD6267 /* libPods-objthemis.a */; };
 		7376D8671F7182B70003AF72 /* SecureMessageTestsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7376D8661F7182B70003AF72 /* SecureMessageTestsSwift.swift */; };
 		73CBA59D2012402B003EC7AC /* SecureComparatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 73CBA59C2012402B003EC7AC /* SecureComparatorTests.m */; };
 		73CBA59F20124BB8003EC7AC /* SecureComparatorTestsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73CBA59E20124BB8003EC7AC /* SecureComparatorTestsSwift.swift */; };
@@ -19,14 +21,12 @@
 		73DDCB7F2181517000CD4CBB /* SecureMessageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7308F54D1F717BF300AE0411 /* SecureMessageTests.m */; };
 		73DDCB802181517000CD4CBB /* SecureCellTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7308F5521F717D2D00AE0411 /* SecureCellTests.m */; };
 		73DDCB812181517000CD4CBB /* SecureComparatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 73CBA59C2012402B003EC7AC /* SecureComparatorTests.m */; };
-		8CE51C4D419C58D68198A4AC /* libPods-objthemis_boring.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 64FC1444BF320CDB6D216E64 /* libPods-objthemis_boring.a */; };
-		E2A18D3763F4AA79B1C8B2A9 /* libPods-objthemis.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D88E9A2999BE4618E97033B /* libPods-objthemis.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		2F6EA0651CF16749E3DF8DF2 /* Pods-objthemis.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-objthemis.release.xcconfig"; path = "Pods/Target Support Files/Pods-objthemis/Pods-objthemis.release.xcconfig"; sourceTree = "<group>"; };
-		4BFAC3193EC111C952C441E6 /* Pods-objthemis_boring.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-objthemis_boring.release.xcconfig"; path = "Pods/Target Support Files/Pods-objthemis_boring/Pods-objthemis_boring.release.xcconfig"; sourceTree = "<group>"; };
-		64FC1444BF320CDB6D216E64 /* libPods-objthemis_boring.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-objthemis_boring.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		26D906F27F31E9CE04E9C7F1 /* Pods-objthemis_boring.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-objthemis_boring.debug.xcconfig"; path = "Pods/Target Support Files/Pods-objthemis_boring/Pods-objthemis_boring.debug.xcconfig"; sourceTree = "<group>"; };
+		40C7BF22CEC5F2B349A2EF03 /* libPods-objthemis_boring.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-objthemis_boring.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		667D1BA31CC54276E7B69943 /* Pods-objthemis.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-objthemis.release.xcconfig"; path = "Pods/Target Support Files/Pods-objthemis/Pods-objthemis.release.xcconfig"; sourceTree = "<group>"; };
 		7308F54D1F717BF300AE0411 /* SecureMessageTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SecureMessageTests.m; sourceTree = "<group>"; };
 		7308F5521F717D2D00AE0411 /* SecureCellTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SecureCellTests.m; sourceTree = "<group>"; };
 		7376D8651F7182B70003AF72 /* objthemis-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "objthemis-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -37,11 +37,11 @@
 		73D358201F71E6F9004E000A /* StaticKeys.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StaticKeys.h; sourceTree = "<group>"; };
 		73D358211F71F06B004E000A /* SecureCellTestsSwift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureCellTestsSwift.swift; sourceTree = "<group>"; };
 		73DDCB882181517000CD4CBB /* objthemis_boring.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = objthemis_boring.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		7D88E9A2999BE4618E97033B /* libPods-objthemis.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-objthemis.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		8296B08908FC2488923F8D38 /* Pods-objthemis_boring.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-objthemis_boring.debug.xcconfig"; path = "Pods/Target Support Files/Pods-objthemis_boring/Pods-objthemis_boring.debug.xcconfig"; sourceTree = "<group>"; };
+		77229469EFA9482F570BD657 /* Pods-objthemis_boring.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-objthemis_boring.release.xcconfig"; path = "Pods/Target Support Files/Pods-objthemis_boring/Pods-objthemis_boring.release.xcconfig"; sourceTree = "<group>"; };
 		843EE74E1B5E1A36003F0138 /* objthemis.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = objthemis.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		843EE7521B5E1A36003F0138 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		B8D41FD17E6C314B81358DDB /* Pods-objthemis.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-objthemis.debug.xcconfig"; path = "Pods/Target Support Files/Pods-objthemis/Pods-objthemis.debug.xcconfig"; sourceTree = "<group>"; };
+		B9266FCF4D3BDFBDCEAD6267 /* libPods-objthemis.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-objthemis.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E6456FB392A8604B41E4B1EC /* Pods-objthemis.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-objthemis.debug.xcconfig"; path = "Pods/Target Support Files/Pods-objthemis/Pods-objthemis.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -49,7 +49,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8CE51C4D419C58D68198A4AC /* libPods-objthemis_boring.a in Frameworks */,
+				0A59E174F159E9266860B285 /* libPods-objthemis_boring.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -57,29 +57,29 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E2A18D3763F4AA79B1C8B2A9 /* libPods-objthemis.a in Frameworks */,
+				735D9F866F353EEC816BC9EA /* libPods-objthemis.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		3F7066E6228816033AE785D6 /* Pods */ = {
+		0E59F6585F26D585AF0D2567 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				B8D41FD17E6C314B81358DDB /* Pods-objthemis.debug.xcconfig */,
-				2F6EA0651CF16749E3DF8DF2 /* Pods-objthemis.release.xcconfig */,
-				8296B08908FC2488923F8D38 /* Pods-objthemis_boring.debug.xcconfig */,
-				4BFAC3193EC111C952C441E6 /* Pods-objthemis_boring.release.xcconfig */,
+				E6456FB392A8604B41E4B1EC /* Pods-objthemis.debug.xcconfig */,
+				667D1BA31CC54276E7B69943 /* Pods-objthemis.release.xcconfig */,
+				26D906F27F31E9CE04E9C7F1 /* Pods-objthemis_boring.debug.xcconfig */,
+				77229469EFA9482F570BD657 /* Pods-objthemis_boring.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
 		};
-		769AA8F9A70AACEE0994C98E /* Frameworks */ = {
+		34AC31C52377FB45730FEE0D /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				7D88E9A2999BE4618E97033B /* libPods-objthemis.a */,
-				64FC1444BF320CDB6D216E64 /* libPods-objthemis_boring.a */,
+				B9266FCF4D3BDFBDCEAD6267 /* libPods-objthemis.a */,
+				40C7BF22CEC5F2B349A2EF03 /* libPods-objthemis_boring.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -89,8 +89,8 @@
 			children = (
 				843EE7501B5E1A36003F0138 /* objthemis */,
 				843EE74F1B5E1A36003F0138 /* Products */,
-				3F7066E6228816033AE785D6 /* Pods */,
-				769AA8F9A70AACEE0994C98E /* Frameworks */,
+				0E59F6585F26D585AF0D2567 /* Pods */,
+				34AC31C52377FB45730FEE0D /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -135,7 +135,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 73DDCB852181517000CD4CBB /* Build configuration list for PBXNativeTarget "objthemis_boring" */;
 			buildPhases = (
-				8CA38DF7AB7AA773B8E0675C /* [CP] Check Pods Manifest.lock */,
+				3D714C22058A6495F63D5C2D /* [CP] Check Pods Manifest.lock */,
 				73DDCB7B2181517000CD4CBB /* Sources */,
 				73DDCB822181517000CD4CBB /* Frameworks */,
 				73DDCB842181517000CD4CBB /* Resources */,
@@ -153,11 +153,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 843EE7551B5E1A36003F0138 /* Build configuration list for PBXNativeTarget "objthemis" */;
 			buildPhases = (
-				5DFE19144E919AE6F39434AD /* [CP] Check Pods Manifest.lock */,
+				B0B4E3DF68139B2EEAEEDB1F /* [CP] Check Pods Manifest.lock */,
 				843EE74A1B5E1A36003F0138 /* Sources */,
 				843EE74B1B5E1A36003F0138 /* Frameworks */,
 				843EE74C1B5E1A36003F0138 /* Resources */,
-				2E6A5E92FD1EEFCE9D81D2FF /* [CP] Embed Pods Frameworks */,
+				7347F2D56C8226159DC7C98C /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -221,7 +221,29 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		2E6A5E92FD1EEFCE9D81D2FF /* [CP] Embed Pods Frameworks */ = {
+		3D714C22058A6495F63D5C2D /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-objthemis_boring-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		7347F2D56C8226159DC7C98C /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -243,7 +265,7 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-objthemis/Pods-objthemis-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		5DFE19144E919AE6F39434AD /* [CP] Check Pods Manifest.lock */ = {
+		B0B4E3DF68139B2EEAEEDB1F /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -259,28 +281,6 @@
 			);
 			outputPaths = (
 				"$(DERIVED_FILE_DIR)/Pods-objthemis-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		8CA38DF7AB7AA773B8E0675C /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-objthemis_boring-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -321,7 +321,7 @@
 /* Begin XCBuildConfiguration section */
 		73DDCB862181517000CD4CBB /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8296B08908FC2488923F8D38 /* Pods-objthemis_boring.debug.xcconfig */;
+			baseConfigurationReference = 26D906F27F31E9CE04E9C7F1 /* Pods-objthemis_boring.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -376,7 +376,7 @@
 		};
 		73DDCB872181517000CD4CBB /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4BFAC3193EC111C952C441E6 /* Pods-objthemis_boring.release.xcconfig */;
+			baseConfigurationReference = 77229469EFA9482F570BD657 /* Pods-objthemis_boring.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -489,7 +489,7 @@
 		};
 		843EE7561B5E1A36003F0138 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B8D41FD17E6C314B81358DDB /* Pods-objthemis.debug.xcconfig */;
+			baseConfigurationReference = E6456FB392A8604B41E4B1EC /* Pods-objthemis.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -543,7 +543,7 @@
 		};
 		843EE7571B5E1A36003F0138 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2F6EA0651CF16749E3DF8DF2 /* Pods-objthemis.release.xcconfig */;
+			baseConfigurationReference = 667D1BA31CC54276E7B69943 /* Pods-objthemis.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";


### PR DESCRIPTION
A final PR for Themis iOS BoringSSL support (#330 #329) – I've updated Themis iOS tests to use latest podspec from master.