### PR TITLE
Fix overflows in Secure Cell

### DIFF
--- a/src/soter/openssl/soter_sym.c
+++ b/src/soter/openssl/soter_sym.c
@@ -92,9 +92,16 @@ soter_sym_ctx_t* soter_sym_ctx_init(const uint32_t alg,
 				    const void* iv,
 				    const size_t iv_length,
 				    bool encrypt){
-  UNUSED(iv_length);
+  const EVP_CIPHER* evp=algid_to_evp(alg);
+  SOTER_CHECK_PARAM_(evp!=NULL);
   SOTER_CHECK_PARAM_(key!=NULL);
   SOTER_CHECK_PARAM_(key_length!=0);
+  if(salt==NULL){
+    SOTER_CHECK_PARAM_(salt_length==0);
+  }
+  if(iv!=NULL){
+    SOTER_CHECK_PARAM_(iv_length>=EVP_CIPHER_iv_length(evp));
+  }
   soter_sym_ctx_t* ctx=NULL;
   ctx=malloc(sizeof(soter_sym_ctx_t));
   SOTER_CHECK_MALLOC_(ctx);
@@ -107,14 +114,11 @@ soter_sym_ctx_t* soter_sym_ctx_init(const uint32_t alg,
     free(ctx);
     return NULL;
   }
-  //  if(iv!=NULL && (iv_length<SOTER_SYM_BLOCK_LENGTH(alg))){ // как проверить длину iv??
-  //  return NULL;
-  //}
   SOTER_IF_FAIL_(soter_withkdf(alg,key, key_length, salt, salt_length, key_, &key_length_)==SOTER_SUCCESS, soter_sym_encrypt_destroy(ctx));
   if(encrypt){
-    SOTER_IF_FAIL_(EVP_EncryptInit_ex(ctx->evp_sym_ctx, algid_to_evp(alg), NULL, key_, iv), soter_sym_encrypt_destroy(ctx));
+    SOTER_IF_FAIL_(EVP_EncryptInit_ex(ctx->evp_sym_ctx, evp, NULL, key_, iv), soter_sym_encrypt_destroy(ctx));
   } else {
-    SOTER_IF_FAIL_(EVP_DecryptInit_ex(ctx->evp_sym_ctx, algid_to_evp(alg), NULL, key_, iv), soter_sym_encrypt_destroy(ctx));
+    SOTER_IF_FAIL_(EVP_DecryptInit_ex(ctx->evp_sym_ctx, evp, NULL, key_, iv), soter_sym_encrypt_destroy(ctx));
   }
   return ctx;
 }
@@ -127,9 +131,16 @@ soter_sym_ctx_t* soter_sym_aead_ctx_init(const uint32_t alg,
 				    const void* iv,
 				    const size_t iv_length,
 				    bool encrypt){
-  UNUSED(iv_length);
+  const EVP_CIPHER* evp=algid_to_evp_aead(alg);
+  SOTER_CHECK_PARAM_(evp!=NULL);
   SOTER_CHECK_PARAM_(key!=NULL);
   SOTER_CHECK_PARAM_(key_length!=0);
+  if(salt==NULL){
+    SOTER_CHECK_PARAM_(salt_length==0);
+  }
+  if(iv!=NULL){
+    SOTER_CHECK_PARAM_(iv_length>=EVP_CIPHER_iv_length(evp));
+  }
   soter_sym_ctx_t* ctx=NULL;
   ctx=malloc(sizeof(soter_sym_ctx_t));
   SOTER_CHECK_MALLOC_(ctx);
@@ -143,9 +154,9 @@ soter_sym_ctx_t* soter_sym_aead_ctx_init(const uint32_t alg,
   }
   SOTER_IF_FAIL_(soter_withkdf(alg,key, key_length, salt, salt_length, key_, &key_length_)==SOTER_SUCCESS, soter_sym_encrypt_destroy(ctx));
   if(encrypt){
-    SOTER_IF_FAIL_(EVP_EncryptInit_ex(ctx->evp_sym_ctx, algid_to_evp_aead(alg), NULL, key_, iv), soter_sym_encrypt_destroy(ctx));
+    SOTER_IF_FAIL_(EVP_EncryptInit_ex(ctx->evp_sym_ctx, evp, NULL, key_, iv), soter_sym_encrypt_destroy(ctx));
   } else {
-    SOTER_IF_FAIL_(EVP_DecryptInit_ex(ctx->evp_sym_ctx, algid_to_evp_aead(alg), NULL, key_, iv), soter_sym_encrypt_destroy(ctx));
+    SOTER_IF_FAIL_(EVP_DecryptInit_ex(ctx->evp_sym_ctx, evp, NULL, key_, iv), soter_sym_encrypt_destroy(ctx));
   }
   return ctx;
 }

--- a/src/themis/secure_cell.c
+++ b/src/themis/secure_cell.c
@@ -47,6 +47,9 @@ themis_status_t themis_secure_cell_decrypt_seal(const uint8_t* master_key,
   size_t ctx_length_=0;
   size_t msg_length_=0;
   THEMIS_STATUS_CHECK(themis_auth_sym_decrypt_message(master_key, master_key_length, user_context, user_context_length, encrypted_message, encrypted_message_length, NULL, 0, NULL, &msg_length_),THEMIS_BUFFER_TOO_SMALL);
+  if(encrypted_message_length<msg_length_){
+    return THEMIS_INVALID_PARAMETER;
+  }
   ctx_length_=encrypted_message_length-msg_length_;
   return themis_auth_sym_decrypt_message(master_key, master_key_length, user_context, user_context_length, encrypted_message, ctx_length_, encrypted_message+ctx_length_, msg_length_, plain_message, plain_message_length);
 }

--- a/tests/soter/soter_sym_test.c
+++ b/tests/soter/soter_sym_test.c
@@ -525,6 +525,69 @@ static void test_auth_tag(void)
 	  testsuite_fail_unless(SOTER_FAIL == res, "detect data tamper");
 }
 
+static void test_invalid_params(void)
+{
+	soter_sym_ctx_t *ctx = NULL;
+	uint8_t key[MAX_KEY_LENGTH] = {0};
+	uint8_t iv[MAX_IV_LENGTH] = {0};
+
+	ctx = soter_sym_encrypt_create(0xFFFFFFFF, key, sizeof(key), NULL, 0, iv, sizeof(iv));
+	testsuite_fail_if(ctx != NULL, "encrypt_create: invalid algorithm");
+	if (ctx != NULL)
+	{
+		soter_sym_encrypt_destroy(ctx);
+	}
+
+	ctx = soter_sym_encrypt_create(SOTER_SYM_AES_GCM | SOTER_SYM_256_KEY_LENGTH, key, 0, NULL, 0, iv, sizeof(iv));
+	testsuite_fail_if(ctx != NULL, "encrypt_create: invalid key length");
+	if (ctx != NULL)
+	{
+		soter_sym_encrypt_destroy(ctx);
+	}
+
+	ctx = soter_sym_encrypt_create(SOTER_SYM_AES_GCM | SOTER_SYM_256_KEY_LENGTH | SOTER_SYM_PBKDF2, key, sizeof(key), NULL, 1, NULL, 0);
+	testsuite_fail_if(ctx != NULL, "encrypt_create: invalid salt length");
+	if (ctx != NULL)
+	{
+		soter_sym_encrypt_destroy(ctx);
+	}
+
+	ctx = soter_sym_encrypt_create(SOTER_SYM_AES_GCM | SOTER_SYM_256_KEY_LENGTH, key, sizeof(key), NULL, 0, iv, 0);
+	testsuite_fail_if(ctx != NULL, "encrypt_create: invalid IV length");
+	if (ctx != NULL)
+	{
+		soter_sym_encrypt_destroy(ctx);
+	}
+
+	ctx = soter_sym_aead_encrypt_create(0xFFFFFFFF, key, sizeof(key), NULL, 0, iv, sizeof(iv));
+	testsuite_fail_if(ctx != NULL, "aead_encrypt_create: invalid algorithm");
+	if (ctx != NULL)
+	{
+		soter_sym_aead_encrypt_destroy(ctx);
+	}
+
+	ctx = soter_sym_aead_encrypt_create(SOTER_SYM_AES_GCM | SOTER_SYM_256_KEY_LENGTH, key, 0, NULL, 0, iv, sizeof(iv));
+	testsuite_fail_if(ctx != NULL, "aead_encrypt_create: invalid key length");
+	if (ctx != NULL)
+	{
+		soter_sym_aead_encrypt_destroy(ctx);
+	}
+
+	ctx = soter_sym_aead_encrypt_create(SOTER_SYM_AES_GCM | SOTER_SYM_256_KEY_LENGTH | SOTER_SYM_PBKDF2, key, sizeof(key), NULL, 1, NULL, 0);
+	testsuite_fail_if(ctx != NULL, "aead_encrypt_create: invalid salt length");
+	if (ctx != NULL)
+	{
+		soter_sym_aead_encrypt_destroy(ctx);
+	}
+
+	ctx = soter_sym_aead_encrypt_create(SOTER_SYM_AES_GCM | SOTER_SYM_256_KEY_LENGTH, key, sizeof(key), NULL, 0, iv, 0);
+	testsuite_fail_if(ctx != NULL, "aead_encrypt_create: invalid IV length");
+	if (ctx != NULL)
+	{
+		soter_sym_aead_encrypt_destroy(ctx);
+	}
+}
+
 void run_soter_sym_test()
 {
   testsuite_enter_suite("soter sym");
@@ -532,5 +595,6 @@ void run_soter_sym_test()
   testsuite_run_test(test_known_values);
   testsuite_run_test(test_known_values_gcm);
   testsuite_run_test(test_auth_tag);
+  testsuite_run_test(test_invalid_params);
   //  soter_sym_test();
 }

--- a/tests/themis/themis_secure_cell.c
+++ b/tests/themis/themis_secure_cell.c
@@ -369,17 +369,35 @@ static void secure_cell_api_test(void)
 /*
  * See themis_auth_sym_message_hdr_t definition.
  */
-static inline uint32_t* context_iv_length(uint8_t* context)
+
+static inline uint32_t get_context_iv_length(const uint8_t* context)
 {
-	return (uint32_t*)context + 1;
+	return ((const uint32_t*)context)[1];
 }
-static inline uint32_t* context_auth_tag_length(uint8_t* context)
+
+static inline void set_context_iv_length(uint8_t* context, uint32_t value)
 {
-	return (uint32_t*)context + 2;
+	((uint32_t*)context)[1] = value;
 }
-static inline uint32_t* context_message_length(uint8_t* context)
+
+static inline uint32_t get_context_auth_tag_length(const uint8_t* context)
 {
-	return (uint32_t*)context + 3;
+	return ((const uint32_t*)context)[2];
+}
+
+static inline void set_context_auth_tag_length(uint8_t* context, uint32_t value)
+{
+	((uint32_t*)context)[2] = value;
+}
+
+static inline uint32_t get_context_message_length(const uint8_t* context)
+{
+	return ((const uint32_t*)context)[3];
+}
+
+static inline void set_context_message_length(uint8_t* context, uint32_t value)
+{
+	((uint32_t*)context)[3] = value;
 }
 
 static themis_status_t encrypt_seal(uint8_t** encrypted_message, size_t* encrypted_message_length)
@@ -444,8 +462,8 @@ static void secure_cell_context_corruption_seal(void)
 	uint8_t* decrypted_message = NULL;
 	size_t decrypted_message_length = 0;
 
-	old_value = *context_iv_length(encrypted_message);
-	*context_iv_length(encrypted_message) = 0xDEADBEEF;
+	old_value = get_context_iv_length(encrypted_message);
+	set_context_iv_length(encrypted_message, 0xDEADBEEF);
 	{
 		res = prepare_decrypt_seal(encrypted_message, encrypted_message_length, &decrypted_message, &decrypted_message_length);
 		if(res!=THEMIS_SUCCESS){
@@ -457,10 +475,10 @@ static void secure_cell_context_corruption_seal(void)
 
 		free(decrypted_message);
 	}
-	*context_iv_length(encrypted_message) = old_value;
+	set_context_iv_length(encrypted_message, old_value);
 
-	old_value = *context_auth_tag_length(encrypted_message);
-	*context_auth_tag_length(encrypted_message) = 0xDEADBEEF;
+	old_value = get_context_auth_tag_length(encrypted_message);
+	set_context_auth_tag_length(encrypted_message, 0xDEADBEEF);
 	{
 		res = prepare_decrypt_seal(encrypted_message, encrypted_message_length, &decrypted_message, &decrypted_message_length);
 		if(res!=THEMIS_SUCCESS){
@@ -472,15 +490,15 @@ static void secure_cell_context_corruption_seal(void)
 
 		free(decrypted_message);
 	}
-	*context_auth_tag_length(encrypted_message) = old_value;
+	set_context_auth_tag_length(encrypted_message, old_value);
 
-	old_value = *context_message_length(encrypted_message);
-	*context_message_length(encrypted_message) = 0xDEADBEEF;
+	old_value = get_context_message_length(encrypted_message);
+	set_context_message_length(encrypted_message, 0xDEADBEEF);
 	{
 		res = themis_secure_cell_decrypt_seal((uint8_t*)passwd, sizeof(passwd), NULL, 0, encrypted_message, encrypted_message_length, NULL, &decrypted_message_length);
 		testsuite_fail_if(res==THEMIS_BUFFER_TOO_SMALL, "themis_secure_cell_decrypt_seal detects corrupted message length");
 	}
-	*context_message_length(encrypted_message) = old_value;
+	set_context_message_length(encrypted_message, old_value);
 
 out:
 	free(encrypted_message);
@@ -558,8 +576,8 @@ static void secure_cell_context_corruption_token_protect(void)
 	uint8_t* decrypted_message = NULL;
 	size_t decrypted_message_length = 0;
 
-	old_value = *context_iv_length(context);
-	*context_iv_length(context) = 0xDEADBEEF;
+	old_value = get_context_iv_length(context);
+	set_context_iv_length(context, 0xDEADBEEF);
 	{
 		res = prepare_decrypt_token_protect(encrypted_message, encrypted_message_length, context, context_length, &decrypted_message, &decrypted_message_length);
 		if(res!=THEMIS_SUCCESS){
@@ -571,10 +589,10 @@ static void secure_cell_context_corruption_token_protect(void)
 
 		free(decrypted_message);
 	}
-	*context_iv_length(context) = old_value;
+	set_context_iv_length(context, old_value);
 
-	old_value = *context_auth_tag_length(context);
-	*context_auth_tag_length(context) = 0xDEADBEEF;
+	old_value = get_context_auth_tag_length(context);
+	set_context_auth_tag_length(context, 0xDEADBEEF);
 	{
 		res = prepare_decrypt_token_protect(encrypted_message, encrypted_message_length, context, context_length, &decrypted_message, &decrypted_message_length);
 		if(res!=THEMIS_SUCCESS){
@@ -586,10 +604,10 @@ static void secure_cell_context_corruption_token_protect(void)
 
 		free(decrypted_message);
 	}
-	*context_auth_tag_length(context) = old_value;
+	set_context_auth_tag_length(context, old_value);
 
-	old_value = *context_message_length(context);
-	*context_message_length(context) = 0xDEADBEEF;
+	old_value = get_context_message_length(context);
+	set_context_message_length(context, 0xDEADBEEF);
 	{
 		res = prepare_decrypt_token_protect(encrypted_message, encrypted_message_length, context, context_length, &decrypted_message, &decrypted_message_length);
 		if(res!=THEMIS_SUCCESS){
@@ -601,7 +619,7 @@ static void secure_cell_context_corruption_token_protect(void)
 
 		free(decrypted_message);
 	}
-	*context_message_length(context) = old_value;
+	set_context_message_length(context, old_value);
 
 out:
 	free(encrypted_message);

--- a/tests/themis/themis_secure_cell.c
+++ b/tests/themis/themis_secure_cell.c
@@ -366,10 +366,261 @@ static void secure_cell_api_test(void)
 	secure_cell_api_test_context_imprint();
 }
 
+/*
+ * See themis_auth_sym_message_hdr_t definition.
+ */
+static inline uint32_t* context_iv_length(uint8_t* context)
+{
+	return (uint32_t*)context + 1;
+}
+static inline uint32_t* context_auth_tag_length(uint8_t* context)
+{
+	return (uint32_t*)context + 2;
+}
+static inline uint32_t* context_message_length(uint8_t* context)
+{
+	return (uint32_t*)context + 3;
+}
+
+static themis_status_t encrypt_seal(uint8_t** encrypted_message, size_t* encrypted_message_length)
+{
+	themis_status_t res = THEMIS_SUCCESS;
+
+	res = themis_secure_cell_encrypt_seal((uint8_t*)passwd, sizeof(passwd), NULL, 0, (uint8_t*)message, sizeof(message), NULL, encrypted_message_length);
+	if(res!=THEMIS_BUFFER_TOO_SMALL){
+		testsuite_fail_if(true, "themis_secure_cell_encrypt_seal: failed to determine encrypted message length");
+		return res;
+	}
+
+	*encrypted_message = malloc(*encrypted_message_length);
+	if(*encrypted_message==NULL){
+		testsuite_fail_if(true, "themis_secure_cell_encrypt_seal: failed to allocate memory for encrypted message");
+		return THEMIS_NO_MEMORY;
+	}
+
+	res = themis_secure_cell_encrypt_seal((uint8_t*)passwd, sizeof(passwd), NULL, 0, (uint8_t*)message, sizeof(message), *encrypted_message, encrypted_message_length);
+	if(res!=THEMIS_SUCCESS){
+		testsuite_fail_if(true, "themis_secure_cell_encrypt_seal: failed to encrypt message");
+		free(encrypted_message);
+		return res;
+	}
+
+	return THEMIS_SUCCESS;
+}
+
+static themis_status_t prepare_decrypt_seal(uint8_t* encrypted_message, size_t encrypted_message_length, uint8_t** decrypted_message, size_t* decrypted_message_length)
+{
+	themis_status_t res = THEMIS_SUCCESS;
+
+	res = themis_secure_cell_decrypt_seal((uint8_t*)passwd, sizeof(passwd), NULL, 0, encrypted_message, encrypted_message_length, NULL, decrypted_message_length);
+	if(res!=THEMIS_BUFFER_TOO_SMALL){
+		testsuite_fail_if(true, "themis_secure_cell_decrypt_seal: failed to determine decrypted message length");
+		return res;
+	}
+
+	*decrypted_message = malloc(*decrypted_message_length);
+	if(*decrypted_message==NULL){
+		testsuite_fail_if(true, "themis_secure_cell_decrypt_seal: failed to allocate memory for decrypted message");
+		return THEMIS_NO_MEMORY;
+	}
+
+	return THEMIS_SUCCESS;
+}
+
+static void secure_cell_context_corruption_seal(void)
+{
+	themis_status_t res = THEMIS_SUCCESS;
+
+	uint8_t* encrypted_message = NULL;
+	size_t encrypted_message_length = 0;
+
+	res = encrypt_seal(&encrypted_message, &encrypted_message_length);
+	if(res!=THEMIS_SUCCESS){
+		goto out;
+	}
+
+	uint32_t old_value = 0;
+
+	uint8_t* decrypted_message = NULL;
+	size_t decrypted_message_length = 0;
+
+	old_value = *context_iv_length(encrypted_message);
+	*context_iv_length(encrypted_message) = 0xDEADBEEF;
+	{
+		res = prepare_decrypt_seal(encrypted_message, encrypted_message_length, &decrypted_message, &decrypted_message_length);
+		if(res!=THEMIS_SUCCESS){
+			goto out;
+		}
+
+		res = themis_secure_cell_decrypt_seal((uint8_t*)passwd, sizeof(passwd), NULL, 0, encrypted_message, encrypted_message_length, decrypted_message, &decrypted_message_length);
+		testsuite_fail_if(res==THEMIS_SUCCESS, "themis_secure_cell_decrypt_seal detects corrupted IV length");
+
+		free(decrypted_message);
+	}
+	*context_iv_length(encrypted_message) = old_value;
+
+	old_value = *context_auth_tag_length(encrypted_message);
+	*context_auth_tag_length(encrypted_message) = 0xDEADBEEF;
+	{
+		res = prepare_decrypt_seal(encrypted_message, encrypted_message_length, &decrypted_message, &decrypted_message_length);
+		if(res!=THEMIS_SUCCESS){
+			goto out;
+		}
+
+		res = themis_secure_cell_decrypt_seal((uint8_t*)passwd, sizeof(passwd), NULL, 0, encrypted_message, encrypted_message_length, decrypted_message, &decrypted_message_length);
+		testsuite_fail_if(res==THEMIS_SUCCESS, "themis_secure_cell_decrypt_seal detects corrupted auth tag length");
+
+		free(decrypted_message);
+	}
+	*context_auth_tag_length(encrypted_message) = old_value;
+
+	old_value = *context_message_length(encrypted_message);
+	*context_message_length(encrypted_message) = 0xDEADBEEF;
+	{
+		res = themis_secure_cell_decrypt_seal((uint8_t*)passwd, sizeof(passwd), NULL, 0, encrypted_message, encrypted_message_length, NULL, &decrypted_message_length);
+		testsuite_fail_if(res==THEMIS_BUFFER_TOO_SMALL, "themis_secure_cell_decrypt_seal detects corrupted message length");
+	}
+	*context_message_length(encrypted_message) = old_value;
+
+out:
+	free(encrypted_message);
+}
+
+static themis_status_t encrypt_token_protect(uint8_t** encrypted_message, size_t* encrypted_message_length, uint8_t** context, size_t* context_length)
+{
+	themis_status_t res = THEMIS_SUCCESS;
+
+	res = themis_secure_cell_encrypt_token_protect((uint8_t*)passwd, sizeof(passwd), NULL, 0, (uint8_t*)message, sizeof(message), NULL, context_length, NULL, encrypted_message_length);
+	if(res!=THEMIS_BUFFER_TOO_SMALL || context_length==0 || encrypted_message_length==0){
+		testsuite_fail_if(true, "themis_secure_cell_encrypt_token_protect: failed to determine encrypted message length");
+		return res;
+	}
+
+	*encrypted_message = malloc(*encrypted_message_length);
+	if(*encrypted_message==NULL){
+		testsuite_fail_if(true, "themis_secure_cell_encrypt_token_protect: failed to allocate memory for encrypted message");
+		return res;
+	}
+
+	*context = malloc(*context_length);
+	if(*context==NULL){
+		testsuite_fail_if(true, "themis_secure_cell_encrypt_token_protect: failed to allocate memory for auth context");
+		free(*encrypted_message);
+		return res;
+	}
+
+	res = themis_secure_cell_encrypt_token_protect((uint8_t*)passwd, sizeof(passwd), NULL, 0, (uint8_t*)message, sizeof(message), *context, context_length, *encrypted_message, encrypted_message_length);
+	if(res!=THEMIS_SUCCESS){
+		testsuite_fail_if(true, "themis_secure_cell_encrypt_token_protect: failed to encrypt message");
+		free(*encrypted_message);
+		free(*context);
+		return res;
+	}
+
+	return THEMIS_SUCCESS;
+}
+
+static themis_status_t prepare_decrypt_token_protect(uint8_t* encrypted_message, size_t encrypted_message_length, uint8_t* context, size_t context_length, uint8_t** decrypted_message, size_t* decrypted_message_length)
+{
+	themis_status_t res = THEMIS_SUCCESS;
+
+	res = themis_secure_cell_decrypt_token_protect((uint8_t*)passwd, sizeof(passwd), NULL, 0, encrypted_message, encrypted_message_length, context, context_length, NULL, decrypted_message_length);
+	if(res!=THEMIS_BUFFER_TOO_SMALL || decrypted_message_length==0){
+		testsuite_fail_if(true, "themis_secure_cell_decrypt_token_protect: failed to determine decrypted message length");
+		return res;
+	}
+
+	*decrypted_message = malloc(*decrypted_message_length);
+	if(*decrypted_message==NULL){
+		testsuite_fail_if(true, "themis_secure_cell_decrypt_token_protect: failed to allocate memory for decrypted message");
+		return THEMIS_NO_MEMORY;
+	}
+
+	return THEMIS_SUCCESS;
+}
+
+static void secure_cell_context_corruption_token_protect(void)
+{
+	themis_status_t res = THEMIS_SUCCESS;
+
+	uint8_t* encrypted_message = NULL;
+	size_t encrypted_message_length = 0;
+	uint8_t* context = NULL;
+	size_t context_length = 0;
+
+	res = encrypt_token_protect(&encrypted_message, &encrypted_message_length, &context, &context_length);
+	if(res!=THEMIS_SUCCESS){
+		goto out;
+	}
+
+	uint32_t old_value = 0;
+
+	uint8_t* decrypted_message = NULL;
+	size_t decrypted_message_length = 0;
+
+	old_value = *context_iv_length(context);
+	*context_iv_length(context) = 0xDEADBEEF;
+	{
+		res = prepare_decrypt_token_protect(encrypted_message, encrypted_message_length, context, context_length, &decrypted_message, &decrypted_message_length);
+		if(res!=THEMIS_SUCCESS){
+			goto out;
+		}
+
+		res = themis_secure_cell_decrypt_token_protect((uint8_t*)passwd, sizeof(passwd), NULL, 0, encrypted_message, encrypted_message_length, context, context_length, decrypted_message, &decrypted_message_length);
+		testsuite_fail_if(res==THEMIS_SUCCESS, "themis_secure_cell_decrypt_token_protect detects corrupted IV length");
+
+		free(decrypted_message);
+	}
+	*context_iv_length(context) = old_value;
+
+	old_value = *context_auth_tag_length(context);
+	*context_auth_tag_length(context) = 0xDEADBEEF;
+	{
+		res = prepare_decrypt_token_protect(encrypted_message, encrypted_message_length, context, context_length, &decrypted_message, &decrypted_message_length);
+		if(res!=THEMIS_SUCCESS){
+			goto out;
+		}
+
+		res = themis_secure_cell_decrypt_token_protect((uint8_t*)passwd, sizeof(passwd), NULL, 0, encrypted_message, encrypted_message_length, context, context_length, decrypted_message, &decrypted_message_length);
+		testsuite_fail_if(res==THEMIS_SUCCESS, "themis_secure_cell_decrypt_token_protect detects corrupted auth tag length");
+
+		free(decrypted_message);
+	}
+	*context_auth_tag_length(context) = old_value;
+
+	old_value = *context_message_length(context);
+	*context_message_length(context) = 0xDEADBEEF;
+	{
+		res = prepare_decrypt_token_protect(encrypted_message, encrypted_message_length, context, context_length, &decrypted_message, &decrypted_message_length);
+		if(res!=THEMIS_SUCCESS){
+			goto out;
+		}
+
+		res = themis_secure_cell_decrypt_token_protect((uint8_t*)passwd, sizeof(passwd), NULL, 0, encrypted_message, encrypted_message_length, context, context_length, decrypted_message, &decrypted_message_length);
+		testsuite_fail_if(res==THEMIS_SUCCESS, "themis_secure_cell_decrypt_token_protect detects corrupted message length");
+
+		free(decrypted_message);
+	}
+	*context_message_length(context) = old_value;
+
+out:
+	free(encrypted_message);
+	free(context);
+}
+
+static void secure_cell_context_corruption(void)
+{
+	secure_cell_context_corruption_seal();
+	secure_cell_context_corruption_token_protect();
+}
+
 void run_secure_cell_test(){
   testsuite_enter_suite("secure cell: basic flow");
   testsuite_run_test(secure_cell_test);
 
   testsuite_enter_suite("secure cell: api test");
   testsuite_run_test(secure_cell_api_test);
+
+  testsuite_enter_suite("secure cell: context corruption");
+  testsuite_run_test(secure_cell_context_corruption);
 }


### PR DESCRIPTION
Fix a couple of bugs that caused crashes found during fuzzing added in #364.

I have been running existing fuzzing tests for about an hour on both Linux and macOS with OpenSSL and BoringSSL alike. There are no new crashes with these changes.

Admittedly, the fuzzing tests cover only Secure Cell so there may be more bugs left unturned, but let's deal with them as they come. 


#### Avoid overflow in Secure Cell decryption in sealed mode

Corrupted secure message header or truncated message can trigger an overflow in message length computation. This integer overflow results in a segmentation fault later. Handle the overflow and return an error.

We do not have enough information to analyze the header and determine whether it is corrupted or not. So in case it is corrupted we still compute a (garbage) message length and then fail decryption if the provided buffer length is not enough.

Add some tests for Secure Cell to verify authentication context corruption. Only sealing and token protect mode have authentication context, there are no tests for context imprint mode.


#### Check IV and salt length for symmetric encryption

If the length values are corrupted or incorrect it may trigger a segmentation fault in cryptographic backend. Both OpenSSL and BoringSSL are affected.

We should check the length of initialization vector before passing it to `EVP_EncryptInit_ex()` or `EVP_DecryptInit_ex()` because [these functions do not perform any length checks][crypt]. They expect the buffers to have suitable lengths (or else they may corrupt the stack).

These functions do not check the length of keys as well, but we do those checks during key derivation.

We should also check that salt length is zero if there is no salt because [`PKCS5_PBKDF2_HMAC()` does not check that][KDF] and may crash due to NULL dereference.

Add some tests to verify this behavior. Encryption and decryption are implemented via a common function so it is enough to check only one of them.

[crypt]: https://www.openssl.org/docs/manmaster/man3/EVP_EncryptInit.html
[KDF]: https://www.openssl.org/docs/manmaster/man3/PKCS5_PBKDF2_HMAC.html