### PR TITLE
Run C++ tests during CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,8 @@ jobs:
       - run: '[ -z "$CIRCLE_PR_NUMBER" ] && ! [ -z "$COVERALLS_TOKEN" ] && cd $HOME/go/src/$GOTHEMIS_IMPORT && $HOME/go/bin/goveralls -v -service=circle-ci -repotoken=$COVERALLS_TOKEN || true'
       - run: sudo /sbin/ldconfig    
       - run: make test
+      - run: make clean_themispp_test && CFLAGS="-std=c++03" make themispp_test && make test_cpp
+      - run: make clean_themispp_test && CFLAGS="-std=c++11" make themispp_test && make test_cpp
       - run: make test_python
       - run: sudo make test_js
       # it's important to set version of ruby precisely.

--- a/tests/themispp/themispp.mk
+++ b/tests/themispp/themispp.mk
@@ -16,3 +16,6 @@
 
 THEMISPP_TEST_SRC = $(wildcard tests/themispp/*.cpp)
 THEMISPP_TEST_OBJ = $(patsubst $(TEST_SRC_PATH)/%.cpp,$(TEST_OBJ_PATH)/%.opp, $(THEMISPP_TEST_SRC))
+
+clean_themispp_test:
+	@rm -f $(THEMISPP_TEST_OBJ)


### PR DESCRIPTION
Well, this is a bit embarrassing, but enable C++ tests in CI builds. They are there but somehow they were lost on the way.

We'd like to test both C++03 and C++11 flavors of ThemisPP. We will need to clean the test objects and recompile the tests for both standards we support. Add a utility Makefile target for that.