### PR TITLE
Ignore ldconfig failures when installing on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -365,7 +365,7 @@ install_pkgconfig: err all make_install_dirs
 
 install: install_soter_headers install_themis_headers install_static_libs install_shared_libs install_pkgconfig
 ifdef IS_LINUX
-	@ldconfig
+	@ldconfig || true
 endif
 
 get_version:

--- a/Makefile
+++ b/Makefile
@@ -365,7 +365,7 @@ install_pkgconfig: err all make_install_dirs
 
 install: install_soter_headers install_themis_headers install_static_libs install_shared_libs install_pkgconfig
 ifdef IS_LINUX
-	@ldconfig || true
+	@ldconfig || (status=$$?; if [ $$(id -u) = "0" ]; then exit $$status; else exit 0; fi)
 endif
 
 get_version:


### PR DESCRIPTION
Currently `make install PREFIX=$HOME/lib/themis` fails on Linux when run without superuser privileges. Installation to non-system directories should not require superuser privileges. This does not work because of an unconditional **ldconfig** invocation.

Linux systems generally require an **ldconfig** invocation after installing shared libraries in order to refresh ld.so's library cache. Themis' `make install` target does that unconditionally when building on Linux. It's not necessary for static libraries or when installing into non-system locations that require special configuration of the dynamic loader (rpath, LD_LIBRATY_PATH, etc.)

Note that **ldconfig** requires superuser privileges as it writes multiple files in `/etc`. However, `make install` is not always run with superuser privileges.

There are two basic use-cases for installing Themis:

- Installation into the system directory

  Typically this is used when packaging Themis library by itself. This installation requires superuser privileges anyway to copy the libraries into system locations. Usually shared libraries are installed together with static libraries.

  This is typically invoked as `sudo make install`

- Installation into a temporary directory

  Typically this is used to build a local copy of Themis for use inside another project. Themis is installed into some non-system location by setting the PREFIX variable accordingly. Usually only static libraries are used. No superuser privileges needed.

  This is typically invoked as `make install PREFIX=$somewhere`

The first use-case works fine now, but the second one is broken by **ldconfig** failing the build without superuser privileges.

Let's fix it in a simple and lazy way by ignoring any errors caused by **ldconfig**. (They are still printed out to stderr though.)

Strictly speaking, we should invoke **ldconfig** only after installing shared libraries. And it's only needed when installing into system locations. However, it's too complex for us to analyze EUID and PREFIX values. And it's certainly easier for the users to simply run "make install" all the time. Though, it's definitely possible to add a new target which will not call **ldconfig**:

```make
install_static: install_soter_headers install_themis_headers \
                install_static_libs install_pkgconfig

install: install_static install_shared_libs
ifdef IS_LINUX
        @ldconfig
endif
```

However, there may be cases when shared libraries need to be installed into non-system locations as well. So it should be more easy to simply ignore **ldconfig** failures.