### PR TITLE
Correct move construction/assignment implementation

### DIFF
--- a/src/wrappers/themis/themispp/secure_session.hpp
+++ b/src/wrappers/themis/themispp/secure_session.hpp
@@ -80,7 +80,7 @@ namespace themispp{
       _session=secure_session_create(&id[0], id.size(), &priv_key[0], priv_key.size(), _callback);
       if(!_session){
         delete _callback;
-        throw themispp::exception_t("Secure Session failde creating");
+        throw themispp::exception_t("Secure Session failed creating");
       }
     }
 

--- a/src/wrappers/themis/themispp/secure_session.hpp
+++ b/src/wrappers/themis/themispp/secure_session.hpp
@@ -87,8 +87,10 @@ namespace themispp{
     virtual ~secure_session_t(){
       if(_session){
         secure_session_destroy(_session);
+        _session=NULL;
       }
       delete _callback;
+      _callback=NULL;
     }
 
 #if __cplusplus >= 201103L


### PR DESCRIPTION
This fixes move constructor implementation added in #369. C++ is full of footguns :fearful: 

Secure Session stores a pointer to callback structure, therefore it must be pinned in memory. We cannot simply copy `secure_session_user_callbacks_t` into a different place in memory. `secure_session_t` will still keep a reference to the old memory location.

We have to store the callback structure on heap as well. This keeps the address constant and we can move the C++ wrapper structure correctly. Other language wrappers use mostly the same approach, keeping both `secure_session_t` and `secure_session_user_callbacks_t` allocated on heap. (JavaScript and Java are exceptions.)

Note that we have to accurately manage the objects stored in fields. We use **new**/**delete** instead of smart pointers in order to be compatible with C++03 (`std::auto_ptr` is broken and deprecated).