### PR TITLE
Fix redirection clause

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -483,11 +483,11 @@ themispp_uninstall:
 
 soter_collect_headers:
 	@mkdir -p $(BIN_PATH)/include/soter
-	@cd src/soter && find . -name \*.h -exec cp --parents {} ../../$(BIN_PATH)/include/soter/ \; && cd - 1 > /dev/null
+	@cd src/soter && find . -name \*.h -exec cp --parents {} ../../$(BIN_PATH)/include/soter/ \; && cd - > /dev/null
 
 themis_collect_headers:
 	@mkdir -p $(BIN_PATH)/include/themis
-	@cd src/themis && find . -name \*.h -exec cp --parents {} ../../$(BIN_PATH)/include/themis/ \; && cd - 1 > /dev/null
+	@cd src/themis && find . -name \*.h -exec cp --parents {} ../../$(BIN_PATH)/include/themis/ \; && cd - > /dev/null
 
 collect_headers: themis_collect_headers soter_collect_headers
 


### PR DESCRIPTION
In the clause `cd - 1 > /dev/null` bash interprets `1` as an argument for `cd` command and causes `/bin/bash: line 0: cd: too many arguments` error. 

File descriptor `1`/`stdout` is used by default in output redirection. Therefore, we have to either explicitly point that `1` is part of the redirection clause (`cd - 1> /dev/null`) or simply remove it, what I've done.