### PR TITLE
 Do not use fixed user context with Secure Cell

### DIFF
--- a/docs/examples/rust/secure_message_client_encrypt.rs
+++ b/docs/examples/rust/secure_message_client_encrypt.rs
@@ -61,7 +61,9 @@ fn main() {
     let receive = thread::spawn(move || {
         let receive_message = || -> io::Result<()> {
             let buffer = recv(&receive_socket)?;
-            let message = receive_secure.unwrap(&buffer).map_err(themis_as_io_error)?;
+            let message = receive_secure
+                .decrypt(&buffer)
+                .map_err(themis_as_io_error)?;
             io::stdout().write_all(&message)?;
             Ok(())
         };
@@ -77,7 +79,7 @@ fn main() {
         let relay_message = || -> io::Result<()> {
             let mut buffer = String::new();
             io::stdin().read_line(&mut buffer)?;
-            let message = relay_secure.wrap(&buffer).map_err(themis_as_io_error)?;
+            let message = relay_secure.encrypt(&buffer).map_err(themis_as_io_error)?;
             relay_socket.send(&message)?;
             Ok(())
         };

--- a/src/wrappers/themis/rust/src/keygen.rs
+++ b/src/wrappers/themis/rust/src/keygen.rs
@@ -38,8 +38,8 @@
 //!
 //! let secure = SecureMessage::new(key_pair);
 //!
-//! let encrypted = secure.wrap(b"message")?;
-//! let decrypted = secure.unwrap(&encrypted)?;
+//! let encrypted = secure.encrypt(b"message")?;
+//! let decrypted = secure.decrypt(&encrypted)?;
 //! assert_eq!(decrypted, b"message");
 //! # Ok(())
 //! # }

--- a/src/wrappers/themis/rust/src/keys.rs
+++ b/src/wrappers/themis/rust/src/keys.rs
@@ -151,11 +151,6 @@ impl KeyBytes {
         KeyBytes(bytes.to_vec())
     }
 
-    /// Makes an empty key.
-    pub fn empty() -> KeyBytes {
-        KeyBytes(Vec::new())
-    }
-
     /// Returns key bytes.
     pub fn as_bytes(&self) -> &[u8] {
         &self.0

--- a/src/wrappers/themis/rust/src/secure_cell.rs
+++ b/src/wrappers/themis/rust/src/secure_cell.rs
@@ -73,7 +73,7 @@
 //! # fn main() -> Result<(), themis::Error> {
 //! use themis::secure_cell::SecureCell;
 //!
-//! let cell = SecureCell::with_key_and_context(b"seekryt", &[1, 42]).seal();
+//! let cell = SecureCell::with_key(b"seekryt").seal();
 //!
 //! let encrypted = cell.encrypt(b"source data")?;
 //! let decrypted = cell.decrypt(&encrypted)?;
@@ -98,11 +98,10 @@ use crate::utils::into_raw_parts;
 
 /// Basic Secure Cell.
 ///
-/// This is modeless, basic cell. First you create a `SecureCell` object with a key and an optional
-/// context then you select the desired operation mode and your Secure Cell is ready to go.
+/// This is modeless, basic cell. First you provide the master key to a new `SecureCell` object
+/// then you select the desired operation mode and your Secure Cell is ready to go.
 pub struct SecureCell {
     master_key: KeyBytes,
-    user_context: KeyBytes,
 }
 
 impl SecureCell {
@@ -125,59 +124,10 @@ impl SecureCell {
     /// SecureCell::with_key(format!("owned string"));
     /// ```
     ///
-    /// This method is equivalent to [`with_key_and_context`] called with an empty context (`&[]`):
-    ///
-    /// ```
-    /// # fn main() -> Result<(), themis::Error> {
-    /// use themis::secure_cell::SecureCell;
-    ///
-    /// let cell1 = SecureCell::with_key(b"key").seal();
-    /// let cell2 = SecureCell::with_key_and_context(b"key", &[]).seal();
-    ///
-    /// let encrypted = cell1.encrypt(b"some data")?;
-    /// let decrypted = cell2.decrypt(&encrypted)?;
-    /// assert_eq!(decrypted, b"some data");
-    /// # Ok(())
-    /// # }
-    /// ```
-    ///
     /// [`keygen`]: ../keygen/index.html
-    /// [`with_key_and_context`]: #method.with_key_and_context
-    pub fn with_key<K: AsRef<[u8]>>(master_key: K) -> Self {
+    pub fn with_key(master_key: impl AsRef<[u8]>) -> Self {
         Self {
             master_key: KeyBytes::copy_slice(master_key.as_ref()),
-            user_context: KeyBytes::empty(),
-        }
-    }
-
-    /// Constructs a new cell secured by a master key and arbitrary “context information”.
-    ///
-    /// User context will be included into encrypted data in a manner specific to the operation
-    /// mode. See [module-level documentation][secure_cell] for details. You will need to provide
-    /// this context again in order to extract the original data from the cell.
-    ///
-    /// # Examples
-    ///
-    /// As with the key, the context information can be anything convertible into a byte slice;
-    ///
-    /// ```
-    /// use themis::secure_cell::SecureCell;
-    ///
-    /// SecureCell::with_key_and_context(b"key", b"byte string");
-    /// SecureCell::with_key_and_context(b"key", &[1, 2, 3, 4, 5]);
-    /// SecureCell::with_key_and_context(b"key", vec![6, 7, 8, 9]);
-    /// SecureCell::with_key_and_context(b"key", format!("owned string"));
-    /// ```
-    ///
-    /// [secure_cell]: ../secure_cell/index.html
-    pub fn with_key_and_context<K, C>(master_key: K, user_context: C) -> Self
-    where
-        K: AsRef<[u8]>,
-        C: AsRef<[u8]>,
-    {
-        Self {
-            master_key: KeyBytes::copy_slice(master_key.as_ref()),
-            user_context: KeyBytes::copy_slice(user_context.as_ref()),
         }
     }
 
@@ -249,10 +199,50 @@ impl SecureCellSeal {
     /// #
     /// assert!(cell.encrypt(&[]).is_err());
     /// ```
-    pub fn encrypt<M: AsRef<[u8]>>(&self, message: M) -> Result<Vec<u8>> {
+    pub fn encrypt(&self, message: impl AsRef<[u8]>) -> Result<Vec<u8>> {
+        self.encrypt_with_context(&[], message)
+    }
+
+    /// Encrypts and puts the provided message together with the context into a sealed cell.
+    ///
+    /// # Examples
+    ///
+    /// You can use anything convertible into a byte slice as a message or a context: a byte slice
+    /// or an array, a `Vec<u8>`, or a `String`.
+    ///
+    /// ```
+    /// # fn main() -> Result<(), themis::Error> {
+    /// use themis::secure_cell::SecureCell;
+    ///
+    /// let cell = SecureCell::with_key(b"password").seal();
+    ///
+    /// cell.encrypt_with_context(b"byte string", format!("owned string"))?;
+    /// cell.encrypt_with_context(&[1, 2, 3, 4, 5], vec![6, 7, 8, 9, 10])?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// The context may be empty (in which case this call is equivalent to [`encrypt`]).
+    /// However, the message must not be empty.
+    ///
+    /// ```
+    /// # use themis::secure_cell::SecureCell;
+    /// #
+    /// # let cell = SecureCell::with_key(b"password").seal();
+    /// #
+    /// assert!(cell.encrypt_with_context(&[], b"message").is_ok());
+    /// assert!(cell.encrypt_with_context(b"context", &[]).is_err());
+    /// ```
+    ///
+    /// [`encrypt`]: struct.SecureCellSeal.html#method.encrypt
+    pub fn encrypt_with_context(
+        &self,
+        user_context: impl AsRef<[u8]>,
+        message: impl AsRef<[u8]>,
+    ) -> Result<Vec<u8>> {
         encrypt_seal(
             self.0.master_key.as_bytes(),
-            self.0.user_context.as_bytes(),
+            user_context.as_ref(),
             message.as_ref(),
         )
     }
@@ -261,7 +251,7 @@ impl SecureCellSeal {
     ///
     /// # Examples
     ///
-    /// If you know the master key and the context then getting back your data is easy:
+    /// If you know the master key then getting back your data is easy:
     ///
     /// ```
     /// # fn main() -> Result<(), themis::Error> {
@@ -276,7 +266,7 @@ impl SecureCellSeal {
     /// # }
     /// ```
     ///
-    /// However, if the key or the context are invalid then decryption fails:
+    /// However, if the key is invalid then decryption fails:
     ///
     /// ```
     /// # use themis::secure_cell::SecureCell;
@@ -285,10 +275,8 @@ impl SecureCellSeal {
     /// # let encrypted = cell.encrypt(b"byte string").unwrap();
     /// #
     /// let different_cell = SecureCell::with_key(b"qwerty123").seal();
-    /// let the_other_cell = SecureCell::with_key_and_context(b"password", b"context").seal();
     ///
     /// assert!(different_cell.decrypt(&encrypted).is_err());
-    /// assert!(the_other_cell.decrypt(&encrypted).is_err());
     /// ```
     ///
     /// Secure Cell in sealing mode checks data integrity and can see if the data was corrupted,
@@ -306,10 +294,66 @@ impl SecureCellSeal {
     ///
     /// assert!(cell.decrypt(&corrupted).is_err());
     /// ```
-    pub fn decrypt<M: AsRef<[u8]>>(&self, message: M) -> Result<Vec<u8>> {
+    pub fn decrypt(&self, message: impl AsRef<[u8]>) -> Result<Vec<u8>> {
+        self.decrypt_with_context(&[], message)
+    }
+
+    /// Extracts the original message from a sealed cell given the context.
+    ///
+    /// # Examples
+    ///
+    /// If you know the master key and the context then getting back your data is easy:
+    ///
+    /// ```
+    /// # fn main() -> Result<(), themis::Error> {
+    /// use themis::secure_cell::SecureCell;
+    ///
+    /// let cell = SecureCell::with_key(b"password").seal();
+    ///
+    /// let encrypted = cell.encrypt_with_context(b"context", b"byte string")?;
+    /// let decrypted = cell.decrypt_with_context(b"context", &encrypted)?;
+    /// assert_eq!(decrypted, b"byte string");
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// However, if the key or the context are invalid then decryption fails:
+    ///
+    /// ```
+    /// # use themis::secure_cell::SecureCell;
+    /// #
+    /// # let cell = SecureCell::with_key(b"password").seal();
+    /// # let encrypted = cell.encrypt_with_context(b"context", b"byte string").unwrap();
+    /// #
+    /// let different_cell = SecureCell::with_key(b"qwerty123").seal();
+    ///
+    /// assert!(different_cell.decrypt_with_context(b"context", &encrypted).is_err());
+    /// assert!(cell.decrypt_with_context(b"different context", &encrypted).is_err());
+    /// ```
+    ///
+    /// Secure Cell in sealing mode checks data integrity and can see if the data was corrupted,
+    /// returning an error on decryption attempts:
+    ///
+    /// ```
+    /// # use themis::secure_cell::SecureCell;
+    /// #
+    /// # let cell = SecureCell::with_key(b"password").seal();
+    /// # let encrypted = cell.encrypt_with_context(b"context", b"byte string").unwrap();
+    /// #
+    /// // Let's flip some bits somewhere.
+    /// let mut corrupted = encrypted.clone();
+    /// corrupted[20] = !corrupted[20];
+    ///
+    /// assert!(cell.decrypt_with_context(b"context", &corrupted).is_err());
+    /// ```
+    pub fn decrypt_with_context(
+        &self,
+        user_context: impl AsRef<[u8]>,
+        message: impl AsRef<[u8]>,
+    ) -> Result<Vec<u8>> {
         decrypt_seal(
             self.0.master_key.as_bytes(),
-            self.0.user_context.as_bytes(),
+            user_context.as_ref(),
             message.as_ref(),
         )
     }
@@ -438,7 +482,7 @@ fn decrypt_seal(master_key: &[u8], user_context: &[u8], message: &[u8]) -> Resul
 pub struct SecureCellTokenProtect(SecureCell);
 
 impl SecureCellTokenProtect {
-    /// Encrypts the provided message and returns the encrypted container and the authentication
+    /// Encrypts the provided message and returns the encrypted container with the authentication
     /// token (in that order).
     ///
     /// The results can be stored or transmitted separately. You will need to provide both later
@@ -472,10 +516,54 @@ impl SecureCellTokenProtect {
     /// #
     /// assert!(cell.encrypt(&[]).is_err());
     /// ```
-    pub fn encrypt<M: AsRef<[u8]>>(&self, message: M) -> Result<(Vec<u8>, Vec<u8>)> {
+    pub fn encrypt(&self, message: impl AsRef<[u8]>) -> Result<(Vec<u8>, Vec<u8>)> {
+        self.encrypt_with_context(&[], message)
+    }
+
+    /// Encrypts the provided message together with the context and returns the encrypted container
+    /// with the authentication token (in that order).
+    ///
+    /// The results can be stored or transmitted separately. You will need to provide all three
+    /// parts later for successful decryption.
+    ///
+    /// # Examples
+    ///
+    /// You can use anything convertible into a byte slice as a message or a context: a byte slice
+    /// or an array, a `Vec<u8>`, or a `String`.
+    ///
+    /// ```
+    /// # fn main() -> Result<(), themis::Error> {
+    /// use themis::secure_cell::SecureCell;
+    ///
+    /// let cell = SecureCell::with_key(b"password").token_protect();
+    ///
+    /// cell.encrypt_with_context(b"byte string", format!("owned string"))?;
+    /// cell.encrypt_with_context(&[1, 2, 3, 4, 5], vec![6, 7, 8, 9, 10])?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// The context may be empty (in which case this call is equivalent to [`encrypt`]).
+    /// However, the message must not be empty.
+    ///
+    /// ```
+    /// # use themis::secure_cell::SecureCell;
+    /// #
+    /// # let cell = SecureCell::with_key(b"password").token_protect();
+    /// #
+    /// assert!(cell.encrypt_with_context(&[], b"message").is_ok());
+    /// assert!(cell.encrypt_with_context(b"context", &[]).is_err());
+    /// ```
+    ///
+    /// [`encrypt`]: struct.SecureCellTokenProtect.html#method.encrypt
+    pub fn encrypt_with_context(
+        &self,
+        user_context: impl AsRef<[u8]>,
+        message: impl AsRef<[u8]>,
+    ) -> Result<(Vec<u8>, Vec<u8>)> {
         encrypt_token_protect(
             self.0.master_key.as_bytes(),
-            self.0.user_context.as_bytes(),
+            user_context.as_ref(),
             message.as_ref(),
         )
     }
@@ -483,11 +571,13 @@ impl SecureCellTokenProtect {
     /// Extracts the original message from encrypted container and validates its authenticity.
     ///
     /// You need to provide both the encrypted container and the authentication token previously
-    /// obtained from `encrypt()`. Decryption will fail if any of them is corrupted or invalid.
+    /// obtained from [`encrypt`]. Decryption will fail if any of them is corrupted or invalid.
+    ///
+    /// [`encrypt`]: struct.SecureCellTokenProtect.html#method.encrypt
     ///
     /// # Examples
     ///
-    /// If you know the master key, the context, and the token then getting back your data is easy:
+    /// If you know the master key and the token then getting back your data is easy:
     ///
     /// ```
     /// # fn main() -> Result<(), themis::Error> {
@@ -549,10 +639,85 @@ impl SecureCellTokenProtect {
     /// assert!(cell.decrypt(&corrupted_data, &auth_token).is_err());
     /// assert!(cell.decrypt(&encrypted, &corrupted_token).is_err());
     /// ```
-    pub fn decrypt<M: AsRef<[u8]>, T: AsRef<[u8]>>(&self, message: M, token: T) -> Result<Vec<u8>> {
+    pub fn decrypt(&self, message: impl AsRef<[u8]>, token: impl AsRef<[u8]>) -> Result<Vec<u8>> {
+        self.decrypt_with_context(&[], message, token)
+    }
+
+    /// Extracts the original message from encrypted container and validates its authenticity
+    /// given the context.
+    ///
+    /// You need to provide the user context used for encryption as well as the encrypted container
+    /// and the authentication token previously obtained from [`encrypt_with_context`]. Decryption
+    /// will fail if any of them is corrupted or invalid.
+    ///
+    /// [`encrypt_with_context`]: struct.SecureCellTokenProtect.html#method.encrypt_with_context
+    ///
+    /// # Examples
+    ///
+    /// If you know the master key, the context, and the token then getting back your data is easy:
+    ///
+    /// ```
+    /// # fn main() -> Result<(), themis::Error> {
+    /// use themis::secure_cell::SecureCell;
+    ///
+    /// let cell = SecureCell::with_key(b"password").token_protect();
+    ///
+    /// let (encrypted, token) = cell.encrypt_with_context(b"context", b"byte string")?;
+    /// let decrypted = cell.decrypt_with_context(b"context", &encrypted, &token)?;
+    /// assert_eq!(decrypted, b"byte string");
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// However, you obviously cannot use tokens produced by Secure Cells with different keys,
+    /// tokens for different data, or different contexts:
+    ///
+    /// ```
+    /// # fn main() -> Result<(), themis::Error> {
+    /// # use themis::secure_cell::SecureCell;
+    /// #
+    /// # let cell = SecureCell::with_key(b"password").token_protect();
+    /// # let (encrypted, token) = cell.encrypt_with_context(b"context", b"byte string").unwrap();
+    /// #
+    /// let different_cell = SecureCell::with_key(b"qwerty123").token_protect();
+    ///
+    /// assert!(different_cell.decrypt_with_context(b"context", &encrypted, &token).is_err());
+    ///
+    /// let (_, other_token) = cell.encrypt_with_context(b"context", b"other data")?;
+    ///
+    /// assert!(cell.decrypt_with_context(b"context", &encrypted, &other_token).is_err());
+    /// assert!(cell.decrypt_with_context(b"other context", &encrypted, &token).is_err());
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Secure Cell in token protect mode checks data integrity and can see if the data (or the
+    /// token) was corrupted, returning an error on decryption attempts:
+    ///
+    /// ```
+    /// # use themis::secure_cell::SecureCell;
+    /// #
+    /// # let cell = SecureCell::with_key(b"password").token_protect();
+    /// # let (encrypted, auth_token) = cell.encrypt_with_context(b"context", b"things").unwrap();
+    /// #
+    /// // Let's flip some bits somewhere.
+    /// let mut corrupted_data = encrypted.clone();
+    /// let mut corrupted_token = auth_token.clone();
+    /// corrupted_data[4] = !corrupted_data[4];
+    /// corrupted_token[9] = !corrupted_token[9];
+    ///
+    /// assert!(cell.decrypt_with_context(b"context", &corrupted_data, &auth_token).is_err());
+    /// assert!(cell.decrypt_with_context(b"context", &encrypted, &corrupted_token).is_err());
+    /// ```
+    pub fn decrypt_with_context(
+        &self,
+        user_context: impl AsRef<[u8]>,
+        message: impl AsRef<[u8]>,
+        token: impl AsRef<[u8]>,
+    ) -> Result<Vec<u8>> {
         decrypt_token_protect(
             self.0.master_key.as_bytes(),
-            self.0.user_context.as_bytes(),
+            user_context.as_ref(),
             message.as_ref(),
             token.as_ref(),
         )
@@ -694,10 +859,10 @@ fn decrypt_token_protect(
 /// # fn main() -> Result<(), themis::Error> {
 /// use themis::secure_cell::SecureCell;
 ///
-/// let cell = SecureCell::with_key_and_context(b"password", b"context").context_imprint();
+/// let cell = SecureCell::with_key(b"password").context_imprint();
 ///
 /// let input = b"test input";
-/// let output = cell.encrypt(input)?;
+/// let output = cell.encrypt_with_context(b"context", input)?;
 ///
 /// assert!(output.len() == input.len());
 /// # Ok(())
@@ -712,7 +877,7 @@ pub struct SecureCellContextImprint(SecureCell);
 // TODO: maybe panic if a SecureCell with an empty context is switched into context imprint mode
 
 impl SecureCellContextImprint {
-    /// Encrypts the provided message, combining it with required user context, and returns
+    /// Encrypts the provided message, combining it with provided user context, and returns
     /// the encrypted data.
     ///
     /// The resulting message has the same length as the input data and does not contain
@@ -721,47 +886,41 @@ impl SecureCellContextImprint {
     ///
     /// # Examples
     ///
-    /// You can use anything convertible into a byte slice as a message: a byte slice or an array,
-    /// a `Vec<u8>`, or a `String`.
+    /// You can use anything convertible into a byte slice as a message or a context: a byte slice
+    /// or an array, a `Vec<u8>`, or a `String`.
     ///
     /// ```
     /// # fn main() -> Result<(), themis::Error> {
     /// use themis::secure_cell::SecureCell;
     ///
-    /// let cell = SecureCell::with_key_and_context(b"password", b"context").context_imprint();
+    /// let cell = SecureCell::with_key(b"password").context_imprint();
     ///
-    /// cell.encrypt(b"byte string")?;
-    /// cell.encrypt(&[1, 2, 3, 4, 5])?;
-    /// cell.encrypt(vec![6, 7, 8, 9])?;
-    /// cell.encrypt(format!("owned string"))?;
+    /// cell.encrypt_with_context(b"byte string", format!("owned string"))?;
+    /// cell.encrypt_with_context(&[1, 2, 3, 4, 5], vec![6, 7, 8, 9, 10])?;
     /// # Ok(())
     /// # }
     /// ```
     ///
-    /// However, the message must not be empty:
+    /// However, the message and context must not be empty:
     ///
     /// ```
     /// # use themis::secure_cell::SecureCell;
     /// #
-    /// # let cell = SecureCell::with_key_and_context(b"password", b"context").context_imprint();
+    /// # let cell = SecureCell::with_key(b"password").context_imprint();
     /// #
-    /// assert!(cell.encrypt(&[]).is_err());
+    /// assert!(cell.encrypt_with_context(b"context", b"message").is_ok());
+    /// assert!(cell.encrypt_with_context(b"context",        b"").is_err());
+    /// assert!(cell.encrypt_with_context(b"",        b"message").is_err());
     /// ```
-    ///
-    /// Also, you cannot use empty context with context imprint mode:
-    ///
-    /// ```
-    /// # use themis::secure_cell::SecureCell;
-    /// #
-    /// let cell = SecureCell::with_key(b"password").context_imprint();
-    ///
-    /// assert!(cell.encrypt(b"otherwise fine message").is_err());
-    /// ```
-    pub fn encrypt<M: AsRef<[u8]>>(&self, message: M) -> Result<Vec<u8>> {
+    pub fn encrypt_with_context(
+        &self,
+        user_context: impl AsRef<[u8]>,
+        message: impl AsRef<[u8]>,
+    ) -> Result<Vec<u8>> {
         encrypt_context_imprint(
             self.0.master_key.as_bytes(),
             message.as_ref(),
-            self.0.user_context.as_bytes(),
+            user_context.as_ref(),
         )
     }
 
@@ -779,10 +938,10 @@ impl SecureCellContextImprint {
     /// # fn main() -> Result<(), themis::Error> {
     /// use themis::secure_cell::SecureCell;
     ///
-    /// let cell = SecureCell::with_key_and_context(b"password", b"context").context_imprint();
+    /// let cell = SecureCell::with_key(b"password").context_imprint();
     ///
-    /// let encrypted = cell.encrypt(b"byte string")?;
-    /// let decrypted = cell.decrypt(&encrypted)?;
+    /// let encrypted = cell.encrypt_with_context(b"context", b"byte string")?;
+    /// let decrypted = cell.decrypt_with_context(b"context", &encrypted)?;
     /// assert_eq!(decrypted, b"byte string");
     /// # Ok(())
     /// # }
@@ -795,11 +954,11 @@ impl SecureCellContextImprint {
     /// # fn main() -> Result<(), themis::Error> {
     /// # use themis::secure_cell::SecureCell;
     /// #
-    /// let cell1 = SecureCell::with_key_and_context(b"XXX", b"---").context_imprint();
-    /// let cell2 = SecureCell::with_key_and_context(b"OOO", b"|||").context_imprint();
+    /// let cell1 = SecureCell::with_key(b"XXX").context_imprint();
+    /// let cell2 = SecureCell::with_key(b"OOO").context_imprint();
     ///
-    /// let encrypted = cell1.encrypt(b"byte string")?;
-    /// let decrypted = cell2.decrypt(&encrypted)?;
+    /// let encrypted = cell1.encrypt_with_context(b"context", b"byte string")?;
+    /// let decrypted = cell2.decrypt_with_context(b"task-switch", &encrypted)?;
     ///
     /// assert_ne!(decrypted, b"byte string");
     /// # Ok(())
@@ -811,21 +970,25 @@ impl SecureCellContextImprint {
     /// ```
     /// # use themis::secure_cell::SecureCell;
     /// #
-    /// # let cell = SecureCell::with_key_and_context(b"password", b"context").context_imprint();
-    /// # let encrypted = cell.encrypt(b"byte string").unwrap();
+    /// # let cell = SecureCell::with_key(b"password").context_imprint();
+    /// # let encrypted = cell.encrypt_with_context(b"context", b"byte string").unwrap();
     /// #
     /// // Let's flip some bits somewhere.
     /// let mut corrupted_data = encrypted.clone();
     /// corrupted_data[10] = !corrupted_data[10];
     ///
-    /// let result = cell.decrypt(&corrupted_data);
+    /// let result = cell.decrypt_with_context(b"context", &corrupted_data);
     /// assert_ne!(result.expect("no verification"), b"byte string");
     /// ```
-    pub fn decrypt<M: AsRef<[u8]>>(&self, message: M) -> Result<Vec<u8>> {
+    pub fn decrypt_with_context(
+        &self,
+        user_context: impl AsRef<[u8]>,
+        message: impl AsRef<[u8]>,
+    ) -> Result<Vec<u8>> {
         decrypt_context_imprint(
             self.0.master_key.as_bytes(),
             message.as_ref(),
-            self.0.user_context.as_bytes(),
+            user_context.as_ref(),
         )
     }
 }

--- a/tests/rust/secure_cell.rs
+++ b/tests/rust/secure_cell.rs
@@ -19,11 +19,11 @@ mod context_imprint {
 
     #[test]
     fn happy_path() {
-        let cell = SecureCell::with_key_and_context(b"deep secret", b"123").context_imprint();
+        let cell = SecureCell::with_key(b"deep secret").context_imprint();
 
         let plaintext = b"example plaintext";
-        let ciphertext = cell.encrypt(&plaintext).unwrap();
-        let recovered = cell.decrypt(&ciphertext).unwrap();
+        let ciphertext = cell.encrypt_with_context(b"123", &plaintext).unwrap();
+        let recovered = cell.decrypt_with_context(b"123", &ciphertext).unwrap();
 
         assert_eq!(recovered, plaintext);
 
@@ -35,43 +35,42 @@ mod context_imprint {
         let cell = SecureCell::with_key(b"deep secret").context_imprint();
 
         let plaintext = b"example plaintext";
-        let error = cell.encrypt(&plaintext).unwrap_err();
+        let error = cell.encrypt_with_context(b"", &plaintext).unwrap_err();
 
         assert_eq!(error.kind(), ErrorKind::InvalidParameter);
     }
 
     #[test]
     fn invalid_key() {
-        let cell1 = SecureCell::with_key_and_context(b"deep secret", b"123").context_imprint();
-        let cell2 = SecureCell::with_key_and_context(b"DEEP SECRET", b"123").context_imprint();
+        let cell1 = SecureCell::with_key(b"deep secret").context_imprint();
+        let cell2 = SecureCell::with_key(b"DEEP SECRET").context_imprint();
 
         let plaintext = b"example plaintext";
-        let ciphertext = cell1.encrypt(&plaintext).unwrap();
-        let recovered = cell2.decrypt(&ciphertext).unwrap();
+        let ciphertext = cell1.encrypt_with_context(b"123", &plaintext).unwrap();
+        let recovered = cell2.decrypt_with_context(b"123", &ciphertext).unwrap();
 
         assert_ne!(recovered, plaintext);
     }
 
     #[test]
     fn invalid_context() {
-        let cell1 = SecureCell::with_key_and_context(b"deep secret", b"123").context_imprint();
-        let cell2 = SecureCell::with_key_and_context(b"deep secret", b"456").context_imprint();
+        let cell = SecureCell::with_key(b"deep secret").context_imprint();
 
         let plaintext = b"example plaintext";
-        let ciphertext = cell1.encrypt(&plaintext).unwrap();
-        let recovered = cell2.decrypt(&ciphertext).unwrap();
+        let ciphertext = cell.encrypt_with_context(b"123", &plaintext).unwrap();
+        let recovered = cell.decrypt_with_context(b"456", &ciphertext).unwrap();
 
         assert_ne!(recovered, plaintext);
     }
 
     #[test]
     fn corrupted_data() {
-        let cell = SecureCell::with_key_and_context(b"deep secret", b"123").context_imprint();
+        let cell = SecureCell::with_key(b"deep secret").context_imprint();
 
         let plaintext = b"example plaintext";
-        let mut ciphertext = cell.encrypt(&plaintext).unwrap();
+        let mut ciphertext = cell.encrypt_with_context(b"123", &plaintext).unwrap();
         ciphertext[10] = !ciphertext[10];
-        let recovered = cell.decrypt(&ciphertext).unwrap();
+        let recovered = cell.decrypt_with_context(b"123", &ciphertext).unwrap();
 
         assert_ne!(recovered, plaintext);
     }
@@ -105,12 +104,11 @@ mod seal {
 
     #[test]
     fn invalid_context() {
-        let seal1 = SecureCell::with_key_and_context(b"deep secret", b"ctx1").seal();
-        let seal2 = SecureCell::with_key_and_context(b"deep secret", b"ctx2").seal();
+        let seal = SecureCell::with_key(b"deep secret").seal();
 
         let plaintext = b"example plaintext";
-        let ciphertext = seal1.encrypt(&plaintext).unwrap();
-        let error = seal2.decrypt(&ciphertext).unwrap_err();
+        let ciphertext = seal.encrypt_with_context(b"ctx1", &plaintext).unwrap();
+        let error = seal.decrypt_with_context(b"ctx2", &ciphertext).unwrap_err();
 
         assert_eq!(error.kind(), ErrorKind::Fail);
     }
@@ -158,12 +156,13 @@ mod token_protect {
 
     #[test]
     fn invalid_context() {
-        let cell1 = SecureCell::with_key_and_context(b"deep secret", b"123").token_protect();
-        let cell2 = SecureCell::with_key_and_context(b"deep secret", b"456").token_protect();
+        let cell = SecureCell::with_key(b"deep secret").token_protect();
 
         let plaintext = b"example plaintext";
-        let (ciphertext, token) = cell1.encrypt(plaintext).unwrap();
-        let error = cell2.decrypt(&ciphertext, &token).unwrap_err();
+        let (ciphertext, token) = cell.encrypt_with_context(b"123", plaintext).unwrap();
+        let error = cell
+            .decrypt_with_context(b"456", &ciphertext, &token)
+            .unwrap_err();
 
         assert_eq!(error.kind(), ErrorKind::Fail);
     }

--- a/tests/rust/secure_message.rs
+++ b/tests/rust/secure_message.rs
@@ -21,8 +21,8 @@ fn mode_encrypt_decrypt() {
     let secure = SecureMessage::new(gen_rsa_key_pair());
 
     let plaintext = b"test message please ignore";
-    let wrapped = secure.wrap(&plaintext).expect("encryption");
-    let recovered_message = secure.unwrap(&wrapped).expect("decryption");
+    let encrypted = secure.encrypt(&plaintext).expect("encryption");
+    let recovered_message = secure.decrypt(&encrypted).expect("decryption");
 
     assert_eq!(recovered_message, plaintext);
 }
@@ -46,8 +46,8 @@ fn invalid_key() {
     let secure2 = SecureMessage::new(gen_ec_key_pair());
 
     let plaintext = b"test message please ignore";
-    let wrapped = secure1.wrap(&plaintext).expect("encryption");
-    let error = secure2.unwrap(&wrapped).expect_err("decryption error");
+    let encrypted = secure1.encrypt(&plaintext).expect("encryption");
+    let error = secure2.decrypt(&encrypted).expect_err("decryption error");
 
     assert_eq!(error.kind(), ErrorKind::Fail);
 }
@@ -60,9 +60,9 @@ fn corrupted_data() {
     // Using index "10" for example leads to a crash with SIGBUS, so Themis definitely
     // could use some audit because it does not really handle corrupted messages well.
     let plaintext = b"test message please ignore";
-    let mut wrapped = secure.wrap(&plaintext).expect("encryption");
-    wrapped[5] = !wrapped[5];
-    let error = secure.unwrap(&wrapped).expect_err("decryption error");
+    let mut encrypted = secure.encrypt(&plaintext).expect("encryption");
+    encrypted[5] = !encrypted[5];
+    let error = secure.decrypt(&encrypted).expect_err("decryption error");
 
     assert_eq!(error.kind(), ErrorKind::InvalidParameter);
 }

--- a/tools/rust/scell_context_string_echo.rs
+++ b/tools/rust/scell_context_string_echo.rs
@@ -33,15 +33,16 @@ fn main() {
     let message = matches.value_of("message").unwrap();
     let context = matches.value_of("context").unwrap();
 
-    // TODO: context should be passed along with the message
-    let cell = SecureCell::with_key_and_context(&key, &context).context_imprint();
+    let cell = SecureCell::with_key(&key).context_imprint();
 
     match mode {
         "enc" => {
-            let encrypted = cell.encrypt(&message).unwrap_or_else(|error| {
-                eprintln!("failed to encrypt message: {}", error);
-                exit(1);
-            });
+            let encrypted = cell
+                .encrypt_with_context(&context, &message)
+                .unwrap_or_else(|error| {
+                    eprintln!("failed to encrypt message: {}", error);
+                    exit(1);
+                });
             println!("{}", base64::encode(&encrypted));
         }
         "dec" => {
@@ -49,10 +50,12 @@ fn main() {
                 eprintln!("failed to decode message: {}", error);
                 exit(1);
             });
-            let decrypted = cell.decrypt(&decoded_message).unwrap_or_else(|error| {
-                eprintln!("failed to decrypt message: {}", error);
-                exit(1);
-            });
+            let decrypted = cell
+                .decrypt_with_context(&context, &decoded_message)
+                .unwrap_or_else(|error| {
+                    eprintln!("failed to decrypt message: {}", error);
+                    exit(1);
+                });
             println!("{}", std::str::from_utf8(&decrypted).expect("UTF-8 string"));
         }
         other => {

--- a/tools/rust/scell_seal_string_echo.rs
+++ b/tools/rust/scell_seal_string_echo.rs
@@ -33,15 +33,16 @@ fn main() {
     let message = matches.value_of("message").unwrap();
     let context = matches.value_of("context").unwrap_or_default();
 
-    // TODO: context should be passed along with the message
-    let cell = SecureCell::with_key_and_context(&key, &context).seal();
+    let cell = SecureCell::with_key(&key).seal();
 
     match mode {
         "enc" => {
-            let encrypted = cell.encrypt(&message).unwrap_or_else(|error| {
-                eprintln!("failed to encrypt message: {}", error);
-                exit(1);
-            });
+            let encrypted = cell
+                .encrypt_with_context(&context, &message)
+                .unwrap_or_else(|error| {
+                    eprintln!("failed to encrypt message: {}", error);
+                    exit(1);
+                });
             println!("{}", base64::encode(&encrypted));
         }
         "dec" => {
@@ -49,10 +50,12 @@ fn main() {
                 eprintln!("failed to decode message: {}", error);
                 exit(1);
             });
-            let decrypted = cell.decrypt(&decoded_message).unwrap_or_else(|error| {
-                eprintln!("failed to decrypt message: {}", error);
-                exit(1);
-            });
+            let decrypted = cell
+                .decrypt_with_context(&context, &decoded_message)
+                .unwrap_or_else(|error| {
+                    eprintln!("failed to decrypt message: {}", error);
+                    exit(1);
+                });
             println!("{}", std::str::from_utf8(&decrypted).expect("UTF-8 string"));
         }
         other => {

--- a/tools/rust/scell_token_string_echo.rs
+++ b/tools/rust/scell_token_string_echo.rs
@@ -37,15 +37,16 @@ fn main() {
     let message = parts.next().unwrap();
     let token = parts.next().unwrap_or("");
 
-    // TODO: context should be passed along with the message
-    let cell = SecureCell::with_key_and_context(&key, &context).token_protect();
+    let cell = SecureCell::with_key(&key).token_protect();
 
     match mode {
         "enc" => {
-            let (encrypted, token) = cell.encrypt(&message).unwrap_or_else(|error| {
-                eprintln!("failed to encrypt message: {}", error);
-                exit(1);
-            });
+            let (encrypted, token) = cell
+                .encrypt_with_context(&context, &message)
+                .unwrap_or_else(|error| {
+                    eprintln!("failed to encrypt message: {}", error);
+                    exit(1);
+                });
             println!("{},{}", base64::encode(&encrypted), base64::encode(&token));
         }
         "dec" => {
@@ -58,7 +59,7 @@ fn main() {
                 exit(1);
             });
             let decrypted = cell
-                .decrypt(&decoded_message, &decoded_token)
+                .decrypt_with_context(&context, &decoded_message, &decoded_token)
                 .unwrap_or_else(|error| {
                     eprintln!("failed to decrypt message: {}", error);
                     exit(1);

--- a/tools/rust/smessage_encryption.rs
+++ b/tools/rust/smessage_encryption.rs
@@ -46,8 +46,7 @@ fn main() {
             let key_pair = KeyPair::try_join(secret_key, public_key).expect("matching keys");
             let encrypter = SecureMessage::new(key_pair);
 
-            // TODO: this reads strange, maybe we should use a better name (like, "encrypt")
-            let encrypted = encrypter.wrap(&message).unwrap_or_else(|error| {
+            let encrypted = encrypter.encrypt(&message).unwrap_or_else(|error| {
                 eprintln!("failed to encrypt message: {}", error);
                 exit(1);
             });
@@ -62,8 +61,7 @@ fn main() {
                 eprintln!("failed to decode message: {}", error);
                 exit(1);
             });
-            // TODO: this reads strange, maybe we should use a better name (like, "decrypt")
-            let decrypted = encrypter.unwrap(&decoded_message).unwrap_or_else(|error| {
+            let decrypted = encrypter.decrypt(&decoded_message).unwrap_or_else(|error| {
                 eprintln!("failed to decrypt message: {}", error);
                 exit(1);
             });


### PR DESCRIPTION
Here are a couple of changes to Secure Cell and Secure Message interface that are long overdue.

- do not use the same context for all messages handled by Secure Cell
- do some cosmetic method renames in Secure Message

To be specific, the `SecureCell::with_key_and_context()` constructor has been removed. It is replaced with the following alternatives:

- `SecureCell*::encrypt_with_context()`
- `SecureCell*::decrypt_with_context()`

Which should remind the user that they should provide a unique context for each individual message.

Furthermore, `encrypt()` and `decrypt()` methods of `SecureCellContextImprint` are removed as well to prompt the users to always use some context in context imprint mode of Secure Cell.

As for Secure Message, here we simply give the methods more fitting names. We don't have to mimic C API in naming because `SecureMessage` and `SecureSign`/`SecureVerify` are different entities in Rust.

---

While we're here, update the API to use a new feature of Rust 2018: _impl Trait_ types. With this it is no longer necessary to introduce ad-hoc generics to accept a parameter implementing a particular trait. The code is a bit easier to read and comprehend without all those magical one-letter identifiers.

Compare

```rust
pub fn decrypt_with_context(
    &self,
    user_context: impl AsRef<[u8]>,
    message: impl AsRef<[u8]>,
    token: impl AsRef<[u8]>,
) -> Result<Vec<u8>> {
}
```

with

```rust
pub fn decrypt_with_context<C, M, T>(
    &self,
    user_context: C,
    message: M,
    token: T,
) -> Result<Vec<u8>>
where
    C: AsRef<[u8]>,
    M: AsRef<[u8]>,
    T: AsRef<[u8]>,
{
}
```

or

```rust
pub fn decrypt_with_context<C: AsRef<[u8]>, M: AsRef<[u8]>, T: AsRef<[u8]>>(
    &self,
    user_context: C,
    message: M,
    token: T,
) -> Result<Vec<u8>> {
}
```

All these forms use the same implementation under the hood. However, with _impl Trait_ it is no longer possible to explicitly specify generic parameters:

```rust
cell.decrypt_with_context::<[u8; 0], &[u8], &[u8]>([], &message, &token);
```

It's not like one would ever need to specify them in the first place (realistically), but this is still a breaking change (technically).

---

These changes are grouped in a single pull request because they are both breaking changes and touch the changelog. I don't want to resolve merge conflicts later.