### PR TITLE
 Improve and extend Secure Session API docs

### DIFF
--- a/src/wrappers/themis/rust/CHANGELOG.md
+++ b/src/wrappers/themis/rust/CHANGELOG.md
@@ -23,9 +23,16 @@ The version currently under development.
   with other language wrappers. They are now called `PrivateKey` instead
   of `SecretKey` (ditto for `RsaSecretKey`, `EcdsaSecretKey`). ([#362])
 
+- `SecureSession` interface has been overhauled for better usability.
+  ([#373], [#374], [#375], [#380])
+
 [#358]: https://github.com/cossacklabs/themis/pull/358
 [#362]: https://github.com/cossacklabs/themis/pull/362
 [#365]: https://github.com/cossacklabs/themis/pull/365
+[#373]: https://github.com/cossacklabs/themis/pull/373
+[#374]: https://github.com/cossacklabs/themis/pull/374
+[#375]: https://github.com/cossacklabs/themis/pull/375
+[#380]: https://github.com/cossacklabs/themis/pull/380
 
 Version 0.0.3 — 2019-01-17
 ==========================

--- a/src/wrappers/themis/rust/src/secure_session.rs
+++ b/src/wrappers/themis/rust/src/secure_session.rs
@@ -517,7 +517,7 @@ impl SecureSession {
     /// [`connect`]: struct.SecureSession.html#method.connect
     /// [`negotiate`]: struct.SecureSession.html#method.negotiate
     /// [`send_data`]: trait.SecureSessionTransport.html#method.send_data
-    pub fn send<M: AsRef<[u8]>>(&mut self, message: M) -> Result<()> {
+    pub fn send(&mut self, message: impl AsRef<[u8]>) -> Result<()> {
         let (message_ptr, message_len) = into_raw_parts(message.as_ref());
 
         unsafe {
@@ -637,7 +637,7 @@ impl SecureSession {
     ///
     /// [`negotiate_reply`]: struct.SecureSession.html#method.negotiate_reply
     /// [`connect_request`]: struct.SecureSession.html#method.connect_request
-    pub fn negotiate_reply<M: AsRef<[u8]>>(&mut self, wrapped: M) -> Result<Vec<u8>> {
+    pub fn negotiate_reply(&mut self, wrapped: impl AsRef<[u8]>) -> Result<Vec<u8>> {
         let (wrapped_ptr, wrapped_len) = into_raw_parts(wrapped.as_ref());
 
         let mut message = Vec::new();
@@ -695,7 +695,7 @@ impl SecureSession {
     /// [`unwrap`]: struct.SecureSession.html#method.unwrap
     /// [`connect_request`]: struct.SecureSession.html#method.connect_request
     /// [`negotiate_reply`]: struct.SecureSession.html#method.negotiate_reply
-    pub fn wrap<M: AsRef<[u8]>>(&mut self, message: M) -> Result<Vec<u8>> {
+    pub fn wrap(&mut self, message: impl AsRef<[u8]>) -> Result<Vec<u8>> {
         let (message_ptr, message_len) = into_raw_parts(message.as_ref());
 
         let mut wrapped = Vec::new();
@@ -746,7 +746,7 @@ impl SecureSession {
     /// [`wrapped`]: struct.SecureSession.html#method.wrap
     /// [`connect_request`]: struct.SecureSession.html#method.connect_request
     /// [`negotiate_reply`]: struct.SecureSession.html#method.negotiate_reply
-    pub fn unwrap<M: AsRef<[u8]>>(&mut self, wrapped: M) -> Result<Vec<u8>> {
+    pub fn unwrap(&mut self, wrapped: impl AsRef<[u8]>) -> Result<Vec<u8>> {
         let (wrapped_ptr, wrapped_len) = into_raw_parts(wrapped.as_ref());
 
         let mut message = Vec::new();

--- a/tests/rust/secure_session.rs
+++ b/tests/rust/secure_session.rs
@@ -34,10 +34,8 @@ fn no_transport() {
     expect_peer(&mut transport_server, &name_client, &public_client);
 
     // The client and the server.
-    let mut client = SecureSession::with_transport(name_client, &private_client, transport_client)
-        .expect("Secure Session client");
-    let mut server = SecureSession::with_transport(name_server, &private_server, transport_server)
-        .expect("Secure Session server");
+    let mut client = SecureSession::new(name_client, &private_client, transport_client);
+    let mut server = SecureSession::new(name_server, &private_server, transport_server);
 
     assert!(!client.is_established());
     assert!(!server.is_established());
@@ -95,10 +93,8 @@ fn with_transport() {
 
     connect_with_channels(&mut transport_client, &mut transport_server);
 
-    let mut client = SecureSession::with_transport(name_client, &private_client, transport_client)
-        .expect("Secure Session client");
-    let mut server = SecureSession::with_transport(name_server, &private_server, transport_server)
-        .expect("Secure Session server");
+    let mut client = SecureSession::new(name_client, &private_client, transport_client);
+    let mut server = SecureSession::new(name_server, &private_server, transport_server);
 
     assert!(!client.is_established());
     assert!(!server.is_established());
@@ -137,10 +133,8 @@ fn connection_state_reporting() {
     let state_client = monitor_state_changes(&mut transport_client);
     let state_server = monitor_state_changes(&mut transport_server);
 
-    let mut client = SecureSession::with_transport(name_client, &private_client, transport_client)
-        .expect("Secure Session client");
-    let mut server = SecureSession::with_transport(name_server, &private_server, transport_server)
-        .expect("Secure Session server");
+    let mut client = SecureSession::new(name_client, &private_client, transport_client);
+    let mut server = SecureSession::new(name_server, &private_server, transport_server);
 
     let connect_request = client.generate_connect_request().expect("connect request");
     assert_eq!(state_client.recv(), Ok(SecureSessionState::Negotiating));
@@ -171,10 +165,8 @@ fn server_does_not_identify_client() {
     let mut transport_server = MockTransport::new();
     expect_no_peers(&mut transport_server);
 
-    let mut client = SecureSession::with_transport(&name_client, &private_client, transport_client)
-        .expect("Secure Session client");
-    let mut server = SecureSession::with_transport(&name_server, &private_server, transport_server)
-        .expect("Secure Session server");
+    let mut client = SecureSession::new(&name_client, &private_client, transport_client);
+    let mut server = SecureSession::new(&name_server, &private_server, transport_server);
 
     let connect_request = client.generate_connect_request().expect("connect request");
 
@@ -200,10 +192,8 @@ fn client_does_not_identify_server() {
     let mut transport_server = MockTransport::new();
     expect_peer(&mut transport_server, &name_client, &public_client);
 
-    let mut client = SecureSession::with_transport(&name_client, &private_client, transport_client)
-        .expect("Secure Session client");
-    let mut server = SecureSession::with_transport(&name_server, &private_server, transport_server)
-        .expect("Secure Session server");
+    let mut client = SecureSession::new(&name_client, &private_client, transport_client);
+    let mut server = SecureSession::new(&name_server, &private_server, transport_server);
 
     let connect_request = client.generate_connect_request().expect("connect request");
     let connect_reply = server.negotiate(&connect_request).expect("server reply");
@@ -225,8 +215,7 @@ fn forward_error_send_at_connection() {
 
     let mut next_client_send = override_send(&mut transport_client);
 
-    let mut client = SecureSession::with_transport(name_client, &private_client, transport_client)
-        .expect("Secure Session client");
+    let mut client = SecureSession::new(name_client, &private_client, transport_client);
 
     next_client_send.will_be(|_| Err(TransportError::new("error")));
 
@@ -254,10 +243,8 @@ fn forward_error_receive_at_connection() {
 
     let mut next_server_receive = override_receive(&mut transport_server);
 
-    let mut client = SecureSession::with_transport(name_client, &private_client, transport_client)
-        .expect("Secure Session client");
-    let mut server = SecureSession::with_transport(name_server, &private_server, transport_server)
-        .expect("Secure Session server");
+    let mut client = SecureSession::new(name_client, &private_client, transport_client);
+    let mut server = SecureSession::new(name_server, &private_server, transport_server);
 
     // Establishing connection.
     client.connect().expect("client-side connection");
@@ -290,10 +277,8 @@ fn forward_error_send_at_negotiation() {
 
     let mut next_server_send = override_send(&mut transport_server);
 
-    let mut client = SecureSession::with_transport(name_client, &private_client, transport_client)
-        .expect("Secure Session client");
-    let mut server = SecureSession::with_transport(name_server, &private_server, transport_server)
-        .expect("Secure Session server");
+    let mut client = SecureSession::new(name_client, &private_client, transport_client);
+    let mut server = SecureSession::new(name_server, &private_server, transport_server);
 
     client.connect().expect("client-side connection");
     server.negotiate_transport().expect("connect reply");
@@ -327,10 +312,8 @@ fn forward_error_receive_at_negotiation() {
 
     let mut next_client_receive = override_receive(&mut transport_client);
 
-    let mut client = SecureSession::with_transport(name_client, &private_client, transport_client)
-        .expect("Secure Session client");
-    let mut server = SecureSession::with_transport(name_server, &private_server, transport_server)
-        .expect("Secure Session server");
+    let mut client = SecureSession::new(name_client, &private_client, transport_client);
+    let mut server = SecureSession::new(name_server, &private_server, transport_server);
 
     client.connect().expect("client-side connection");
     server.negotiate_transport().expect("connect reply");
@@ -363,10 +346,8 @@ fn forward_error_send_at_exchange() {
 
     let mut next_client_send = override_send(&mut transport_client);
 
-    let mut client = SecureSession::with_transport(name_client, &private_client, transport_client)
-        .expect("Secure Session client");
-    let mut server = SecureSession::with_transport(name_server, &private_server, transport_server)
-        .expect("Secure Session server");
+    let mut client = SecureSession::new(name_client, &private_client, transport_client);
+    let mut server = SecureSession::new(name_server, &private_server, transport_server);
 
     client.connect().expect("client-side connection");
     server.negotiate_transport().expect("connect reply");
@@ -405,10 +386,8 @@ fn forward_error_receive_at_exchange() {
 
     let mut next_server_receive = override_receive(&mut transport_server);
 
-    let mut client = SecureSession::with_transport(name_client, &private_client, transport_client)
-        .expect("Secure Session client");
-    let mut server = SecureSession::with_transport(name_server, &private_server, transport_server)
-        .expect("Secure Session server");
+    let mut client = SecureSession::new(name_client, &private_client, transport_client);
+    let mut server = SecureSession::new(name_server, &private_server, transport_server);
 
     client.connect().expect("client-side connection");
     server.negotiate_transport().expect("connect reply");
@@ -447,10 +426,8 @@ fn cannot_send_empty_message() {
 
     connect_with_channels(&mut transport_client, &mut transport_server);
 
-    let mut client = SecureSession::with_transport(name_client, &private_client, transport_client)
-        .expect("Secure Session client");
-    let mut server = SecureSession::with_transport(name_server, &private_server, transport_server)
-        .expect("Secure Session server");
+    let mut client = SecureSession::new(name_client, &private_client, transport_client);
+    let mut server = SecureSession::new(name_server, &private_server, transport_server);
 
     client.connect().expect("client-side connection");
     server.negotiate_transport().expect("connect reply");
@@ -482,10 +459,8 @@ fn cannot_receive_empty_message() {
 
     let mut next_client_receive = override_receive(&mut transport_client);
 
-    let mut client = SecureSession::with_transport(name_client, &private_client, transport_client)
-        .expect("Secure Session client");
-    let mut server = SecureSession::with_transport(name_server, &private_server, transport_server)
-        .expect("Secure Session server");
+    let mut client = SecureSession::new(name_client, &private_client, transport_client);
+    let mut server = SecureSession::new(name_server, &private_server, transport_server);
 
     client.connect().expect("client-side connection");
     server.negotiate_transport().expect("connect reply");

--- a/tests/rust/secure_session.rs
+++ b/tests/rust/secure_session.rs
@@ -22,6 +22,17 @@ use themis::secure_session::{
 use themis::ErrorKind;
 
 #[test]
+fn invalid_client_id() {
+    let (private, _) = gen_ec_key_pair().split();
+    let transport = MockTransport::new();
+
+    let error = SecureSession::new(&[], &private, transport)
+        .expect_err("construction with empty client ID");
+
+    assert_eq!(error.kind(), ErrorKind::InvalidParameter);
+}
+
+#[test]
 fn no_transport() {
     let (name_client, name_server) = ("client", "server");
     let (private_client, public_client) = gen_ec_key_pair().split();

--- a/tests/rust/secure_session.rs
+++ b/tests/rust/secure_session.rs
@@ -34,8 +34,10 @@ fn no_transport() {
     expect_peer(&mut transport_server, &name_client, &public_client);
 
     // The client and the server.
-    let mut client = SecureSession::new(name_client, &private_client, transport_client);
-    let mut server = SecureSession::new(name_server, &private_server, transport_server);
+    let mut client = SecureSession::new(name_client, &private_client, transport_client)
+        .expect("Secure Session client");
+    let mut server = SecureSession::new(name_server, &private_server, transport_server)
+        .expect("Secure Session server");
 
     assert!(!client.is_established());
     assert!(!server.is_established());
@@ -99,8 +101,10 @@ fn with_transport() {
 
     connect_with_channels(&mut transport_client, &mut transport_server);
 
-    let mut client = SecureSession::new(name_client, &private_client, transport_client);
-    let mut server = SecureSession::new(name_server, &private_server, transport_server);
+    let mut client = SecureSession::new(name_client, &private_client, transport_client)
+        .expect("Secure Session client");
+    let mut server = SecureSession::new(name_server, &private_server, transport_server)
+        .expect("Secure Session server");
 
     assert!(!client.is_established());
     assert!(!server.is_established());
@@ -139,8 +143,10 @@ fn connection_state_reporting() {
     let state_client = monitor_state_changes(&mut transport_client);
     let state_server = monitor_state_changes(&mut transport_server);
 
-    let mut client = SecureSession::new(name_client, &private_client, transport_client);
-    let mut server = SecureSession::new(name_server, &private_server, transport_server);
+    let mut client = SecureSession::new(name_client, &private_client, transport_client)
+        .expect("Secure Session client");
+    let mut server = SecureSession::new(name_server, &private_server, transport_server)
+        .expect("Secure Session server");
 
     let connect_request = client.connect_request().expect("connect request");
     assert_eq!(state_client.recv(), Ok(SecureSessionState::Negotiating));
@@ -177,8 +183,10 @@ fn server_does_not_identify_client() {
     let mut transport_server = MockTransport::new();
     expect_no_peers(&mut transport_server);
 
-    let mut client = SecureSession::new(&name_client, &private_client, transport_client);
-    let mut server = SecureSession::new(&name_server, &private_server, transport_server);
+    let mut client = SecureSession::new(&name_client, &private_client, transport_client)
+        .expect("Secure Session client");
+    let mut server = SecureSession::new(&name_server, &private_server, transport_server)
+        .expect("Secure Session server");
 
     let connect_request = client.connect_request().expect("connect request");
 
@@ -204,8 +212,10 @@ fn client_does_not_identify_server() {
     let mut transport_server = MockTransport::new();
     expect_peer(&mut transport_server, &name_client, &public_client);
 
-    let mut client = SecureSession::new(&name_client, &private_client, transport_client);
-    let mut server = SecureSession::new(&name_server, &private_server, transport_server);
+    let mut client = SecureSession::new(&name_client, &private_client, transport_client)
+        .expect("Secure Session client");
+    let mut server = SecureSession::new(&name_server, &private_server, transport_server)
+        .expect("Secure Session server");
 
     let connect_request = client.connect_request().expect("connect request");
     let connect_reply = server
@@ -231,7 +241,8 @@ fn forward_error_send_at_connection() {
 
     let mut next_client_send = override_send(&mut transport_client);
 
-    let mut client = SecureSession::new(name_client, &private_client, transport_client);
+    let mut client = SecureSession::new(name_client, &private_client, transport_client)
+        .expect("Secure Session client");
 
     next_client_send.will_be(|_| Err(TransportError::new("error")));
 
@@ -259,8 +270,10 @@ fn forward_error_receive_at_connection() {
 
     let mut next_server_receive = override_receive(&mut transport_server);
 
-    let mut client = SecureSession::new(name_client, &private_client, transport_client);
-    let mut server = SecureSession::new(name_server, &private_server, transport_server);
+    let mut client = SecureSession::new(name_client, &private_client, transport_client)
+        .expect("Secure Session client");
+    let mut server = SecureSession::new(name_server, &private_server, transport_server)
+        .expect("Secure Session server");
 
     // Establishing connection.
     client.connect().expect("client-side connection");
@@ -293,8 +306,10 @@ fn forward_error_send_at_negotiation() {
 
     let mut next_server_send = override_send(&mut transport_server);
 
-    let mut client = SecureSession::new(name_client, &private_client, transport_client);
-    let mut server = SecureSession::new(name_server, &private_server, transport_server);
+    let mut client = SecureSession::new(name_client, &private_client, transport_client)
+        .expect("Secure Session client");
+    let mut server = SecureSession::new(name_server, &private_server, transport_server)
+        .expect("Secure Session server");
 
     client.connect().expect("client-side connection");
     server.negotiate().expect("connect reply");
@@ -328,8 +343,10 @@ fn forward_error_receive_at_negotiation() {
 
     let mut next_client_receive = override_receive(&mut transport_client);
 
-    let mut client = SecureSession::new(name_client, &private_client, transport_client);
-    let mut server = SecureSession::new(name_server, &private_server, transport_server);
+    let mut client = SecureSession::new(name_client, &private_client, transport_client)
+        .expect("Secure Session client");
+    let mut server = SecureSession::new(name_server, &private_server, transport_server)
+        .expect("Secure Session server");
 
     client.connect().expect("client-side connection");
     server.negotiate().expect("connect reply");
@@ -362,8 +379,10 @@ fn forward_error_send_at_exchange() {
 
     let mut next_client_send = override_send(&mut transport_client);
 
-    let mut client = SecureSession::new(name_client, &private_client, transport_client);
-    let mut server = SecureSession::new(name_server, &private_server, transport_server);
+    let mut client = SecureSession::new(name_client, &private_client, transport_client)
+        .expect("Secure Session client");
+    let mut server = SecureSession::new(name_server, &private_server, transport_server)
+        .expect("Secure Session server");
 
     client.connect().expect("client-side connection");
     server.negotiate().expect("connect reply");
@@ -402,8 +421,10 @@ fn forward_error_receive_at_exchange() {
 
     let mut next_server_receive = override_receive(&mut transport_server);
 
-    let mut client = SecureSession::new(name_client, &private_client, transport_client);
-    let mut server = SecureSession::new(name_server, &private_server, transport_server);
+    let mut client = SecureSession::new(name_client, &private_client, transport_client)
+        .expect("Secure Session client");
+    let mut server = SecureSession::new(name_server, &private_server, transport_server)
+        .expect("Secure Session server");
 
     client.connect().expect("client-side connection");
     server.negotiate().expect("connect reply");
@@ -442,8 +463,10 @@ fn cannot_send_empty_message() {
 
     connect_with_channels(&mut transport_client, &mut transport_server);
 
-    let mut client = SecureSession::new(name_client, &private_client, transport_client);
-    let mut server = SecureSession::new(name_server, &private_server, transport_server);
+    let mut client = SecureSession::new(name_client, &private_client, transport_client)
+        .expect("Secure Session client");
+    let mut server = SecureSession::new(name_server, &private_server, transport_server)
+        .expect("Secure Session server");
 
     client.connect().expect("client-side connection");
     server.negotiate().expect("connect reply");
@@ -475,8 +498,10 @@ fn cannot_receive_empty_message() {
 
     let mut next_client_receive = override_receive(&mut transport_client);
 
-    let mut client = SecureSession::new(name_client, &private_client, transport_client);
-    let mut server = SecureSession::new(name_server, &private_server, transport_server);
+    let mut client = SecureSession::new(name_client, &private_client, transport_client)
+        .expect("Secure Session client");
+    let mut server = SecureSession::new(name_server, &private_server, transport_server)
+        .expect("Secure Session server");
 
     client.connect().expect("client-side connection");
     server.negotiate().expect("connect reply");


### PR DESCRIPTION
I'm closing in on the API of Secure Session which looks okay for me. This PR adds more information on how to use Secure Session to API docs, and updates the interface. You can view the docs by running

```
cargo doc --open
```

Some notable changes:

- constructor is now called `SecureSession::new()` ~~and it panics instead of returning a Result~~
- some other methods have been renamed for consistency with other language wrappers:
  - callback API: `connect`, `negotiate`, `send`, `receive`
  - buffer-oriented API: `connect_request`, `negotiate_reply`, `wrap`, `unwrap`
- impl Traits are used instead of explicit generics

The docs currently refer to nonexistent examples of Secure Session usage. They are currently cooking in a separate branch and will be added later in a separate pull request.