### PR TITLE
Define non-member global functions as inline

### DIFF
--- a/src/wrappers/themis/themispp/secure_session.hpp
+++ b/src/wrappers/themis/themispp/secure_session.hpp
@@ -33,14 +33,14 @@ namespace themispp{
     virtual const data_t& receive(){throw themispp::exception_t("Secure Session failed receiving, receive callback not set");}
   };
 
-  ssize_t send_callback(const uint8_t* data, size_t data_length, void *user_data){
+  inline ssize_t send_callback(const uint8_t* data, size_t data_length, void *user_data){
     try{
       ((secure_session_callback_interface_t*)user_data)->send(std::vector<uint8_t>((uint8_t*)data, (uint8_t*)data+data_length));
     }catch(...){return -1;}
     return ssize_t(data_length);
   }
 
-  ssize_t receive_callback(uint8_t* data, size_t data_length, void *user_data){
+  inline ssize_t receive_callback(uint8_t* data, size_t data_length, void *user_data){
     try{
       std::vector<uint8_t> received_data=((secure_session_callback_interface_t*)user_data)->receive();
       memcpy(data, &received_data[0], received_data.size());
@@ -49,7 +49,7 @@ namespace themispp{
     return -1;
   }
 
-  int get_public_key_for_id_callback(const void *id, size_t id_length, void *key_buffer, size_t key_buffer_length, void *user_data){
+  inline int get_public_key_for_id_callback(const void *id, size_t id_length, void *key_buffer, size_t key_buffer_length, void *user_data){
     std::vector<uint8_t> pubk=((secure_session_callback_interface_t*)user_data)->get_pub_key_by_id(std::vector<uint8_t>(static_cast<const uint8_t*>(id), static_cast<const uint8_t*>(id)+id_length));
     if(pubk.size()>key_buffer_length){
       return THEMIS_BUFFER_TOO_SMALL;


### PR DESCRIPTION
ThemisPP is a header-only library. We should define freestanding functions as **inline** in order to trigger [the _one definition rule_](https://en.wikipedia.org/wiki/One_Definition_Rule) and avoid issues during linkage when multiple instances of the functions are found in different translation units.

This can happen if multiple translation units include `<themispp/secure_session.hpp>` which leads to weird error messages from linker:

```
/usr/bin/ld: /tmp/ccfnI73m.o: in function `themispp::send_callback(unsigned char const*, unsigned long, void*)':
a2.cpp:(.text+0x0): multiple definition of `themispp::send_callback(unsigned char const*, unsigned long, void*)'; /tmp/cc7vbiXX.o:a1.cpp:(.text+0x0): first defined here
/usr/bin/ld: /tmp/ccfnI73m.o: in function `themispp::receive_callback(unsigned char*, unsigned long, void*)':
a2.cpp:(.text+0xc6): multiple definition of `themispp::receive_callback(unsigned char*, unsigned long, void*)'; /tmp/cc7vbiXX.o:a1.cpp:(.text+0xc6): first defined here
/usr/bin/ld: /tmp/ccfnI73m.o: in function `themispp::get_public_key_for_id_callback(void const*, unsigned long, void*, unsigned long, void*)':
a2.cpp:(.text+0x176): multiple definition of `themispp::get_public_key_for_id_callback(void const*, unsigned long, void*, unsigned long, void*)'; /tmp/cc7vbiXX.o:a1.cpp:(.text+0x176): first defined here
collect2: error: ld returned 1 exit status
```

(We don't have to mark class methods in headers as inline, they are treated as inline automatically.)