### PR TITLE
Add more Secure Session tests

### DIFF
--- a/src/wrappers/themis/rust/src/secure_session.rs
+++ b/src/wrappers/themis/rust/src/secure_session.rs
@@ -62,6 +62,11 @@ struct SecureSessionContext {
 /// [`get_public_key_for_id`]: trait.SecureSessionTransport.html#tymethod.get_public_key_for_id
 #[allow(unused_variables)]
 pub trait SecureSessionTransport {
+    /// Get a public key corresponding to a peer ID.
+    ///
+    /// Return `None` if you are unable to find a corresponding public key.
+    fn get_public_key_for_id(&mut self, id: &[u8]) -> Option<EcdsaPublicKey>;
+
     /// Send the provided data to the peer, return the number of bytes transferred.
     ///
     /// This callback will be called when Secure Session needs to send some data to its peer.
@@ -97,11 +102,6 @@ pub trait SecureSessionTransport {
     ///
     /// This method is truly optional and has no effect on Secure Session operation.
     fn state_changed(&mut self, state: SecureSessionState) {}
-
-    /// Get a public key corresponding to a peer ID.
-    ///
-    /// Return `None` if you are unable to find a corresponding public key.
-    fn get_public_key_for_id(&mut self, id: &[u8]) -> Option<EcdsaPublicKey>;
 }
 
 /// Transport layer error.

--- a/src/wrappers/themis/rust/src/secure_session.rs
+++ b/src/wrappers/themis/rust/src/secure_session.rs
@@ -220,7 +220,7 @@ impl TransportError {
 }
 
 /// State of Secure Session connection.
-#[derive(PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SecureSessionState {
     /// Newly created sessions start in this state.
     Idle,


### PR DESCRIPTION
This PR updates the tests for Secure Session with new cases.

Now we check more happy and failure paths in Secure Session. We verify that errors are correctly forwarded from transport callbacks, and that this causes the whole session to fail. We also test the session change callback. Finally, we test a couple of edge cases with empty messages.

We also make a couple of other tweaks. There are more details in individual commit messages.

Unfortunately it is not possible to write tests for buffer size overflow handling as that will require the current implementation to actually allocate a buffer of 4 GB or larger which usually segfaults. Buffer sizes are completely under control of Secure Session user though.