### PR TITLE
Android: distribute via maven

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,11 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
+
+        // Two necessary plugins for uploading .aar to bintray
+        // from: https://android.jlelse.eu/how-to-distribute-android-library-in-a-convenient-way-d43fb68304a7
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
     }
 }
 
@@ -37,11 +42,61 @@ android {
 	}
 
     // ensure we execute boringssl tasks first
-    tasks.whenTaskAdded({Task task -> task.dependsOn('boringssl:' + task.name)})
+    // tasks.whenTaskAdded({Task task -> task.dependsOn('boringssl:' + task.name)})
+
+    // publishing and bitray upload tasks should not run for ':boringssl' project
+    tasks.whenTaskAdded { task ->
+        println "executing $task ..."
+        if (task.name != 'bintrayUpload' && task.name != 'publishProductionPublicationToMavenLocal' && task.name != 'generatePomFileForProductionPublication') {
+            task.dependsOn('boringssl:' + task.name)
+        }
+    }
 
 	externalNativeBuild {
 	    ndkBuild {
 	        path "jni/Android.mk"
 	    }
 	}
+}
+
+// distribution
+
+apply plugin: 'com.jfrog.bintray'
+apply plugin: 'maven-publish'
+
+publishing {
+    publications {
+        Production(MavenPublication) {
+            artifact("$buildDir/outputs/aar/mainfork-release.aar")
+            groupId 'com.cossacklabs.com'
+            artifactId 'themis'
+            version '0.10.0'
+        }
+    }
+}
+
+bintray {
+    // Get Bintray credential from environment variable
+    user = System.getenv('BINTRAY_USER') // Get bintray User
+    key = System.getenv('BINTRAY_KEY') // Get bintray API Key from https://bintray.com/profile/edit -> APIKey
+    configurations = ['archives']
+    pkg {
+        repo = 'maven'
+        name = 'themis'
+        userOrg = 'cossacklabs'
+        licenses = ['Apache-2.0']
+        desc = 'Easy to use cryptographic framework for data protection: secure messaging with forward secrecy and secure data storage. Has unified APIs across ten platforms.'
+        websiteUrl = "https://cossacklabs.com/themis/"
+        vcsUrl = 'https://github.com/cossacklabs/themis.git'
+        publish = true
+        version {
+            name = '0.10.0'
+            released  = new Date()            
+            gpg {
+                sign = true
+                passphrase = System.getenv('BINTRAY_GPG_PASSPHRASE')
+            }
+        }
+    }
+    publications = ['Production']
 }


### PR DESCRIPTION
_Disclaimer: first time I'm trying to setup maven distribution._

I've updated `build.gradle` to distribute `themis.aar` to bintray.

**Problem** I've got that `:boringssl` target doesn't support `bintrayUpload` obviously. Lines [48-53](https://github.com/cossacklabs/themis/compare/vixentael/android?expand=1#diff-c197962302397baf3a4cc36463dce5eaR48) are dirty hack to avoid calling distribution target for `:borinssl` project.
Please advice how to manage it properly.

**Repository**
https://bintray.com/cossacklabs/maven/themis

**Distribution**
1. Export env variables
```
export BINTRAY_USER=cossacklabs
export BINTRAY_KEY=<from bintray profile / edit / API keys > 
export BINTRAY_GPG_PASSPHRASE=<passphrase to unlock private GPG key> 
```
2. Run
```
./gradlew clean assembleRelease bintrayUpload
```

**Usage in Android project**
1. Add bintray repository into your repositories from `build.gradle`
```
repositories {
        maven { url "https://dl.bintray.com/cossacklabs/maven/" }
}
```

2. Link to themis from `app/build.gradle`
```
dependencies {
     // ....
    implementation 'com.cossacklabs.com:themis:0.10.0'
}
```

**Usage example**: https://github.com/cossacklabs/themis-java-examples/pull/2