### PR TITLE
Panic on empty input for Secure Cell

### DIFF
--- a/src/wrappers/themis/rust/CHANGELOG.md
+++ b/src/wrappers/themis/rust/CHANGELOG.md
@@ -14,7 +14,11 @@ The version currently under development.
   `encrypt` and `decrypt` respectively. Their parameters have been
   changed to use _impl Trait_ instead of explicit generics. ([#358])
 
+- `SecureCell` methods panic instead of returning errors when called with
+  forbidden empty key, message, token, or user context parameters. ([#363])
+
 [#358]: https://github.com/cossacklabs/themis/pull/358
+[#363]: https://github.com/cossacklabs/themis/pull/363
 
 Version 0.0.3 — 2019-01-17
 ==========================


### PR DESCRIPTION
It does not make much sense to use an empty master key for encryption, or encrypt or decrypt empty messages. Secure Cell does not allow such inputs and returns errors if the user insists. Additionally, context imprint mode of Secure Cell requires a non-empty user context.

The programmers should never really use Secure Cell in this way. If an empty key, or message, or token, or user context is used anywhere then it's most likely to be a programming error. Therefore treat it as such — like using an invalid index with a slice — and panic instead of returning an error code if we encounter empty inputs.