### PR TITLE
 Introduce TransportError type

### DIFF
--- a/src/wrappers/themis/rust/src/secure_session.rs
+++ b/src/wrappers/themis/rust/src/secure_session.rs
@@ -61,8 +61,6 @@ struct SecureSessionContext {
 /// [`get_public_key_for_id`]: trait.SecureSessionTransport.html#tymethod.get_public_key_for_id
 #[allow(unused_variables)]
 pub trait SecureSessionTransport {
-    // TODO: consider send/receive use std::io::Error for errors (or a custom type)
-
     /// Send the provided data to the peer, return the number of bytes transferred.
     ///
     /// This callback will be called when Secure Session needs to send some data to its peer.
@@ -75,8 +73,8 @@ pub trait SecureSessionTransport {
     /// [`connect`]: struct.SecureSession.html#method.connect
     /// [`negotiate_transport`]: struct.SecureSession.html#method.negotiate_transport
     /// [`send`]: struct.SecureSession.html#method.send
-    fn send_data(&mut self, data: &[u8]) -> result::Result<usize, ()> {
-        Err(())
+    fn send_data(&mut self, data: &[u8]) -> result::Result<usize, TransportError> {
+        Err(TransportError::unspecified())
     }
 
     /// Receive some data from the peer into the provided buffer, return the number of bytes.
@@ -90,8 +88,8 @@ pub trait SecureSessionTransport {
     ///
     /// [`negotiate_transport`]: struct.SecureSession.html#method.negotiate_transport
     /// [`receive`]: struct.SecureSession.html#method.receive
-    fn receive_data(&mut self, data: &mut [u8]) -> result::Result<usize, ()> {
-        Err(())
+    fn receive_data(&mut self, data: &mut [u8]) -> result::Result<usize, TransportError> {
+        Err(TransportError::unspecified())
     }
 
     /// Notification about connection state of Secure Session.


### PR DESCRIPTION
It is not very convenient to use `()` for Result error type. Unit type does not implement Error trait and thus cannot be used with the `?` operator. It is not very convenient for users which may need to return arbitrary errors from their transport callbacks. These may be IO errors from the standard library or some custom errors.

Introduce a new type **TransportError** which will represent errors for transport callbacks. It is an enumeration which can hold three kinds of errors:

  - Arbitrary std::error::Error type

    This kind allows to wrap any other error into a TransportError.    We implement a `From` conversion so that TransportError works with    the `?` operator. This makes it very convenient to forward existing errors out of SecureSessionTransport callbacks.

  - Custom human-readable string

    This kind is useful when you don't have an `Error` handy but still    want to return something more descriptive. Anything that can be    converted into a `String` will do.

  - Unspecified kind

    This kind is useful to explicity say that we do not have any    detailed information on the error. It will be used in some    conversions of raw Themis errors.

Unfortunately, it's not possible to implement `Error` trait for TransportError because of a blanket impl on From/Into traits: it conflicts with out custom `From<T: Error>` implementation. Well, it's not a big deal for now, but may bite us later.

However, we do implement all other Error requirements like `Display` so the error should be convenient enough to use.

Note that the error itself is a struct which wraps an enumeration. This allows us to not expose enumeration variants to the user.

Also note the additional `Send + Sync` trait bounds on the Error impl. It is important to have these traits implemented if we want to be able to transfer errors between threads.

Update the SecureSessionTransport trait to use the new type.

Update usage in tests. Note how `?` is used to forward channel errors and `TransportError::new()` usage for custom error reporting.
