### PR TITLE
Improve Secure Session ergonomics with STL containers

### DIFF
--- a/src/wrappers/themis/themispp/secure_session.hpp
+++ b/src/wrappers/themis/themispp/secure_session.hpp
@@ -61,7 +61,11 @@ namespace themispp{
   class secure_session_t{
   public:
     typedef std::vector<uint8_t> data_t; 
-    
+
+    secure_session_t():
+      _session(nullptr){
+    }
+
     secure_session_t(const data_t& id, const data_t& priv_key, secure_session_callback_interface_t* callbacks):
       _session(NULL),
       _res(0){

--- a/src/wrappers/themis/themispp/secure_session.hpp
+++ b/src/wrappers/themis/themispp/secure_session.hpp
@@ -63,7 +63,7 @@ namespace themispp{
     typedef std::vector<uint8_t> data_t; 
 
     secure_session_t():
-      _session(nullptr){
+      _session(NULL){
     }
 
     secure_session_t(const data_t& id, const data_t& priv_key, secure_session_callback_interface_t* callbacks):
@@ -85,6 +85,7 @@ namespace themispp{
       }
     }
 
+#if __cplusplus >= 201103L
     secure_session_t(const secure_session_t&) = delete;
     secure_session_t& operator=(const secure_session_t&) = delete;
 
@@ -104,6 +105,12 @@ namespace themispp{
       }
       return *this;
     }
+#else
+  private:
+    secure_session_t(const secure_session_t&);
+    secure_session_t& operator=(const secure_session_t&);
+  public:
+#endif
 
     const data_t& unwrap(const std::vector<uint8_t>& data){
       if(!_session){

--- a/src/wrappers/themis/themispp/secure_session.hpp
+++ b/src/wrappers/themis/themispp/secure_session.hpp
@@ -106,6 +106,9 @@ namespace themispp{
     }
 
     const data_t& unwrap(const std::vector<uint8_t>& data){
+      if(!_session){
+        throw themispp::exception_t("uninitialized Secure Session");
+      }
       size_t unwrapped_data_length=0;
       themis_status_t r=secure_session_unwrap(_session, &data[0],data.size(), NULL, &unwrapped_data_length);
       if(r==THEMIS_SUCCESS){_res.resize(0); return _res;}
@@ -120,6 +123,9 @@ namespace themispp{
     }
 
     const data_t& wrap(const std::vector<uint8_t>& data){
+      if(!_session){
+        throw themispp::exception_t("uninitialized Secure Session");
+      }
       size_t wrapped_message_length=0;
       if(secure_session_wrap(_session, &data[0], data.size(), NULL, &wrapped_message_length)!=THEMIS_BUFFER_TOO_SMALL)
 	throw themispp::exception_t("Secure Session failed encrypting");
@@ -130,6 +136,9 @@ namespace themispp{
     }
     
     const data_t& init(){
+      if(!_session){
+        throw themispp::exception_t("uninitialized Secure Session");
+      }
       size_t init_data_length=0;
       if(secure_session_generate_connect_request(_session, NULL, &init_data_length)!=THEMIS_BUFFER_TOO_SMALL)
 	throw themispp::exception_t("Secure Session failed making connection request");
@@ -139,14 +148,25 @@ namespace themispp{
       return _res;
     }
     
-    const bool is_established(){return secure_session_is_established(_session);}
+    const bool is_established(){
+      if(!_session){
+        throw themispp::exception_t("uninitialized Secure Session");
+      }
+      return secure_session_is_established(_session);
+    }
 
     void connect(){
+      if(!_session){
+        throw themispp::exception_t("uninitialized Secure Session");
+      }
       if(secure_session_connect(_session)!=THEMIS_SUCCESS)
 	throw themispp::exception_t("Secure Session failed connecting");
     }
 
     const data_t& receive(){
+      if(!_session){
+        throw themispp::exception_t("uninitialized Secure Session");
+      }
       _res.resize(THEMISPP_SECURE_SESSION_MAX_MESSAGE_SIZE);
       ssize_t recv_size=secure_session_receive(_session, &_res[0], _res.size());
       if(recv_size<=0)
@@ -156,6 +176,9 @@ namespace themispp{
     }
 
     void send(const data_t& data){
+      if(!_session){
+        throw themispp::exception_t("uninitialized Secure Session");
+      }
       ssize_t send_size=secure_session_send(_session, &data[0], data.size());
       if(send_size<=0)
 	throw themispp::exception_t("Secure Session failed sending");

--- a/src/wrappers/themis/themispp/secure_session.hpp
+++ b/src/wrappers/themis/themispp/secure_session.hpp
@@ -76,7 +76,29 @@ namespace themispp{
     }
 
     virtual ~secure_session_t(){
-      secure_session_destroy(_session);
+      if(_session){
+        secure_session_destroy(_session);
+      }
+    }
+
+    secure_session_t(const secure_session_t&) = delete;
+    secure_session_t& operator=(const secure_session_t&) = delete;
+
+    secure_session_t(secure_session_t&& other){
+      _session=other._session;
+      _callback=other._callback;
+      _res=other._res;
+      other._session=nullptr;
+    }
+
+    secure_session_t& operator=(secure_session_t&& other){
+      if(this!=&other){
+        _session=other._session;
+        _callback=other._callback;
+        _res=other._res;
+        other._session=nullptr;
+      }
+      return *this;
     }
 
     const data_t& unwrap(const std::vector<uint8_t>& data){

--- a/tests/themispp/secure_session_test.hpp
+++ b/tests/themispp/secure_session_test.hpp
@@ -20,6 +20,7 @@
 #include <common/sput.h>
 #include <string.h>
 #include <themispp/secure_session.hpp>
+#include <unordered_map>
 
 namespace themispp{
   namespace secure_session_test{
@@ -70,10 +71,50 @@ namespace themispp{
       std::vector<uint8_t> msg4=client.unwrap(msg3);
       sput_fail_unless(strcmp(mes.c_str(), (const char*)(&msg4[0]))==0, "client get message", __LINE__);
     }
-    
+
+    void secure_session_uninitialized(){
+      themispp::secure_session_t client;
+
+      bool init_throws=false;
+      try{
+        client.init();
+      }
+      catch(const themispp::exception_t&){
+        init_throws=true;
+      }
+      sput_fail_unless(init_throws, "using uninitialized session", __LINE__);
+    }
+
+    void secure_session_moved(){
+      callback client_callbacks;
+      std::string client_id("client");
+      themispp::secure_session_t client(std::vector<uint8_t>(client_id.c_str(), client_id.c_str()+client_id.length()), std::vector<uint8_t>(client_priv, client_priv+sizeof(client_priv)), &client_callbacks);
+
+      std::unordered_map<std::string, themispp::secure_session_t> clients;
+      clients.emplace(client_id, std::move(client));
+
+      bool init_throws=false;
+      try{
+        client.init();
+      }
+      catch(const themispp::exception_t&){
+        init_throws=true;
+      }
+      sput_fail_unless(init_throws, "deny using moved-out session", __LINE__);
+
+      std::vector<uint8_t> control_msg1=clients.at(client_id).init();
+      sput_fail_if(control_msg1.empty(), "initializing moved session", __LINE__);
+
+      client=std::move(clients.at(client_id));
+
+      sput_fail_if(client.is_established(), "using moved session again", __LINE__);
+    }
+
     int run_secure_session_test(){
       sput_enter_suite("ThemisPP secure session test");
       sput_run_test(secure_session_test, "secure_session_test", __FILE__);
+      sput_run_test(secure_session_uninitialized, "secure_session_uninitialized", __FILE__);
+      sput_run_test(secure_session_moved, "secure_session_moved", __FILE__);
       return 0;
     }
   }

--- a/tests/themispp/secure_session_test.hpp
+++ b/tests/themispp/secure_session_test.hpp
@@ -20,7 +20,10 @@
 #include <common/sput.h>
 #include <string.h>
 #include <themispp/secure_session.hpp>
+
+#if __cplusplus >= 201103L
 #include <unordered_map>
+#endif
 
 namespace themispp{
   namespace secure_session_test{
@@ -85,6 +88,7 @@ namespace themispp{
       sput_fail_unless(init_throws, "using uninitialized session", __LINE__);
     }
 
+#if __cplusplus >= 201103L
     void secure_session_moved(){
       callback client_callbacks;
       std::string client_id("client");
@@ -109,6 +113,11 @@ namespace themispp{
 
       sput_fail_if(client.is_established(), "using moved session again", __LINE__);
     }
+#else
+    void secure_session_moved(){
+      sput_fail_if(false, "move semantics (disabled for C++03)", __LINE__);
+    }
+#endif
 
     int run_secure_session_test(){
       sput_enter_suite("ThemisPP secure session test");


### PR DESCRIPTION
Secure Session is not designed to be copyable but it currently is in C++ wrapper due to C++ being C++. STL containers like to copy objects around by default. If a session is copied then a destructor will be called twice for the same session object (a double-free error), usually resulting in a crash. Explicitly delete copy constructor and copy-assignment operator. Now they won't be automatically generated for us by the compiler.

However, Secure Session _can_ be moved. This is an important property for Secure Session being usable with STL containers. Implement a move constructor and move-assignment operator for it. The session that has been moved becomes uninitialized and unusable.

Implement the default constructor as well. It is not intended to be used directly, but it is required for some use-cases with STL containers (e.g., `operator[]`). Default-constructed objects have the same semantics as moved-out ones (i.e, they cannot be used).

Check if the session object is unusable and throw an exception if that's the case. The users should never do this, and Themis core cannot handle null session objects anyway.

Finally, add some tests to ensure that we do not crash during these operations, that Secure Session can be used with STL containers, and that it throws correct exceptions when it should throw.