### PR TITLE
Use Bash as shell in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@
 #
 
 #CC = clang
+SHELL = /bin/bash
 SRC_PATH = src
 ifneq ($(BUILD_PATH),)
 	BIN_PATH = $(BUILD_PATH)


### PR DESCRIPTION
This issue has been bugging me for a while and I was finally triggered enough to do something about it. If one runs make on macOS then `echo` ignores the `-n` flag which suppresses newline output. Then instead of a nice output:

<img width="400" title="make output of a healthy person" src="https://user-images.githubusercontent.com/1256587/48984937-cb71cd00-f10a-11e8-82af-19a4d3aae5a3.png">

one sees the following monstrosity:

<img width="400" title="make output of a smoker" src="https://user-images.githubusercontent.com/1256587/48984942-d3ca0800-f10a-11e8-85fc-816fb521d83c.png">

This is caused by multitude of factors. First of all, GNU make uses `/bin/sh` by default to execute shell commands. This can be overridden by setting the SHELL make variable (*environment* variable is ignored).

Usually on UNIX systems /bin/sh is a symlink or a drop-in replacement to some 'maximally portable POSIX shell' which resembles the original Bourne shell. On macOS /bin/sh is renamed Bash binary. I believe some other UNIX systems do so as well. When Bash is invoked as "sh" it enables Bourne shell compatibility mode:

> If bash is invoked with the name sh, it tries to mimic the startup behavior of historical versions of sh as closely as possible, while conforming to the POSIX standard as well.
>
> _— man 1 bash_

`echo` is normally a shell built-in (so that the shell does not execute actual /bin/echo all the time), so its options are determined by the shell and its compatibility mode. The `-n` option is supported by Bash and by most of echo binaries, but not by Bourne shell's echo builtin.

So, set SHELL to Bash in order to have nice behavior of the "echo" builtin. A more correct way would be to disable the builtin and make sure that the shell runs /bin/echo, but that's much harder to do. This can be offensive towards POSIX compatibility purists, but if they run Themis builds on a system where Bash is not available they can comment out that line and get their /bin/sh back. While we're gonna enjoy nice progress reports with correct newlines.