### PR TITLE
Update Themis.podspec to use bitcode

### DIFF
--- a/docs/examples/objc/Podfile
+++ b/docs/examples/objc/Podfile
@@ -23,7 +23,7 @@ use_frameworks!
 
 target :"ThemisTest" do
 
-  pod 'themis', '0.10.0'
+  pod 'themis', '0.10.2'
 
 end
 

--- a/docs/examples/objc/Podfile.lock
+++ b/docs/examples/objc/Podfile.lock
@@ -1,17 +1,19 @@
 PODS:
-  - GRKOpenSSLFramework (1.0.1.20.4)
-  - themis (0.10.0):
-    - GRKOpenSSLFramework (= 1.0.1.20.4)
-    - themis/core (= 0.10.0)
-    - themis/objcwrapper (= 0.10.0)
-  - themis/core (0.10.0):
-    - GRKOpenSSLFramework (= 1.0.1.20.4)
-  - themis/objcwrapper (0.10.0):
-    - GRKOpenSSLFramework (= 1.0.1.20.4)
-    - themis/core
+  - GRKOpenSSLFramework (1.0.2.15)
+  - themis (0.10.2):
+    - themis/themis-openssl (= 0.10.2)
+  - themis/themis-openssl (0.10.2):
+    - GRKOpenSSLFramework (~> 1.0.1)
+    - themis/themis-openssl/core (= 0.10.2)
+    - themis/themis-openssl/objcwrapper (= 0.10.2)
+  - themis/themis-openssl/core (0.10.2):
+    - GRKOpenSSLFramework (~> 1.0.1)
+  - themis/themis-openssl/objcwrapper (0.10.2):
+    - GRKOpenSSLFramework (~> 1.0.1)
+    - themis/themis-openssl/core
 
 DEPENDENCIES:
-  - themis (= 0.10.0)
+  - themis (= 0.10.2)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -19,9 +21,9 @@ SPEC REPOS:
     - themis
 
 SPEC CHECKSUMS:
-  GRKOpenSSLFramework: b6172cc34db9b999002483878772a4bf2a1687ba
-  themis: f06f5690dbb18276e98f3c8d7c9ba90e8100bd09
+  GRKOpenSSLFramework: 8180d66833be66fc0f2d4942757d095edb0778d0
+  themis: bb0d7915dcb400748942969d9ab4c48f95193514
 
-PODFILE CHECKSUM: 1e963e072c7246908b254b958a140d32c5bd6993
+PODFILE CHECKSUM: e12aecd89bf2d7c109e1c22f7e55952a7e2cb54c
 
 COCOAPODS: 1.5.3

--- a/docs/examples/objc/ThemisTest/ThemisTest.xcodeproj/project.pbxproj
+++ b/docs/examples/objc/ThemisTest/ThemisTest.xcodeproj/project.pbxproj
@@ -18,7 +18,7 @@
 		73156E171ADBDF0F00E3E520 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 73156E161ADBDF0F00E3E520 /* Images.xcassets */; };
 		731624981ADB174200972A7A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 731624971ADB174200972A7A /* main.m */; };
 		731624B21ADB174200972A7A /* ThemisTestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 731624B11ADB174200972A7A /* ThemisTestTests.m */; };
-		E7B0506C2648A672E19A1619 /* Pods_ThemisTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B7CB41E88A9465FFC42D099F /* Pods_ThemisTest.framework */; };
+		DFE2ACA5C43205BF45855E4F /* Pods_ThemisTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 977FB68B0A47ACE6FE487C78 /* Pods_ThemisTest.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -36,7 +36,7 @@
 		192EA533E67AA52864927032 /* server.pub */ = {isa = PBXFileReference; lastKnownFileType = file.pub; path = server.pub; sourceTree = "<group>"; };
 		192EA61539E5DA001A808B56 /* client.pub */ = {isa = PBXFileReference; lastKnownFileType = file.pub; path = client.pub; sourceTree = "<group>"; };
 		192EAEE7A8A8277025A0F60C /* client.priv */ = {isa = PBXFileReference; lastKnownFileType = file.priv; path = client.priv; sourceTree = "<group>"; };
-		6BE8BA545D3BEB785286ADA8 /* Pods-ThemisTest.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ThemisTest.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-ThemisTest/Pods-ThemisTest.debug.xcconfig"; sourceTree = "<group>"; };
+		67E869A8317E705AE8FBD12D /* Pods-ThemisTest.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ThemisTest.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-ThemisTest/Pods-ThemisTest.debug.xcconfig"; sourceTree = "<group>"; };
 		73156E031ADBDE7900E3E520 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = LaunchScreen.xib; sourceTree = "<group>"; };
 		73156E051ADBDE7900E3E520 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Main.storyboard; sourceTree = "<group>"; };
 		73156E0D1ADBDF0800E3E520 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -51,8 +51,8 @@
 		731624B01ADB174200972A7A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		731624B11ADB174200972A7A /* ThemisTestTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ThemisTestTests.m; sourceTree = "<group>"; };
 		738D1E7F1ADBBEBB00661F4A /* libobjcthemis.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libobjcthemis.a; path = ../themis/objcthemis/ios/lib/libobjcthemis.a; sourceTree = "<group>"; };
-		B7CB41E88A9465FFC42D099F /* Pods_ThemisTest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ThemisTest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		C55E617C2A3C2C0CFF5C48C1 /* Pods-ThemisTest.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ThemisTest.release.xcconfig"; path = "../Pods/Target Support Files/Pods-ThemisTest/Pods-ThemisTest.release.xcconfig"; sourceTree = "<group>"; };
+		977FB68B0A47ACE6FE487C78 /* Pods_ThemisTest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ThemisTest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9E10EB87854CB85811ED6754 /* Pods-ThemisTest.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ThemisTest.release.xcconfig"; path = "../Pods/Target Support Files/Pods-ThemisTest/Pods-ThemisTest.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -60,7 +60,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E7B0506C2648A672E19A1619 /* Pods_ThemisTest.framework in Frameworks */,
+				DFE2ACA5C43205BF45855E4F /* Pods_ThemisTest.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -100,7 +100,7 @@
 			isa = PBXGroup;
 			children = (
 				738D1E7F1ADBBEBB00661F4A /* libobjcthemis.a */,
-				B7CB41E88A9465FFC42D099F /* Pods_ThemisTest.framework */,
+				977FB68B0A47ACE6FE487C78 /* Pods_ThemisTest.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -123,7 +123,7 @@
 				731624AE1ADB174200972A7A /* ThemisTestTests */,
 				731624931ADB174200972A7A /* Products */,
 				1F5F881BD0CD342D1E9B9E25 /* Frameworks */,
-				8955180910949D48A2E584B0 /* Pods */,
+				D1F50389FD689D03DD83EB2C /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -172,11 +172,11 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
-		8955180910949D48A2E584B0 /* Pods */ = {
+		D1F50389FD689D03DD83EB2C /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				6BE8BA545D3BEB785286ADA8 /* Pods-ThemisTest.debug.xcconfig */,
-				C55E617C2A3C2C0CFF5C48C1 /* Pods-ThemisTest.release.xcconfig */,
+				67E869A8317E705AE8FBD12D /* Pods-ThemisTest.debug.xcconfig */,
+				9E10EB87854CB85811ED6754 /* Pods-ThemisTest.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -188,11 +188,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 731624B51ADB174200972A7A /* Build configuration list for PBXNativeTarget "ThemisTest" */;
 			buildPhases = (
-				67747E78A7DCBBFC45423F3C /* [CP] Check Pods Manifest.lock */,
+				334601230A899E592C753E95 /* [CP] Check Pods Manifest.lock */,
 				7316248E1ADB174200972A7A /* Sources */,
 				7316248F1ADB174200972A7A /* Frameworks */,
 				731624901ADB174200972A7A /* Resources */,
-				068CD7001C475DB274D3EE08 /* [CP] Embed Pods Frameworks */,
+				31D22FF91376528D28148625 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -285,7 +285,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		068CD7001C475DB274D3EE08 /* [CP] Embed Pods Frameworks */ = {
+		31D22FF91376528D28148625 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -309,7 +309,7 @@
 			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-ThemisTest/Pods-ThemisTest-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		67747E78A7DCBBFC45423F3C /* [CP] Check Pods Manifest.lock */ = {
+		334601230A899E592C753E95 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -483,7 +483,7 @@
 		};
 		731624B61ADB174200972A7A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6BE8BA545D3BEB785286ADA8 /* Pods-ThemisTest.debug.xcconfig */;
+			baseConfigurationReference = 67E869A8317E705AE8FBD12D /* Pods-ThemisTest.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -499,7 +499,7 @@
 		};
 		731624B71ADB174200972A7A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C55E617C2A3C2C0CFF5C48C1 /* Pods-ThemisTest.release.xcconfig */;
+			baseConfigurationReference = 9E10EB87854CB85811ED6754 /* Pods-ThemisTest.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";

--- a/themis.podspec
+++ b/themis.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
     s.subspec 'themis-openssl' do |so|
         # Enable bitcode for openssl only, unfortunately boringssl with bitcode not available at the moment
         # 'bitcode-marker' directive omits bitcode payload in binary for debug builds
-        so.pod_target_xcconfig = {
+        so.ios.pod_target_xcconfig = {
             'OTHER_CFLAGS[config=Debug]'                => '$(inherited) -fembed-bitcode-marker',
             'OTHER_CFLAGS[config=Release]'              => '$(inherited) -fembed-bitcode',
             'BITCODE_GENERATION_MODE[config=Release]'   => 'bitcode',

--- a/themis.podspec
+++ b/themis.podspec
@@ -1,17 +1,18 @@
 Pod::Spec.new do |s|
     s.name = "themis"
-    s.version = "0.10.1"
+    s.version = "0.10.2"
     s.summary = "Data security library for network communication and data storage for iOS and mac OS"
     s.description = "Themis is a data security library, providing users with high-quality security services for secure messaging of any kinds and flexible data storage. Themis is aimed at modern development practices, with high level OOP wrappers for iOS / macOS, NodeJS, Go, Ruby, Python, PHP and Java / Android. It is designed with ease of use in mind, high security and cross-platform availability."
     s.homepage = "https://cossacklabs.com"
     s.license = { :type => 'Apache 2.0'}    
 
-    # will update to particular tag on next release
+    # will update to particular tag on next release (0.11.0)
     #s.source = { :git => "https://github.com/cossacklabs/themis.git", :tag => "#{s.version}" }
 
     # this commit has fixes in soter that allow to support BoringSSL for iOS
     # more: https://github.com/cossacklabs/themis/pull/330
-    s.source = { :git => "https://github.com/cossacklabs/themis.git", :commit => 'efe288ebaaababa1c7adc633e3f8cf325e3db0be'}
+    # this is a latest master commit as for today
+    s.source = { :git => "https://github.com/cossacklabs/themis.git", :commit => 'a47c962a86f038927e9c9e58e24726ff2314d9eb'}
 
     s.author = {'cossacklabs' => 'info@cossacklabs.com'}
 

--- a/themis.podspec
+++ b/themis.podspec
@@ -25,6 +25,14 @@ Pod::Spec.new do |s|
 
     # use `themis/themis-openssl` as separate target to use Themis with OpenSSL
     s.subspec 'themis-openssl' do |so|
+        # Enable bitcode for openssl only, unfortunately boringssl with bitcode not available at the moment
+        # 'bitcode-marker' directive omits bitcode payload in binary for debug builds
+        so.pod_target_xcconfig = {
+            'OTHER_CFLAGS[config=Debug]'                => '$(inherited) -fembed-bitcode-marker',
+            'OTHER_CFLAGS[config=Release]'              => '$(inherited) -fembed-bitcode',
+            'BITCODE_GENERATION_MODE[config=Release]'   => 'bitcode',
+            'BITCODE_GENERATION_MODE[config=Debug]'     => 'bitcode-marker'
+        }
 
         so.dependency 'GRKOpenSSLFramework', '~> 1.0.1'
 


### PR DESCRIPTION
Based on #354 and @deszip improvements.

- podspec is updated to use bitcode only for Themis iOS with OpenSSL.
- new podspec is validated and pushed
- examples are updated to use themis `0.10.2`