### PR TITLE
Early check for master key length in Secure Cell

### DIFF
--- a/docs/examples/rust/secure_cell.rs
+++ b/docs/examples/rust/secure_cell.rs
@@ -37,7 +37,7 @@ fn main() {
     let input_path = matches.value_of("input").unwrap();
     let output_path = matches.value_of("output").unwrap();
 
-    let cell = SecureCell::with_key(&password).seal();
+    let cell = SecureCell::with_key(&password).unwrap().seal();
 
     let input = read_file(&input_path).unwrap();
     let output = if encrypt {

--- a/src/wrappers/themis/rust/CHANGELOG.md
+++ b/src/wrappers/themis/rust/CHANGELOG.md
@@ -6,9 +6,14 @@ The version currently under development.
 ## Breaking changes
 
 - `SecureCell` interface has been overhauled for better usability and
-  security. User context has to be provided together with messages
-  instead of being fixed at construction time. The methods now use
-  _impl Trait_ instead of explicit generics as well. ([#358])
+  security.
+
+  - User context has to be provided together with messages
+    instead of being fixed at construction time. The methods now use
+    _impl Trait_ instead of explicit generics as well. ([#358])
+
+  - `SecureCell::with_key()` now checks the master key and returns a
+    `Result<SecureCell>` instead of `SecureCell` directly. ([#365])
 
 - `SecureMessage` methods `wrap` and `unwrap` have been renamed into
   `encrypt` and `decrypt` respectively. Their parameters have been
@@ -20,6 +25,7 @@ The version currently under development.
 
 [#358]: https://github.com/cossacklabs/themis/pull/358
 [#362]: https://github.com/cossacklabs/themis/pull/362
+[#365]: https://github.com/cossacklabs/themis/pull/365
 
 Version 0.0.3 — 2019-01-17
 ==========================

--- a/src/wrappers/themis/rust/src/keys.rs
+++ b/src/wrappers/themis/rust/src/keys.rs
@@ -142,13 +142,17 @@ pub(crate) struct KeyBytes(Vec<u8>);
 
 impl KeyBytes {
     /// Makes a key from an owned byte vector.
-    pub fn from_vec(bytes: Vec<u8>) -> KeyBytes {
-        KeyBytes(bytes)
+    pub fn from_vec(bytes: Vec<u8>) -> Result<KeyBytes> {
+        if bytes.is_empty() {
+            Err(Error::with_kind(ErrorKind::InvalidParameter))
+        } else {
+            Ok(KeyBytes(bytes))
+        }
     }
 
     /// Makes a key from a copy of a byte slice.
-    pub fn copy_slice(bytes: &[u8]) -> KeyBytes {
-        KeyBytes(bytes.to_vec())
+    pub fn copy_slice(bytes: &[u8]) -> Result<KeyBytes> {
+        KeyBytes::from_vec(bytes.to_vec())
     }
 
     /// Returns key bytes.
@@ -380,7 +384,7 @@ impl RsaPrivateKey {
     ///
     /// Returns an error if the slice does not contain a valid RSA private key.
     pub fn try_from_slice<T: AsRef<[u8]>>(bytes: T) -> Result<Self> {
-        let key = KeyBytes::copy_slice(bytes.as_ref());
+        let key = KeyBytes::copy_slice(bytes.as_ref())?;
         match get_key_kind(&key)? {
             KeyKind::RsaPrivate => Ok(Self { inner: key }),
             _ => Err(Error::with_kind(ErrorKind::InvalidParameter)),
@@ -389,7 +393,7 @@ impl RsaPrivateKey {
 
     /// Wraps an existing trusted byte vector into a key.
     pub(crate) fn from_vec(bytes: Vec<u8>) -> Self {
-        let key = KeyBytes::from_vec(bytes);
+        let key = KeyBytes::from_vec(bytes).expect("invalid empty key");
         debug_assert_eq!(get_key_kind(&key), Ok(KeyKind::RsaPrivate));
         Self { inner: key }
     }
@@ -400,7 +404,7 @@ impl RsaPublicKey {
     ///
     /// Returns an error if the slice does not contain a valid RSA public key.
     pub fn try_from_slice<T: AsRef<[u8]>>(bytes: T) -> Result<Self> {
-        let key = KeyBytes::copy_slice(bytes.as_ref());
+        let key = KeyBytes::copy_slice(bytes.as_ref())?;
         match get_key_kind(&key)? {
             KeyKind::RsaPublic => Ok(Self { inner: key }),
             _ => Err(Error::with_kind(ErrorKind::InvalidParameter)),
@@ -409,7 +413,7 @@ impl RsaPublicKey {
 
     /// Wraps an existing trusted byte vector into a key.
     pub(crate) fn from_vec(bytes: Vec<u8>) -> Self {
-        let key = KeyBytes::from_vec(bytes);
+        let key = KeyBytes::from_vec(bytes).expect("invalid empty key");
         debug_assert_eq!(get_key_kind(&key), Ok(KeyKind::RsaPublic));
         Self { inner: key }
     }
@@ -420,7 +424,7 @@ impl EcdsaPrivateKey {
     ///
     /// Returns an error if the slice does not contain a valid ECDSA private key.
     pub fn try_from_slice<T: AsRef<[u8]>>(bytes: T) -> Result<Self> {
-        let key = KeyBytes::copy_slice(bytes.as_ref());
+        let key = KeyBytes::copy_slice(bytes.as_ref())?;
         match get_key_kind(&key)? {
             KeyKind::EcdsaPrivate => Ok(Self { inner: key }),
             _ => Err(Error::with_kind(ErrorKind::InvalidParameter)),
@@ -429,7 +433,7 @@ impl EcdsaPrivateKey {
 
     /// Wraps an existing trusted byte vector into a key.
     pub(crate) fn from_vec(bytes: Vec<u8>) -> Self {
-        let key = KeyBytes::from_vec(bytes);
+        let key = KeyBytes::from_vec(bytes).expect("invalid empty key");
         debug_assert_eq!(get_key_kind(&key), Ok(KeyKind::EcdsaPrivate));
         Self { inner: key }
     }
@@ -440,7 +444,7 @@ impl EcdsaPublicKey {
     ///
     /// Returns an error if the slice does not contain a valid ECDSA public key.
     pub fn try_from_slice<T: AsRef<[u8]>>(bytes: T) -> Result<Self> {
-        let key = KeyBytes::copy_slice(bytes.as_ref());
+        let key = KeyBytes::copy_slice(bytes.as_ref())?;
         match get_key_kind(&key)? {
             KeyKind::EcdsaPublic => Ok(Self { inner: key }),
             _ => Err(Error::with_kind(ErrorKind::InvalidParameter)),
@@ -449,7 +453,7 @@ impl EcdsaPublicKey {
 
     /// Wraps an existing trusted byte vector into a key.
     pub(crate) fn from_vec(bytes: Vec<u8>) -> Self {
-        let key = KeyBytes::from_vec(bytes);
+        let key = KeyBytes::from_vec(bytes).expect("invalid empty key");
         debug_assert_eq!(get_key_kind(&key), Ok(KeyKind::EcdsaPublic));
         Self { inner: key }
     }
@@ -465,7 +469,7 @@ impl PrivateKey {
     ///
     /// Returns an error if the slice does not contain a valid RSA or ECDSA private key.
     pub fn try_from_slice<T: AsRef<[u8]>>(bytes: T) -> Result<Self> {
-        let key = KeyBytes::copy_slice(bytes.as_ref());
+        let key = KeyBytes::copy_slice(bytes.as_ref())?;
         match get_key_kind(&key)? {
             KeyKind::RsaPrivate => Ok(Self { inner: key }),
             KeyKind::EcdsaPrivate => Ok(Self { inner: key }),
@@ -484,7 +488,7 @@ impl PublicKey {
     ///
     /// Returns an error if the slice does not contain a valid RSA or ECDSA public key.
     pub fn try_from_slice<T: AsRef<[u8]>>(bytes: T) -> Result<Self> {
-        let key = KeyBytes::copy_slice(bytes.as_ref());
+        let key = KeyBytes::copy_slice(bytes.as_ref())?;
         match get_key_kind(&key)? {
             KeyKind::RsaPublic => Ok(Self { inner: key }),
             KeyKind::EcdsaPublic => Ok(Self { inner: key }),

--- a/src/wrappers/themis/rust/src/secure_cell.rs
+++ b/src/wrappers/themis/rust/src/secure_cell.rs
@@ -73,7 +73,7 @@
 //! # fn main() -> Result<(), themis::Error> {
 //! use themis::secure_cell::SecureCell;
 //!
-//! let cell = SecureCell::with_key(b"seekryt").seal();
+//! let cell = SecureCell::with_key(b"seekryt")?.seal();
 //!
 //! let encrypted = cell.encrypt(b"source data")?;
 //! let decrypted = cell.decrypt(&encrypted)?;
@@ -113,22 +113,25 @@ impl SecureCell {
     /// array, a `Vec<u8>`, or a `String`.
     ///
     /// Note that it is actually _a password_. It is not required to be an actual key generated
-    /// by one of the [`keygen`] functions (though you definitely can use those keys as well):
+    /// by one of the [`keygen`] functions (though you definitely can use those keys as well).
+    /// The master key cannot be empty.
     ///
     /// ```
     /// use themis::secure_cell::SecureCell;
     ///
-    /// SecureCell::with_key(b"byte string");
-    /// SecureCell::with_key(&[1, 2, 3, 4, 5]);
-    /// SecureCell::with_key(vec![6, 7, 8, 9]);
-    /// SecureCell::with_key(format!("owned string"));
+    /// assert!(SecureCell::with_key(b"byte string").is_ok());
+    /// assert!(SecureCell::with_key(&[1, 2, 3, 4, 5]).is_ok());
+    /// assert!(SecureCell::with_key(vec![6, 7, 8, 9]).is_ok());
+    /// assert!(SecureCell::with_key(format!("owned string")).is_ok());
+    ///
+    /// assert!(SecureCell::with_key(b"").is_err());
     /// ```
     ///
     /// [`keygen`]: ../keygen/index.html
-    pub fn with_key(master_key: impl AsRef<[u8]>) -> Self {
-        Self {
-            master_key: KeyBytes::copy_slice(master_key.as_ref()).expect("unimplemented"),
-        }
+    pub fn with_key(master_key: impl AsRef<[u8]>) -> Result<Self> {
+        Ok(Self {
+            master_key: KeyBytes::copy_slice(master_key.as_ref())?,
+        })
     }
 
     /// Switches this Secure Cell to the _sealing_ operation mode.
@@ -157,7 +160,7 @@ impl SecureCell {
 /// # fn main() -> Result<(), themis::Error> {
 /// use themis::secure_cell::SecureCell;
 ///
-/// let cell = SecureCell::with_key(b"password").seal();
+/// let cell = SecureCell::with_key(b"password")?.seal();
 ///
 /// let input = b"test input";
 /// let output = cell.encrypt(input)?;
@@ -180,7 +183,7 @@ impl SecureCellSeal {
     /// # fn main() -> Result<(), themis::Error> {
     /// use themis::secure_cell::SecureCell;
     ///
-    /// let cell = SecureCell::with_key(b"password").seal();
+    /// let cell = SecureCell::with_key(b"password")?.seal();
     ///
     /// cell.encrypt(b"byte string")?;
     /// cell.encrypt(&[1, 2, 3, 4, 5])?;
@@ -195,7 +198,7 @@ impl SecureCellSeal {
     /// ```
     /// # use themis::secure_cell::SecureCell;
     /// #
-    /// # let cell = SecureCell::with_key(b"password").seal();
+    /// # let cell = SecureCell::with_key(b"password").unwrap().seal();
     /// #
     /// assert!(cell.encrypt(&[]).is_err());
     /// ```
@@ -214,7 +217,7 @@ impl SecureCellSeal {
     /// # fn main() -> Result<(), themis::Error> {
     /// use themis::secure_cell::SecureCell;
     ///
-    /// let cell = SecureCell::with_key(b"password").seal();
+    /// let cell = SecureCell::with_key(b"password")?.seal();
     ///
     /// cell.encrypt_with_context(b"byte string", format!("owned string"))?;
     /// cell.encrypt_with_context(&[1, 2, 3, 4, 5], vec![6, 7, 8, 9, 10])?;
@@ -228,7 +231,7 @@ impl SecureCellSeal {
     /// ```
     /// # use themis::secure_cell::SecureCell;
     /// #
-    /// # let cell = SecureCell::with_key(b"password").seal();
+    /// # let cell = SecureCell::with_key(b"password").unwrap().seal();
     /// #
     /// assert!(cell.encrypt_with_context(b"message", &[]).is_ok());
     /// assert!(cell.encrypt_with_context(&[], b"context").is_err());
@@ -257,7 +260,7 @@ impl SecureCellSeal {
     /// # fn main() -> Result<(), themis::Error> {
     /// use themis::secure_cell::SecureCell;
     ///
-    /// let cell = SecureCell::with_key(b"password").seal();
+    /// let cell = SecureCell::with_key(b"password")?.seal();
     ///
     /// let encrypted = cell.encrypt(b"byte string")?;
     /// let decrypted = cell.decrypt(&encrypted)?;
@@ -269,14 +272,17 @@ impl SecureCellSeal {
     /// However, if the key is invalid then decryption fails:
     ///
     /// ```
+    /// # fn main() -> Result<(), themis::Error> {
     /// # use themis::secure_cell::SecureCell;
     /// #
-    /// # let cell = SecureCell::with_key(b"password").seal();
+    /// # let cell = SecureCell::with_key(b"password").unwrap().seal();
     /// # let encrypted = cell.encrypt(b"byte string").unwrap();
     /// #
-    /// let different_cell = SecureCell::with_key(b"qwerty123").seal();
+    /// let different_cell = SecureCell::with_key(b"qwerty123")?.seal();
     ///
     /// assert!(different_cell.decrypt(&encrypted).is_err());
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// Secure Cell in sealing mode checks data integrity and can see if the data was corrupted,
@@ -285,7 +291,7 @@ impl SecureCellSeal {
     /// ```
     /// # use themis::secure_cell::SecureCell;
     /// #
-    /// # let cell = SecureCell::with_key(b"password").seal();
+    /// # let cell = SecureCell::with_key(b"password").unwrap().seal();
     /// # let encrypted = cell.encrypt(b"byte string").unwrap();
     /// #
     /// // Let's flip some bits somewhere.
@@ -308,7 +314,7 @@ impl SecureCellSeal {
     /// # fn main() -> Result<(), themis::Error> {
     /// use themis::secure_cell::SecureCell;
     ///
-    /// let cell = SecureCell::with_key(b"password").seal();
+    /// let cell = SecureCell::with_key(b"password")?.seal();
     ///
     /// let encrypted = cell.encrypt_with_context(b"byte string", b"context")?;
     /// let decrypted = cell.decrypt_with_context(&encrypted, b"context")?;
@@ -320,15 +326,18 @@ impl SecureCellSeal {
     /// However, if the key or the context are invalid then decryption fails:
     ///
     /// ```
+    /// # fn main() -> Result<(), themis::Error> {
     /// # use themis::secure_cell::SecureCell;
     /// #
-    /// # let cell = SecureCell::with_key(b"password").seal();
+    /// # let cell = SecureCell::with_key(b"password").unwrap().seal();
     /// # let encrypted = cell.encrypt_with_context(b"byte string", b"context").unwrap();
     /// #
-    /// let different_cell = SecureCell::with_key(b"qwerty123").seal();
+    /// let different_cell = SecureCell::with_key(b"qwerty123")?.seal();
     ///
     /// assert!(different_cell.decrypt_with_context(&encrypted, b"context").is_err());
     /// assert!(cell.decrypt_with_context(&encrypted, b"different context").is_err());
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// Secure Cell in sealing mode checks data integrity and can see if the data was corrupted,
@@ -337,7 +346,7 @@ impl SecureCellSeal {
     /// ```
     /// # use themis::secure_cell::SecureCell;
     /// #
-    /// # let cell = SecureCell::with_key(b"password").seal();
+    /// # let cell = SecureCell::with_key(b"password").unwrap().seal();
     /// # let encrypted = cell.encrypt_with_context(b"byte string", b"context").unwrap();
     /// #
     /// // Let's flip some bits somewhere.
@@ -470,7 +479,7 @@ fn decrypt_seal(master_key: &[u8], user_context: &[u8], message: &[u8]) -> Resul
 /// # fn main() -> Result<(), themis::Error> {
 /// use themis::secure_cell::SecureCell;
 ///
-/// let cell = SecureCell::with_key(b"password").token_protect();
+/// let cell = SecureCell::with_key(b"password")?.token_protect();
 ///
 /// let input = b"test input";
 /// let (output, token) = cell.encrypt(input)?;
@@ -497,7 +506,7 @@ impl SecureCellTokenProtect {
     /// # fn main() -> Result<(), themis::Error> {
     /// use themis::secure_cell::SecureCell;
     ///
-    /// let cell = SecureCell::with_key(b"password").token_protect();
+    /// let cell = SecureCell::with_key(b"password")?.token_protect();
     ///
     /// cell.encrypt(b"byte string")?;
     /// cell.encrypt(&[1, 2, 3, 4, 5])?;
@@ -512,7 +521,7 @@ impl SecureCellTokenProtect {
     /// ```
     /// # use themis::secure_cell::SecureCell;
     /// #
-    /// # let cell = SecureCell::with_key(b"password").token_protect();
+    /// # let cell = SecureCell::with_key(b"password").unwrap().token_protect();
     /// #
     /// assert!(cell.encrypt(&[]).is_err());
     /// ```
@@ -535,7 +544,7 @@ impl SecureCellTokenProtect {
     /// # fn main() -> Result<(), themis::Error> {
     /// use themis::secure_cell::SecureCell;
     ///
-    /// let cell = SecureCell::with_key(b"password").token_protect();
+    /// let cell = SecureCell::with_key(b"password").unwrap().token_protect();
     ///
     /// cell.encrypt_with_context(b"byte string", format!("owned string"))?;
     /// cell.encrypt_with_context(&[1, 2, 3, 4, 5], vec![6, 7, 8, 9, 10])?;
@@ -549,7 +558,7 @@ impl SecureCellTokenProtect {
     /// ```
     /// # use themis::secure_cell::SecureCell;
     /// #
-    /// # let cell = SecureCell::with_key(b"password").token_protect();
+    /// # let cell = SecureCell::with_key(b"password").unwrap().token_protect();
     /// #
     /// assert!(cell.encrypt_with_context(b"message", &[]).is_ok());
     /// assert!(cell.encrypt_with_context(&[], b"context").is_err());
@@ -583,7 +592,7 @@ impl SecureCellTokenProtect {
     /// # fn main() -> Result<(), themis::Error> {
     /// use themis::secure_cell::SecureCell;
     ///
-    /// let cell = SecureCell::with_key(b"password").token_protect();
+    /// let cell = SecureCell::with_key(b"password")?.token_protect();
     ///
     /// let (encrypted, token) = cell.encrypt(b"byte string")?;
     /// let decrypted = cell.decrypt(&encrypted, &token)?;
@@ -595,14 +604,17 @@ impl SecureCellTokenProtect {
     /// However, you obviously cannot use tokens produced by Secure Cells with different keys:
     ///
     /// ```
+    /// # fn main() -> Result<(), themis::Error> {
     /// # use themis::secure_cell::SecureCell;
     /// #
-    /// # let cell = SecureCell::with_key(b"password").token_protect();
+    /// # let cell = SecureCell::with_key(b"password").unwrap().token_protect();
     /// # let (encrypted, token) = cell.encrypt(b"byte string").unwrap();
     /// #
-    /// let different_cell = SecureCell::with_key(b"qwerty123").token_protect();
+    /// let different_cell = SecureCell::with_key(b"qwerty123")?.token_protect();
     ///
     /// assert!(different_cell.decrypt(&encrypted, &token).is_err());
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// Or by the same Secure Cell for different data:
@@ -611,7 +623,7 @@ impl SecureCellTokenProtect {
     /// # fn main() -> Result<(), themis::Error> {
     /// # use themis::secure_cell::SecureCell;
     /// #
-    /// # let cell = SecureCell::with_key(b"password").token_protect();
+    /// # let cell = SecureCell::with_key(b"password").unwrap().token_protect();
     /// #
     /// let (encrypted,   _) = cell.encrypt(b"byte string")?;
     /// let (_, other_token) = cell.encrypt(b"other data")?;
@@ -627,7 +639,7 @@ impl SecureCellTokenProtect {
     /// ```
     /// # use themis::secure_cell::SecureCell;
     /// #
-    /// # let cell = SecureCell::with_key(b"password").token_protect();
+    /// # let cell = SecureCell::with_key(b"password").unwrap().token_protect();
     /// # let (encrypted, auth_token) = cell.encrypt(b"byte string").unwrap();
     /// #
     /// // Let's flip some bits somewhere.
@@ -660,7 +672,7 @@ impl SecureCellTokenProtect {
     /// # fn main() -> Result<(), themis::Error> {
     /// use themis::secure_cell::SecureCell;
     ///
-    /// let cell = SecureCell::with_key(b"password").token_protect();
+    /// let cell = SecureCell::with_key(b"password")?.token_protect();
     ///
     /// let (encrypted, token) = cell.encrypt_with_context(b"byte string", b"context")?;
     /// let decrypted = cell.decrypt_with_context(&encrypted, &token, b"context")?;
@@ -676,10 +688,10 @@ impl SecureCellTokenProtect {
     /// # fn main() -> Result<(), themis::Error> {
     /// # use themis::secure_cell::SecureCell;
     /// #
-    /// # let cell = SecureCell::with_key(b"password").token_protect();
+    /// # let cell = SecureCell::with_key(b"password").unwrap().token_protect();
     /// # let (encrypted, token) = cell.encrypt_with_context(b"byte string", b"context").unwrap();
     /// #
-    /// let different_cell = SecureCell::with_key(b"qwerty123").token_protect();
+    /// let different_cell = SecureCell::with_key(b"qwerty123")?.token_protect();
     ///
     /// assert!(different_cell.decrypt_with_context(&encrypted, &token, b"context").is_err());
     ///
@@ -697,7 +709,7 @@ impl SecureCellTokenProtect {
     /// ```
     /// # use themis::secure_cell::SecureCell;
     /// #
-    /// # let cell = SecureCell::with_key(b"password").token_protect();
+    /// # let cell = SecureCell::with_key(b"password").unwrap().token_protect();
     /// # let (encrypted, auth_token) = cell.encrypt_with_context(b"things", b"context").unwrap();
     /// #
     /// // Let's flip some bits somewhere.
@@ -859,7 +871,7 @@ fn decrypt_token_protect(
 /// # fn main() -> Result<(), themis::Error> {
 /// use themis::secure_cell::SecureCell;
 ///
-/// let cell = SecureCell::with_key(b"password").context_imprint();
+/// let cell = SecureCell::with_key(b"password")?.context_imprint();
 ///
 /// let input = b"test input";
 /// let output = cell.encrypt_with_context(input, b"context")?;
@@ -893,7 +905,7 @@ impl SecureCellContextImprint {
     /// # fn main() -> Result<(), themis::Error> {
     /// use themis::secure_cell::SecureCell;
     ///
-    /// let cell = SecureCell::with_key(b"password").context_imprint();
+    /// let cell = SecureCell::with_key(b"password")?.context_imprint();
     ///
     /// cell.encrypt_with_context(b"byte string", format!("owned string"))?;
     /// cell.encrypt_with_context(&[1, 2, 3, 4, 5], vec![6, 7, 8, 9, 10])?;
@@ -906,7 +918,7 @@ impl SecureCellContextImprint {
     /// ```
     /// # use themis::secure_cell::SecureCell;
     /// #
-    /// # let cell = SecureCell::with_key(b"password").context_imprint();
+    /// # let cell = SecureCell::with_key(b"password").unwrap().context_imprint();
     /// #
     /// assert!(cell.encrypt_with_context(b"message", b"context").is_ok());
     /// assert!(cell.encrypt_with_context(b"",        b"context").is_err());
@@ -938,7 +950,7 @@ impl SecureCellContextImprint {
     /// # fn main() -> Result<(), themis::Error> {
     /// use themis::secure_cell::SecureCell;
     ///
-    /// let cell = SecureCell::with_key(b"password").context_imprint();
+    /// let cell = SecureCell::with_key(b"password")?.context_imprint();
     ///
     /// let encrypted = cell.encrypt_with_context(b"byte string", b"context")?;
     /// let decrypted = cell.decrypt_with_context(&encrypted, b"context")?;
@@ -954,8 +966,8 @@ impl SecureCellContextImprint {
     /// # fn main() -> Result<(), themis::Error> {
     /// # use themis::secure_cell::SecureCell;
     /// #
-    /// let cell1 = SecureCell::with_key(b"XXX").context_imprint();
-    /// let cell2 = SecureCell::with_key(b"OOO").context_imprint();
+    /// let cell1 = SecureCell::with_key(b"XXX")?.context_imprint();
+    /// let cell2 = SecureCell::with_key(b"OOO")?.context_imprint();
     ///
     /// let encrypted = cell1.encrypt_with_context(b"byte string", b"context")?;
     /// let decrypted = cell2.decrypt_with_context(&encrypted, b"task-switch")?;
@@ -970,7 +982,7 @@ impl SecureCellContextImprint {
     /// ```
     /// # use themis::secure_cell::SecureCell;
     /// #
-    /// # let cell = SecureCell::with_key(b"password").context_imprint();
+    /// # let cell = SecureCell::with_key(b"password").unwrap().context_imprint();
     /// # let encrypted = cell.encrypt_with_context(b"byte string", b"context").unwrap();
     /// #
     /// // Let's flip some bits somewhere.

--- a/src/wrappers/themis/rust/src/secure_cell.rs
+++ b/src/wrappers/themis/rust/src/secure_cell.rs
@@ -127,7 +127,7 @@ impl SecureCell {
     /// [`keygen`]: ../keygen/index.html
     pub fn with_key(master_key: impl AsRef<[u8]>) -> Self {
         Self {
-            master_key: KeyBytes::copy_slice(master_key.as_ref()),
+            master_key: KeyBytes::copy_slice(master_key.as_ref()).expect("unimplemented"),
         }
     }
 

--- a/tests/rust/secure_cell.rs
+++ b/tests/rust/secure_cell.rs
@@ -14,12 +14,19 @@
 
 use themis::{secure_cell::SecureCell, ErrorKind};
 
+#[test]
+fn empty_master_key() {
+    assert!(SecureCell::with_key(b"").is_err());
+}
+
 mod context_imprint {
     use super::*;
 
     #[test]
     fn happy_path() {
-        let cell = SecureCell::with_key(b"deep secret").context_imprint();
+        let cell = SecureCell::with_key(b"deep secret")
+            .unwrap()
+            .context_imprint();
 
         let plaintext = b"example plaintext";
         let ciphertext = cell.encrypt_with_context(&plaintext, b"123").unwrap();
@@ -32,7 +39,9 @@ mod context_imprint {
 
     #[test]
     fn empty_context() {
-        let cell = SecureCell::with_key(b"deep secret").context_imprint();
+        let cell = SecureCell::with_key(b"deep secret")
+            .unwrap()
+            .context_imprint();
 
         let plaintext = b"example plaintext";
         let error = cell.encrypt_with_context(&plaintext, b"").unwrap_err();
@@ -42,8 +51,12 @@ mod context_imprint {
 
     #[test]
     fn invalid_key() {
-        let cell1 = SecureCell::with_key(b"deep secret").context_imprint();
-        let cell2 = SecureCell::with_key(b"DEEP SECRET").context_imprint();
+        let cell1 = SecureCell::with_key(b"deep secret")
+            .unwrap()
+            .context_imprint();
+        let cell2 = SecureCell::with_key(b"DEEP SECRET")
+            .unwrap()
+            .context_imprint();
 
         let plaintext = b"example plaintext";
         let ciphertext = cell1.encrypt_with_context(&plaintext, b"123").unwrap();
@@ -54,7 +67,9 @@ mod context_imprint {
 
     #[test]
     fn invalid_context() {
-        let cell = SecureCell::with_key(b"deep secret").context_imprint();
+        let cell = SecureCell::with_key(b"deep secret")
+            .unwrap()
+            .context_imprint();
 
         let plaintext = b"example plaintext";
         let ciphertext = cell.encrypt_with_context(&plaintext, b"123").unwrap();
@@ -65,7 +80,9 @@ mod context_imprint {
 
     #[test]
     fn corrupted_data() {
-        let cell = SecureCell::with_key(b"deep secret").context_imprint();
+        let cell = SecureCell::with_key(b"deep secret")
+            .unwrap()
+            .context_imprint();
 
         let plaintext = b"example plaintext";
         let mut ciphertext = cell.encrypt_with_context(&plaintext, b"123").unwrap();
@@ -81,7 +98,7 @@ mod seal {
 
     #[test]
     fn happy_path() {
-        let seal = SecureCell::with_key("deep secret").seal();
+        let seal = SecureCell::with_key("deep secret").unwrap().seal();
 
         let plaintext = b"example plaintext";
         let ciphertext = seal.encrypt(&plaintext).unwrap();
@@ -92,8 +109,8 @@ mod seal {
 
     #[test]
     fn invalid_key() {
-        let seal1 = SecureCell::with_key(b"deep secret").seal();
-        let seal2 = SecureCell::with_key(b"DEEP SECRET").seal();
+        let seal1 = SecureCell::with_key(b"deep secret").unwrap().seal();
+        let seal2 = SecureCell::with_key(b"DEEP SECRET").unwrap().seal();
 
         let plaintext = b"example plaintext";
         let ciphertext = seal1.encrypt(&plaintext).unwrap();
@@ -104,7 +121,7 @@ mod seal {
 
     #[test]
     fn invalid_context() {
-        let seal = SecureCell::with_key(b"deep secret").seal();
+        let seal = SecureCell::with_key(b"deep secret").unwrap().seal();
 
         let plaintext = b"example plaintext";
         let ciphertext = seal.encrypt_with_context(&plaintext, b"ctx1").unwrap();
@@ -115,7 +132,7 @@ mod seal {
 
     #[test]
     fn corrupted_data() {
-        let seal = SecureCell::with_key(b"deep secret").seal();
+        let seal = SecureCell::with_key(b"deep secret").unwrap().seal();
 
         let plaintext = b"example plaintext";
         let mut ciphertext = seal.encrypt(&plaintext).unwrap();
@@ -131,7 +148,9 @@ mod token_protect {
 
     #[test]
     fn happy_path() {
-        let cell = SecureCell::with_key(b"deep secret").token_protect();
+        let cell = SecureCell::with_key(b"deep secret")
+            .unwrap()
+            .token_protect();
 
         let plaintext = b"example plaintext";
         let (ciphertext, token) = cell.encrypt(&plaintext).unwrap();
@@ -144,8 +163,12 @@ mod token_protect {
 
     #[test]
     fn invalid_key() {
-        let cell1 = SecureCell::with_key(b"deep secret").token_protect();
-        let cell2 = SecureCell::with_key(b"DEEP SECRET").token_protect();
+        let cell1 = SecureCell::with_key(b"deep secret")
+            .unwrap()
+            .token_protect();
+        let cell2 = SecureCell::with_key(b"DEEP SECRET")
+            .unwrap()
+            .token_protect();
 
         let plaintext = b"example plaintext";
         let (ciphertext, token) = cell1.encrypt(plaintext).unwrap();
@@ -156,7 +179,9 @@ mod token_protect {
 
     #[test]
     fn invalid_context() {
-        let cell = SecureCell::with_key(b"deep secret").token_protect();
+        let cell = SecureCell::with_key(b"deep secret")
+            .unwrap()
+            .token_protect();
 
         let plaintext = b"example plaintext";
         let (ciphertext, token) = cell.encrypt_with_context(plaintext, b"123").unwrap();
@@ -169,7 +194,9 @@ mod token_protect {
 
     #[test]
     fn corrupted_data() {
-        let cell = SecureCell::with_key(b"deep secret").token_protect();
+        let cell = SecureCell::with_key(b"deep secret")
+            .unwrap()
+            .token_protect();
 
         let plaintext = b"example plaintext";
         let (mut ciphertext, token) = cell.encrypt(&plaintext).unwrap();
@@ -181,7 +208,9 @@ mod token_protect {
 
     #[test]
     fn corrupted_token() {
-        let cell = SecureCell::with_key(b"deep secret").token_protect();
+        let cell = SecureCell::with_key(b"deep secret")
+            .unwrap()
+            .token_protect();
 
         let plaintext = b"example plaintext";
         let (ciphertext, mut token) = cell.encrypt(&plaintext).unwrap();

--- a/tools/rust/scell_context_string_echo.rs
+++ b/tools/rust/scell_context_string_echo.rs
@@ -33,7 +33,12 @@ fn main() {
     let message = matches.value_of("message").unwrap();
     let context = matches.value_of("context").unwrap();
 
-    let cell = SecureCell::with_key(&key).context_imprint();
+    let cell = SecureCell::with_key(&key)
+        .unwrap_or_else(|_| {
+            eprintln!("invalid parameters: empty master key");
+            exit(1);
+        })
+        .context_imprint();
 
     match mode {
         "enc" => {

--- a/tools/rust/scell_seal_string_echo.rs
+++ b/tools/rust/scell_seal_string_echo.rs
@@ -33,7 +33,12 @@ fn main() {
     let message = matches.value_of("message").unwrap();
     let context = matches.value_of("context").unwrap_or_default();
 
-    let cell = SecureCell::with_key(&key).seal();
+    let cell = SecureCell::with_key(&key)
+        .unwrap_or_else(|_| {
+            eprintln!("invalid parameters: empty master key");
+            exit(1);
+        })
+        .seal();
 
     match mode {
         "enc" => {

--- a/tools/rust/scell_token_string_echo.rs
+++ b/tools/rust/scell_token_string_echo.rs
@@ -37,7 +37,12 @@ fn main() {
     let message = parts.next().unwrap();
     let token = parts.next().unwrap_or("");
 
-    let cell = SecureCell::with_key(&key).token_protect();
+    let cell = SecureCell::with_key(&key)
+        .unwrap_or_else(|_| {
+            eprintln!("invalid parameters: empty master key");
+            exit(1);
+        })
+        .token_protect();
 
     match mode {
         "enc" => {


### PR DESCRIPTION
This PR supersedes #363 by limiting the scope to Secure Cell construction.

* Enforce non-empty keys in `KeyBytes`

It does not really make sense to have empty key material so let's enforce this restriction globally. Add length checks to all `KeyBytes` constructors and have them return`Result` which can be an error if the provided byte slice is empty.

`from_vec()` constructors are used internally to wrap key bytes that we receive from key generation functions. These should never be empty so it's okay to panic if they happen to be empty.

`try_from_slice()` constructors are intended for users. They can pass empty slices here, but we do check for that and return an error. The API already uses result and `get_key_kind()` already performs length checks so there are no breaking changes here.

* Early check for master key length in Secure Cell

Secure Cell forbids empty master keys but if the user happens to use one then the error reporting may be quite delayed. The error will be apparent only they the Secure Cell is used for encryption or decryption while the key has been obtained much earlier.

We're going to perform the check earlier, on `SecureCell::with_key()` construction. Now this method returns a Result which will contain an error if the provided key is empty.

The users now have to check the construction result before using Secure Cell. Updated tests and documentation examples give an idea of the interface. Usually it will be enough to simply add `?`, but the users may also opt for `expect()` or `unwrap()` if they know the key is not empty.