### PR TITLE
Initial Rust binding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,8 @@ docs/examples/Themis-server/swift/Pods
 docs/examples/Themis-server/Obj-C/Pods
 docs/examples/swift/Pods
 docs/examples/objc/Pods
+
+# rust
+/target
+**/*.rs.bk
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,75 @@
+[package]
+name = "themis"
+version = "0.0.2"
+authors = ["rust-themis developers"]
+description = "High-level cryptographic services for storage and messaging"
+homepage = "https://www.cossacklabs.com/themis/"
+repository = "https://github.com/cossacklabs/themis"
+readme = "src/wrappers/themis/rust/README.md"
+keywords = ["crypto", "Themis"]
+categories = ["cryptography", "api-bindings"]
+license = "Apache-2.0"
+include = [
+    "Cargo.toml",
+    "docs/examples/rust/**/*",
+    "src/wrappers/themis/rust/**/*",
+    "tests/rust/**/*",
+]
+
+[workspace]
+
+[lib]
+path = "src/wrappers/themis/rust/src/lib.rs"
+
+[[example]]
+name = "keygen"
+path = "docs/examples/rust/keygen.rs"
+
+[[example]]
+name = "secure_cell"
+path = "docs/examples/rust/secure_cell.rs"
+
+[[example]]
+name = "secure_compare"
+path = "docs/examples/rust/secure_compare.rs"
+
+[[example]]
+name = "secure_message_client_encrypt"
+path = "docs/examples/rust/secure_message_client_encrypt.rs"
+
+[[example]]
+name = "secure_message_client_verify"
+path = "docs/examples/rust/secure_message_client_verify.rs"
+
+[[example]]
+name = "secure_message_server"
+path = "docs/examples/rust/secure_message_server.rs"
+
+[[test]]
+name = "keys"
+path = "tests/rust/keys.rs"
+
+[[test]]
+name = "secure_cell"
+path = "tests/rust/secure_cell.rs"
+
+[[test]]
+name = "secure_comparator"
+path = "tests/rust/secure_comparator.rs"
+
+[[test]]
+name = "secure_message"
+path = "tests/rust/secure_message.rs"
+
+[[test]]
+name = "secure_session"
+path = "tests/rust/secure_session.rs"
+
+[dependencies]
+libthemis-sys = { path = "src/wrappers/themis/rust/libthemis-sys", version = "=0.0.2" }
+
+[dev-dependencies]
+byteorder = "1.2.7"
+clap = "2.32"
+log = "0.4.5"
+env_logger = "0.5.13"

--- a/docs/examples/rust/README.md
+++ b/docs/examples/rust/README.md
@@ -1,0 +1,150 @@
+Here we have some examples of Themis usage.
+
+* [**keygen**](keygen.rs) —
+  a tool for generating ECDSA keys (usable by other examples) 
+* [**secure_cell**](secure_cell.rs) —
+  simple file encryption/decryption based on Secure Cell
+* [**secure_compare**](secure_compare.rs) —
+  zero-knowledge secret comparison based on Secure Comparator
+* <b>secure_message_*</b> —
+  secure group chat implemented with Secure Messages 
+  * [**secure_message_server**](secure_message_server.rs) —
+    simple relay server
+  * [**secure_message_client_encrypt**](secure_message_client_encrypt.rs) —
+    chat client which encrypts messages
+  * [**secure_message_client_verify**](secure_message_client_verify.rs) —
+    chat client which signs and verifies messages
+
+You can run the examples with Cargo like this:
+
+```console
+$ cargo run --example keygen -- --help
+keygen 0.0.1
+Generating private-public ECDSA key pairs.
+
+USAGE:
+    keygen [OPTIONS]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+        --private <path>    Private key file (default: private.key)
+        --public <path>     Public key file (default: public.key)
+```
+
+Note that the arguments are passed after `--`.
+
+
+## keygen
+
+This tool can be used to generate key files usable by other examples.
+
+Themis supports RSA keys for some use-cases,
+but most of the features expect ECDSA keys.
+
+
+## secure_cell
+
+This is a simple file encryption tool.
+It supports only seal mode of _Secure Cell_.
+
+
+## secure_compare
+
+This tool can be used to compare secrets over network
+without actually sharing them.
+It is made possible by _Secure Comparator_.
+
+The tool includes both the server and the client
+selectable via command-line.
+Both accept the secrets on the _standard input_
+and start comparison after input is complete
+(use Ctrl-D in a typical terminal for this).
+
+Typical comparison session looks like this:
+
+```console
+$ echo "secret" | cargo run --example secure_compare -- server
+[+] match OK
+```
+
+```console
+$ cargo run --example secure_compare -- client
+secret
+^D
+[+] match OK
+```
+
+
+## secure_message
+
+This is a more involved example of relay chat over UDP using _Secure Messages_.
+It is deliberately kept simple,
+but the same principle can be applied to properly framed TCP transports
+as well as to using Tokio for async IO instead of blocking stdlib.
+
+Usually you don't need to specify any custom options,
+the command-line defaults are expected to work right away.
+But you can override the defaults for port assignment and key file locations if necessary.
+
+First you'll need to generate the keys for clients.
+It also may be useful to enable logging before starting the server.
+This example uses [`env_logger` crate][env_logger] for logging
+which is configurable via environment variable `RUST_LOG`.
+
+[env_logger]: https://docs.rs/env_logger/0.6.0/env_logger/
+
+```console
+$ export RUST_LOG=secure_message=info
+$ cargo run --example keygen
+```
+
+Then you can start up the server as well as some clients
+(in separate terminal sessions):
+
+```console
+$ cargo run --example secure_message_server
+ INFO 2018-09-30T19:39:49Z: secure_message_server: listening on port 7573
+ INFO 2018-09-30T19:40:33Z: secure_message_server: new peer: [::1]:56375
+ INFO 2018-09-30T19:40:36Z: secure_message_server: new peer: [::1]:56376
+```
+
+```console
+$ cargo run --example secure_message_client_encrypt
+2: hello
+1: hello
+```
+
+The first message from the client will introduce it to the server
+after which the server will relay other clients' messages to the newly joined peer.
+(Sorry, you'll have to manually type in nicknames at the moment.)
+
+The clients use the generated keys to secure communications.
+You can observe the exchange with `tcpdump`:
+
+```console
+$ sudo tcpdump -i any -n -X udp port 7573
+tcpdump: data link type PKTAP
+tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
+listening on any, link-type PKTAP (Apple DLT_PKTAP), capture size 262144 bytes
+22:45:11.587870 IP6 ::1.56375 > ::1.7573: UDP, length 63
+	0x0000:  1e00 0000 6004 da0e 0047 1140 0000 0000  ....`....G.@....
+	0x0010:  0000 0000 0000 0000 0000 0001 0000 0000  ................
+	0x0020:  0000 0000 0000 0000 0000 0001 dc37 1d95  .............7..
+	0x0030:  0047 005a 2027 0426 3f00 0000 0001 0140  .G.Z.'.&?......@
+	0x0040:  0c00 0000 1000 0000 0b00 0000 9786 7d70  ..............}p
+	0x0050:  080f 1812 8aeb 0a92 18ca 91fb 008e 355c  ..............5\
+	0x0060:  8e6a 657b 05f1 a365 3e40 a921 50cd 9a8c  .je{...e>@.!P...
+	0x0070:  6825 9a                                  h%.
+```
+
+Some notable things about this example:
+
+* The relay server has _zero knowledge_ of the encrypted message content.
+* The sign/verify client does not encrypt the messages
+  (as you may see with `tcpdump`).
+  But it still verifies their integrity.
+
+Currently all clients are expected to use the same keys.

--- a/docs/examples/rust/keygen.rs
+++ b/docs/examples/rust/keygen.rs
@@ -1,0 +1,50 @@
+// Copyright 2018 (c) rust-themis developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[macro_use]
+extern crate clap;
+extern crate themis;
+
+use std::fs::File;
+use std::io::{self, Write};
+
+use themis::keygen::gen_ec_key_pair;
+
+fn main() {
+    let matches = clap_app!(keygen =>
+        (version: env!("CARGO_PKG_VERSION"))
+        (about: "Generating ECDSA key pairs.")
+        (@arg secret: --secret [path] "Secret key file (default: secret.key)")
+        (@arg public: --public [path] "Public key file (default: public.key)")
+    ).get_matches();
+    let secret_path = matches.value_of("secret").unwrap_or("secret.key");
+    let public_path = matches.value_of("public").unwrap_or("public.key");
+
+    let (secret_key, public_key) = gen_ec_key_pair().split();
+
+    match write_file(&secret_key, &secret_path) {
+        Ok(_) => eprintln!("wrote secret key to {}", secret_path),
+        Err(e) => eprintln!("failed to write secret key to {}: {}", secret_path, e),
+    }
+    match write_file(&public_key, &public_path) {
+        Ok(_) => eprintln!("wrote public key to {}", public_path),
+        Err(e) => eprintln!("failed to write public key to {}: {}", public_path, e),
+    }
+}
+
+fn write_file<K: AsRef<[u8]>>(key: K, path: &str) -> io::Result<()> {
+    let mut file = File::create(path)?;
+    file.write_all(key.as_ref())?;
+    Ok(())
+}

--- a/docs/examples/rust/secure_cell.rs
+++ b/docs/examples/rust/secure_cell.rs
@@ -1,0 +1,70 @@
+// Copyright 2018 (c) rust-themis developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[macro_use]
+extern crate clap;
+extern crate themis;
+
+use std::fs::File;
+use std::io::{self, Read, Write};
+
+use themis::secure_cell::SecureCell;
+
+fn main() {
+    let matches = clap_app!(secure_cell =>
+        (version: env!("CARGO_PKG_VERSION"))
+        (about: "Simple encryption with Secure Cell.")
+        (@group mode =>
+            (@arg encrypt: -e --encrypt "Encrypt the input [default]")
+            (@arg decrypt: -d --decrypt "Decrypt the input")
+        )
+        (@arg password: -p --password <string> "Password to use")
+        (@arg input:  +required "Input file")
+        (@arg output: +required "Output file")
+    ).get_matches();
+
+    let encrypt = !matches.is_present("decrypt");
+    let password = matches.value_of("password").unwrap();
+    let input_path = matches.value_of("input").unwrap();
+    let output_path = matches.value_of("output").unwrap();
+
+    let cell = SecureCell::with_key(&password).seal();
+
+    let input = read_file(&input_path).unwrap();
+    let output = if encrypt {
+        cell.encrypt(&input).unwrap()
+    } else {
+        cell.decrypt(&input).unwrap()
+    };
+    write_file(&output_path, &output).unwrap();
+
+    if encrypt {
+        eprintln!("encrypted {} as {}", input_path, output_path);
+    } else {
+        eprintln!("decrypted {} into {}", input_path, output_path);
+    }
+}
+
+fn read_file(path: &str) -> Result<Vec<u8>, io::Error> {
+    let mut file = File::open(path)?;
+    let mut content = Vec::new();
+    file.read_to_end(&mut content)?;
+    Ok(content)
+}
+
+fn write_file(path: &str, data: &[u8]) -> Result<(), io::Error> {
+    let mut file = File::create(path)?;
+    file.write_all(data)?;
+    Ok(())
+}

--- a/docs/examples/rust/secure_compare.rs
+++ b/docs/examples/rust/secure_compare.rs
@@ -1,0 +1,115 @@
+// Copyright 2018 (c) rust-themis developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate byteorder;
+#[macro_use]
+extern crate clap;
+extern crate themis;
+
+use std::io::{self, Read, Write};
+use std::net::{TcpListener, TcpStream};
+
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use themis::secure_comparator::SecureComparator;
+
+fn main() {
+    let matches = clap_app!(secure_compare =>
+        (version: env!("CARGO_PKG_VERSION"))
+        (about: "Zero-knowledge secret comparison with Secure Comparator.")
+        (after_help:
+            "Both the client and the server expect to read the secret from standard input\n\
+             until the end before they proceed with comparison. Usually this is achieved\n\
+             by piping a file into them. You can use interactive terminal as well, just\n\
+             make sure to terminate the stream with ^D.")
+        (@subcommand server =>
+            (about: "Expect a client for comparison")
+            (@arg port: -p --port [number] "Listening port (default: 7575)")
+        )
+        (@subcommand client =>
+            (about: "Connect to server for comparison")
+            (@arg address: -c --connect [address] "Server address (default: [::1]:7575)")
+        )
+    ).get_matches();
+
+    let mut comparison = SecureComparator::new();
+
+    let mut buffer = [0; 4096];
+    loop {
+        let bytes = io::stdin().read(&mut buffer).expect("read secret");
+        if bytes == 0 {
+            break;
+        }
+        comparison
+            .append_secret(&buffer[..bytes])
+            .expect("append secret");
+    }
+
+    if let Some(matches) = matches.subcommand_matches("client") {
+        let address = matches.value_of("address").unwrap_or("[::1]:7575");
+        let mut server = TcpStream::connect(address).expect("client connect");
+
+        let mut request = comparison.begin_compare().expect("begin");
+
+        while !comparison.is_complete() {
+            send_msg(&request, &mut server).expect("send");
+            let reply = receive_msg(&mut server).expect("receive");
+            request = comparison.proceed_compare(&reply).expect("proceed");
+        }
+    }
+
+    if let Some(matches) = matches.subcommand_matches("server") {
+        let port = matches
+            .value_of("port")
+            .unwrap_or("7575")
+            .parse()
+            .expect("port number");
+        let (mut client, _) = TcpListener::bind(("::", port))
+            .expect("server bind")
+            .accept()
+            .expect("client accept");
+
+        while !comparison.is_complete() {
+            let request = receive_msg(&mut client).expect("receive");
+            let reply = comparison.proceed_compare(&request).expect("proceed");
+            send_msg(&reply, &mut client).expect("send");
+        }
+    }
+
+    if comparison.get_result().expect("result") {
+        println!("[+] match OK");
+    } else {
+        println!("[-] no match");
+    }
+}
+
+// TCP is a streaming protocol so we'll need to frame our messages. We use a simple approach:
+// prefix each message with its length in bytes serialized as a 4-byte value in little endian.
+
+fn send_msg(message: &[u8], peer: &mut TcpStream) -> io::Result<()> {
+    if message.len() > u32::max_value() as usize {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "too big message",
+        ));
+    }
+    peer.write_u32::<LittleEndian>(message.len() as u32)?;
+    peer.write_all(&message)
+}
+
+fn receive_msg(peer: &mut TcpStream) -> io::Result<Vec<u8>> {
+    let len = peer.read_u32::<LittleEndian>()?;
+    let mut msg = vec![0; len as usize];
+    peer.read_exact(&mut msg)?;
+    Ok(msg)
+}

--- a/docs/examples/rust/secure_message_client_encrypt.rs
+++ b/docs/examples/rust/secure_message_client_encrypt.rs
@@ -1,0 +1,114 @@
+// Copyright 2018 (c) rust-themis developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[macro_use]
+extern crate clap;
+extern crate env_logger;
+extern crate themis;
+#[macro_use]
+extern crate log;
+
+use std::fs::File;
+use std::io::{self, Read, Write};
+use std::net::UdpSocket;
+use std::sync::Arc;
+use std::thread;
+
+use themis::keys::{KeyPair, PublicKey, SecretKey};
+use themis::secure_message::SecureMessage;
+
+fn main() {
+    env_logger::init();
+
+    let matches = clap_app!(secure_message_client_encrypt =>
+        (version: env!("CARGO_PKG_VERSION"))
+        (about: "Secure Message chat client (encrypt).")
+        (@arg secret: --secret [path] "Secret key file (default: secret.key)")
+        (@arg public: --public [path] "Public key file (default: public.key)")
+        (@arg address: -c --connect [addr] "Relay server address (default: localhost:7573)")
+    ).get_matches();
+
+    let secret_path = matches.value_of("secret").unwrap_or("secret.key");
+    let public_path = matches.value_of("public").unwrap_or("public.key");
+    let remote_addr = matches.value_of("address").unwrap_or("localhost:7573");
+
+    let secret_key = read_file(&secret_path).expect("read secret key");
+    let secret_key = SecretKey::try_from_slice(secret_key).expect("parse secret key");
+    let public_key = read_file(&public_path).expect("read public key");
+    let public_key = PublicKey::try_from_slice(public_key).expect("parse public key");
+    let key_pair = KeyPair::try_join(secret_key, public_key).expect("matching keys");
+
+    let socket = UdpSocket::bind("localhost:0").expect("client socket");
+    socket.connect(&remote_addr).expect("client connection");
+
+    let receive_socket = socket;
+    let relay_socket = receive_socket.try_clone().unwrap();
+
+    // SecureMessage objects are stateless so they can be shared between threads without issues.
+    // Also note that SecureMessage API is deliberately different from SecureSign/SecureVerify.
+    let receive_secure = Arc::new(SecureMessage::new(key_pair));
+    let relay_secure = receive_secure.clone();
+
+    let receive = thread::spawn(move || {
+        let receive_message = || -> io::Result<()> {
+            let buffer = recv(&receive_socket)?;
+            let message = receive_secure.unwrap(&buffer).map_err(themis_as_io_error)?;
+            io::stdout().write_all(&message)?;
+            Ok(())
+        };
+        loop {
+            if let Err(e) = receive_message() {
+                error!("failed to receive message: {}", e);
+                break;
+            }
+        }
+    });
+
+    let relay = thread::spawn(move || {
+        let relay_message = || -> io::Result<()> {
+            let mut buffer = String::new();
+            io::stdin().read_line(&mut buffer)?;
+            let message = relay_secure.wrap(&buffer).map_err(themis_as_io_error)?;
+            relay_socket.send(&message)?;
+            Ok(())
+        };
+        loop {
+            if let Err(e) = relay_message() {
+                error!("failed to relay message: {}", e);
+                break;
+            }
+        }
+    });
+
+    receive.join().unwrap();
+    relay.join().unwrap();
+}
+
+fn read_file(path: &str) -> io::Result<Vec<u8>> {
+    let mut file = File::open(path)?;
+    let mut content = Vec::new();
+    file.read_to_end(&mut content)?;
+    Ok(content)
+}
+
+fn recv(socket: &UdpSocket) -> io::Result<Vec<u8>> {
+    let mut message = vec![0; 65536];
+    let length = socket.recv(&mut message)?;
+    message.truncate(length);
+    Ok(message)
+}
+
+fn themis_as_io_error(e: themis::Error) -> io::Error {
+    io::Error::new(io::ErrorKind::Other, e)
+}

--- a/docs/examples/rust/secure_message_client_verify.rs
+++ b/docs/examples/rust/secure_message_client_verify.rs
@@ -1,0 +1,112 @@
+// Copyright 2018 (c) rust-themis developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[macro_use]
+extern crate clap;
+extern crate env_logger;
+extern crate themis;
+#[macro_use]
+extern crate log;
+
+use std::fs::File;
+use std::io::{self, Read, Write};
+use std::net::UdpSocket;
+use std::thread;
+
+use themis::keys::{PublicKey, SecretKey};
+use themis::secure_message::{SecureSign, SecureVerify};
+
+fn main() {
+    env_logger::init();
+
+    let matches = clap_app!(secure_message_client_verify =>
+        (version: env!("CARGO_PKG_VERSION"))
+        (about: "Secure Message chat client (sign/verify).")
+        (@arg secret: --secret [path] "Secret key file (default: secret.key)")
+        (@arg public: --public [path] "Public key file (default: public.key)")
+        (@arg address: -c --connect [addr] "Relay server address (default: localhost:7573)")
+    ).get_matches();
+
+    let secret_path = matches.value_of("secret").unwrap_or("secret.key");
+    let public_path = matches.value_of("public").unwrap_or("public.key");
+    let remote_addr = matches.value_of("address").unwrap_or("localhost:7573");
+
+    let secret_key = read_file(&secret_path).expect("read secret key");
+    let secret_key = SecretKey::try_from_slice(secret_key).expect("parse secret key");
+    let public_key = read_file(&public_path).expect("read public key");
+    let public_key = PublicKey::try_from_slice(public_key).expect("parse public key");
+
+    let socket = UdpSocket::bind("localhost:0").expect("client socket");
+    socket.connect(&remote_addr).expect("client connection");
+
+    let receive_socket = socket;
+    let relay_socket = receive_socket.try_clone().unwrap();
+
+    // Each of the threads is using its own object for message processing.
+    // Also note that SecureSign/SecureVerify API is deliberately different from SecureMessage.
+    let receive_secure = SecureVerify::new(public_key);
+    let relay_secure = SecureSign::new(secret_key);
+
+    let receive = thread::spawn(move || {
+        let receive_message = || -> io::Result<()> {
+            let buffer = recv(&receive_socket)?;
+            let message = receive_secure.verify(&buffer).map_err(themis_as_io_error)?;
+            io::stdout().write_all(&message)?;
+            Ok(())
+        };
+        loop {
+            if let Err(e) = receive_message() {
+                error!("failed to receive message: {}", e);
+                break;
+            }
+        }
+    });
+
+    let relay = thread::spawn(move || {
+        let relay_message = || -> io::Result<()> {
+            let mut buffer = String::new();
+            io::stdin().read_line(&mut buffer)?;
+            let message = relay_secure.sign(&buffer).map_err(themis_as_io_error)?;
+            relay_socket.send(&message)?;
+            Ok(())
+        };
+        loop {
+            if let Err(e) = relay_message() {
+                error!("failed to relay message: {}", e);
+                break;
+            }
+        }
+    });
+
+    receive.join().unwrap();
+    relay.join().unwrap();
+}
+
+fn read_file(path: &str) -> io::Result<Vec<u8>> {
+    let mut file = File::open(path)?;
+    let mut content = Vec::new();
+    file.read_to_end(&mut content)?;
+    Ok(content)
+}
+
+fn recv(socket: &UdpSocket) -> io::Result<Vec<u8>> {
+    let mut message = vec![0; 65536];
+    let length = socket.recv(&mut message)?;
+    message.truncate(length);
+    Ok(message)
+}
+
+fn themis_as_io_error(e: themis::Error) -> io::Error {
+    io::Error::new(io::ErrorKind::Other, e)
+}

--- a/docs/examples/rust/secure_message_server.rs
+++ b/docs/examples/rust/secure_message_server.rs
@@ -1,0 +1,74 @@
+// Copyright 2018 (c) rust-themis developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[macro_use]
+extern crate clap;
+extern crate env_logger;
+#[macro_use]
+extern crate log;
+
+use std::collections::HashSet;
+use std::io;
+use std::net::{SocketAddr, UdpSocket};
+
+fn main() {
+    env_logger::init();
+
+    let matches = clap_app!(secure_message_server =>
+        (version: env!("CARGO_PKG_VERSION"))
+        (about: "Relay server for Secure Message chat client.")
+        (@arg port: -p --port [number] "Listening port (default: 7573)")
+    ).get_matches();
+
+    let port = matches.value_of("port").unwrap_or("7573").parse().unwrap();
+    let listen_addr = SocketAddr::new([0; 16].into(), port);
+
+    let socket = UdpSocket::bind(&listen_addr).expect("server listen");
+    let mut peers = HashSet::new();
+    let mut process_message = || -> io::Result<()> {
+        let (message, sender) = recv_from(&socket)?;
+
+        // We never actually remove peers from this list. It does not do any visible harm because
+        // UDP allows sending datagrams to any address. However, this does add up to network spam.
+        // A proper chat would track peer connections in some way, but we're too lazy for that.
+        if peers.insert(sender) {
+            info!("new peer: {}", sender);
+        }
+
+        for peer in &peers {
+            // Avoid relaying the message to the original sender.
+            if *peer == sender {
+                continue;
+            }
+            socket.send_to(&message, peer)?;
+        }
+
+        Ok(())
+    };
+
+    info!("listening on port {}", port);
+    loop {
+        if let Err(e) = process_message() {
+            error!("failed to process message: {}", e);
+            break;
+        }
+    }
+}
+
+fn recv_from(socket: &UdpSocket) -> io::Result<(Vec<u8>, SocketAddr)> {
+    let mut message = vec![0; 65536];
+    let (length, sender) = socket.recv_from(&mut message)?;
+    message.truncate(length);
+    Ok((message, sender))
+}

--- a/src/wrappers/themis/rust/CHANGELOG.md
+++ b/src/wrappers/themis/rust/CHANGELOG.md
@@ -1,0 +1,62 @@
+[Unreleased]
+============
+
+The version currently under development.
+
+Version 0.0.2 — 2018-11-18
+==========================
+
+Improving type safety and dependency management.
+
+## New features
+
+- `SecureComparator` now implements `Default`.
+
+- Type alias `themis::Result` with native Themis error is now available.
+
+- `SecureComparator` now provides `is_complete()` method.
+
+- `SecureCell` and `SecureMessage` now own the provided keys, which will be
+  copied if necessary. This relaxes lifetime restrictions on instances
+  constructed using byte slices.
+
+- Themis now uses strong types for keys instead of `Vec<u8>` and `&[u8]`.
+  See [#4] for details. This is likely a **breaking change**.
+
+- `libthemis-sys` will now use **pkg-config** to locate native Themis library.
+  See [#2], [#5], [#7] and README for details.
+
+## Breaking changes
+
+- `SecureSessionState::Negotiate` enumeration variant is now properly spelled
+  as `Negotiating` in order to be consistent with the core library.
+
+- `gen_rsa_key_pair()`, `gen_ec_key_pair()`, `SecureComparator::new()` now
+  return their results directly instead of wrapping errors into `Result` or
+  `Option`. These functions may fail only on likely unrecoverable internal
+  errors of Themis so now they simply panic in this case.
+
+- `SecureSession::with_transport()` now returns `Result` instead of `Option`.
+
+[#2]: https://github.com/ilammy/rust-themis/issues/2
+[#4]: https://github.com/ilammy/rust-themis/issues/4
+[#5]: https://github.com/ilammy/rust-themis/pull/5
+[#7]: https://github.com/ilammy/rust-themis/pull/7
+
+Version 0.0.1 — 2018-10-04
+==========================
+
+The first release of Themis for Rust.
+
+- Full API coverage:
+  * Key generation
+  * Secure Cell
+  * Secure Message
+  * Secure Session
+  * Secure Comparator
+- Basic API documentation
+- Basic test suite
+- Basic code samples:
+  * Key generation tool
+  * File encryption using Secure Cell
+  * Relay chat using Secure Message

--- a/src/wrappers/themis/rust/LICENSE
+++ b/src/wrappers/themis/rust/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2018 (c) rust-themis developers
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/wrappers/themis/rust/README.md
+++ b/src/wrappers/themis/rust/README.md
@@ -1,0 +1,128 @@
+# rust-themis
+
+Rust binding for [Themis] crypto library.
+
+[Themis]: https://github.com/cossacklabs/themis
+
+## Usage
+
+First you need to install the native Themis library.
+Please refer to [the quickstart guide] for installation instructions.
+
+Then you simply add this to your Cargo.toml:
+
+```toml
+[dependencies]
+themis = "0.0.2"
+```
+
+And you're ready to go.
+You can start off experimenting with [the examples].
+
+[the quickstart guide]: /README.md#quickstart
+[the examples]: /docs/examples/rust
+
+## Building
+
+This is a binding so it requires a native Themis library.
+After that all the usual Cargo commands like `cargo test` should work out-of-the-box.
+
+### Native Themis library
+
+The easiest way to make native Themis available is to install it into your system.
+Please refer to [the quickstart guide] for installation instructions for your platform.
+Once that's done the build should complete successfully.
+
+If the compilation fails with a message like this:
+
+```
+   Compiling libthemis-sys v0.0.2
+error: failed to run custom build command for `libthemis-sys v0.0.2`
+process didn't exit successfully: `target/debug/build/libthemis-sys-caf961089016a618/build-script-build` (exit code: 101)
+--- stdout
+cargo:rerun-if-env-changed=LIBTHEMIS_NO_PKG_CONFIG
+
+[ some lines omitted ]
+
+cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR
+
+--- stderr
+thread 'main' panicked at '
+
+`libthemis-sys` could not find Themis installation in your system.
+
+[ some lines omitted ]
+
+', libthemis-sys/build.rs:60:13
+note: Run with `RUST_BACKTRACE=1` for a backtrace.
+```
+
+then please read the message carefully and help the build find your library.
+
+We use **pkg-config** to locate the native Themis library.
+Make sure you have this tool installed and correctly configured.
+If you use a non-standard installation path
+(e.g., `/opt/themis`)
+then you need to set `PKG_CONFIG_PATH` environment variable
+to the directory containing *.pc files
+(e.g., `/opt/themis/lib/pkgconfig`).
+
+### Tweaking the build
+
+You can set other environment variables to control how pkg-config resolves native dependencies.
+
+- `LIBTHEMIS_STATIC` — set to prefer static linking
+- `LIBTHEMIS_DYNAMIC` — set to prefer dynamic linking
+
+Refer to [the `pkg_config` documentation] for more information about available environment variables.
+
+[the `pkg_config` documentation]: https://docs.rs/pkg-config/latest/pkg_config/
+
+### 🍺 A note for Homebrew users
+
+If you install Themis via `brew` on macOS then it will be using Homebrew's OpenSSL libraries.
+Homebrew does not install OpenSSL into default system location (it's _keg-only_).
+That's because your system is likely to contain its own OpenSSL installation in default path
+and Homebrew won't replace it to avoid accidental breakage.
+
+You need to tell pkg-config to use Homebrew's OpenSSL
+by setting `PKG_CONFIG_PATH` to the keg location of OpenSSL used by Themis.
+You can usually find out where it is with a spell like this:
+
+```console
+$ find $(brew --prefix $(brew deps themis-openssl)) -follow -type d -name pkgconfig
+/usr/local/opt/openssl/lib/pkgconfig
+```
+
+### ⛑ Bundled *.pc files
+
+Unfortunately, Themis packages currently do not include *.pc files for pkg-config.
+You can use the ones bundled with this repository as a temporary measure.
+Take a look into [`pkgconfig`](pkgconfig) directory:
+
+- `pkgconfig/system/*.pc` —
+  if you install Themis into `/usr/lib`
+  (usually the case on Linux with package managers)
+- `pkgconfig/local/*.pc` —
+  if you install Themis into `/usr/local/lib`
+  (usually the case on macOS or with `make install`)
+
+Copy these files somewhere in your home directory, for example,
+and tell pkg-config to use them:
+
+```console
+$ mkdir ~/pkgconfig
+$ cp pkgconfig/usr/local/lib/pkgconfig/*.pc ~/pkgconfig/
+$ export PKG_CONFIG_PATH=$HOME/pkgconfig
+```
+
+Multiple paths in `PKG_CONFIG_PATH` are separated with colons,
+like this:
+
+```console
+$ export PKG_CONFIG_PATH=$HOME/pkgconfig:/usr/local/opt/openssl/lib/pkgconfig
+```
+
+## Licensing
+
+The code is distributed under [Apache 2.0 license](LICENSE).

--- a/src/wrappers/themis/rust/libthemis-sys/Cargo.toml
+++ b/src/wrappers/themis/rust/libthemis-sys/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "libthemis-sys"
+version = "0.0.2"
+authors = ["rust-themis developers"]
+description = "FFI binding to libthemis"
+homepage = "https://www.cossacklabs.com/themis/"
+repository = "https://github.com/cossacklabs/themis"
+readme = "README.md"
+keywords = ["crypto", "Themis"]
+categories = ["cryptography", "external-ffi-bindings"]
+license = "Apache-2.0"
+links = "themis"
+
+[build-dependencies]
+bindgen = "0.42.0"
+cc = "1.0"
+pkg-config = "0.3.14"

--- a/src/wrappers/themis/rust/libthemis-sys/LICENSE
+++ b/src/wrappers/themis/rust/libthemis-sys/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2018 (c) rust-themis developers
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/wrappers/themis/rust/libthemis-sys/README.md
+++ b/src/wrappers/themis/rust/libthemis-sys/README.md
@@ -1,0 +1,8 @@
+# libthemis-sys
+
+A customary `*-sys` crate that contains raw FFI bindings to **libthemis**.
+It is not expected to be used directly.
+
+## Licensing
+
+The code is distributed under [Apache 2.0 license](LICENSE).

--- a/src/wrappers/themis/rust/libthemis-sys/build.rs
+++ b/src/wrappers/themis/rust/libthemis-sys/build.rs
@@ -1,0 +1,118 @@
+// Copyright 2018 (c) rust-themis developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate bindgen;
+extern crate cc;
+extern crate pkg_config;
+
+use std::env;
+use std::path::{Path, PathBuf};
+
+use pkg_config::Library;
+
+fn main() {
+    let themis = get_themis();
+
+    let whitelist = "(THEMIS|themis|secure_(comparator|session)|STATE)_.*";
+    let bindings = bindgen::Builder::default()
+        .clang_args(clang_include_paths(&themis))
+        .clang_args(clang_library_paths(&themis))
+        .header("src/wrapper.h")
+        .whitelist_function(whitelist)
+        .whitelist_type(whitelist)
+        .whitelist_var(whitelist)
+        .rustified_enum("themis_key_kind")
+        .generate()
+        .expect("generating bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("writing bindings!");
+
+    cc::Build::new()
+        .file("src/wrapper.c")
+        .include("src")
+        .includes(&themis.include_paths)
+        .compile("themis_shims");
+}
+
+/// Embarks on an incredible adventure and returns with a suitable Themis (or dies trying).
+fn get_themis() -> Library {
+    let result = pkg_config::Config::new()
+        .env_metadata(true)
+        .arg("libsoter") // TODO: remove this together with themis_shims
+        .probe("libthemis");
+    match result {
+        Ok(library) => return library,
+        Err(error) => panic!(format!(
+            "
+
+`libthemis-sys` could not find Themis installation in your system.
+
+Please make sure you have appropriate development package installed.
+On Linux it's called `libthemis-dev`, not just `libthemis`.
+On macOS Homebrew formula is called `themis` or `themis-openssl`.
+
+Please refer to the documentation for installation instructions:
+
+    https://github.com/cossacklabs/themis#quickstart
+
+This crate uses `pkg-config` to locate the library. If you use
+non-standard installation of Themis then you can help pkg-config
+to locate your library by setting the PKG_CONFIG_PATH environment
+variable to path where `libthemis.pc` file is located.
+
+{}
+",
+            error
+        )),
+    }
+}
+
+fn clang_include_paths(library: &Library) -> Vec<String> {
+    library
+        .include_paths
+        .iter()
+        .map(|p| format!("-I{}", p.display()))
+        .collect()
+}
+
+fn clang_library_paths(library: &Library) -> Vec<String> {
+    library
+        .link_paths
+        .iter()
+        .map(|p| format!("-L{}", p.display()))
+        .collect()
+}
+
+trait CCBuildEx {
+    fn includes<I>(&mut self, dirs: I) -> &mut Self
+    where
+        I: IntoIterator,
+        I::Item: AsRef<Path>;
+}
+
+impl CCBuildEx for cc::Build {
+    fn includes<I>(&mut self, dirs: I) -> &mut Self
+    where
+        I: IntoIterator,
+        I::Item: AsRef<Path>,
+    {
+        for dir in dirs {
+            self.include(dir);
+        }
+        self
+    }
+}

--- a/src/wrappers/themis/rust/libthemis-sys/src/lib.rs
+++ b/src/wrappers/themis/rust/libthemis-sys/src/lib.rs
@@ -1,0 +1,27 @@
+// Copyright 2018 (c) rust-themis developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Raw FFI bindings to libthemis.
+
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+// For some weird reasons Clippy gets run on this crate as it's a path dependency of themis.
+// This should not happen (see https://github.com/rust-lang-nursery/rust-clippy/issues/1066)
+// but until that's fixed again, disable all lints which get triggered by the code generated
+// by bindgen. We're using the stable version of compiler and I don't want to pull nightly
+// just for clippy, so we have to enumerate all lints explicitly instead of "clippy::all".
+#![cfg_attr(feature = "cargo-clippy", allow(const_static_lifetime))]
+
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/src/wrappers/themis/rust/libthemis-sys/src/wrapper.c
+++ b/src/wrappers/themis/rust/libthemis-sys/src/wrapper.c
@@ -1,0 +1,96 @@
+// Copyright 2018 (c) rust-themis developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "wrapper.h"
+
+#include <string.h>
+
+#include <arpa/inet.h>
+
+#include <soter/soter_container.h>
+#include <soter/soter_ec_key.h>
+#include <soter/soter_rsa_key.h>
+
+themis_status_t themis_is_valid_key(const uint8_t *key, size_t length)
+{
+    // FIXME: do something about alignment mismatch in Themis code
+    //
+    // Strictly speaking, this cast is actually an undefined behavior because `key` is not
+    // guaranteed to be aligned for soter_container_hdr_t. The compiler actually produces
+    // a warning for the cast. We silence it by using void*, just like the rest of C code
+    // in Themis.
+    //
+    // The behavior is undefined because some architectures (most of the modern ones) allow
+    // unaligned memory accesses. Other CPUs may issue an exception, which may be handled
+    // by the OS, which may result in a SIGBUS being sent to the process, which usually
+    // kills it. Or you may silently read data from a wrong memory address and that's it.
+    //
+    // This kinda tends to work because modern hardware and software is forgiving. Themis
+    // is mostly used and tested on i386 and AMD64 which handle unaligned accesses just fine
+    // (albeit slower). The next most popular architecture -- ARM -- used to have strict
+    // alignment requirements, but they are significantly relaxed now on modern processors.
+    // Furthermore, you need to get lucky with actually using an improperly unaligned pointer.
+    // That's why you almost never observe any catastrophic results from such unsafe casts.
+    //
+    // In rust-themis we do our best to keep the pointers aligned. That's the reason for copying
+    // the byte slices into a fresh new KeyBytes before passing them to any C function.
+    //
+    // However, this is still undefined behavior. I have killed yet another internet kitten
+    // for the following line. I am sorry and ready to bear my sin.
+    const soter_container_hdr_t *container = (const void*) key;
+
+    if (!key || (length < sizeof(soter_container_hdr_t)))
+    {
+        return THEMIS_INVALID_PARAMETER;
+    }
+
+    if (length != ntohl(container->size))
+    {
+        return THEMIS_INVALID_PARAMETER;
+    }
+
+    if (SOTER_SUCCESS != soter_verify_container_checksum(container))
+    {
+        return THEMIS_DATA_CORRUPT;
+    }
+
+    return THEMIS_SUCCESS;
+}
+
+enum themis_key_kind themis_get_key_kind(const uint8_t *key, size_t length)
+{
+    if (!key || (length < sizeof(soter_container_hdr_t)))
+    {
+        return THEMIS_KEY_INVALID;
+    }
+
+    if (!memcmp(key, RSA_PRIV_KEY_PREF, strlen(RSA_PRIV_KEY_PREF)))
+    {
+        return THEMIS_KEY_RSA_PRIVATE;
+    }
+    if (!memcmp(key, RSA_PUB_KEY_PREF, strlen(RSA_PUB_KEY_PREF)))
+    {
+        return THEMIS_KEY_RSA_PUBLIC;
+    }
+    if (!memcmp(key, EC_PRIV_KEY_PREF, strlen(EC_PRIV_KEY_PREF)))
+    {
+        return THEMIS_KEY_EC_PRIVATE;
+    }
+    if (!memcmp(key, EC_PUB_KEY_PREF, strlen(EC_PUB_KEY_PREF)))
+    {
+        return THEMIS_KEY_EC_PUBLIC;
+    }
+
+    return THEMIS_KEY_INVALID;
+}

--- a/src/wrappers/themis/rust/libthemis-sys/src/wrapper.h
+++ b/src/wrappers/themis/rust/libthemis-sys/src/wrapper.h
@@ -1,0 +1,41 @@
+// Copyright 2018 (c) rust-themis developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Wrapper header for bindgen containing all Themis API declarations.
+
+#include <themis/themis.h>
+
+// TODO: move shims into Themis core
+//
+// These shims are here because they use C macros which are not exported by bindgen.
+// Ideally, Themis should provide this functionality, but it's too unstable now
+// for inclusion into the core library.
+
+#include <stddef.h>
+#include <stdint.h>
+
+enum themis_key_kind
+{
+    THEMIS_KEY_INVALID,
+    THEMIS_KEY_RSA_PRIVATE,
+    THEMIS_KEY_RSA_PUBLIC,
+    THEMIS_KEY_EC_PRIVATE,
+    THEMIS_KEY_EC_PUBLIC,
+};
+
+/// Checks if the buffer contains a valid Themis key.
+themis_status_t themis_is_valid_key(const uint8_t *key, size_t length);
+
+/// Extracts the presumed key kind from the buffer.
+enum themis_key_kind themis_get_key_kind(const uint8_t *key, size_t length);

--- a/src/wrappers/themis/rust/libthemis-sys/tests/sanity.rs
+++ b/src/wrappers/themis/rust/libthemis-sys/tests/sanity.rs
@@ -1,0 +1,29 @@
+// Copyright 2018 (c) rust-themis developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate libthemis_sys;
+
+use std::ffi::CStr;
+
+#[test]
+fn check_version() {
+    let version = unsafe { CStr::from_ptr(libthemis_sys::themis_version()) };
+    // Themis 0.10.0 is slightly buggy and identifies itself as 0.9.
+    assert!(
+        version
+            .to_str()
+            .expect("valid UTF-8")
+            .contains("themis 0.9")
+    );
+}

--- a/src/wrappers/themis/rust/pkgconfig/local/libsoter.pc
+++ b/src/wrappers/themis/rust/pkgconfig/local/libsoter.pc
@@ -1,0 +1,6 @@
+Name: libsoter
+Description: libsoter
+Version: 0.10.0
+Requires.private: libcrypto
+Cflags: -I/usr/local/include
+Libs: -L/usr/local/lib -lsoter

--- a/src/wrappers/themis/rust/pkgconfig/local/libthemis.pc
+++ b/src/wrappers/themis/rust/pkgconfig/local/libthemis.pc
@@ -1,0 +1,6 @@
+Name: libthemis
+Description: libthemis
+Version: 0.10.0
+Requires.private: libsoter
+Cflags: -I/usr/local/include
+Libs: -L/usr/local/lib -lthemis

--- a/src/wrappers/themis/rust/pkgconfig/system/libsoter.pc
+++ b/src/wrappers/themis/rust/pkgconfig/system/libsoter.pc
@@ -1,0 +1,6 @@
+Name: libsoter
+Description: libsoter
+Version: 0.10.0
+Requires.private: libcrypto
+Cflags: -I/usr/include
+Libs: -L/usr/lib -lsoter

--- a/src/wrappers/themis/rust/pkgconfig/system/libthemis.pc
+++ b/src/wrappers/themis/rust/pkgconfig/system/libthemis.pc
@@ -1,0 +1,6 @@
+Name: libthemis
+Description: libthemis
+Version: 0.10.0
+Requires.private: libsoter
+Cflags: -I/usr/include
+Libs: -L/usr/lib -lthemis

--- a/src/wrappers/themis/rust/src/error.rs
+++ b/src/wrappers/themis/rust/src/error.rs
@@ -1,0 +1,205 @@
+// Copyright 2018 (c) rust-themis developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Themis error types.
+//!
+//! This module wraps Themis error types and provides useful Rust API for them.
+
+use std::{error, fmt, result};
+
+use bindings::{
+    THEMIS_BUFFER_TOO_SMALL, THEMIS_DATA_CORRUPT, THEMIS_FAIL, THEMIS_INVALID_PARAMETER,
+    THEMIS_INVALID_SIGNATURE, THEMIS_NOT_SUPPORTED, THEMIS_NO_MEMORY, THEMIS_SCOMPARE_MATCH,
+    THEMIS_SCOMPARE_NOT_READY, THEMIS_SCOMPARE_NO_MATCH, THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER,
+    THEMIS_SSESSION_GET_PUB_FOR_ID_CALLBACK_ERROR, THEMIS_SSESSION_KA_NOT_FINISHED,
+    THEMIS_SSESSION_SEND_OUTPUT_TO_PEER, THEMIS_SSESSION_TRANSPORT_ERROR, THEMIS_SUCCESS,
+};
+
+/// Themis status code.
+pub(crate) use bindings::themis_status_t;
+
+/// Result type for most Themis operations.
+pub type Result<T> = result::Result<T, Error>;
+
+/// The error type for most Themis operations.
+///
+/// Errors are usually caused by invalid, malformed or malicious input as well as incorrect usage
+/// of the library. However, they may also result from underlying OS errors. See [`ErrorKind`] for
+/// details.
+///
+/// [`ErrorKind`]: enum.ErrorKind.html
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Error {
+    kind: ErrorKind,
+}
+
+impl Error {
+    /// Constructs a new error of given kind.
+    pub(crate) fn with_kind(kind: ErrorKind) -> Error {
+        Error { kind }
+    }
+
+    /// Converts generic Themis status codes.
+    pub(crate) fn from_themis_status(status: themis_status_t) -> Error {
+        let kind = match status as u32 {
+            THEMIS_SUCCESS => ErrorKind::Success,
+            THEMIS_FAIL => ErrorKind::Fail,
+            THEMIS_INVALID_PARAMETER => ErrorKind::InvalidParameter,
+            THEMIS_NO_MEMORY => ErrorKind::NoMemory,
+            THEMIS_BUFFER_TOO_SMALL => ErrorKind::BufferTooSmall,
+            THEMIS_DATA_CORRUPT => ErrorKind::DataCorrupt,
+            THEMIS_INVALID_SIGNATURE => ErrorKind::InvalidSignature,
+            THEMIS_NOT_SUPPORTED => ErrorKind::NotSupported,
+            _ => ErrorKind::UnknownError(status),
+        };
+        Error { kind }
+    }
+
+    /// Converts status codes returned by Secure Session.
+    pub(crate) fn from_session_status(status: themis_status_t) -> Error {
+        let kind = match status as u32 {
+            THEMIS_SSESSION_SEND_OUTPUT_TO_PEER => ErrorKind::SessionSendOutputToPeer,
+            THEMIS_SSESSION_KA_NOT_FINISHED => ErrorKind::SessionKeyAgreementNotFinished,
+            THEMIS_SSESSION_TRANSPORT_ERROR => ErrorKind::SessionTransportError,
+            THEMIS_SSESSION_GET_PUB_FOR_ID_CALLBACK_ERROR => {
+                ErrorKind::SessionGetPublicKeyForIdError
+            }
+            _ => return Error::from_themis_status(status),
+        };
+        Error { kind }
+    }
+
+    /// Converts status codes returned by Secure Comparator data exchange.
+    pub(crate) fn from_compare_status(status: themis_status_t) -> Error {
+        let kind = match status as u32 {
+            THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER => ErrorKind::CompareSendOutputToPeer,
+            _ => return Error::from_themis_status(status),
+        };
+        Error { kind }
+    }
+
+    /// Converts status codes returned by Secure Comparator status query.
+    pub(crate) fn from_match_status(status: themis_status_t) -> Error {
+        let kind = match status as u32 {
+            THEMIS_SCOMPARE_NOT_READY => ErrorKind::CompareNotReady,
+            THEMIS_SCOMPARE_MATCH => ErrorKind::CompareMatch,
+            THEMIS_SCOMPARE_NO_MATCH => ErrorKind::CompareNoMatch,
+            _ => return Error::from_themis_status(status),
+        };
+        Error { kind }
+    }
+
+    /// Returns the corresponding `ErrorKind` for this error.
+    pub fn kind(&self) -> ErrorKind {
+        self.kind
+    }
+}
+
+impl error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.kind {
+            ErrorKind::UnknownError(status) => write!(f, "unknown error: {}", status),
+            ErrorKind::Success => write!(f, "success"),
+
+            ErrorKind::Fail => write!(f, "failure"),
+            ErrorKind::InvalidParameter => write!(f, "invalid parameter"),
+            ErrorKind::NoMemory => write!(f, "out of memory"),
+            ErrorKind::BufferTooSmall => write!(f, "buffer too small"),
+            ErrorKind::DataCorrupt => write!(f, "corrupted data"),
+            ErrorKind::InvalidSignature => write!(f, "invalid signature"),
+            ErrorKind::NotSupported => write!(f, "operation not supported"),
+
+            ErrorKind::SessionSendOutputToPeer => write!(f, "send key agreement data to peer"),
+            ErrorKind::SessionKeyAgreementNotFinished => write!(f, "key agreement not finished"),
+            ErrorKind::SessionTransportError => write!(f, "transport layer error"),
+            ErrorKind::SessionGetPublicKeyForIdError => {
+                write!(f, "failed to get public key for ID")
+            }
+
+            ErrorKind::CompareSendOutputToPeer => write!(f, "send comparison data to peer"),
+            ErrorKind::CompareMatch => write!(f, "data matches"),
+            ErrorKind::CompareNoMatch => write!(f, "data does not match"),
+            ErrorKind::CompareNotReady => write!(f, "comparator not ready"),
+        }
+    }
+}
+
+/// A list of Themis error categories.
+///
+/// This enumeration is used by [`Error`] type, returned by most Themis functions. Some error kinds
+/// are specific to particular functions, and some are used internally by the library.
+///
+/// [`Error`]: struct.Error.html
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum ErrorKind {
+    /// Catch-all generic error.
+    ///
+    /// If you encounter this error kind then the Themis binding is likely to be out of sync with
+    /// the core library. The contained error code has not been mapped onto `ErrorKind` value.
+    #[doc(hidden)]
+    UnknownError(i32),
+    /// "Fatal error: success!"
+    ///
+    /// This value is used internally to distinguish successful function calls conveniently.
+    /// End-users should never encounter it.
+    #[doc(hidden)]
+    Success,
+
+    /// General failure.
+    Fail,
+    /// Some input parameter has incorrect value.
+    InvalidParameter,
+    /// Could not allocate memory.
+    NoMemory,
+    /// The provided buffer is too small to fit the result.
+    BufferTooSmall,
+    /// Input data is corrupted.
+    DataCorrupt,
+    /// Input data contains invalid signature.
+    InvalidSignature,
+    /// Operation not supported.
+    NotSupported,
+
+    /// Send output with internal data of Secure Session to the peer.
+    ///
+    /// This is not actually an error and the end-user should never see it.
+    #[doc(hidden)]
+    SessionSendOutputToPeer,
+    /// Attempt to use Secure Session before completing key exchange.
+    SessionKeyAgreementNotFinished,
+    /// Transport layer returned error.
+    SessionTransportError,
+    /// Could not retrieve a public key corresponding to peer ID.
+    SessionGetPublicKeyForIdError,
+
+    /// Send output with internal data of Secure Comparator to the peer.
+    ///
+    /// This is not actually an error and the end-user should never see it.
+    #[doc(hidden)]
+    CompareSendOutputToPeer,
+    /// Indicates that compared data matches.
+    ///
+    /// This is not actually an error and the end-user should never see it.
+    #[doc(hidden)]
+    CompareMatch,
+    /// Indicates that compared data does not match.
+    ///
+    /// This is not actually an error and the end-user should never see it.
+    #[doc(hidden)]
+    CompareNoMatch,
+    /// Attempt to use Secure Comparator before completing nonce exchange.
+    CompareNotReady,
+}

--- a/src/wrappers/themis/rust/src/keygen.rs
+++ b/src/wrappers/themis/rust/src/keygen.rs
@@ -1,0 +1,142 @@
+// Copyright 2018 (c) rust-themis developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Generating key material.
+//!
+//! This module contains functions for generating random key pairs for use by Themis.
+//!
+//! Currently Themis supports two key kinds: RSA and ECDSA. Most of the functions accept either,
+//! but some work only with ECDSA.
+
+use std::ptr;
+
+use bindings::{themis_gen_ec_key_pair, themis_gen_rsa_key_pair};
+use error::{Error, ErrorKind, Result};
+use keys::{EcdsaKeyPair, EcdsaPublicKey, EcdsaSecretKey, RsaKeyPair, RsaPublicKey, RsaSecretKey};
+
+/// Generates a pair of RSA keys.
+///
+/// # Panics
+///
+/// This function may panic in case of unrecoverable errors inside the library (e.g., out-of-memory
+/// or assertion violations).
+pub fn gen_rsa_key_pair() -> RsaKeyPair {
+    match try_gen_rsa_key_pair() {
+        Ok(keys) => keys,
+        Err(e) => panic!("themis_gen_rsa_key_pair() failed: {}", e),
+    }
+}
+
+/// Generates a secret-public pair of RSA keys.
+fn try_gen_rsa_key_pair() -> Result<RsaKeyPair> {
+    let mut secret_key = Vec::new();
+    let mut public_key = Vec::new();
+    let mut secret_key_len = 0;
+    let mut public_key_len = 0;
+
+    unsafe {
+        let status = themis_gen_rsa_key_pair(
+            ptr::null_mut(),
+            &mut secret_key_len,
+            ptr::null_mut(),
+            &mut public_key_len,
+        );
+        let error = Error::from_themis_status(status);
+        if error.kind() != ErrorKind::BufferTooSmall {
+            return Err(error);
+        }
+    }
+
+    secret_key.reserve(secret_key_len);
+    public_key.reserve(secret_key_len);
+
+    unsafe {
+        let status = themis_gen_rsa_key_pair(
+            secret_key.as_mut_ptr(),
+            &mut secret_key_len,
+            public_key.as_mut_ptr(),
+            &mut public_key_len,
+        );
+        let error = Error::from_themis_status(status);
+        if error.kind() != ErrorKind::Success {
+            return Err(error);
+        }
+        debug_assert!(secret_key_len <= secret_key.capacity());
+        debug_assert!(public_key_len <= public_key.capacity());
+        secret_key.set_len(secret_key_len as usize);
+        public_key.set_len(public_key_len as usize);
+    }
+
+    let secret_key = RsaSecretKey::from_vec(secret_key);
+    let public_key = RsaPublicKey::from_vec(public_key);
+    Ok(RsaKeyPair::join(secret_key, public_key))
+}
+
+/// Generates a pair of ECDSA keys.
+///
+/// # Panics
+///
+/// This function may panic in case of unrecoverable errors inside the library (e.g., out-of-memory
+/// or assertion violations).
+pub fn gen_ec_key_pair() -> EcdsaKeyPair {
+    match try_gen_ec_key_pair() {
+        Ok(keys) => keys,
+        Err(e) => panic!("themis_gen_ec_key_pair() failed: {}", e),
+    }
+}
+
+/// Generates a secret-public pair of ECDSA keys.
+fn try_gen_ec_key_pair() -> Result<EcdsaKeyPair> {
+    let mut secret_key = Vec::new();
+    let mut public_key = Vec::new();
+    let mut secret_key_len = 0;
+    let mut public_key_len = 0;
+
+    unsafe {
+        let status = themis_gen_ec_key_pair(
+            ptr::null_mut(),
+            &mut secret_key_len,
+            ptr::null_mut(),
+            &mut public_key_len,
+        );
+        let error = Error::from_themis_status(status);
+        if error.kind() != ErrorKind::BufferTooSmall {
+            return Err(error);
+        }
+    }
+
+    secret_key.reserve(secret_key_len);
+    public_key.reserve(secret_key_len);
+
+    unsafe {
+        let status = themis_gen_ec_key_pair(
+            secret_key.as_mut_ptr(),
+            &mut secret_key_len,
+            public_key.as_mut_ptr(),
+            &mut public_key_len,
+        );
+        let error = Error::from_themis_status(status);
+        if error.kind() != ErrorKind::Success {
+            return Err(error);
+        }
+        debug_assert!(secret_key_len <= secret_key.capacity());
+        debug_assert!(public_key_len <= public_key.capacity());
+        secret_key.set_len(secret_key_len as usize);
+        public_key.set_len(public_key_len as usize);
+    }
+
+    let secret_key = EcdsaSecretKey::from_vec(secret_key);
+    let public_key = EcdsaPublicKey::from_vec(public_key);
+    Ok(EcdsaKeyPair::join(secret_key, public_key))
+}

--- a/src/wrappers/themis/rust/src/keys.rs
+++ b/src/wrappers/themis/rust/src/keys.rs
@@ -1,0 +1,516 @@
+// Copyright 2018 (c) rust-themis developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Cryptographic keys.
+//!
+//! This module contains data structures for keys supported by Themis: RSA and ECDSA key pairs.
+
+use std::fmt;
+
+use bindings::{themis_get_key_kind, themis_is_valid_key};
+use error::{Error, ErrorKind, Result};
+use utils::into_raw_parts;
+
+/// Key material.
+#[derive(Clone, Eq, PartialEq, Hash)]
+pub(crate) struct KeyBytes(Vec<u8>);
+
+// TODO: securely zero memory when dropping KeyBytes (?)
+
+impl KeyBytes {
+    /// Makes a key from an owned byte vector.
+    pub fn from_vec(bytes: Vec<u8>) -> KeyBytes {
+        KeyBytes(bytes)
+    }
+
+    /// Makes a key from a copy of a byte slice.
+    pub fn copy_slice(bytes: &[u8]) -> KeyBytes {
+        KeyBytes(bytes.to_vec())
+    }
+
+    /// Makes an empty key.
+    pub fn empty() -> KeyBytes {
+        KeyBytes(Vec::new())
+    }
+
+    /// Returns key bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl fmt::Debug for KeyBytes {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "KeyBytes({} bytes)", self.0.len())
+    }
+}
+
+//
+// Key type definitions
+//
+
+/// RSA secret key.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct RsaSecretKey {
+    inner: KeyBytes,
+}
+
+/// RSA public key.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct RsaPublicKey {
+    inner: KeyBytes,
+}
+
+/// RSA key pair.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct RsaKeyPair {
+    secret_key: KeyBytes,
+    public_key: KeyBytes,
+}
+
+/// ECDSA secret key.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct EcdsaSecretKey {
+    inner: KeyBytes,
+}
+
+/// ECDSA public key.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct EcdsaPublicKey {
+    inner: KeyBytes,
+}
+
+/// ECDSA key pair.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct EcdsaKeyPair {
+    secret_key: KeyBytes,
+    public_key: KeyBytes,
+}
+
+/// A secret key.
+///
+/// This structure is used by cryptographic services which can support any kind of key.
+/// [`RsaSecretKey`] or [`EcdsaSecretKey`] can be turned into a `SecretKey` at no cost.
+///
+/// [`RsaSecretKey`]: struct.RsaSecretKey.html
+/// [`EcdsaSecretKey`]: struct.EcdsaSecretKey.html
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct SecretKey {
+    inner: KeyBytes,
+}
+
+/// A public key.
+///
+/// This structure is used by cryptographic services which can support any kind of key.
+/// [`RsaPublicKey`] or [`EcdsaPublicKey`] can be turned into a `PublicKey` at no cost.
+///
+/// [`RsaPublicKey`]: struct.RsaPublicKey.html
+/// [`EcdsaPublicKey`]: struct.EcdsaPublicKey.html
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct PublicKey {
+    inner: KeyBytes,
+}
+
+/// A pair of asymmetric keys.
+///
+/// This structure is used by cryptographic services which can support any kind of key pair.
+/// [`RsaKeyPair`] or [`EcdsaKeyPair`] can be turned into a `KeyPair` at no cost. A pair of
+/// [`SecretKey`] and [`PublicKey`] can be joined into a `KeyPair` after a quick type check
+/// if their kinds match (either RSA or ECDSA).
+///
+/// [`RsaKeyPair`]: struct.RsaKeyPair.html
+/// [`EcdsaKeyPair`]: struct.EcdsaKeyPair.html
+/// [`SecretKey`]: struct.SecretKey.html
+/// [`PublicKey`]: struct.PublicKey.html
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct KeyPair {
+    secret_key: KeyBytes,
+    public_key: KeyBytes,
+}
+
+/// Kind of an asymmetric key.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum KeyKind {
+    /// RSA secret key.
+    RsaSecret,
+    /// RSA public key.
+    RsaPublic,
+    /// ECDSA secret key.
+    EcdsaSecret,
+    /// ECDSA public key.
+    EcdsaPublic,
+}
+
+//
+// Key pairs
+//
+
+impl RsaKeyPair {
+    /// Splits this key pair into secret and public keys.
+    pub fn split(self) -> (RsaSecretKey, RsaPublicKey) {
+        (
+            RsaSecretKey {
+                inner: self.secret_key,
+            },
+            RsaPublicKey {
+                inner: self.public_key,
+            },
+        )
+    }
+
+    /// Joins a pair of secret and public keys.
+    ///
+    /// Note that this method _does not_ verify that the keys match: i.e., that it is possible
+    /// to use the secret key to decrypt data encrypted with the public key.
+    pub fn join(secret_key: RsaSecretKey, public_key: RsaPublicKey) -> RsaKeyPair {
+        RsaKeyPair {
+            secret_key: secret_key.inner,
+            public_key: public_key.inner,
+        }
+    }
+}
+
+impl EcdsaKeyPair {
+    /// Splits this key pair into secret and public keys.
+    pub fn split(self) -> (EcdsaSecretKey, EcdsaPublicKey) {
+        (
+            EcdsaSecretKey {
+                inner: self.secret_key,
+            },
+            EcdsaPublicKey {
+                inner: self.public_key,
+            },
+        )
+    }
+
+    /// Joins a pair of secret and public keys.
+    ///
+    /// Note that this method _does not_ verify that the keys match: i.e., that it is possible
+    /// to use the secret key to decrypt data encrypted with the public key.
+    pub fn join(secret_key: EcdsaSecretKey, public_key: EcdsaPublicKey) -> EcdsaKeyPair {
+        EcdsaKeyPair {
+            secret_key: secret_key.inner,
+            public_key: public_key.inner,
+        }
+    }
+}
+
+impl KeyPair {
+    /// Access bytes of the secret key.
+    pub(crate) fn secret_key_bytes(&self) -> &[u8] {
+        self.secret_key.as_bytes()
+    }
+
+    /// Access bytes of the public key.
+    pub(crate) fn public_key_bytes(&self) -> &[u8] {
+        self.public_key.as_bytes()
+    }
+
+    /// Splits this key pair into secret and public keys.
+    pub fn split(self) -> (SecretKey, PublicKey) {
+        (
+            SecretKey {
+                inner: self.secret_key,
+            },
+            PublicKey {
+                inner: self.public_key,
+            },
+        )
+    }
+
+    /// Joins a pair of secret and public keys.
+    ///
+    /// Note that this method _does not_ verify that the keys match: i.e., that it is possible
+    /// to use the secret key to decrypt data encrypted with the public key.
+    ///
+    /// However, it does verify that _the kinds_ of the keys match: i.e., that they are both
+    /// either RSA or ECDSA keys. An error is returned if that's not the case. You can check
+    /// the kind of the key beforehand via its `kind()` method.
+    pub fn try_join<S, P>(secret_key: S, public_key: P) -> Result<KeyPair>
+    where
+        S: Into<SecretKey>,
+        P: Into<PublicKey>,
+    {
+        let (secret_key, public_key) = (secret_key.into(), public_key.into());
+        match (secret_key.kind(), public_key.kind()) {
+            (KeyKind::RsaSecret, KeyKind::RsaPublic) => {}
+            (KeyKind::EcdsaSecret, KeyKind::EcdsaPublic) => {}
+            _ => {
+                return Err(Error::with_kind(ErrorKind::InvalidParameter));
+            }
+        }
+        Ok(KeyPair {
+            secret_key: secret_key.inner,
+            public_key: public_key.inner,
+        })
+    }
+}
+
+//
+// Individual keys
+//
+
+impl RsaSecretKey {
+    /// Parses a key from a byte slice.
+    ///
+    /// Returns an error if the slice does not contain a valid RSA secret key.
+    pub fn try_from_slice<T: AsRef<[u8]>>(bytes: T) -> Result<Self> {
+        let key = KeyBytes::copy_slice(bytes.as_ref());
+        match get_key_kind(&key)? {
+            KeyKind::RsaSecret => Ok(Self { inner: key }),
+            _ => Err(Error::with_kind(ErrorKind::InvalidParameter)),
+        }
+    }
+
+    /// Wraps an existing trusted byte vector into a key.
+    pub(crate) fn from_vec(bytes: Vec<u8>) -> Self {
+        let key = KeyBytes::from_vec(bytes);
+        debug_assert_eq!(get_key_kind(&key), Ok(KeyKind::RsaSecret));
+        Self { inner: key }
+    }
+}
+
+impl RsaPublicKey {
+    /// Parses a key from a byte slice.
+    ///
+    /// Returns an error if the slice does not contain a valid RSA public key.
+    pub fn try_from_slice<T: AsRef<[u8]>>(bytes: T) -> Result<Self> {
+        let key = KeyBytes::copy_slice(bytes.as_ref());
+        match get_key_kind(&key)? {
+            KeyKind::RsaPublic => Ok(Self { inner: key }),
+            _ => Err(Error::with_kind(ErrorKind::InvalidParameter)),
+        }
+    }
+
+    /// Wraps an existing trusted byte vector into a key.
+    pub(crate) fn from_vec(bytes: Vec<u8>) -> Self {
+        let key = KeyBytes::from_vec(bytes);
+        debug_assert_eq!(get_key_kind(&key), Ok(KeyKind::RsaPublic));
+        Self { inner: key }
+    }
+}
+
+impl EcdsaSecretKey {
+    /// Parses a key from a byte slice.
+    ///
+    /// Returns an error if the slice does not contain a valid ECDSA secret key.
+    pub fn try_from_slice<T: AsRef<[u8]>>(bytes: T) -> Result<Self> {
+        let key = KeyBytes::copy_slice(bytes.as_ref());
+        match get_key_kind(&key)? {
+            KeyKind::EcdsaSecret => Ok(Self { inner: key }),
+            _ => Err(Error::with_kind(ErrorKind::InvalidParameter)),
+        }
+    }
+
+    /// Wraps an existing trusted byte vector into a key.
+    pub(crate) fn from_vec(bytes: Vec<u8>) -> Self {
+        let key = KeyBytes::from_vec(bytes);
+        debug_assert_eq!(get_key_kind(&key), Ok(KeyKind::EcdsaSecret));
+        Self { inner: key }
+    }
+}
+
+impl EcdsaPublicKey {
+    /// Parses a key from a byte slice.
+    ///
+    /// Returns an error if the slice does not contain a valid ECDSA public key.
+    pub fn try_from_slice<T: AsRef<[u8]>>(bytes: T) -> Result<Self> {
+        let key = KeyBytes::copy_slice(bytes.as_ref());
+        match get_key_kind(&key)? {
+            KeyKind::EcdsaPublic => Ok(Self { inner: key }),
+            _ => Err(Error::with_kind(ErrorKind::InvalidParameter)),
+        }
+    }
+
+    /// Wraps an existing trusted byte vector into a key.
+    pub(crate) fn from_vec(bytes: Vec<u8>) -> Self {
+        let key = KeyBytes::from_vec(bytes);
+        debug_assert_eq!(get_key_kind(&key), Ok(KeyKind::EcdsaPublic));
+        Self { inner: key }
+    }
+}
+
+impl SecretKey {
+    /// Retrieves actual kind of the stored key.
+    pub fn kind(&self) -> KeyKind {
+        get_key_kind_trusted(&self.inner)
+    }
+
+    /// Parses a key from a byte slice.
+    ///
+    /// Returns an error if the slice does not contain a valid RSA or ECDSA secret key.
+    pub fn try_from_slice<T: AsRef<[u8]>>(bytes: T) -> Result<Self> {
+        let key = KeyBytes::copy_slice(bytes.as_ref());
+        match get_key_kind(&key)? {
+            KeyKind::RsaSecret => Ok(Self { inner: key }),
+            KeyKind::EcdsaSecret => Ok(Self { inner: key }),
+            _ => Err(Error::with_kind(ErrorKind::InvalidParameter)),
+        }
+    }
+}
+
+impl PublicKey {
+    /// Retrieves actual kind of the stored key.
+    pub fn kind(&self) -> KeyKind {
+        get_key_kind_trusted(&self.inner)
+    }
+
+    /// Parses a key from a byte slice.
+    ///
+    /// Returns an error if the slice does not contain a valid RSA or ECDSA public key.
+    pub fn try_from_slice<T: AsRef<[u8]>>(bytes: T) -> Result<Self> {
+        let key = KeyBytes::copy_slice(bytes.as_ref());
+        match get_key_kind(&key)? {
+            KeyKind::RsaPublic => Ok(Self { inner: key }),
+            KeyKind::EcdsaPublic => Ok(Self { inner: key }),
+            _ => Err(Error::with_kind(ErrorKind::InvalidParameter)),
+        }
+    }
+}
+
+// The following functions have to be called in a particular sequence in order to be safe to use.
+// That's why they are free functions, not methods of KeyBytes.
+//
+// You can call get_key_kind() on any byte slice. If you get an Ok result back then you can call
+// get_key_kind_trusted() again on the very same byte slice to get the result faster.
+//
+// There's also a reason why they receive &KeyBytes, not just &[u8]. This is to maintain correct
+// pointer alignment. See "libthemis-sys/src/wrapper.c" for details.
+
+fn get_key_kind(key: &KeyBytes) -> Result<KeyKind> {
+    is_valid_themis_key(key)?;
+    try_get_key_kind(key)
+}
+
+fn get_key_kind_trusted(key: &KeyBytes) -> KeyKind {
+    debug_assert!(is_valid_themis_key(key).is_ok());
+    try_get_key_kind(key).expect("get_key_kind_trusted() called for invalid key")
+}
+
+fn is_valid_themis_key(key: &KeyBytes) -> Result<()> {
+    let (ptr, len) = into_raw_parts(key.as_bytes());
+    let status = unsafe { themis_is_valid_key(ptr, len) };
+    let error = Error::from_themis_status(status);
+    if error.kind() != ErrorKind::Success {
+        return Err(error);
+    }
+    Ok(())
+}
+
+fn try_get_key_kind(key: &KeyBytes) -> Result<KeyKind> {
+    use bindings::themis_key_kind::*;
+    let (ptr, len) = into_raw_parts(key.as_bytes());
+    let kind = unsafe { themis_get_key_kind(ptr, len) };
+    match kind {
+        THEMIS_KEY_RSA_PRIVATE => Ok(KeyKind::RsaSecret),
+        THEMIS_KEY_RSA_PUBLIC => Ok(KeyKind::RsaPublic),
+        THEMIS_KEY_EC_PRIVATE => Ok(KeyKind::EcdsaSecret),
+        THEMIS_KEY_EC_PUBLIC => Ok(KeyKind::EcdsaPublic),
+        THEMIS_KEY_INVALID => Err(Error::with_kind(ErrorKind::InvalidParameter)),
+    }
+}
+
+//
+// AsRef<[u8]> casts
+//
+
+impl AsRef<[u8]> for RsaSecretKey {
+    fn as_ref(&self) -> &[u8] {
+        self.inner.as_bytes()
+    }
+}
+
+impl AsRef<[u8]> for RsaPublicKey {
+    fn as_ref(&self) -> &[u8] {
+        self.inner.as_bytes()
+    }
+}
+
+impl AsRef<[u8]> for EcdsaSecretKey {
+    fn as_ref(&self) -> &[u8] {
+        self.inner.as_bytes()
+    }
+}
+
+impl AsRef<[u8]> for EcdsaPublicKey {
+    fn as_ref(&self) -> &[u8] {
+        self.inner.as_bytes()
+    }
+}
+
+impl AsRef<[u8]> for SecretKey {
+    fn as_ref(&self) -> &[u8] {
+        self.inner.as_bytes()
+    }
+}
+
+impl AsRef<[u8]> for PublicKey {
+    fn as_ref(&self) -> &[u8] {
+        self.inner.as_bytes()
+    }
+}
+
+//
+// From/Into conversions
+//
+
+impl From<RsaSecretKey> for SecretKey {
+    fn from(secret_key: RsaSecretKey) -> SecretKey {
+        SecretKey {
+            inner: secret_key.inner,
+        }
+    }
+}
+
+impl From<RsaPublicKey> for PublicKey {
+    fn from(public_key: RsaPublicKey) -> PublicKey {
+        PublicKey {
+            inner: public_key.inner,
+        }
+    }
+}
+
+impl From<EcdsaSecretKey> for SecretKey {
+    fn from(secret_key: EcdsaSecretKey) -> SecretKey {
+        SecretKey {
+            inner: secret_key.inner,
+        }
+    }
+}
+
+impl From<EcdsaPublicKey> for PublicKey {
+    fn from(public_key: EcdsaPublicKey) -> PublicKey {
+        PublicKey {
+            inner: public_key.inner,
+        }
+    }
+}
+
+impl From<RsaKeyPair> for KeyPair {
+    fn from(key_pair: RsaKeyPair) -> KeyPair {
+        KeyPair {
+            secret_key: key_pair.secret_key,
+            public_key: key_pair.public_key,
+        }
+    }
+}
+
+impl From<EcdsaKeyPair> for KeyPair {
+    fn from(key_pair: EcdsaKeyPair) -> KeyPair {
+        KeyPair {
+            secret_key: key_pair.secret_key,
+            public_key: key_pair.public_key,
+        }
+    }
+}

--- a/src/wrappers/themis/rust/src/lib.rs
+++ b/src/wrappers/themis/rust/src/lib.rs
@@ -1,0 +1,33 @@
+// Copyright 2018 (c) rust-themis developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # Themis Library
+//!
+//! Themis is a high-level cryptographic library.
+
+#![warn(missing_docs)]
+
+extern crate libthemis_sys as bindings;
+
+pub mod keygen;
+pub mod keys;
+pub mod secure_cell;
+pub mod secure_comparator;
+pub mod secure_message;
+pub mod secure_session;
+
+mod error;
+mod utils;
+
+pub use error::{Error, ErrorKind, Result};

--- a/src/wrappers/themis/rust/src/secure_cell.rs
+++ b/src/wrappers/themis/rust/src/secure_cell.rs
@@ -1,0 +1,491 @@
+// Copyright 2018 (c) rust-themis developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Secure Cell service.
+//!
+//! **Secure Сell** is a high-level cryptographic service aimed at protecting arbitrary data
+//! stored in various types of storage (e.g., databases, filesystem files, document archives,
+//! cloud storage, etc.)
+
+use std::ptr;
+
+use bindings::{
+    themis_secure_cell_decrypt_context_imprint, themis_secure_cell_decrypt_seal,
+    themis_secure_cell_decrypt_token_protect, themis_secure_cell_encrypt_context_imprint,
+    themis_secure_cell_encrypt_seal, themis_secure_cell_encrypt_token_protect,
+};
+use error::{Error, ErrorKind, Result};
+use keys::KeyBytes;
+use utils::into_raw_parts;
+
+/// Basic Secure Cell.
+///
+/// This is modeless, basic cell. Specific operation mode must be selected by one of the calls:
+///
+/// * `seal()`
+/// * `token_protect()`
+/// * `context_imprint()`
+pub struct SecureCell {
+    master_key: KeyBytes,
+    user_context: KeyBytes,
+}
+
+impl SecureCell {
+    /// Constructs a new cell secured by a master key.
+    pub fn with_key<K: AsRef<[u8]>>(master_key: K) -> Self {
+        Self {
+            master_key: KeyBytes::copy_slice(master_key.as_ref()),
+            user_context: KeyBytes::empty(),
+        }
+    }
+
+    /// Constructs a new cell secured by a master key and arbitrary user data.
+    ///
+    /// User context will be included into encrypted data in a manner specific to the operation
+    /// mode. See module-level documentation for details. You will need to provide this context
+    /// again in order to extract the original data from the cell.
+    pub fn with_key_and_context<K, C>(master_key: K, user_context: C) -> Self
+    where
+        K: AsRef<[u8]>,
+        C: AsRef<[u8]>,
+    {
+        Self {
+            master_key: KeyBytes::copy_slice(master_key.as_ref()),
+            user_context: KeyBytes::copy_slice(user_context.as_ref()),
+        }
+    }
+
+    /// Switches this Secure Cell to the _sealing_ operation mode.
+    pub fn seal(self) -> SecureCellSeal {
+        SecureCellSeal(self)
+    }
+
+    /// Switches this Secure Cell to the _token protect_ operation mode.
+    pub fn token_protect(self) -> SecureCellTokenProtect {
+        SecureCellTokenProtect(self)
+    }
+
+    /// Switches this Secure Cell to the _context imprint_ operation mode.
+    pub fn context_imprint(self) -> SecureCellContextImprint {
+        SecureCellContextImprint(self)
+    }
+}
+
+/// Secure Cell in a _sealing_ operation mode.
+pub struct SecureCellSeal(SecureCell);
+
+impl SecureCellSeal {
+    /// Encrypts and puts the provided message into a sealed cell.
+    pub fn encrypt<M: AsRef<[u8]>>(&self, message: M) -> Result<Vec<u8>> {
+        encrypt_seal(
+            self.0.master_key.as_bytes(),
+            self.0.user_context.as_bytes(),
+            message.as_ref(),
+        )
+    }
+
+    /// Extracts the original message from a sealed cell.
+    pub fn decrypt<M: AsRef<[u8]>>(&self, message: M) -> Result<Vec<u8>> {
+        decrypt_seal(
+            self.0.master_key.as_bytes(),
+            self.0.user_context.as_bytes(),
+            message.as_ref(),
+        )
+    }
+}
+
+/// Encrypts `message` with `master_key` including optional `user_context` for verification.
+fn encrypt_seal(master_key: &[u8], user_context: &[u8], message: &[u8]) -> Result<Vec<u8>> {
+    let (master_key_ptr, master_key_len) = into_raw_parts(master_key);
+    let (user_context_ptr, user_context_len) = into_raw_parts(user_context);
+    let (message_ptr, message_len) = into_raw_parts(message);
+
+    let mut encrypted_message = Vec::new();
+    let mut encrypted_message_len = 0;
+
+    unsafe {
+        let status = themis_secure_cell_encrypt_seal(
+            master_key_ptr,
+            master_key_len,
+            user_context_ptr,
+            user_context_len,
+            message_ptr,
+            message_len,
+            ptr::null_mut(),
+            &mut encrypted_message_len,
+        );
+        let error = Error::from_themis_status(status);
+        if error.kind() != ErrorKind::BufferTooSmall {
+            return Err(error);
+        }
+    }
+
+    encrypted_message.reserve(encrypted_message_len as usize);
+
+    unsafe {
+        let status = themis_secure_cell_encrypt_seal(
+            master_key_ptr,
+            master_key_len,
+            user_context_ptr,
+            user_context_len,
+            message_ptr,
+            message_len,
+            encrypted_message.as_mut_ptr(),
+            &mut encrypted_message_len,
+        );
+        let error = Error::from_themis_status(status);
+        if error.kind() != ErrorKind::Success {
+            return Err(error);
+        }
+        debug_assert!(encrypted_message_len <= encrypted_message.capacity());
+        encrypted_message.set_len(encrypted_message_len as usize);
+    }
+
+    Ok(encrypted_message)
+}
+
+/// Decrypts `message` with `master_key` and verifies authenticity of `user_context`.
+fn decrypt_seal(master_key: &[u8], user_context: &[u8], message: &[u8]) -> Result<Vec<u8>> {
+    let (master_key_ptr, master_key_len) = into_raw_parts(master_key);
+    let (user_context_ptr, user_context_len) = into_raw_parts(user_context);
+    let (message_ptr, message_len) = into_raw_parts(message);
+
+    let mut decrypted_message = Vec::new();
+    let mut decrypted_message_len = 0;
+
+    unsafe {
+        let status = themis_secure_cell_decrypt_seal(
+            master_key_ptr,
+            master_key_len,
+            user_context_ptr,
+            user_context_len,
+            message_ptr,
+            message_len,
+            ptr::null_mut(),
+            &mut decrypted_message_len,
+        );
+        let error = Error::from_themis_status(status);
+        if error.kind() != ErrorKind::BufferTooSmall {
+            return Err(error);
+        }
+    }
+
+    decrypted_message.reserve(decrypted_message_len as usize);
+
+    unsafe {
+        let status = themis_secure_cell_decrypt_seal(
+            master_key_ptr,
+            master_key_len,
+            user_context_ptr,
+            user_context_len,
+            message_ptr,
+            message_len,
+            decrypted_message.as_mut_ptr(),
+            &mut decrypted_message_len,
+        );
+        let error = Error::from_themis_status(status);
+        if error.kind() != ErrorKind::Success {
+            return Err(error);
+        }
+        debug_assert!(decrypted_message_len <= decrypted_message.capacity());
+        decrypted_message.set_len(decrypted_message_len as usize);
+    }
+
+    Ok(decrypted_message)
+}
+
+/// Secure Cell in a _token protect_ operation mode.
+pub struct SecureCellTokenProtect(SecureCell);
+
+impl SecureCellTokenProtect {
+    /// Encrypts the provided message and returns the ciphertext with authentication token.
+    ///
+    /// The ciphertext and authentication token could be stored or transmitted separately.
+    /// You will need to provide both later for successful decryption.
+    pub fn encrypt<M: AsRef<[u8]>>(&self, message: M) -> Result<(Vec<u8>, Vec<u8>)> {
+        encrypt_token_protect(
+            self.0.master_key.as_bytes(),
+            self.0.user_context.as_bytes(),
+            message.as_ref(),
+        )
+    }
+
+    /// Decrypts the ciphertext then validates and returns the original message.
+    ///
+    /// You need to provide both the ciphertext and the authentication token previously obtained
+    /// from `encrypt()`. Decryption will fail if any of them is corrupted or invalid.
+    pub fn decrypt<M: AsRef<[u8]>, T: AsRef<[u8]>>(&self, message: M, token: T) -> Result<Vec<u8>> {
+        decrypt_token_protect(
+            self.0.master_key.as_bytes(),
+            self.0.user_context.as_bytes(),
+            message.as_ref(),
+            token.as_ref(),
+        )
+    }
+}
+
+/// Encrypts `message` with `master_key` including optional `user_context` for verification.
+/// Returns `(ciphertext, auth_token)` tuple.
+fn encrypt_token_protect(
+    master_key: &[u8],
+    user_context: &[u8],
+    message: &[u8],
+) -> Result<(Vec<u8>, Vec<u8>)> {
+    let (master_key_ptr, master_key_len) = into_raw_parts(master_key);
+    let (user_context_ptr, user_context_len) = into_raw_parts(user_context);
+    let (message_ptr, message_len) = into_raw_parts(message);
+
+    let mut token = Vec::new();
+    let mut token_len = 0;
+    let mut encrypted_message = Vec::new();
+    let mut encrypted_message_len = 0;
+
+    unsafe {
+        let status = themis_secure_cell_encrypt_token_protect(
+            master_key_ptr,
+            master_key_len,
+            user_context_ptr,
+            user_context_len,
+            message_ptr,
+            message_len,
+            ptr::null_mut(),
+            &mut token_len,
+            ptr::null_mut(),
+            &mut encrypted_message_len,
+        );
+        let error = Error::from_themis_status(status);
+        if error.kind() != ErrorKind::BufferTooSmall {
+            return Err(error);
+        }
+    }
+
+    token.reserve(token_len as usize);
+    encrypted_message.reserve(encrypted_message_len as usize);
+
+    unsafe {
+        let status = themis_secure_cell_encrypt_token_protect(
+            master_key_ptr,
+            master_key_len,
+            user_context_ptr,
+            user_context_len,
+            message_ptr,
+            message_len,
+            token.as_mut_ptr(),
+            &mut token_len,
+            encrypted_message.as_mut_ptr(),
+            &mut encrypted_message_len,
+        );
+        let error = Error::from_themis_status(status);
+        if error.kind() != ErrorKind::Success {
+            return Err(error);
+        }
+        debug_assert!(token_len <= token.capacity());
+        token.set_len(token_len as usize);
+        debug_assert!(encrypted_message_len <= encrypted_message.capacity());
+        encrypted_message.set_len(encrypted_message_len as usize);
+    }
+
+    Ok((encrypted_message, token))
+}
+
+/// Decrypts `message` with `master_key` and `token` verifying `user_context`.
+fn decrypt_token_protect(
+    master_key: &[u8],
+    user_context: &[u8],
+    message: &[u8],
+    token: &[u8],
+) -> Result<Vec<u8>> {
+    let (master_key_ptr, master_key_len) = into_raw_parts(master_key);
+    let (user_context_ptr, user_context_len) = into_raw_parts(user_context);
+    let (message_ptr, message_len) = into_raw_parts(message);
+    let (token_ptr, token_len) = into_raw_parts(token);
+
+    let mut decrypted_message = Vec::new();
+    let mut decrypted_message_len = 0;
+
+    unsafe {
+        let status = themis_secure_cell_decrypt_token_protect(
+            master_key_ptr,
+            master_key_len,
+            user_context_ptr,
+            user_context_len,
+            message_ptr,
+            message_len,
+            token_ptr,
+            token_len,
+            ptr::null_mut(),
+            &mut decrypted_message_len,
+        );
+        let error = Error::from_themis_status(status);
+        if error.kind() != ErrorKind::BufferTooSmall {
+            return Err(error);
+        }
+    }
+
+    decrypted_message.reserve(decrypted_message_len as usize);
+
+    unsafe {
+        let status = themis_secure_cell_decrypt_token_protect(
+            master_key_ptr,
+            master_key_len,
+            user_context_ptr,
+            user_context_len,
+            message_ptr,
+            message_len,
+            token_ptr,
+            token_len,
+            decrypted_message.as_mut_ptr(),
+            &mut decrypted_message_len,
+        );
+        let error = Error::from_themis_status(status);
+        if error.kind() != ErrorKind::Success {
+            return Err(error);
+        }
+        debug_assert!(decrypted_message_len <= decrypted_message.capacity());
+        decrypted_message.set_len(decrypted_message_len as usize);
+    }
+
+    Ok(decrypted_message)
+}
+
+/// Secure Cell in a _context imprint_ operation mode.
+pub struct SecureCellContextImprint(SecureCell);
+
+impl SecureCellContextImprint {
+    /// Encrypts the provided message and returns the ciphertext.
+    ///
+    /// The resulting message has the same length as the input data and does not contain
+    /// an authentication token. There is no way to ensure correctness of later decryption
+    /// if the message gets corrupted or misplaced.
+    pub fn encrypt<M: AsRef<[u8]>>(&self, message: M) -> Result<Vec<u8>> {
+        encrypt_context_imprint(
+            self.0.master_key.as_bytes(),
+            message.as_ref(),
+            self.0.user_context.as_bytes(),
+        )
+    }
+
+    /// Decrypts the ciphertext and returns the original message.
+    ///
+    /// Note that in context imprint mode the messages do not include any authentication token
+    /// for validation, thus the returned message might not be the original one even if has been
+    /// decrypted successfully.
+    pub fn decrypt<M: AsRef<[u8]>>(&self, message: M) -> Result<Vec<u8>> {
+        decrypt_context_imprint(
+            self.0.master_key.as_bytes(),
+            message.as_ref(),
+            self.0.user_context.as_bytes(),
+        )
+    }
+}
+
+/// Encrypts `message` with `master_key` including optional `context`.
+fn encrypt_context_imprint(master_key: &[u8], message: &[u8], context: &[u8]) -> Result<Vec<u8>> {
+    let (master_key_ptr, master_key_len) = into_raw_parts(master_key);
+    let (message_ptr, message_len) = into_raw_parts(message);
+    let (context_ptr, context_len) = into_raw_parts(context);
+
+    let mut encrypted_message = Vec::new();
+    let mut encrypted_message_len = 0;
+
+    unsafe {
+        let status = themis_secure_cell_encrypt_context_imprint(
+            master_key_ptr,
+            master_key_len,
+            message_ptr,
+            message_len,
+            context_ptr,
+            context_len,
+            ptr::null_mut(),
+            &mut encrypted_message_len,
+        );
+        let error = Error::from_themis_status(status);
+        if error.kind() != ErrorKind::BufferTooSmall {
+            return Err(error);
+        }
+    }
+
+    encrypted_message.reserve(encrypted_message_len as usize);
+
+    unsafe {
+        let status = themis_secure_cell_encrypt_context_imprint(
+            master_key_ptr,
+            master_key_len,
+            message_ptr,
+            message_len,
+            context_ptr,
+            context_len,
+            encrypted_message.as_mut_ptr(),
+            &mut encrypted_message_len,
+        );
+        let error = Error::from_themis_status(status);
+        if error.kind() != ErrorKind::Success {
+            return Err(error);
+        }
+        debug_assert!(encrypted_message_len <= encrypted_message.capacity());
+        encrypted_message.set_len(encrypted_message_len as usize);
+    }
+
+    Ok(encrypted_message)
+}
+
+/// Decrypts `message` with `master_key` and expected `context`, but do not verify data.
+fn decrypt_context_imprint(master_key: &[u8], message: &[u8], context: &[u8]) -> Result<Vec<u8>> {
+    let (master_key_ptr, master_key_len) = into_raw_parts(master_key);
+    let (message_ptr, message_len) = into_raw_parts(message);
+    let (context_ptr, context_len) = into_raw_parts(context);
+
+    let mut decrypted_message = Vec::new();
+    let mut decrypted_message_len = 0;
+
+    unsafe {
+        let status = themis_secure_cell_decrypt_context_imprint(
+            master_key_ptr,
+            master_key_len,
+            message_ptr,
+            message_len,
+            context_ptr,
+            context_len,
+            ptr::null_mut(),
+            &mut decrypted_message_len,
+        );
+        let error = Error::from_themis_status(status);
+        if error.kind() != ErrorKind::BufferTooSmall {
+            return Err(error);
+        }
+    }
+
+    decrypted_message.reserve(decrypted_message_len as usize);
+
+    unsafe {
+        let status = themis_secure_cell_decrypt_context_imprint(
+            master_key_ptr,
+            master_key_len,
+            message_ptr,
+            message_len,
+            context_ptr,
+            context_len,
+            decrypted_message.as_mut_ptr(),
+            &mut decrypted_message_len,
+        );
+        let error = Error::from_themis_status(status);
+        if error.kind() != ErrorKind::Success {
+            return Err(error);
+        }
+        debug_assert!(decrypted_message_len <= decrypted_message.capacity());
+        decrypted_message.set_len(decrypted_message_len as usize);
+    }
+
+    Ok(decrypted_message)
+}

--- a/src/wrappers/themis/rust/src/secure_comparator.rs
+++ b/src/wrappers/themis/rust/src/secure_comparator.rs
@@ -1,0 +1,239 @@
+// Copyright 2018 (c) rust-themis developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Secure Comparator service.
+//!
+//! **Secure Comparator** is an implementation of _Zero-Knowledge Proof_-based protocol,
+//! built around OTR SMP implementation.
+
+use std::os::raw::c_void;
+use std::ptr;
+
+use bindings::{
+    secure_comparator_append_secret, secure_comparator_begin_compare, secure_comparator_create,
+    secure_comparator_destroy, secure_comparator_get_result, secure_comparator_proceed_compare,
+    secure_comparator_t,
+};
+use error::{Error, ErrorKind, Result};
+use utils::into_raw_parts;
+
+/// Secure Comparison context.
+pub struct SecureComparator {
+    comp_ctx: *mut secure_comparator_t,
+}
+
+impl SecureComparator {
+    /// Prepares for a new comparison.
+    ///
+    /// # Panics
+    ///
+    /// May panic on internal unrecoverable errors (like memory allocation).
+    pub fn new() -> Self {
+        match SecureComparator::try_new() {
+            Ok(comparator) => comparator,
+            Err(e) => panic!("secure_comparator_create() failed: {}", e),
+        }
+    }
+
+    /// Prepares for a new comparison.
+    fn try_new() -> Result<Self> {
+        let comp_ctx = unsafe { secure_comparator_create() };
+
+        if comp_ctx.is_null() {
+            // This function is most likely to fail on memory allocation. Some internal errors
+            // in the crypto library are also possible, but unlikely. We have no way to find out.
+            return Err(Error::with_kind(ErrorKind::NoMemory));
+        }
+
+        Ok(Self { comp_ctx })
+    }
+
+    /// Collects the data to be compared.
+    ///
+    /// Note that there is no way to remove data. If even a single byte is mismatched by the peers
+    /// then the comparison will always return `false`. In this case you will need to recreate
+    /// a `SecureComparator` to make a new comparison.
+    ///
+    /// You can use this method between completed comparisons, but not when you're in the middle
+    /// of one. That is, [`append_secret`] is safe call either before [`begin_compare`]
+    /// or after [`get_result`]. Otherwise it will fail and return an error.
+    ///
+    /// [`append_secret`]: struct.SecureComparator.html#method.append_secret
+    /// [`begin_compare`]: struct.SecureComparator.html#method.begin_compare
+    /// [`get_result`]: struct.SecureComparator.html#method.get_result
+    pub fn append_secret<S: AsRef<[u8]>>(&mut self, secret: S) -> Result<()> {
+        let (secret_ptr, secret_len) = into_raw_parts(secret.as_ref());
+
+        unsafe {
+            let status = secure_comparator_append_secret(
+                self.comp_ctx,
+                secret_ptr as *const c_void,
+                secret_len,
+            );
+            let error = Error::from_compare_status(status);
+            if error.kind() != ErrorKind::Success {
+                return Err(error);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Starts comparison on the client returning the first message.
+    ///
+    /// This method should be called by the client which initiates the comparison. Make sure you
+    /// have appended all the data you need before you call this method.
+    ///
+    /// The resulting message should be transferred to the remote peer and passed to the
+    /// [`proceed_compare`] of its `SecureComparator`. The remote peer should have also appended
+    /// all the data by this point.
+    ///
+    /// [`proceed_compare`]: struct.SecureComparator.html#method.proceed_compare
+    pub fn begin_compare(&mut self) -> Result<Vec<u8>> {
+        let mut compare_data = Vec::new();
+        let mut compare_data_len = 0;
+
+        unsafe {
+            let status = secure_comparator_begin_compare(
+                self.comp_ctx,
+                ptr::null_mut(),
+                &mut compare_data_len,
+            );
+            let error = Error::from_compare_status(status);
+            if error.kind() != ErrorKind::BufferTooSmall {
+                return Err(error);
+            }
+        }
+
+        compare_data.reserve(compare_data_len);
+
+        unsafe {
+            let status = secure_comparator_begin_compare(
+                self.comp_ctx,
+                compare_data.as_mut_ptr() as *mut c_void,
+                &mut compare_data_len,
+            );
+            let error = Error::from_compare_status(status);
+            if error.kind() != ErrorKind::CompareSendOutputToPeer {
+                return Err(error);
+            }
+            debug_assert!(compare_data_len <= compare_data.capacity());
+            compare_data.set_len(compare_data_len);
+        }
+
+        Ok(compare_data)
+    }
+
+    /// Continues comparison process with given message.
+    ///
+    /// This method should be called by the responding server with a message received from the
+    /// client. It returns another message which should be passed back to the client and put
+    /// into its [`proceed_compare`] method (that is, this method again). The client then should
+    /// do the same. The process repeats at both sides until [`is_complete`] signals that the
+    /// comparison is complete.
+    ///
+    /// Both peers should have appended all the compared data before using this method, and no
+    /// additional data should be appended while the comparison is underway.
+    ///
+    /// [`proceed_compare`]: struct.SecureComparator.html#method.proceed_compare
+    /// [`is_complete`]: struct.SecureComparator.html#method.is_complete
+    pub fn proceed_compare<D: AsRef<[u8]>>(&mut self, peer_data: D) -> Result<Vec<u8>> {
+        let (peer_compare_data_ptr, peer_compare_data_len) = into_raw_parts(peer_data.as_ref());
+
+        let mut compare_data = Vec::new();
+        let mut compare_data_len = 0;
+
+        unsafe {
+            let status = secure_comparator_proceed_compare(
+                self.comp_ctx,
+                peer_compare_data_ptr as *const c_void,
+                peer_compare_data_len,
+                ptr::null_mut(),
+                &mut compare_data_len,
+            );
+            let error = Error::from_compare_status(status);
+            if error.kind() != ErrorKind::BufferTooSmall {
+                return Err(error);
+            }
+        }
+
+        compare_data.reserve(compare_data_len);
+
+        unsafe {
+            let status = secure_comparator_proceed_compare(
+                self.comp_ctx,
+                peer_compare_data_ptr as *const c_void,
+                peer_compare_data_len,
+                compare_data.as_mut_ptr() as *mut c_void,
+                &mut compare_data_len,
+            );
+            let error = Error::from_compare_status(status);
+            match error.kind() {
+                ErrorKind::CompareSendOutputToPeer => {}
+                // TODO: signal that this does not need to be sent
+                ErrorKind::Success => {}
+                _ => {
+                    return Err(error);
+                }
+            }
+            debug_assert!(compare_data_len <= compare_data.capacity());
+            compare_data.set_len(compare_data_len);
+        }
+
+        Ok(compare_data)
+    }
+
+    /// Returns the result of comparison.
+    ///
+    /// Let it be a surprise: `true` if data has been found equal on both peers, `false` otherwise.
+    /// Or an error if you call this method too early.
+    pub fn get_result(&self) -> Result<bool> {
+        let status = unsafe { secure_comparator_get_result(self.comp_ctx) };
+        let error = Error::from_match_status(status);
+        match error.kind() {
+            ErrorKind::CompareMatch => Ok(true),
+            ErrorKind::CompareNoMatch => Ok(false),
+            _ => Err(error),
+        }
+    }
+
+    /// Checks if this comparison is complete.
+    ///
+    /// Comparison that failed irrecoverably due to an error is also considered complete.
+    pub fn is_complete(&self) -> bool {
+        match self.get_result() {
+            Err(ref e) if e.kind() == ErrorKind::CompareNotReady => false,
+            _ => true,
+        }
+    }
+}
+
+impl Default for SecureComparator {
+    fn default() -> Self {
+        SecureComparator::new()
+    }
+}
+
+#[doc(hidden)]
+impl Drop for SecureComparator {
+    fn drop(&mut self) {
+        unsafe {
+            let status = secure_comparator_destroy(self.comp_ctx);
+            let error = Error::from_themis_status(status);
+            if (cfg!(debug) || cfg!(test)) && error.kind() != ErrorKind::Success {
+                panic!("secure_comparator_destroy() failed: {}", error);
+            }
+        }
+    }
+}

--- a/src/wrappers/themis/rust/src/secure_message.rs
+++ b/src/wrappers/themis/rust/src/secure_message.rs
@@ -1,0 +1,210 @@
+// Copyright 2018 (c) rust-themis developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Secure Message service.
+//!
+//! **Secure Message** is a lightweight service that can help deliver some message or data
+//! to your peer in a secure manner.
+
+use std::ptr;
+
+use bindings::{themis_secure_message_unwrap, themis_secure_message_wrap};
+use error::{Error, ErrorKind, Result};
+use keys::{KeyPair, PublicKey, SecretKey};
+use utils::into_raw_parts;
+
+/// Secure Message encryption.
+///
+/// Messages produced by this object will be encrypted and verified for integrity.
+#[derive(Clone)]
+pub struct SecureMessage {
+    key_pair: KeyPair,
+}
+
+impl SecureMessage {
+    /// Makes a new Secure Message using given key pair.
+    pub fn new<K: Into<KeyPair>>(key_pair: K) -> Self {
+        Self {
+            key_pair: key_pair.into(),
+        }
+    }
+
+    /// Wraps the provided message into a secure encrypted message.
+    pub fn wrap<M: AsRef<[u8]>>(&self, message: M) -> Result<Vec<u8>> {
+        wrap(
+            self.key_pair.secret_key_bytes(),
+            self.key_pair.public_key_bytes(),
+            message.as_ref(),
+        )
+    }
+
+    /// Unwraps an encrypted message back into its original form.
+    pub fn unwrap<M: AsRef<[u8]>>(&self, wrapped: M) -> Result<Vec<u8>> {
+        unwrap(
+            self.key_pair.secret_key_bytes(),
+            self.key_pair.public_key_bytes(),
+            wrapped.as_ref(),
+        )
+    }
+}
+
+/// Secure Message signing.
+///
+/// Messages produced by this object will be signed and verified for integrity, but not encrypted.
+///
+/// The signatures can be checked with [`SecureVerify`].
+///
+/// [`SecureVerify`]: struct.SecureVerify.html
+#[derive(Clone)]
+pub struct SecureSign {
+    secret_key: SecretKey,
+}
+
+impl SecureSign {
+    /// Makes a new Secure Message using given secret key.
+    pub fn new<S: Into<SecretKey>>(secret_key: S) -> Self {
+        Self {
+            secret_key: secret_key.into(),
+        }
+    }
+
+    /// Securely signs a message and returns it with signature attached.
+    pub fn sign<M: AsRef<[u8]>>(&self, message: M) -> Result<Vec<u8>> {
+        wrap(self.secret_key.as_ref(), &[], message.as_ref())
+    }
+}
+
+/// Secure Message verification.
+///
+/// Verifies signatures produced by [`SecureSign`].
+///
+/// [`SecureSign`]: struct.SecureSign.html
+#[derive(Clone)]
+pub struct SecureVerify {
+    public_key: PublicKey,
+}
+
+impl SecureVerify {
+    /// Makes a new Secure Message using given public key.
+    pub fn new<P: Into<PublicKey>>(public_key: P) -> Self {
+        Self {
+            public_key: public_key.into(),
+        }
+    }
+
+    /// Verifies a signature and returns the original message.
+    pub fn verify<M: AsRef<[u8]>>(&self, message: M) -> Result<Vec<u8>> {
+        unwrap(&[], self.public_key.as_ref(), message.as_ref())
+    }
+}
+
+/// Wrap a message into a secure message.
+fn wrap(secret_key: &[u8], public_key: &[u8], message: &[u8]) -> Result<Vec<u8>> {
+    let (secret_key_ptr, secret_key_len) = into_raw_parts(secret_key);
+    let (public_key_ptr, public_key_len) = into_raw_parts(public_key);
+    let (message_ptr, message_len) = into_raw_parts(message);
+
+    let mut wrapped = Vec::new();
+    let mut wrapped_len = 0;
+
+    unsafe {
+        let status = themis_secure_message_wrap(
+            secret_key_ptr,
+            secret_key_len,
+            public_key_ptr,
+            public_key_len,
+            message_ptr,
+            message_len,
+            ptr::null_mut(),
+            &mut wrapped_len,
+        );
+        let error = Error::from_themis_status(status);
+        if error.kind() != ErrorKind::BufferTooSmall {
+            return Err(error);
+        }
+    }
+
+    wrapped.reserve(wrapped_len);
+
+    unsafe {
+        let status = themis_secure_message_wrap(
+            secret_key_ptr,
+            secret_key_len,
+            public_key_ptr,
+            public_key_len,
+            message_ptr,
+            message_len,
+            wrapped.as_mut_ptr(),
+            &mut wrapped_len,
+        );
+        let error = Error::from_themis_status(status);
+        if error.kind() != ErrorKind::Success {
+            return Err(error);
+        }
+        debug_assert!(wrapped_len <= wrapped.capacity());
+        wrapped.set_len(wrapped_len as usize);
+    }
+
+    Ok(wrapped)
+}
+
+/// Unwrap a secure message into a message.
+fn unwrap(secret_key: &[u8], public_key: &[u8], wrapped: &[u8]) -> Result<Vec<u8>> {
+    let (secret_key_ptr, secret_key_len) = into_raw_parts(secret_key);
+    let (public_key_ptr, public_key_len) = into_raw_parts(public_key);
+    let (wrapped_ptr, wrapped_len) = into_raw_parts(wrapped);
+
+    let mut message = Vec::new();
+    let mut message_len = 0;
+
+    unsafe {
+        let status = themis_secure_message_unwrap(
+            secret_key_ptr,
+            secret_key_len,
+            public_key_ptr,
+            public_key_len,
+            wrapped_ptr,
+            wrapped_len,
+            ptr::null_mut(),
+            &mut message_len,
+        );
+        let error = Error::from_themis_status(status);
+        if error.kind() != ErrorKind::BufferTooSmall {
+            return Err(error);
+        }
+    }
+
+    message.reserve(message_len);
+
+    unsafe {
+        let status = themis_secure_message_unwrap(
+            secret_key_ptr,
+            secret_key_len,
+            public_key_ptr,
+            public_key_len,
+            wrapped_ptr,
+            wrapped_len,
+            message.as_mut_ptr(),
+            &mut message_len,
+        );
+        let error = Error::from_themis_status(status);
+        if error.kind() != ErrorKind::Success {
+            return Err(error);
+        }
+        debug_assert!(message_len <= message.capacity());
+        message.set_len(message_len as usize);
+    }
+
+    Ok(message)
+}

--- a/src/wrappers/themis/rust/src/secure_session.rs
+++ b/src/wrappers/themis/rust/src/secure_session.rs
@@ -1,0 +1,661 @@
+// Copyright 2018 (c) rust-themis developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Secure Session service.
+//!
+//! **Secure Session** is a lightweight mechanism for securing any kind of network communication
+//! (both private and public networks, including the Internet).
+
+use std::os::raw::{c_int, c_void};
+use std::{ptr, result, slice};
+
+use bindings::{
+    secure_session_connect, secure_session_create, secure_session_destroy,
+    secure_session_generate_connect_request, secure_session_get_remote_id,
+    secure_session_is_established, secure_session_receive, secure_session_send, secure_session_t,
+    secure_session_unwrap, secure_session_user_callbacks_t, secure_session_wrap, STATE_ESTABLISHED,
+    STATE_IDLE, STATE_NEGOTIATING,
+};
+use error::{themis_status_t, Error, ErrorKind, Result};
+use keys::{EcdsaPublicKey, EcdsaSecretKey};
+use utils::into_raw_parts;
+
+/// Secure Session context.
+pub struct SecureSession<T> {
+    session_ctx: *mut secure_session_t,
+    _delegate: Box<SecureSessionDelegate<T>>,
+}
+
+/// Transport delegate for Secure Session.
+///
+/// This is an interface you need to provide for Secure Session operation.
+///
+/// The only required method is [`get_public_key_for_id`]. It is required for public key
+/// authentication. Other methods are optional, you can use Secure Session without them,
+/// but some functionality may be unavailable.
+///
+/// [`get_public_key_for_id`]: trait.SecureSessionTransport.html#tymethod.get_public_key_for_id
+#[allow(unused_variables)]
+pub trait SecureSessionTransport {
+    // TODO: consider send/receive use std::io::Error for errors (or a custom type)
+
+    /// Send the provided data to the peer, return the number of bytes transferred.
+    ///
+    /// This callback will be called when Secure Session needs to send some data to its peer.
+    /// The whole message is expected to be transferred so returning anything other than
+    /// `Ok(data.len())` is considered an error.
+    ///
+    /// This method is used by the transport API ([`connect`], [`negotiate_transport`], [`send`]).
+    /// You need to implement it in order to use this API.
+    ///
+    /// [`connect`]: struct.SecureSession.html#method.connect
+    /// [`negotiate_transport`]: struct.SecureSession.html#method.negotiate_transport
+    /// [`send`]: struct.SecureSession.html#method.send
+    fn send_data(&mut self, data: &[u8]) -> result::Result<usize, ()> {
+        Err(())
+    }
+
+    /// Receive some data from the peer into the provided buffer, return the number of bytes.
+    ///
+    /// This callback will be called when Secure Session expects to receive some data. The length
+    /// of the buffer indicates the maximum amount of data expected. Put the received data into
+    /// the provided buffer and return the number of bytes that you used.
+    ///
+    /// This method is used by the transport API ([`negotiate_transport`], [`receive`]).
+    /// You need to implement it in order to use this API.
+    ///
+    /// [`negotiate_transport`]: struct.SecureSession.html#method.negotiate_transport
+    /// [`receive`]: struct.SecureSession.html#method.receive
+    fn receive_data(&mut self, data: &mut [u8]) -> result::Result<usize, ()> {
+        Err(())
+    }
+
+    /// Notification about connection state of Secure Session.
+    ///
+    /// This method is truly optional and has no effect on Secure Session operation.
+    fn state_changed(&mut self, state: SecureSessionState) {}
+
+    /// Get a public key corresponding to a peer ID.
+    ///
+    /// Return `None` if you are unable to find a corresponding public key.
+    fn get_public_key_for_id(&mut self, id: &[u8]) -> Option<EcdsaPublicKey>;
+}
+
+// We keep this struct in a box so that it has fixed address. Themis does *not* copy
+// the callback struct into session context, it keeps a pointer to it. The callback
+// structure itself also stores a `user_data` pointer to itself, so it's important
+// to have this structure pinned in memory.
+struct SecureSessionDelegate<T> {
+    callbacks: secure_session_user_callbacks_t,
+    transport: T,
+}
+
+/// State of Secure Session connection.
+#[derive(PartialEq, Eq)]
+pub enum SecureSessionState {
+    /// Newly created sessions start in this state.
+    Idle,
+    /// Connection establishment in progress.
+    Negotiating,
+    /// Connection has been established, data exchange may commence.
+    Established,
+}
+
+impl SecureSessionState {
+    fn from_int(state: c_int) -> Option<Self> {
+        match state as u32 {
+            STATE_IDLE => Some(SecureSessionState::Idle),
+            STATE_NEGOTIATING => Some(SecureSessionState::Negotiating),
+            STATE_ESTABLISHED => Some(SecureSessionState::Established),
+            _ => None,
+        }
+    }
+}
+
+impl<T> SecureSession<T>
+where
+    T: SecureSessionTransport,
+{
+    // TODO: introduce a builder
+
+    /// Creates a new Secure Session.
+    ///
+    /// ID is an arbitrary byte sequence used to identify this peer.
+    ///
+    /// Secure Session supports only ECDSA keys.
+    pub fn with_transport<I>(id: I, key: &EcdsaSecretKey, transport: T) -> Result<Self>
+    where
+        I: AsRef<[u8]>,
+    {
+        let (id_ptr, id_len) = into_raw_parts(id.as_ref());
+        let (key_ptr, key_len) = into_raw_parts(key.as_ref());
+        let delegate = SecureSessionDelegate::new(transport);
+
+        let user_callbacks = delegate.user_callbacks();
+        let session_ctx = unsafe {
+            secure_session_create(
+                id_ptr as *const c_void,
+                id_len,
+                key_ptr as *const c_void,
+                key_len,
+                user_callbacks,
+            )
+        };
+
+        if session_ctx.is_null() {
+            // Technically, this may be an allocation error but we have no way to know so just
+            // assume that the user messed up and provided invalid keys (which is more likely).
+            return Err(Error::with_kind(ErrorKind::InvalidParameter));
+        }
+
+        Ok(Self {
+            session_ctx,
+            _delegate: delegate,
+        })
+    }
+
+    /// Returns `true` if this Secure Session may be used for data transfer.
+    pub fn is_established(&self) -> bool {
+        unsafe { secure_session_is_established(self.session_ctx) }
+    }
+
+    // TODO: abstract out the 'check-allocate-leap' pattern
+    //
+    // This is really common here to call a C function to get a size of the buffer, then allocate
+    // memory, then call the function again to do actual work, then fix the length of the vector.
+    // It would be nice to have this abstracted out so that we don't have to repeat ourselves.
+
+    /// Returns ID of the remote peer.
+    ///
+    /// This method will return an error if the connection has not been established yet.
+    pub fn get_remote_id(&self) -> Result<Vec<u8>> {
+        let mut id = Vec::new();
+        let mut id_len = 0;
+
+        unsafe {
+            let status =
+                secure_session_get_remote_id(self.session_ctx, ptr::null_mut(), &mut id_len);
+            let error = Error::from_session_status(status);
+            if error.kind() != ErrorKind::BufferTooSmall {
+                return Err(error);
+            }
+        }
+
+        id.reserve(id_len);
+
+        unsafe {
+            let status =
+                secure_session_get_remote_id(self.session_ctx, id.as_mut_ptr(), &mut id_len);
+            let error = Error::from_session_status(status);
+            if error.kind() != ErrorKind::Success {
+                return Err(error);
+            }
+            debug_assert!(id_len <= id.capacity());
+            id.set_len(id_len);
+        }
+
+        Ok(id)
+    }
+
+    /// Initiates connection to the remote peer.
+    ///
+    /// This is the first method to call. It uses transport callbacks to send the resulting
+    /// connection request to the peer. Afterwards call [`negotiate_transport`] until the
+    /// connection is established. That is, until the [`state_changed`] callback of your
+    /// `SecureSessionTransport` tells you that the connection is `Established`, or until
+    /// [`is_established`] on this Secure Session returns `true`.
+    ///
+    /// This method is a part of transport API and requires [`send_data`] method of
+    /// `SecureSessionTransport`.
+    ///
+    /// [`negotiate_transport`]: struct.SecureSession.html#method.negotiate_transport
+    /// [`state_changed`]: trait.SecureSessionTransport.html#method.state_changed
+    /// [`is_established`]: struct.SecureSession.html#method.is_established
+    /// [`send_data`]: trait.SecureSessionTransport.html#method.send_data
+    pub fn connect(&mut self) -> Result<()> {
+        unsafe {
+            let status = secure_session_connect(self.session_ctx);
+            let error = Error::from_session_status(status);
+            if error.kind() != ErrorKind::Success {
+                return Err(error);
+            }
+        }
+        Ok(())
+    }
+
+    /// Initiates connection to the remote peer, returns connection message.
+    ///
+    /// This is the first method to call. It returns you a message that you must somehow
+    /// transfer to the remote peer and give it to its [`negotiate`] method. This results in
+    /// another message which must be transferred back to this Secure Session and passed to
+    /// its [`negotiate`] method. Continue passing these message around until the connection
+    /// is established. That is, until the [`state_changed`] callback of your
+    /// `SecureSessionTransport` tells you that the connection is `Established`, or until
+    /// [`is_established`] on this Secure Session returns `true`, or until [`negotiate`]
+    /// returns an empty message.
+    ///
+    /// [`negotiate`]: struct.SecureSession.html#method.negotiate
+    /// [`state_changed`]: trait.SecureSessionTransport.html#method.state_changed
+    /// [`is_established`]: struct.SecureSession.html#method.is_established
+    pub fn generate_connect_request(&mut self) -> Result<Vec<u8>> {
+        let mut output = Vec::new();
+        let mut output_len = 0;
+
+        unsafe {
+            let status = secure_session_generate_connect_request(
+                self.session_ctx,
+                ptr::null_mut(),
+                &mut output_len,
+            );
+            let error = Error::from_session_status(status);
+            if error.kind() != ErrorKind::BufferTooSmall {
+                return Err(error);
+            }
+        }
+
+        output.reserve(output_len);
+
+        unsafe {
+            let status = secure_session_generate_connect_request(
+                self.session_ctx,
+                output.as_mut_ptr() as *mut c_void,
+                &mut output_len,
+            );
+            let error = Error::from_session_status(status);
+            if error.kind() != ErrorKind::Success {
+                return Err(error);
+            }
+            debug_assert!(output_len <= output.capacity());
+            output.set_len(output_len);
+        }
+
+        Ok(output)
+    }
+
+    /// Wraps a message and returns it.
+    ///
+    /// The message can be transferred to the remote peer and unwrapped there with [`unwrap`].
+    ///
+    /// Wrapped message are independent and can be exchanged out of order. You can wrap multiple
+    /// messages then unwrap them in any order or don't unwrap some of them at all.
+    ///
+    /// This method will fail if a secure connection has not been established yet.
+    ///
+    /// [`unwrap`]: struct.SecureSession.html#method.unwrap
+    pub fn wrap<M: AsRef<[u8]>>(&mut self, message: M) -> Result<Vec<u8>> {
+        let (message_ptr, message_len) = into_raw_parts(message.as_ref());
+
+        let mut wrapped = Vec::new();
+        let mut wrapped_len = 0;
+
+        unsafe {
+            let status = secure_session_wrap(
+                self.session_ctx,
+                message_ptr as *const c_void,
+                message_len,
+                ptr::null_mut(),
+                &mut wrapped_len,
+            );
+            let error = Error::from_session_status(status);
+            if error.kind() != ErrorKind::BufferTooSmall {
+                return Err(error);
+            }
+        }
+
+        wrapped.reserve(wrapped_len);
+
+        unsafe {
+            let status = secure_session_wrap(
+                self.session_ctx,
+                message_ptr as *const c_void,
+                message_len,
+                wrapped.as_mut_ptr() as *mut c_void,
+                &mut wrapped_len,
+            );
+            let error = Error::from_session_status(status);
+            if error.kind() != ErrorKind::Success {
+                return Err(error);
+            }
+            debug_assert!(wrapped_len <= wrapped.capacity());
+            wrapped.set_len(wrapped_len);
+        }
+
+        Ok(wrapped)
+    }
+
+    /// Unwraps a message and returns it.
+    ///
+    /// Unwraps a message previously [wrapped] by the remote peer.
+    ///
+    /// This method will fail if a secure connection has not been established yet.
+    ///
+    /// [wrapped]: struct.SecureSession.html#method.wrap
+    pub fn unwrap<M: AsRef<[u8]>>(&mut self, wrapped: M) -> Result<Vec<u8>> {
+        let (wrapped_ptr, wrapped_len) = into_raw_parts(wrapped.as_ref());
+
+        let mut message = Vec::new();
+        let mut message_len = 0;
+
+        unsafe {
+            let status = secure_session_unwrap(
+                self.session_ctx,
+                wrapped_ptr as *const c_void,
+                wrapped_len,
+                ptr::null_mut(),
+                &mut message_len,
+            );
+            let error = Error::from_session_status(status);
+            if error.kind() != ErrorKind::BufferTooSmall {
+                return Err(error);
+            }
+        }
+
+        message.reserve(message_len);
+
+        unsafe {
+            let status = secure_session_unwrap(
+                self.session_ctx,
+                wrapped_ptr as *const c_void,
+                wrapped_len,
+                message.as_mut_ptr() as *mut c_void,
+                &mut message_len,
+            );
+            let error = Error::from_session_status(status);
+            if error.kind() != ErrorKind::Success {
+                return Err(error);
+            }
+            debug_assert!(message_len <= message.capacity());
+            message.set_len(message_len);
+        }
+
+        Ok(message)
+    }
+
+    /// Continues connection negotiation with given message.
+    ///
+    /// This method performs one step of connection negotiation. The server should call this
+    /// method first with a message received from client's [`generate_connect_request`].
+    /// Its result is another negotiation message that should be transferred to the client.
+    /// The client then calls this method on a message and forwards the resulting message
+    /// to the server. If the returned message is empty then negotiation is complete and
+    /// the Secure Session is ready to be used.
+    ///
+    /// [`negotiate`]: struct.SecureSession.html#method.negotiate
+    /// [`generate_connect_request`]: struct.SecureSession.html#method.generate_connect_request
+    pub fn negotiate<M: AsRef<[u8]>>(&mut self, wrapped: M) -> Result<Vec<u8>> {
+        let (wrapped_ptr, wrapped_len) = into_raw_parts(wrapped.as_ref());
+
+        let mut message = Vec::new();
+        let mut message_len = 0;
+
+        unsafe {
+            let status = secure_session_unwrap(
+                self.session_ctx,
+                wrapped_ptr as *const c_void,
+                wrapped_len,
+                ptr::null_mut(),
+                &mut message_len,
+            );
+            let error = Error::from_session_status(status);
+            if error.kind() == ErrorKind::Success {
+                return Ok(message);
+            }
+            if error.kind() != ErrorKind::BufferTooSmall {
+                return Err(error);
+            }
+        }
+
+        message.reserve(message_len);
+
+        unsafe {
+            let status = secure_session_unwrap(
+                self.session_ctx,
+                wrapped_ptr as *const c_void,
+                wrapped_len,
+                message.as_mut_ptr() as *mut c_void,
+                &mut message_len,
+            );
+            let error = Error::from_session_status(status);
+            if error.kind() != ErrorKind::SessionSendOutputToPeer {
+                assert_ne!(error.kind(), ErrorKind::Success);
+                return Err(error);
+            }
+            debug_assert!(message_len <= message.capacity());
+            message.set_len(message_len);
+        }
+
+        Ok(message)
+    }
+
+    // TODO: make Themis improve the error reporting for send and receive
+    //
+    // Themis sends messages in full. Partial transfer is considered an error. In case of an
+    // error the error code is returned in-band and cannot be distinguished from a successful
+    // return of message length. This is the best we can do at the moment.
+    //
+    // Furthermore, Themis expects the send callback to send the whole message so it is kinda
+    // pointless to return the amount of bytes send. The receive callback returns accurate number
+    // of bytes, but I do not really like the Rust interface this implies. It could be made better.
+
+    /// Sends a message to the remote peer.
+    ///
+    /// This method will fail if a secure connection has not been established yet.
+    ///
+    /// This method is a part of transport API and requires [`send_data`] method of
+    /// `SecureSessionTransport`.
+    ///
+    /// [`send_data`]: trait.SecureSessionTransport.html#method.send_data
+    pub fn send<M: AsRef<[u8]>>(&mut self, message: M) -> Result<()> {
+        let (message_ptr, message_len) = into_raw_parts(message.as_ref());
+
+        unsafe {
+            let length =
+                secure_session_send(self.session_ctx, message_ptr as *const c_void, message_len);
+            if length <= 21 {
+                return Err(Error::from_session_status(length as themis_status_t));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Receives a message from the remote peer.
+    ///
+    /// Maximum length of the message is specified by the parameter. The message will be truncated
+    /// to this length if the peer sends something larger.
+    ///
+    /// This method will fail if a secure connection has not been established yet.
+    ///
+    /// This method is a part of transport API and requires [`receive_data`] method of
+    /// `SecureSessionTransport`.
+    ///
+    /// [`receive_data`]: trait.SecureSessionTransport.html#method.receive_data
+    pub fn receive(&mut self, max_len: usize) -> Result<Vec<u8>> {
+        let mut message = Vec::with_capacity(max_len);
+
+        unsafe {
+            let length = secure_session_receive(
+                self.session_ctx,
+                message.as_mut_ptr() as *mut c_void,
+                message.capacity(),
+            );
+            if length <= 21 {
+                return Err(Error::from_session_status(length as themis_status_t));
+            }
+            debug_assert!(length as usize <= message.capacity());
+            message.set_len(length as usize);
+        }
+
+        Ok(message)
+    }
+
+    /// Continues connection negotiation.
+    ///
+    /// This method performs one step of connection negotiation. This is the first method to call
+    /// for the server, the client calls it after the initial [`connect`]. Both peers shall then
+    /// repeatedly call this method until the connection is established (see [`connect`] for
+    /// details).
+    ///
+    /// This method is a part of transport API and requires [`send_data`] and [`receive_data`]
+    /// methods of `SecureSessionTransport`.
+    ///
+    /// [`connect`]: struct.SecureSession.html#method.connect
+    /// [`send_data`]: trait.SecureSessionTransport.html#method.send_data
+    /// [`receive_data`]: trait.SecureSessionTransport.html#method.receive_data
+    pub fn negotiate_transport(&mut self) -> Result<()> {
+        unsafe {
+            let result = secure_session_receive(self.session_ctx, ptr::null_mut(), 0);
+            let error = Error::from_session_status(result as themis_status_t);
+            if error.kind() != ErrorKind::Success {
+                return Err(error);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl<T> SecureSessionDelegate<T>
+where
+    T: SecureSessionTransport,
+{
+    pub fn new(transport: T) -> Box<Self> {
+        let mut delegate = Box::new(Self {
+            callbacks: secure_session_user_callbacks_t {
+                send_data: Some(Self::send_data),
+                receive_data: Some(Self::receive_data),
+                state_changed: Some(Self::state_changed),
+                get_public_key_for_id: Some(Self::get_public_key_for_id),
+                user_data: ptr::null_mut(),
+            },
+            transport,
+        });
+        delegate.callbacks.user_data = delegate.transport_ptr();
+        delegate
+    }
+
+    pub fn user_callbacks(&self) -> *const secure_session_user_callbacks_t {
+        &self.callbacks
+    }
+
+    // These functions are unsafe. They should be used only for `user_data` conversion.
+
+    fn transport_ptr(&mut self) -> *mut c_void {
+        &mut self.transport as *mut T as *mut c_void
+    }
+
+    fn transport<'a>(ptr: *mut c_void) -> &'a mut T {
+        unsafe { &mut *(ptr as *mut T) }
+    }
+
+    unsafe extern "C" fn send_data(
+        data_ptr: *const u8,
+        data_len: usize,
+        user_data: *mut c_void,
+    ) -> isize {
+        let data = byte_slice_from_ptr(data_ptr, data_len);
+        let transport = Self::transport(user_data);
+
+        transport
+            .send_data(data)
+            .ok()
+            .and_then(as_isize)
+            .unwrap_or(-1)
+    }
+
+    unsafe extern "C" fn receive_data(
+        data_ptr: *mut u8,
+        data_len: usize,
+        user_data: *mut c_void,
+    ) -> isize {
+        let data = byte_slice_from_ptr_mut(data_ptr, data_len);
+        let transport = Self::transport(user_data);
+
+        transport
+            .receive_data(data)
+            .ok()
+            .and_then(as_isize)
+            .unwrap_or(-1)
+    }
+
+    unsafe extern "C" fn state_changed(event: c_int, user_data: *mut c_void) {
+        let transport = Self::transport(user_data);
+
+        if let Some(state) = SecureSessionState::from_int(event) {
+            transport.state_changed(state);
+        }
+    }
+
+    unsafe extern "C" fn get_public_key_for_id(
+        id_ptr: *const c_void,
+        id_len: usize,
+        key_ptr: *mut c_void,
+        key_len: usize,
+        user_data: *mut c_void,
+    ) -> c_int {
+        let id = byte_slice_from_ptr(id_ptr as *const u8, id_len);
+        let key_out = byte_slice_from_ptr_mut(key_ptr as *mut u8, key_len);
+        let transport = Self::transport(user_data);
+
+        if let Some(key) = transport.get_public_key_for_id(id) {
+            let key = key.as_ref();
+            if key_out.len() >= key.len() {
+                key_out[0..key.len()].copy_from_slice(key);
+                return 0;
+            }
+        }
+        -1
+    }
+}
+
+#[doc(hidden)]
+impl<D> Drop for SecureSession<D> {
+    fn drop(&mut self) {
+        unsafe {
+            let status = secure_session_destroy(self.session_ctx);
+            let error = Error::from_session_status(status);
+            if (cfg!(debug) || cfg!(test)) && error.kind() != ErrorKind::Success {
+                panic!("secure_session_destroy() failed: {}", error);
+            }
+        }
+    }
+}
+
+fn as_isize(n: usize) -> Option<isize> {
+    if n <= isize::max_value() as usize {
+        Some(n as isize)
+    } else {
+        None
+    }
+}
+
+// These functions are technically unsafe. You must trust the C code to give you correct pointers
+// and lengths. Note that empty Rust slices must *not* be constructed from a null raw pointer,
+// they should use a special value instead. This is important for some LLVM magic.
+
+fn byte_slice_from_ptr<'a>(ptr: *const u8, len: usize) -> &'a [u8] {
+    unsafe { slice::from_raw_parts(escape_null_ptr(ptr as *mut u8), len) }
+}
+
+fn byte_slice_from_ptr_mut<'a>(ptr: *mut u8, len: usize) -> &'a mut [u8] {
+    unsafe { slice::from_raw_parts_mut(escape_null_ptr(ptr), len) }
+}
+
+fn escape_null_ptr<T>(ptr: *mut T) -> *mut T {
+    if ptr.is_null() {
+        ptr::NonNull::dangling().as_ptr()
+    } else {
+        ptr
+    }
+}

--- a/src/wrappers/themis/rust/src/utils.rs
+++ b/src/wrappers/themis/rust/src/utils.rs
@@ -1,0 +1,30 @@
+// Copyright 2018 (c) rust-themis developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Miscellaneous utilities.
+//!
+//! This module contains various small utilities used across several modules.
+
+use std::ptr;
+
+/// Splits a slice into raw pointer and length for C code to use.
+pub fn into_raw_parts(slice: &[u8]) -> (*const u8, usize) {
+    let len = slice.len();
+    let ptr = if len == 0 {
+        ptr::null()
+    } else {
+        slice.as_ptr()
+    };
+    (ptr, len)
+}

--- a/tests/rust/keys.rs
+++ b/tests/rust/keys.rs
@@ -1,0 +1,88 @@
+// Copyright 2018 (c) rust-themis developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate themis;
+
+use themis::keygen::{gen_ec_key_pair, gen_rsa_key_pair};
+use themis::keys::{
+    EcdsaPublicKey, EcdsaSecretKey, KeyKind, KeyPair, PublicKey, RsaPublicKey, RsaSecretKey,
+    SecretKey,
+};
+use themis::ErrorKind;
+
+#[test]
+fn generated_key_kinds() {
+    let (secret_ec, public_ec) = KeyPair::from(gen_ec_key_pair()).split();
+    let (secret_rsa, public_rsa) = KeyPair::from(gen_rsa_key_pair()).split();
+
+    assert_eq!(secret_ec.kind(), KeyKind::EcdsaSecret);
+    assert_eq!(public_ec.kind(), KeyKind::EcdsaPublic);
+    assert_eq!(secret_rsa.kind(), KeyKind::RsaSecret);
+    assert_eq!(public_rsa.kind(), KeyKind::RsaPublic);
+}
+
+// No cheating here: keys borrowed from PyThemis.
+const ECDSA_SECRET: &[u8] = b"\x52\x45\x43\x32\x00\x00\x00\x2d\x51\xf4\xaa\x72\x00\x9f\x0f\x09\xce\xbe\x09\x33\xc2\x5e\x9a\x05\x99\x53\x9d\xb2\x32\xa2\x34\x64\x7a\xde\xde\x83\x8f\x65\xa9\x2a\x14\x6d\xaa\x90\x01";
+const ECDSA_PUBLIC: &[u8] = b"\x55\x45\x43\x32\x00\x00\x00\x2d\x13\x8b\xdf\x0c\x02\x1f\x09\x88\x39\xd9\x73\x3a\x84\x8f\xa8\x50\xd9\x2b\xed\x3d\x38\xcf\x1d\xd0\xce\xf4\xae\xdb\xcf\xaf\xcb\x6b\xa5\x4a\x08\x11\x21";
+
+#[test]
+fn parse_bytes() {
+    EcdsaSecretKey::try_from_slice(ECDSA_SECRET).expect("ECDSA secret key");
+    EcdsaPublicKey::try_from_slice(ECDSA_PUBLIC).expect("ECDSA public key");
+
+    SecretKey::try_from_slice(ECDSA_SECRET).expect("ECDSA secret key (generic)");
+    PublicKey::try_from_slice(ECDSA_PUBLIC).expect("ECDSA public key (generic)");
+
+    RsaSecretKey::try_from_slice(ECDSA_SECRET).expect_err("ECDSA secret key (as RSA)");
+    RsaPublicKey::try_from_slice(ECDSA_PUBLIC).expect_err("ECDSA public key (as RSA)");
+
+    EcdsaPublicKey::try_from_slice(ECDSA_SECRET).expect_err("ECDSA secret key (as public)");
+    EcdsaSecretKey::try_from_slice(ECDSA_PUBLIC).expect_err("ECDSA public key (as secret)");
+}
+
+#[test]
+fn parse_generated_keys_back() {
+    let (secret_gen, public_gen) = gen_rsa_key_pair().split();
+
+    let secret_parse = RsaSecretKey::try_from_slice(&secret_gen).expect("RSA secret key");
+    let public_parse = RsaPublicKey::try_from_slice(&public_gen).expect("RSA public key");
+
+    assert_eq!(secret_gen, secret_parse);
+    assert_eq!(public_gen, public_parse);
+}
+
+#[test]
+fn parse_invalid_buffers() {
+    let error = EcdsaPublicKey::try_from_slice(&[1, 2, 3]).expect_err("parse failure");
+    assert_eq!(error.kind(), ErrorKind::InvalidParameter);
+
+    let error = RsaSecretKey::try_from_slice(&[]).expect_err("parse failure");
+    assert_eq!(error.kind(), ErrorKind::InvalidParameter);
+}
+
+#[test]
+fn join_matching_keys() {
+    let (secret_ec, public_ec) = gen_ec_key_pair().split();
+
+    assert!(KeyPair::try_join(secret_ec, public_ec).is_ok());
+}
+
+#[test]
+fn join_mismatching_keys() {
+    let (secret_ec, _) = gen_ec_key_pair().split();
+    let (_, public_rsa) = gen_rsa_key_pair().split();
+
+    let error = KeyPair::try_join(secret_ec, public_rsa).expect_err("kind mismatch");
+    assert_eq!(error.kind(), ErrorKind::InvalidParameter);
+}

--- a/tests/rust/secure_cell.rs
+++ b/tests/rust/secure_cell.rs
@@ -1,0 +1,196 @@
+// Copyright 2018 (c) rust-themis developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate themis;
+
+use themis::{secure_cell::SecureCell, ErrorKind};
+
+mod context_imprint {
+    use super::*;
+
+    #[test]
+    fn happy_path() {
+        let cell = SecureCell::with_key_and_context(b"deep secret", b"123").context_imprint();
+
+        let plaintext = b"example plaintext";
+        let ciphertext = cell.encrypt(&plaintext).unwrap();
+        let recovered = cell.decrypt(&ciphertext).unwrap();
+
+        assert_eq!(recovered, plaintext);
+
+        assert_eq!(plaintext.len(), ciphertext.len());
+    }
+
+    #[test]
+    fn empty_context() {
+        let cell = SecureCell::with_key(b"deep secret").context_imprint();
+
+        let plaintext = b"example plaintext";
+        let error = cell.encrypt(&plaintext).unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::InvalidParameter);
+    }
+
+    #[test]
+    fn invalid_key() {
+        let cell1 = SecureCell::with_key_and_context(b"deep secret", b"123").context_imprint();
+        let cell2 = SecureCell::with_key_and_context(b"DEEP SECRET", b"123").context_imprint();
+
+        let plaintext = b"example plaintext";
+        let ciphertext = cell1.encrypt(&plaintext).unwrap();
+        let recovered = cell2.decrypt(&ciphertext).unwrap();
+
+        assert_ne!(recovered, plaintext);
+    }
+
+    #[test]
+    fn invalid_context() {
+        let cell1 = SecureCell::with_key_and_context(b"deep secret", b"123").context_imprint();
+        let cell2 = SecureCell::with_key_and_context(b"deep secret", b"456").context_imprint();
+
+        let plaintext = b"example plaintext";
+        let ciphertext = cell1.encrypt(&plaintext).unwrap();
+        let recovered = cell2.decrypt(&ciphertext).unwrap();
+
+        assert_ne!(recovered, plaintext);
+    }
+
+    #[test]
+    fn corrupted_data() {
+        let cell = SecureCell::with_key_and_context(b"deep secret", b"123").context_imprint();
+
+        let plaintext = b"example plaintext";
+        let mut ciphertext = cell.encrypt(&plaintext).unwrap();
+        ciphertext[10] = 42;
+        let recovered = cell.decrypt(&ciphertext).unwrap();
+
+        assert_ne!(recovered, plaintext);
+    }
+}
+
+mod seal {
+    use super::*;
+
+    #[test]
+    fn happy_path() {
+        let seal = SecureCell::with_key("deep secret").seal();
+
+        let plaintext = b"example plaintext";
+        let ciphertext = seal.encrypt(&plaintext).unwrap();
+        let recovered = seal.decrypt(&ciphertext).unwrap();
+
+        assert_eq!(recovered, plaintext);
+    }
+
+    #[test]
+    fn invalid_key() {
+        let seal1 = SecureCell::with_key(b"deep secret").seal();
+        let seal2 = SecureCell::with_key(b"DEEP SECRET").seal();
+
+        let plaintext = b"example plaintext";
+        let ciphertext = seal1.encrypt(&plaintext).unwrap();
+        let error = seal2.decrypt(&ciphertext).unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::Fail);
+    }
+
+    #[test]
+    fn invalid_context() {
+        let seal1 = SecureCell::with_key_and_context(b"deep secret", b"ctx1").seal();
+        let seal2 = SecureCell::with_key_and_context(b"deep secret", b"ctx2").seal();
+
+        let plaintext = b"example plaintext";
+        let ciphertext = seal1.encrypt(&plaintext).unwrap();
+        let error = seal2.decrypt(&ciphertext).unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::Fail);
+    }
+
+    #[test]
+    fn corrupted_data() {
+        let seal = SecureCell::with_key(b"deep secret").seal();
+
+        let plaintext = b"example plaintext";
+        let mut ciphertext = seal.encrypt(&plaintext).unwrap();
+        ciphertext[10] = 42;
+        let error = seal.decrypt(&ciphertext).unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::InvalidParameter);
+    }
+}
+
+mod token_protect {
+    use super::*;
+
+    #[test]
+    fn happy_path() {
+        let cell = SecureCell::with_key(b"deep secret").token_protect();
+
+        let plaintext = b"example plaintext";
+        let (ciphertext, token) = cell.encrypt(&plaintext).unwrap();
+        let recovered = cell.decrypt(&ciphertext, &token).unwrap();
+
+        assert_eq!(recovered, plaintext);
+
+        assert_eq!(plaintext.len(), ciphertext.len());
+    }
+
+    #[test]
+    fn invalid_key() {
+        let cell1 = SecureCell::with_key(b"deep secret").token_protect();
+        let cell2 = SecureCell::with_key(b"DEEP SECRET").token_protect();
+
+        let plaintext = b"example plaintext";
+        let (ciphertext, token) = cell1.encrypt(plaintext).unwrap();
+        let error = cell2.decrypt(&ciphertext, &token).unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::Fail);
+    }
+
+    #[test]
+    fn invalid_context() {
+        let cell1 = SecureCell::with_key_and_context(b"deep secret", b"123").token_protect();
+        let cell2 = SecureCell::with_key_and_context(b"deep secret", b"456").token_protect();
+
+        let plaintext = b"example plaintext";
+        let (ciphertext, token) = cell1.encrypt(plaintext).unwrap();
+        let error = cell2.decrypt(&ciphertext, &token).unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::Fail);
+    }
+
+    #[test]
+    fn corrupted_data() {
+        let cell = SecureCell::with_key(b"deep secret").token_protect();
+
+        let plaintext = b"example plaintext";
+        let (mut ciphertext, token) = cell.encrypt(&plaintext).unwrap();
+        ciphertext[10] = 42;
+        let error = cell.decrypt(&ciphertext, &token).unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::Fail);
+    }
+
+    #[test]
+    fn corrupted_token() {
+        let cell = SecureCell::with_key(b"deep secret").token_protect();
+
+        let plaintext = b"example plaintext";
+        let (ciphertext, mut token) = cell.encrypt(&plaintext).unwrap();
+        token[10] = 42;
+        let error = cell.decrypt(&ciphertext, &token).unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::InvalidParameter);
+    }
+}

--- a/tests/rust/secure_comparator.rs
+++ b/tests/rust/secure_comparator.rs
@@ -1,0 +1,167 @@
+// Copyright 2018 (c) rust-themis developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate themis;
+
+use themis::{secure_comparator::SecureComparator, ErrorKind};
+
+#[test]
+fn compare_matching_data() {
+    let mut comparator1 = SecureComparator::new();
+    let mut comparator2 = SecureComparator::new();
+
+    comparator1.append_secret(b"se-e-ecrets").unwrap();
+    comparator2.append_secret(b"se-e-ecrets").unwrap();
+
+    let data = comparator1.begin_compare().unwrap();
+    let data = comparator2.proceed_compare(&data).unwrap();
+    let data = comparator1.proceed_compare(&data).unwrap();
+    let data = comparator2.proceed_compare(&data).unwrap();
+    let _ata = comparator1.proceed_compare(&data).unwrap();
+
+    assert!(comparator1.is_complete());
+    assert!(comparator2.is_complete());
+
+    assert!(comparator1.get_result().unwrap());
+    assert!(comparator2.get_result().unwrap());
+}
+
+#[test]
+fn compare_different_data() {
+    let mut comparator1 = SecureComparator::new();
+    let mut comparator2 = SecureComparator::new();
+
+    assert!(!comparator1.is_complete());
+    assert!(!comparator2.is_complete());
+
+    comparator1
+        .append_secret(b"far from the worn path of reason")
+        .unwrap();
+    comparator2
+        .append_secret(b"further away from the sane")
+        .unwrap();
+
+    let data = comparator1.begin_compare().unwrap();
+    let data = comparator2.proceed_compare(&data).unwrap();
+    let data = comparator1.proceed_compare(&data).unwrap();
+    let data = comparator2.proceed_compare(&data).unwrap();
+    let _ata = comparator1.proceed_compare(&data).unwrap();
+
+    assert!(!comparator1.get_result().unwrap());
+    assert!(!comparator2.get_result().unwrap());
+}
+
+#[test]
+fn split_secrets() {
+    let mut comparator1 = SecureComparator::new();
+    let mut comparator2 = SecureComparator::new();
+
+    comparator1.append_secret(b"123").unwrap();
+    comparator1.append_secret(b"456").unwrap();
+    comparator2.append_secret(b"123456").unwrap();
+
+    let data = comparator1.begin_compare().unwrap();
+    let data = comparator2.proceed_compare(&data).unwrap();
+    let data = comparator1.proceed_compare(&data).unwrap();
+    let data = comparator2.proceed_compare(&data).unwrap();
+    let _ata = comparator1.proceed_compare(&data).unwrap();
+
+    assert!(comparator1.get_result().unwrap());
+    assert!(comparator2.get_result().unwrap());
+}
+
+#[test]
+fn simultaneous_start() {
+    let mut comparator1 = SecureComparator::new();
+    let mut comparator2 = SecureComparator::new();
+
+    comparator1.append_secret(b"se-e-ecrets").unwrap();
+    comparator2.append_secret(b"se-e-ecrets").unwrap();
+
+    let data1 = comparator1.begin_compare().unwrap();
+    let data2 = comparator2.begin_compare().unwrap();
+
+    let error1 = comparator1.proceed_compare(&data2).unwrap_err();
+    let error2 = comparator2.proceed_compare(&data1).unwrap_err();
+
+    assert_eq!(error1.kind(), ErrorKind::InvalidParameter);
+    assert_eq!(error2.kind(), ErrorKind::InvalidParameter);
+
+    assert!(!comparator1.is_complete());
+    assert!(!comparator2.is_complete());
+}
+
+// TODO: write some robust test for data corruption
+//
+// This one works, but the results are intermittent. Sometimes the comparisons don't match,
+// sometimes the comparators fail with 'invalid parameter' errors. Maybe we could make use
+// of some data fuzzing framework in the future.
+#[test]
+#[ignore]
+fn data_corruption() {
+    let mut comparator1 = SecureComparator::new();
+    let mut comparator2 = SecureComparator::new();
+
+    comparator1.append_secret(b"se-e-ecrets").unwrap();
+    comparator2.append_secret(b"se-e-ecrets").unwrap();
+
+    let data = comparator1.begin_compare().unwrap();
+    let mut data = comparator2.proceed_compare(&data).unwrap();
+    data[20] = 42;
+    let data = comparator1.proceed_compare(&data).unwrap();
+    let data = comparator2.proceed_compare(&data).unwrap();
+    let _ata = comparator1.proceed_compare(&data).unwrap();
+
+    assert!(comparator1.get_result().unwrap());
+    assert!(comparator2.get_result().unwrap());
+}
+
+// TODO: investigate crash in BoringSSL
+//
+// This tests crashes when Themis uses BoringSSL. It suggests that one cannot reuse Secure
+// Comparators at all because the crypto engine denies this (e.g., can't compute hash twice).
+// Investigate, probably file an issue in core Themis repo as this state should be tracked
+// by Themis library to avoid misuse. However, this may be a feature of Secure Comparator
+// so it may require a workaround.
+#[test]
+fn reusing_comparators() {
+    // TODO: avoid reusing comparators via a better API
+    let mut comparator1 = SecureComparator::new();
+    let mut comparator2 = SecureComparator::new();
+
+    comparator1.append_secret(b"test").unwrap();
+    comparator2.append_secret(b"data").unwrap();
+
+    let data = comparator1.begin_compare().unwrap();
+    let data = comparator2.proceed_compare(&data).unwrap();
+    let data = comparator1.proceed_compare(&data).unwrap();
+    let data = comparator2.proceed_compare(&data).unwrap();
+    let _ata = comparator1.proceed_compare(&data).unwrap();
+
+    assert!(!comparator1.get_result().unwrap());
+    assert!(!comparator2.get_result().unwrap());
+
+    comparator1.append_secret(b"same").unwrap();
+    comparator2.append_secret(b"same").unwrap();
+
+    let data = comparator1.begin_compare().unwrap();
+    let data = comparator2.proceed_compare(&data).unwrap();
+    let data = comparator1.proceed_compare(&data).unwrap();
+    let data = comparator2.proceed_compare(&data).unwrap();
+    let _ata = comparator1.proceed_compare(&data).unwrap();
+
+    // Previous data is still appended and can't be unappended.
+    assert!(!comparator1.get_result().unwrap());
+    assert!(!comparator2.get_result().unwrap());
+}

--- a/tests/rust/secure_message.rs
+++ b/tests/rust/secure_message.rs
@@ -1,0 +1,72 @@
+// Copyright 2018 (c) rust-themis developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate themis;
+
+use themis::{
+    keygen::{gen_ec_key_pair, gen_rsa_key_pair},
+    secure_message::{SecureMessage, SecureSign, SecureVerify},
+    ErrorKind,
+};
+
+#[test]
+fn mode_encrypt_decrypt() {
+    let secure = SecureMessage::new(gen_rsa_key_pair());
+
+    let plaintext = b"test message please ignore";
+    let wrapped = secure.wrap(&plaintext).expect("encryption");
+    let recovered_message = secure.unwrap(&wrapped).expect("decryption");
+
+    assert_eq!(recovered_message, plaintext);
+}
+
+#[test]
+fn mode_sign_verify() {
+    let (secret, public) = gen_rsa_key_pair().split();
+    let sign = SecureSign::new(secret);
+    let verify = SecureVerify::new(public);
+
+    let plaintext = b"test message please ignore";
+    let signed_message = sign.sign(&plaintext).unwrap();
+    let recovered_message = verify.verify(&signed_message).unwrap();
+
+    assert_eq!(recovered_message, plaintext);
+}
+
+#[test]
+fn invalid_key() {
+    let secure1 = SecureMessage::new(gen_ec_key_pair());
+    let secure2 = SecureMessage::new(gen_ec_key_pair());
+
+    let plaintext = b"test message please ignore";
+    let wrapped = secure1.wrap(&plaintext).expect("encryption");
+    let error = secure2.unwrap(&wrapped).expect_err("decryption error");
+
+    assert_eq!(error.kind(), ErrorKind::Fail);
+}
+
+#[test]
+fn corrupted_data() {
+    let secure = SecureMessage::new(gen_rsa_key_pair());
+
+    // TODO: investigate crashes in Themis
+    // Using index "10" for example leads to a crash with SIGBUS, so Themis definitely
+    // could use some audit because it does not really handle corrupted messages well.
+    let plaintext = b"test message please ignore";
+    let mut wrapped = secure.wrap(&plaintext).expect("encryption");
+    wrapped[5] = 42;
+    let error = secure.unwrap(&wrapped).expect_err("decryption error");
+
+    assert_eq!(error.kind(), ErrorKind::InvalidParameter);
+}

--- a/tests/rust/secure_session.rs
+++ b/tests/rust/secure_session.rs
@@ -1,0 +1,206 @@
+// Copyright 2018 (c) rust-themis developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate themis;
+
+use std::{
+    collections::BTreeMap,
+    rc::Rc,
+    sync::mpsc::{channel, Receiver, Sender},
+};
+
+use themis::{
+    keygen::gen_ec_key_pair,
+    keys::EcdsaPublicKey,
+    secure_session::{SecureSession, SecureSessionTransport},
+};
+
+struct DummyTransport {
+    key_map: Rc<BTreeMap<Vec<u8>, EcdsaPublicKey>>,
+}
+
+impl DummyTransport {
+    fn new(key_map: &Rc<BTreeMap<Vec<u8>, EcdsaPublicKey>>) -> Self {
+        Self {
+            key_map: key_map.clone(),
+        }
+    }
+}
+
+impl SecureSessionTransport for DummyTransport {
+    fn get_public_key_for_id(&mut self, id: &[u8]) -> Option<EcdsaPublicKey> {
+        self.key_map.get(id).cloned()
+    }
+}
+
+struct ChannelTransport {
+    key_map: Rc<BTreeMap<Vec<u8>, EcdsaPublicKey>>,
+    tx: Sender<Vec<u8>>,
+    rx: Receiver<Vec<u8>>,
+}
+
+impl ChannelTransport {
+    fn new(key_map: &Rc<BTreeMap<Vec<u8>, EcdsaPublicKey>>) -> (Self, Self) {
+        let (tx12, rx21) = channel();
+        let (tx21, rx12) = channel();
+
+        let transport1 = Self {
+            key_map: key_map.clone(),
+            tx: tx12,
+            rx: rx12,
+        };
+        let transport2 = Self {
+            key_map: key_map.clone(),
+            tx: tx21,
+            rx: rx21,
+        };
+
+        (transport1, transport2)
+    }
+}
+
+impl SecureSessionTransport for ChannelTransport {
+    fn send_data(&mut self, data: &[u8]) -> Result<usize, ()> {
+        self.tx
+            .send(data.to_vec())
+            .map(|_| data.len())
+            .map_err(|_| ())
+    }
+
+    fn receive_data(&mut self, data: &mut [u8]) -> Result<usize, ()> {
+        let msg = self.rx.recv().map_err(|_| ())?;
+        if msg.len() > data.len() {
+            return Err(());
+        }
+        data[0..msg.len()].copy_from_slice(&msg);
+        Ok(msg.len())
+    }
+
+    fn get_public_key_for_id(&mut self, id: &[u8]) -> Option<EcdsaPublicKey> {
+        self.key_map.get(id).cloned()
+    }
+}
+
+#[test]
+fn no_transport() {
+    // Peer credentials. Secure Session supports only ECDSA.
+    // TODO: tests that confirm RSA failure
+    let (secret_client, public_client) = gen_ec_key_pair().split();
+    let (secret_server, public_server) = gen_ec_key_pair().split();
+    let (name_client, name_server) = ("client", "server");
+
+    // Shared storage of public peer credentials. These should be communicated between
+    // the peers beforehand in some unspecified trusted way.
+    let mut key_map = BTreeMap::new();
+    key_map.insert(name_client.as_bytes().to_vec(), public_client);
+    key_map.insert(name_server.as_bytes().to_vec(), public_server);
+    let key_map = Rc::new(key_map);
+
+    // The client and the server.
+    let mut client =
+        SecureSession::with_transport(name_client, &secret_client, DummyTransport::new(&key_map))
+            .unwrap();
+    let mut server =
+        SecureSession::with_transport(name_server, &secret_server, DummyTransport::new(&key_map))
+            .unwrap();
+
+    assert!(!client.is_established());
+    assert!(!server.is_established());
+    assert!(client.get_remote_id().unwrap().is_empty());
+    assert!(server.get_remote_id().unwrap().is_empty());
+
+    // Connection and key negotiation sequence.
+    let connect_request = client.generate_connect_request().expect("connect request");
+    let connect_reply = server.negotiate(&connect_request).expect("connect reply");
+    let key_proposed = client.negotiate(&connect_reply).expect("key proposed");
+    let key_accepted = server.negotiate(&key_proposed).expect("key accepted");
+    let key_confirmed = client.negotiate(&key_accepted).expect("key confirmed");
+    assert!(key_confirmed.is_empty());
+
+    assert!(client.is_established());
+    assert!(server.is_established());
+    assert_eq!(client.get_remote_id().unwrap(), name_server.as_bytes());
+    assert_eq!(server.get_remote_id().unwrap(), name_client.as_bytes());
+
+    // TODO: check connection states reported to transport delegate
+
+    // Try sending a message back and forth.
+    let plaintext = b"test message please ignore";
+
+    let wrapped = client.wrap(&plaintext).expect("wrap 1 -> 2 message");
+    let unwrapped = server.unwrap(&wrapped).expect("unwrap 1 -> 2 message");
+    assert_eq!(unwrapped, plaintext);
+
+    let wrapped = server.wrap(&plaintext).expect("wrap 2 -> 1 message");
+    let unwrapped = client.unwrap(&wrapped).expect("unwrap 2 -> 1 message");
+    assert_eq!(unwrapped, plaintext);
+
+    // TODO: it seems that one cannot wrap an empty message, check it out
+
+    // Messages are independent, can come out-of-order and be lost.
+    client.wrap(b"some message").expect("lost message 1");
+    client.wrap(b"some message").expect("lost message 2");
+    server.wrap(b"some message").expect("lost message 3");
+
+    let wrapped1 = client.wrap(b"message 1").expect("message 1");
+    let wrapped2 = client.wrap(b"message 2").expect("message 2");
+    let unwrapped2 = server.unwrap(&wrapped2).expect("message 2");
+    let unwrapped1 = server.unwrap(&wrapped1).expect("message 1");
+    assert_eq!(unwrapped1, b"message 1");
+    assert_eq!(unwrapped2, b"message 2");
+}
+
+#[test]
+fn with_transport() {
+    // Peer credentials. Secure Session supports only ECDSA.
+    // TODO: tests that confirm RSA failure
+    let (secret_client, public_client) = gen_ec_key_pair().split();
+    let (secret_server, public_server) = gen_ec_key_pair().split();
+    let (name_client, name_server) = ("client", "server");
+
+    // Shared storage of public peer credentials. These should be communicated between
+    // the peers beforehand in some unspecified trusted way.
+    let mut key_map = BTreeMap::new();
+    key_map.insert(name_client.as_bytes().to_vec(), public_client);
+    key_map.insert(name_server.as_bytes().to_vec(), public_server);
+    let key_map = Rc::new(key_map);
+
+    // The client and the server.
+    let (transport_client, transport_server) = ChannelTransport::new(&key_map);
+    let mut client =
+        SecureSession::with_transport(name_client, &secret_client, transport_client).unwrap();
+    let mut server =
+        SecureSession::with_transport(name_server, &secret_server, transport_server).unwrap();
+
+    assert!(!client.is_established());
+    assert!(!server.is_established());
+
+    // Establishing connection.
+    client.connect().expect("client-side connection");
+    server.negotiate_transport().expect("connect reply");
+    client.negotiate_transport().expect("key proposed");
+    server.negotiate_transport().expect("key accepted");
+    client.negotiate_transport().expect("key confirmed");
+
+    assert!(client.is_established());
+    assert!(server.is_established());
+
+    // Try sending a message back and forth.
+    let message = b"test message please ignore";
+    client.send(&message).expect("send message");
+
+    let received = server.receive(1024).expect("receive message");
+
+    assert_eq!(received, message);
+}


### PR DESCRIPTION
This adds initial Rust binding for Themis.

The code comes from here, version 0.0.2:

https://github.com/ilammy/rust-themis

I could have transferred the whole git history, but that's too much of a bother and I don't think anybody would be interested in it that much. If you wish to read the older commit messages you can always look into the original repo. Not very convenient but that's at least something.

The core repository layout is a bit different from a traditional one for Rust projects. I have moved the files into appropriate places and adapted the Cargo.toml file to that. Importantly, it now requires an `include` directive so that published crates include only Rust code.

Here's the current layout of Rust code:

    .
    ├─ Cargo.toml           -  root Cargo.toml file
    ├─ docs/examples
    │  └─ rust              -  Rust wrapper examples
    ├─ src/wrappers/themis
    │  └─ rust              -  root of the "themis" crate
    │     ├─ libthemis-sys  -  root of the "libthemis-sys" crate
    │     └─ src            -  Rust wrapper source code
    └─ tests
       └─ rust              -  Rust wrapper tests

The Cargo.toml file is placed in the root directory so that all usual Cargo commands work from there after a fresh checkout. They do work indeed, but the Rust binding is not integrated into the core build system. We'll improve that later.

The links throughout the docs and Cargo.toml files have been updated to point to Cossack Labs repo. I have also removed TravisCI badges because Rust wrapper is going to use CircleCI just like the other bindings.

I have kept the original README files. These are used when publishing on crates.io and contain Rust-specific instructions. The LICENSE files in Rust wrappers are also kept intact in accordance with item 4.a of the Apache 2.0 license.

As for licensing of this contribution, I'm not a lawyer, but Apache license gives the same rights to the original licensor as well as any future contributors. That's why I did not bother updating all the boilerplate comments all over the code. They still assign copyright of Rust code to "rust-themis developers". By submitting this code to the core repository the developers agree to keep the Apache 2.0 license for it, as per item 5 of the license. There are no separate prior agreements other than that.