### PR TITLE
Make rustfmt happy

### DIFF
--- a/tools/rust/keygen_tool.rs
+++ b/tools/rust/keygen_tool.rs
@@ -36,11 +36,11 @@ fn main() {
     let (secret_key, public_key) = gen_ec_key_pair().split();
 
     match write_file(&secret_key, &secret_path, 0o400) {
-        Ok(_) => {},
+        Ok(_) => {}
         Err(e) => eprintln!("failed to write secret key to {}: {}", secret_path, e),
     }
     match write_file(&public_key, &public_path, 0o666) {
-        Ok(_) => {},
+        Ok(_) => {}
         Err(e) => eprintln!("failed to write public key to {}: {}", public_path, e),
     }
 }


### PR DESCRIPTION
Off to a great start! Let's fix the broken build on master.

It turned out that PR #356 uses incorrect code style. It has been merged before #353 thus the CI did not catch that. Fix code formatting to keep rustfmt happy and have a green build.

(I should _really_ check that “Format code on commit” checkbox in my IDE... I'm sorry orz)