### PR TITLE
Update BoringSSL submodule config to use Clang and new gradle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - run: ./gradlew --no-daemon --no-parallel --max-workers=2 connectedAndroidTest
   x86_64:
     docker:
-      - image: cossacklabs/android-build
+      - image: cossacklabs/android-build:2019.01
     environment:
       GOTHEMIS_IMPORT: github.com/cossacklabs/themis/gothemis
       CFLAGS: "-DCIRICLE_TEST"
@@ -89,7 +89,7 @@ jobs:
 
   integration_tests:
     docker:
-      - image: cossacklabs/android-build
+      - image: cossacklabs/android-build:2019.01
     environment:
       GOTHEMIS_IMPORT: github.com/cossacklabs/themis/gothemis
       CFLAGS: "-DCIRICLE_TEST"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   android:
     docker:
-      - image: cossacklabs/android-build
+      - image: cossacklabs/android-build:2019.01
     steps:
       - checkout
       - run: git submodule update --init

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -19,6 +19,6 @@ APP_MODULES := libthemis_jni
 # we needs this to prevent ndk-build complaining about missing
 # prebuilt boringssl static libraries
 APP_ALLOW_MISSING_DEPS := true
-# currently boringssl does not build well with clang for all archs
-# so we use GCC for Themis as well for maximum compatibility
-NDK_TOOLCHAIN_VERSION := 4.9
+# currently boringssl supports only clang
+#  GCC is no longer supported.  See
+# https://android.googlesource.com/platform/ndk/+/master/docs/ClangMigration.md

--- a/third_party/boringssl/build.gradle
+++ b/third_party/boringssl/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 }
 
@@ -22,7 +22,6 @@ android {
 		    cmake {
 		        arguments "-DCMAKE_TOOLCHAIN_FILE=" + android.ndkDirectory + "/build/cmake/android.toolchain.cmake",
 		                  "-DANDROID_NATIVE_API_LEVEL=21",
-		                  "-DANDROID_TOOLCHAIN=gcc",
 		                  "-DCMAKE_BUILD_TYPE=Release",
 		                  "-GNinja"
 		    }


### PR DESCRIPTION
Update BoringSSL submodule build rules (see #350) to make Themis Android wrapper great again!

- Change default compiler to build BoringSSL to Clang due to their giving up the GCC.

```
  CMake Error at /home/user/android-sdk/ndk-bundle/build/cmake/android.toolchain.cmake:169 (message):
   GCC is no longer supported.  See
   https://android.googlesource.com/platform/ndk/+/master/docs/ClangMigration.md.
```

- Update gradle to build BoringSSL.

Author of these changes is @ilammy, all appreciation send to him, I'm just PR'ing them.

Together with update in Android Dockerfile (https://github.com/cossacklabs/dockerfiles/pull/1) this change should fix Android CI builds (as soon as `cossacklabs/android-build` DockerImage will be recompiled on Dockerhub -> https://hub.docker.com/r/cossacklabs/android-build)