### PR TITLE
 Fix themis_gen_rsa_key_pair return logic

### DIFF
--- a/src/themis/secure_message.c
+++ b/src/themis/secure_message.c
@@ -52,6 +52,7 @@ themis_status_t themis_gen_rsa_key_pair(uint8_t* private_key,
 				    uint8_t* public_key,
 				    size_t* public_key_length){
   soter_rsa_key_pair_gen_t* key_pair_ctx=soter_rsa_key_pair_gen_create(THEMIS_RSA_KEY_LENGTH);
+  THEMIS_CHECK(key_pair_ctx!=NULL);
   soter_status_t res=soter_rsa_key_pair_gen_export_key(key_pair_ctx, private_key, private_key_length, true);
   if(res!=THEMIS_SUCCESS && res != THEMIS_BUFFER_TOO_SMALL){
     soter_rsa_key_pair_gen_destroy(key_pair_ctx);

--- a/src/themis/secure_message.c
+++ b/src/themis/secure_message.c
@@ -31,7 +31,7 @@ themis_status_t themis_gen_key_pair(soter_sign_alg_t alg,
   soter_sign_ctx_t* ctx=soter_sign_create(alg,NULL,0,NULL,0);
   THEMIS_CHECK(ctx!=NULL);
   soter_status_t res=soter_sign_export_key(ctx, private_key, private_key_length, true);
-  if(res!=THEMIS_SUCCESS && res != THEMIS_BUFFER_TOO_SMALL){
+  if(res!=THEMIS_SUCCESS && res!=THEMIS_BUFFER_TOO_SMALL){
     soter_sign_destroy(ctx);
     return res;
   }
@@ -52,10 +52,21 @@ themis_status_t themis_gen_rsa_key_pair(uint8_t* private_key,
 				    uint8_t* public_key,
 				    size_t* public_key_length){
   soter_rsa_key_pair_gen_t* key_pair_ctx=soter_rsa_key_pair_gen_create(THEMIS_RSA_KEY_LENGTH);
-  themis_status_t res=soter_rsa_key_pair_gen_export_key(key_pair_ctx, private_key, private_key_length, true);
-  themis_status_t res1=soter_rsa_key_pair_gen_export_key(key_pair_ctx, public_key, public_key_length, false);
+  soter_status_t res=soter_rsa_key_pair_gen_export_key(key_pair_ctx, private_key, private_key_length, true);
+  if(res!=THEMIS_SUCCESS && res != THEMIS_BUFFER_TOO_SMALL){
+    soter_rsa_key_pair_gen_destroy(key_pair_ctx);
+    return res;
+  }
+  soter_status_t res2=soter_rsa_key_pair_gen_export_key(key_pair_ctx, public_key, public_key_length, false);
+  if(res2!=THEMIS_SUCCESS && res2!=THEMIS_BUFFER_TOO_SMALL){
+    soter_rsa_key_pair_gen_destroy(key_pair_ctx);
+    return res2;
+  }
   soter_rsa_key_pair_gen_destroy(key_pair_ctx);
-  return (res<res1)?res:res1;
+  if(res==THEMIS_BUFFER_TOO_SMALL || res2==THEMIS_BUFFER_TOO_SMALL){
+    return THEMIS_BUFFER_TOO_SMALL;
+  }
+  return THEMIS_SUCCESS;
 }
 
 themis_status_t themis_gen_ec_key_pair(uint8_t* private_key,


### PR DESCRIPTION
The function is "overoptimised": even if the private key export fails with
"buffer too small", the overall return value will be success because of the
incorrect return logic. Make the logic same as in `themis_gen_key_pair`, which
works.

Fixes #333 