### PR TITLE
Forward transport errors from Secure Session callbacks

### DIFF
--- a/src/wrappers/themis/rust/src/error.rs
+++ b/src/wrappers/themis/rust/src/error.rs
@@ -157,6 +157,10 @@ impl fmt::Display for Error {
 /// [`Error`]: struct.Error.html
 #[derive(Debug)]
 pub enum ErrorKind {
+    /*
+     * If you add a new error kind then please add it to the error_kinds_equal() function below
+     * as well. Unfortunately, we cannot derive PartialEq implementation automatically.
+     */
     /// Catch-all generic error.
     ///
     /// If you encounter this error kind then the Themis binding is likely to be out of sync with

--- a/src/wrappers/themis/rust/src/secure_session.rs
+++ b/src/wrappers/themis/rust/src/secure_session.rs
@@ -569,6 +569,7 @@ impl SecureSession {
     // Furthermore, Themis expects the send callback to send the whole message so it is kinda
     // pointless to return the amount of bytes send. The receive callback returns accurate number
     // of bytes, but I do not really like the Rust interface this implies. It could be made better.
+    const THEMIX_MAX_ERROR: isize = 21;
 
     /// Sends a message to the remote peer.
     ///
@@ -591,7 +592,7 @@ impl SecureSession {
             if length == TRANSPORT_OVERFLOW {
                 return Err(Error::with_kind(ErrorKind::BufferTooSmall));
             }
-            if length <= 21 {
+            if length <= Self::THEMIX_MAX_ERROR {
                 return Err(Error::from_session_status(length as themis_status_t));
             }
         }
@@ -626,7 +627,7 @@ impl SecureSession {
             if length == TRANSPORT_OVERFLOW {
                 return Err(Error::with_kind(ErrorKind::BufferTooSmall));
             }
-            if length <= 21 {
+            if length <= Self::THEMIX_MAX_ERROR {
                 return Err(Error::from_session_status(length as themis_status_t));
             }
             debug_assert!(length as usize <= message.capacity());

--- a/src/wrappers/themis/rust/src/secure_session.rs
+++ b/src/wrappers/themis/rust/src/secure_session.rs
@@ -653,6 +653,13 @@ impl SecureSession {
     pub fn negotiate_transport(&mut self) -> Result<()> {
         unsafe {
             let result = secure_session_receive(self.session, ptr::null_mut(), 0);
+            if result == TRANSPORT_FAILURE {
+                let error = self.context.last_error.take().expect("missing error");
+                return Err(Error::from_transport_error(error));
+            }
+            if result == TRANSPORT_OVERFLOW {
+                return Err(Error::with_kind(ErrorKind::BufferTooSmall));
+            }
             let error = Error::from_session_status(result as themis_status_t);
             if error.kind() != ErrorKind::Success {
                 return Err(error);


### PR DESCRIPTION
And one more usability improvement for Secure Session. Currently it simply ignores and loses any TransportErrors that happen inside the transport callbacks. This was fine when errors were simply `()` but now they can be rich, detailed errors. The users are likely to be interested in the reason why their transport callbacks fail. Let's thread the error through the C call stack and return it the caller.

This behavior is currently not tested. I'll add tests in a separate PR which will also improve existing tests for Secure Session. (And note all the breaking changes in the changelog as well.)

#### Add TransportError to themis::Error

We will need to return TransportErrors from Secure Session methods on failures to extend the ErrorKind enumeration to actually contain the transport error inside its `ErrorKind::SessionTransportError` variant.

This change has a number of implications. First of all, TransportError is not copyable. Therefore we have to let go of the `Clone` and `Copy` implementations on the ErrorKind as well as the Clone impl on Error. One should not usually copy errors anyway so this should be okay. Note that `Error::kind()` now returns a reference to the stored error kind instead of its copy.

Another important thing is that TransportError does not implement `PartialEq` as it is not possible to compare abstract errors in any meaningful way. This implies that we cannot automatically derive implementation of PartialEq for ErrorKind. We have to implement it manually. We need to compare *kinds* of errors here so it is okay to simply ignore the details of transport errors and treat them as equivalent.

#### Forward transport errors from Secure Session callbacks

Now that we are able to store TransportError inside of a `themis::Error` we can actually forward the error from the callback to the method call. With this the user can actually see why the transport layer has failed.

Use the provided `SecureSessionContext` to temporarily store the error while the control is still in the C code. Then we extract the error and return it. Such implementation does not support concurrent usage of Secure Session from multiple threads but it's not thread-safe anyway so it is fine to use this approach.

We can use negative return values to indicate implementation-specific errors in Secure Session callbacks. The C code returns them as is for us to inspect. While we're here, stop using bare constant `-1` and give it a name. Also, handle the overflow with a different error kind.