### PR TITLE
Improve error reporting in ThemisPP

### DIFF
--- a/src/wrappers/themis/themispp/exception.hpp
+++ b/src/wrappers/themis/themispp/exception.hpp
@@ -18,13 +18,29 @@
 #define THEMISPP_EXCEPTION_HPP_
 
 #include <stdexcept>
+#include <themis/themis.h>
 
 namespace themispp{
-    class exception_t: public std::runtime_error{
-	public:
-	explicit exception_t(const char* what):
-	    std::runtime_error(what){}
-    };
+  class exception_t: public std::runtime_error
+  {
+  public:
+    explicit exception_t(const char* what)
+      : std::runtime_error(what)
+      , status_(THEMIS_INVALID_PARAMETER)
+    {}
+
+    exception_t(const char* what, ::themis_status_t status)
+      : std::runtime_error(what)
+      , status_(status)
+    {}
+
+    ::themis_status_t status() const {
+      return status_;
+    }
+
+  private:
+    ::themis_status_t status_;
+  };
 }//themispp ns
 
 #endif

--- a/src/wrappers/themis/themispp/secure_cell.hpp
+++ b/src/wrappers/themis/themispp/secure_cell.hpp
@@ -115,14 +115,18 @@ namespace themispp{
       secure_cell_optional_context_t(password){}
 
     const data_t& encrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end,  data_t::const_iterator context_begin, data_t::const_iterator context_end){
+      if(data_end-data_begin==0){
+        throw themispp::exception_t("Secure Cell (Seal) failed to encrypt message: data must be non-empty");
+      }
       themis_status_t status=THEMIS_FAIL;
+      const uint8_t* context_ptr=(context_end-context_begin>0) ? &(*context_begin) : NULL;
       size_t encrypted_length=0;
-      status=themis_secure_cell_encrypt_seal(&_password[0], _password.size(), &(*context_begin), context_end-context_begin, &(*data_begin), data_end-data_begin, NULL, &encrypted_length);
+      status=themis_secure_cell_encrypt_seal(&_password[0], _password.size(), context_ptr, context_end-context_begin, &(*data_begin), data_end-data_begin, NULL, &encrypted_length);
       if(status!=THEMIS_BUFFER_TOO_SMALL){
         throw themispp::exception_t("Secure Cell (Seal) failed to encrypt message", status);
       }
       _res.resize(encrypted_length);
-      status=themis_secure_cell_encrypt_seal(&_password[0], _password.size(), &(*context_begin), context_end-context_begin, &(*data_begin), data_end-data_begin, &_res[0], &encrypted_length);
+      status=themis_secure_cell_encrypt_seal(&_password[0], _password.size(), context_ptr, context_end-context_begin, &(*data_begin), data_end-data_begin, &_res[0], &encrypted_length);
       if(status!=THEMIS_SUCCESS){
         throw themispp::exception_t("Secure Cell (Seal) failed to encrypt message", status);
       }
@@ -131,16 +135,20 @@ namespace themispp{
     using secure_cell_optional_context_t::encrypt;
     
     const data_t& decrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end,  data_t::const_iterator context_begin, data_t::const_iterator context_end){
+      if(data_end-data_begin==0){
+        throw themispp::exception_t("Secure Cell (Seal) failed to decrypt message: data must be non-empty");
+      }
       themis_status_t status=THEMIS_FAIL;
+      const uint8_t* context_ptr=(context_end-context_begin>0) ? &(*context_begin) : NULL;
       size_t decrypted_length=0;
-      status=themis_secure_cell_decrypt_seal(&_password[0], _password.size(), &(*context_begin), context_end-context_begin, &(*data_begin), data_end-data_begin, NULL, &decrypted_length);
+      status=themis_secure_cell_decrypt_seal(&_password[0], _password.size(), context_ptr, context_end-context_begin, &(*data_begin), data_end-data_begin, NULL, &decrypted_length);
       if(status!=THEMIS_BUFFER_TOO_SMALL){
-        throw themispp::exception_t("Secure Cell (Seal) failed to decrypt", status);
+        throw themispp::exception_t("Secure Cell (Seal) failed to decrypt message", status);
       }
       _res.resize(decrypted_length);
-      status=themis_secure_cell_decrypt_seal(&_password[0], _password.size(), &(*context_begin), context_end-context_begin, &(*data_begin), data_end-data_begin, &_res[0], &decrypted_length);
+      status=themis_secure_cell_decrypt_seal(&_password[0], _password.size(), context_ptr, context_end-context_begin, &(*data_begin), data_end-data_begin, &_res[0], &decrypted_length);
       if(status!=THEMIS_SUCCESS){
-        throw themispp::exception_t("Secure Cell (Seal) failed to decrypt", status);
+        throw themispp::exception_t("Secure Cell (Seal) failed to decrypt message", status);
       }
       return _res;
     }
@@ -158,34 +166,45 @@ namespace themispp{
       _token(0){}
 
     const data_t& encrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end, data_t::const_iterator context_begin, data_t::const_iterator context_end){
+      if(data_end-data_begin==0){
+        throw themispp::exception_t("Secure Cell (Token Protect) failed to encrypt message: data must be non-empty");
+      }
       themis_status_t status=THEMIS_FAIL;
+      const uint8_t* context_ptr=(context_end-context_begin>0) ? &(*context_begin) : NULL;
       size_t encrypted_length=0;
       size_t token_length=0;
-      status=themis_secure_cell_encrypt_token_protect(&_password[0], _password.size(), &(*context_begin), context_end-context_begin, &(*data_begin), data_end-data_begin, NULL, &token_length, NULL, &encrypted_length);
+      status=themis_secure_cell_encrypt_token_protect(&_password[0], _password.size(), context_ptr, context_end-context_begin, &(*data_begin), data_end-data_begin, NULL, &token_length, NULL, &encrypted_length);
       if(status!=THEMIS_BUFFER_TOO_SMALL){
-        throw themispp::exception_t("Secure Cell (Token Protect) failed to encrypt", status);
+        throw themispp::exception_t("Secure Cell (Token Protect) failed to encrypt message", status);
       }
       _res.resize(encrypted_length);
       _token.resize(token_length);
-      status=themis_secure_cell_encrypt_token_protect(&_password[0], _password.size(), &(*context_begin), context_end-context_begin, &(*data_begin), data_end-data_begin, &_token[0], &token_length, &_res[0], &encrypted_length);
+      status=themis_secure_cell_encrypt_token_protect(&_password[0], _password.size(), context_ptr, context_end-context_begin, &(*data_begin), data_end-data_begin, &_token[0], &token_length, &_res[0], &encrypted_length);
       if(status!=THEMIS_SUCCESS){
-        throw themispp::exception_t("Secure Cell (Token Protect) failed to encrypt", status);
+        throw themispp::exception_t("Secure Cell (Token Protect) failed to encrypt message", status);
       }
       return _res;
     }
     using secure_cell_optional_context_t::encrypt;
 
     const data_t& decrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end, data_t::const_iterator context_begin, data_t::const_iterator context_end){
+      if(data_end-data_begin==0){
+        throw themispp::exception_t("Secure Cell (Token Protect) failed to decrypt message: data must be non-empty");
+      }
+      if(_token.empty()){
+        throw themispp::exception_t("Secure Cell (Token Protect) failed to decrypt message: token must be non-empty (set with set_token())");
+      }
       themis_status_t status=THEMIS_FAIL;
+      const uint8_t* context_ptr=(context_end-context_begin>0) ? &(*context_begin) : NULL;
       size_t decrypted_length=0;
-      status=themis_secure_cell_decrypt_token_protect(&_password[0], _password.size(), &(*context_begin), context_end-context_begin, &(*data_begin), data_end-data_begin, &_token[0], _token.size(), NULL, &decrypted_length);
+      status=themis_secure_cell_decrypt_token_protect(&_password[0], _password.size(), context_ptr, context_end-context_begin, &(*data_begin), data_end-data_begin, &_token[0], _token.size(), NULL, &decrypted_length);
       if(status!=THEMIS_BUFFER_TOO_SMALL){
-        throw themispp::exception_t("Secure Cell (Token Protect) failed to decrypt", status);
+        throw themispp::exception_t("Secure Cell (Token Protect) failed to decrypt message", status);
       }
       _res.resize(decrypted_length);
-      status=themis_secure_cell_decrypt_token_protect(&_password[0], _password.size(), &(*context_begin), context_end-context_begin, &(*data_begin), data_end-data_begin, &_token[0], _token.size(), &_res[0], &decrypted_length);
+      status=themis_secure_cell_decrypt_token_protect(&_password[0], _password.size(), context_ptr, context_end-context_begin, &(*data_begin), data_end-data_begin, &_token[0], _token.size(), &_res[0], &decrypted_length);
       if(status!=THEMIS_SUCCESS){
-        throw themispp::exception_t("Secure Cell (Token Protect) failed to decrypt", status);
+        throw themispp::exception_t("Secure Cell (Token Protect) failed to decrypt message", status);
       }
       return _res;
     }
@@ -204,32 +223,44 @@ namespace themispp{
       secure_cell_t(password){}
 
     const data_t& encrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end, data_t::const_iterator context_begin, data_t::const_iterator context_end){
+      if(data_end-data_begin==0){
+        throw themispp::exception_t("Secure Cell (Context Imprint) failed to encrypt message: data must be non-empty");
+      }
+      if(context_end-context_begin==0){
+        throw themispp::exception_t("Secure Cell (Context Imprint) failed to encrypt message: context must be non-empty");
+      }
       themis_status_t status=THEMIS_FAIL;
       size_t encrypted_length=0;
       status=themis_secure_cell_encrypt_context_imprint(&_password[0], _password.size(), &(*context_begin), context_end-context_begin, &(*data_begin), data_end-data_begin, NULL, &encrypted_length);
       if(status!=THEMIS_BUFFER_TOO_SMALL){
-        throw themispp::exception_t("Secure Cell (Context Imprint) failed to encrypt", status);
+        throw themispp::exception_t("Secure Cell (Context Imprint) failed to encrypt message", status);
       }
       _res.resize(encrypted_length);
       status=themis_secure_cell_encrypt_context_imprint(&_password[0], _password.size(), &(*context_begin), context_end-context_begin, &(*data_begin), data_end-data_begin, &_res[0], &encrypted_length);
       if(status!=THEMIS_SUCCESS){
-        throw themispp::exception_t("Secure Cell (Context Imprint) failed to encrypt", status);
+        throw themispp::exception_t("Secure Cell (Context Imprint) failed to encrypt message", status);
       }
       return _res;
     }
     using secure_cell_t::encrypt;
 
     const data_t& decrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end, data_t::const_iterator context_begin, data_t::const_iterator context_end){
+      if(data_end-data_begin==0){
+        throw themispp::exception_t("Secure Cell (Context Imprint) failed to decrypt message: data must be non-empty");
+      }
+      if(context_end-context_begin==0){
+        throw themispp::exception_t("Secure Cell (Context Imprint) failed to decrypt message: context must be non-empty");
+      }
       themis_status_t status=THEMIS_FAIL;
       size_t decrypted_length=0;
       status=themis_secure_cell_decrypt_context_imprint(&_password[0], _password.size(), &(*context_begin), context_end-context_begin, &(*data_begin), data_end-data_begin, NULL, &decrypted_length);
       if(status!=THEMIS_BUFFER_TOO_SMALL){
-        throw themispp::exception_t("Secure Cell (Context Imprint) failed to decrypt", status);
+        throw themispp::exception_t("Secure Cell (Context Imprint) failed to decrypt message", status);
       }
       _res.resize(decrypted_length);
       status=themis_secure_cell_decrypt_context_imprint(&_password[0], _password.size(), &(*context_begin), context_end-context_begin, &(*data_begin), data_end-data_begin, &_res[0], &decrypted_length);
       if(status!=THEMIS_SUCCESS){
-        throw themispp::exception_t("Secure Cell (Context Imprint) failed to decrypt", status);
+        throw themispp::exception_t("Secure Cell (Context Imprint) failed to decrypt message", status);
       }
       return _res;
     }

--- a/src/wrappers/themis/themispp/secure_cell.hpp
+++ b/src/wrappers/themis/themispp/secure_cell.hpp
@@ -115,18 +115,19 @@ namespace themispp{
       secure_cell_optional_context_t(password){}
 
     const data_t& encrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end,  data_t::const_iterator context_begin, data_t::const_iterator context_end){
-      if(data_end-data_begin==0){
+      if(data_end<=data_begin){
         throw themispp::exception_t("Secure Cell (Seal) failed to encrypt message: data must be non-empty");
       }
       themis_status_t status=THEMIS_FAIL;
-      const uint8_t* context_ptr=(context_end-context_begin>0) ? &(*context_begin) : NULL;
+      const uint8_t* context_ptr=(context_end>context_begin) ? &(*context_begin) : NULL;
+      const size_t context_len=(context_end>context_begin) ? (context_end-context_begin) : 0;
       size_t encrypted_length=0;
-      status=themis_secure_cell_encrypt_seal(&_password[0], _password.size(), context_ptr, context_end-context_begin, &(*data_begin), data_end-data_begin, NULL, &encrypted_length);
+      status=themis_secure_cell_encrypt_seal(&_password[0], _password.size(), context_ptr, context_len, &(*data_begin), data_end-data_begin, NULL, &encrypted_length);
       if(status!=THEMIS_BUFFER_TOO_SMALL){
         throw themispp::exception_t("Secure Cell (Seal) failed to encrypt message", status);
       }
       _res.resize(encrypted_length);
-      status=themis_secure_cell_encrypt_seal(&_password[0], _password.size(), context_ptr, context_end-context_begin, &(*data_begin), data_end-data_begin, &_res[0], &encrypted_length);
+      status=themis_secure_cell_encrypt_seal(&_password[0], _password.size(), context_ptr, context_len, &(*data_begin), data_end-data_begin, &_res[0], &encrypted_length);
       if(status!=THEMIS_SUCCESS){
         throw themispp::exception_t("Secure Cell (Seal) failed to encrypt message", status);
       }
@@ -135,18 +136,19 @@ namespace themispp{
     using secure_cell_optional_context_t::encrypt;
     
     const data_t& decrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end,  data_t::const_iterator context_begin, data_t::const_iterator context_end){
-      if(data_end-data_begin==0){
+      if(data_end<=data_begin){
         throw themispp::exception_t("Secure Cell (Seal) failed to decrypt message: data must be non-empty");
       }
       themis_status_t status=THEMIS_FAIL;
-      const uint8_t* context_ptr=(context_end-context_begin>0) ? &(*context_begin) : NULL;
+      const uint8_t* context_ptr=(context_end>context_begin) ? &(*context_begin) : NULL;
+      const size_t context_len=(context_end>context_begin) ? (context_end-context_begin) : 0;
       size_t decrypted_length=0;
-      status=themis_secure_cell_decrypt_seal(&_password[0], _password.size(), context_ptr, context_end-context_begin, &(*data_begin), data_end-data_begin, NULL, &decrypted_length);
+      status=themis_secure_cell_decrypt_seal(&_password[0], _password.size(), context_ptr, context_len, &(*data_begin), data_end-data_begin, NULL, &decrypted_length);
       if(status!=THEMIS_BUFFER_TOO_SMALL){
         throw themispp::exception_t("Secure Cell (Seal) failed to decrypt message", status);
       }
       _res.resize(decrypted_length);
-      status=themis_secure_cell_decrypt_seal(&_password[0], _password.size(), context_ptr, context_end-context_begin, &(*data_begin), data_end-data_begin, &_res[0], &decrypted_length);
+      status=themis_secure_cell_decrypt_seal(&_password[0], _password.size(), context_ptr, context_len, &(*data_begin), data_end-data_begin, &_res[0], &decrypted_length);
       if(status!=THEMIS_SUCCESS){
         throw themispp::exception_t("Secure Cell (Seal) failed to decrypt message", status);
       }
@@ -166,20 +168,21 @@ namespace themispp{
       _token(0){}
 
     const data_t& encrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end, data_t::const_iterator context_begin, data_t::const_iterator context_end){
-      if(data_end-data_begin==0){
+      if(data_end<=data_begin){
         throw themispp::exception_t("Secure Cell (Token Protect) failed to encrypt message: data must be non-empty");
       }
       themis_status_t status=THEMIS_FAIL;
-      const uint8_t* context_ptr=(context_end-context_begin>0) ? &(*context_begin) : NULL;
+      const uint8_t* context_ptr=(context_end>context_begin) ? &(*context_begin) : NULL;
+      const size_t context_len=(context_end>context_begin) ? (context_end-context_begin) : 0;
       size_t encrypted_length=0;
       size_t token_length=0;
-      status=themis_secure_cell_encrypt_token_protect(&_password[0], _password.size(), context_ptr, context_end-context_begin, &(*data_begin), data_end-data_begin, NULL, &token_length, NULL, &encrypted_length);
+      status=themis_secure_cell_encrypt_token_protect(&_password[0], _password.size(), context_ptr, context_len, &(*data_begin), data_end-data_begin, NULL, &token_length, NULL, &encrypted_length);
       if(status!=THEMIS_BUFFER_TOO_SMALL){
         throw themispp::exception_t("Secure Cell (Token Protect) failed to encrypt message", status);
       }
       _res.resize(encrypted_length);
       _token.resize(token_length);
-      status=themis_secure_cell_encrypt_token_protect(&_password[0], _password.size(), context_ptr, context_end-context_begin, &(*data_begin), data_end-data_begin, &_token[0], &token_length, &_res[0], &encrypted_length);
+      status=themis_secure_cell_encrypt_token_protect(&_password[0], _password.size(), context_ptr, context_len, &(*data_begin), data_end-data_begin, &_token[0], &token_length, &_res[0], &encrypted_length);
       if(status!=THEMIS_SUCCESS){
         throw themispp::exception_t("Secure Cell (Token Protect) failed to encrypt message", status);
       }
@@ -188,21 +191,22 @@ namespace themispp{
     using secure_cell_optional_context_t::encrypt;
 
     const data_t& decrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end, data_t::const_iterator context_begin, data_t::const_iterator context_end){
-      if(data_end-data_begin==0){
+      if(data_end<=data_begin){
         throw themispp::exception_t("Secure Cell (Token Protect) failed to decrypt message: data must be non-empty");
       }
       if(_token.empty()){
         throw themispp::exception_t("Secure Cell (Token Protect) failed to decrypt message: token must be non-empty (set with set_token())");
       }
       themis_status_t status=THEMIS_FAIL;
-      const uint8_t* context_ptr=(context_end-context_begin>0) ? &(*context_begin) : NULL;
+      const uint8_t* context_ptr=(context_end>context_begin) ? &(*context_begin) : NULL;
+      const size_t context_len=(context_end>context_begin) ? (context_end-context_begin) : 0;
       size_t decrypted_length=0;
-      status=themis_secure_cell_decrypt_token_protect(&_password[0], _password.size(), context_ptr, context_end-context_begin, &(*data_begin), data_end-data_begin, &_token[0], _token.size(), NULL, &decrypted_length);
+      status=themis_secure_cell_decrypt_token_protect(&_password[0], _password.size(), context_ptr, context_len, &(*data_begin), data_end-data_begin, &_token[0], _token.size(), NULL, &decrypted_length);
       if(status!=THEMIS_BUFFER_TOO_SMALL){
         throw themispp::exception_t("Secure Cell (Token Protect) failed to decrypt message", status);
       }
       _res.resize(decrypted_length);
-      status=themis_secure_cell_decrypt_token_protect(&_password[0], _password.size(), context_ptr, context_end-context_begin, &(*data_begin), data_end-data_begin, &_token[0], _token.size(), &_res[0], &decrypted_length);
+      status=themis_secure_cell_decrypt_token_protect(&_password[0], _password.size(), context_ptr, context_len, &(*data_begin), data_end-data_begin, &_token[0], _token.size(), &_res[0], &decrypted_length);
       if(status!=THEMIS_SUCCESS){
         throw themispp::exception_t("Secure Cell (Token Protect) failed to decrypt message", status);
       }
@@ -223,10 +227,10 @@ namespace themispp{
       secure_cell_t(password){}
 
     const data_t& encrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end, data_t::const_iterator context_begin, data_t::const_iterator context_end){
-      if(data_end-data_begin==0){
+      if(data_end<=data_begin){
         throw themispp::exception_t("Secure Cell (Context Imprint) failed to encrypt message: data must be non-empty");
       }
-      if(context_end-context_begin==0){
+      if(context_end<=context_begin){
         throw themispp::exception_t("Secure Cell (Context Imprint) failed to encrypt message: context must be non-empty");
       }
       themis_status_t status=THEMIS_FAIL;
@@ -245,10 +249,10 @@ namespace themispp{
     using secure_cell_t::encrypt;
 
     const data_t& decrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end, data_t::const_iterator context_begin, data_t::const_iterator context_end){
-      if(data_end-data_begin==0){
+      if(data_end<=data_begin){
         throw themispp::exception_t("Secure Cell (Context Imprint) failed to decrypt message: data must be non-empty");
       }
-      if(context_end-context_begin==0){
+      if(context_end<=context_begin){
         throw themispp::exception_t("Secure Cell (Context Imprint) failed to decrypt message: context must be non-empty");
       }
       themis_status_t status=THEMIS_FAIL;

--- a/src/wrappers/themis/themispp/secure_comparator.hpp
+++ b/src/wrappers/themis/themispp/secure_comparator.hpp
@@ -31,6 +31,9 @@ namespace themispp{
     
     secure_comparator_t(const data_t& shared_secret):
       comparator_(NULL){
+      if(shared_secret.empty()){
+        throw themispp::exception_t("Secure Comparator must have non-empty shared secret");
+      }
       res_.reserve(512);
       comparator_=secure_comparator_create();
       if(!comparator_){
@@ -62,6 +65,9 @@ namespace themispp{
     }
 
     const data_t& proceed(const std::vector<uint8_t>& data){
+      if(data.empty()){
+        throw themispp::exception_t("Secure Comparator failed to proceed comparison: data must be non-empty");
+      }
       themis_status_t status=THEMIS_FAIL;
       size_t res_data_length=0;
       status=secure_comparator_proceed_compare(comparator_, &data[0], data.size(), NULL, &res_data_length);

--- a/src/wrappers/themis/themispp/secure_comparator.hpp
+++ b/src/wrappers/themis/themispp/secure_comparator.hpp
@@ -33,10 +33,13 @@ namespace themispp{
       comparator_(NULL){
       res_.reserve(512);
       comparator_=secure_comparator_create();
-      if(!comparator_)
-	throw themispp::exception_t("Secure Comparator failed creating");
-      if(THEMIS_SUCCESS!=secure_comparator_append_secret(comparator_, &shared_secret[0], shared_secret.size()))
-	throw themispp::exception_t("Secure Comparator failed appending secret");	
+      if(!comparator_){
+        throw themispp::exception_t("Secure Comparator construction failed");
+      }
+      themis_status_t status=secure_comparator_append_secret(comparator_, &shared_secret[0], shared_secret.size());
+      if(THEMIS_SUCCESS!=status){
+        throw themispp::exception_t("Secure Comparator failed to append secret", status);
+      }
     }
 
     virtual ~secure_comparator_t(){
@@ -44,23 +47,32 @@ namespace themispp{
     }
 
     const data_t& init(){
+      themis_status_t status=THEMIS_FAIL;
       size_t data_length=0;
-      if(THEMIS_BUFFER_TOO_SMALL!=secure_comparator_begin_compare(comparator_, NULL, &data_length))
-	throw themispp::exception_t("Secure Comparator failed making initialisation message");
+      status=secure_comparator_begin_compare(comparator_, NULL, &data_length);
+      if(THEMIS_BUFFER_TOO_SMALL!=status){
+        throw themispp::exception_t("Secure Comparator failed to initialize comparison", status);
+      }
       res_.resize(data_length);
-      if(THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER!=secure_comparator_begin_compare(comparator_, &res_[0], &data_length))
-	throw themispp::exception_t("Secure Comparator failed making initialisation message");
+      status=secure_comparator_begin_compare(comparator_, &res_[0], &data_length);
+      if(THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER!=status){
+        throw themispp::exception_t("Secure Comparator failed to initialize comparison", status);
+      }
       return res_;
     }
 
     const data_t& proceed(const std::vector<uint8_t>& data){
+      themis_status_t status=THEMIS_FAIL;
       size_t res_data_length=0;
-      if(THEMIS_BUFFER_TOO_SMALL!=secure_comparator_proceed_compare(comparator_, &data[0], data.size(), NULL, &res_data_length))
-	throw themispp::exception_t("Secure Comparator failed proceeding message");
+      status=secure_comparator_proceed_compare(comparator_, &data[0], data.size(), NULL, &res_data_length);
+      if(THEMIS_BUFFER_TOO_SMALL!=status){
+        throw themispp::exception_t("Secure Comparator failed to proceed comparison", status);
+      }
       res_.resize(res_data_length);
-      themis_status_t res=secure_comparator_proceed_compare(comparator_, &data[0], data.size(), &res_[0], &res_data_length);
-      if(THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER!=res && THEMIS_SUCCESS!=res)
-	throw themispp::exception_t("Secure Comparator failed proceeding message");
+      status=secure_comparator_proceed_compare(comparator_, &data[0], data.size(), &res_[0], &res_data_length);
+      if(THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER!=status && THEMIS_SUCCESS!=status){
+        throw themispp::exception_t("Secure Comparator failed to proceed comparison", status);
+      }
       return res_;
     }
     

--- a/src/wrappers/themis/themispp/secure_keygen.hpp
+++ b/src/wrappers/themis/themispp/secure_keygen.hpp
@@ -39,19 +39,24 @@ namespace themispp{
     }
     
     void gen(){
+      themis_status_t status=THEMIS_FAIL;
       size_t private_key_length=max_key_length_t_p;
       size_t public_key_length=max_key_length_t_p;
       switch(alg_t_p){
       case EC:
-	if(themis_gen_ec_key_pair(&private_key[0], &private_key_length, &public_key[0], &public_key_length)!=THEMIS_SUCCESS)
-	  throw themispp::exception_t("Themis failed generating EC KeyPair");
-	break;
+        status=themis_gen_ec_key_pair(&private_key[0], &private_key_length, &public_key[0], &public_key_length);
+        if(status!=THEMIS_SUCCESS){
+          throw themispp::exception_t("Themis failed to generate EC key pair", status);
+        }
+        break;
       case RSA:
-	if(themis_gen_rsa_key_pair(&private_key[0], &private_key_length, &public_key[0], &public_key_length)!=THEMIS_SUCCESS)
-	  throw themispp::exception_t("Themis failed generating RSA KeyPair");
-	break;
+        status=themis_gen_rsa_key_pair(&private_key[0], &private_key_length, &public_key[0], &public_key_length);
+        if(status!=THEMIS_SUCCESS){
+          throw themispp::exception_t("Themis failed to generate RSA key pair", status);
+        }
+        break;
       default:
-	throw themispp::exception_t("Themis failed generating KeyPair, unsupported algorithm");
+        throw themispp::exception_t("Themis failed generate key pair: unsupported algorithm");
       }
       private_key.resize(private_key_length);
       public_key.resize(public_key_length);

--- a/src/wrappers/themis/themispp/secure_message.hpp
+++ b/src/wrappers/themis/themispp/secure_message.hpp
@@ -47,12 +47,23 @@ namespace themispp {
     virtual ~secure_message_t(){}
 
     const data_t& encrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end){
+      if(private_key_.empty()){
+        throw themispp::exception_t("Secure Message failed to encrypt message: private key not set");
+      }
+      if(peer_public_key_.empty()){
+        throw themispp::exception_t("Secure Message failed to encrypt message: public key not set");
+      }
+      themis_status_t status=THEMIS_FAIL;
       size_t encrypted_data_length=0;
-      if(themis_secure_message_wrap(&private_key_[0], private_key_.size(), &peer_public_key_[0], peer_public_key_.size(), &(*data_begin), data_end-data_begin, NULL, &encrypted_data_length)!=THEMIS_BUFFER_TOO_SMALL)
-	throw themispp::exception_t("Secure Message failed encrypting");
+      status=themis_secure_message_wrap(&private_key_[0], private_key_.size(), &peer_public_key_[0], peer_public_key_.size(), &(*data_begin), data_end-data_begin, NULL, &encrypted_data_length);
+      if(status!=THEMIS_BUFFER_TOO_SMALL){
+        throw themispp::exception_t("Secure Message failed to encrypt message", status);
+      }
       res_.resize(encrypted_data_length);
-      if(themis_secure_message_wrap(&private_key_[0], private_key_.size(), &peer_public_key_[0], peer_public_key_.size(), &(*data_begin), data_end-data_begin, &res_[0], &encrypted_data_length)!=THEMIS_SUCCESS)
-	throw themispp::exception_t("Secure Message failed encrypting");
+      status=themis_secure_message_wrap(&private_key_[0], private_key_.size(), &peer_public_key_[0], peer_public_key_.size(), &(*data_begin), data_end-data_begin, &res_[0], &encrypted_data_length);
+      if(status!=THEMIS_SUCCESS){
+        throw themispp::exception_t("Secure Message failed to encrypt message", status);
+      }
       return res_;
     }
 
@@ -61,12 +72,23 @@ namespace themispp {
     }
 
     const data_t& decrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end){
+      if(private_key_.empty()){
+        throw themispp::exception_t("Secure Message failed to decrypt message: private key not set");
+      }
+      if(peer_public_key_.empty()){
+        throw themispp::exception_t("Secure Message failed to decrypt message: public key not set");
+      }
+      themis_status_t status=THEMIS_FAIL;
       size_t decrypted_data_length=0;
-      if(themis_secure_message_unwrap(&private_key_[0], private_key_.size(), &peer_public_key_[0], peer_public_key_.size(), &(*data_begin), data_end-data_begin, NULL, &decrypted_data_length)!=THEMIS_BUFFER_TOO_SMALL)
-	throw themispp::exception_t("Secure Message failed decrypting");
+      status=themis_secure_message_unwrap(&private_key_[0], private_key_.size(), &peer_public_key_[0], peer_public_key_.size(), &(*data_begin), data_end-data_begin, NULL, &decrypted_data_length);
+      if(status!=THEMIS_BUFFER_TOO_SMALL){
+        throw themispp::exception_t("Secure Message failed to decrypt message", status);
+      }
       res_.resize(decrypted_data_length);
-      if(themis_secure_message_unwrap(&private_key_[0], private_key_.size(), &peer_public_key_[0], peer_public_key_.size(), &(*data_begin), data_end-data_begin, &res_[0], &decrypted_data_length)!=THEMIS_SUCCESS)
-	throw themispp::exception_t("Secure Message failed decrypting");
+      status=themis_secure_message_unwrap(&private_key_[0], private_key_.size(), &peer_public_key_[0], peer_public_key_.size(), &(*data_begin), data_end-data_begin, &res_[0], &decrypted_data_length);
+      if(status!=THEMIS_SUCCESS){
+        throw themispp::exception_t("Secure Message failed to decrypt message", status);
+      }
       return res_;
     }
 
@@ -75,12 +97,20 @@ namespace themispp {
     }
 
     const data_t& sign(data_t::const_iterator data_begin, data_t::const_iterator data_end){
+      if(private_key_.empty()){
+        throw themispp::exception_t("Secure Message failed to sign message: private key not set");
+      }
+      themis_status_t status=THEMIS_FAIL;
       size_t encrypted_data_length=0;
-      if(themis_secure_message_wrap(&private_key_[0], private_key_.size(), NULL, 0, &(*data_begin), data_end-data_begin, NULL, &encrypted_data_length)!=THEMIS_BUFFER_TOO_SMALL)
-	throw themispp::exception_t("Secure Message failed singing");
+      status=themis_secure_message_wrap(&private_key_[0], private_key_.size(), NULL, 0, &(*data_begin), data_end-data_begin, NULL, &encrypted_data_length);
+      if(status!=THEMIS_BUFFER_TOO_SMALL){
+        throw themispp::exception_t("Secure Message failed to sign message", status);
+      }
       res_.resize(encrypted_data_length);
-      if(themis_secure_message_wrap(&private_key_[0], private_key_.size(), NULL, 0, &(*data_begin), data_end-data_begin, &res_[0], &encrypted_data_length)!=THEMIS_SUCCESS)
-	throw themispp::exception_t("Secure Message failed singing");
+      status=themis_secure_message_wrap(&private_key_[0], private_key_.size(), NULL, 0, &(*data_begin), data_end-data_begin, &res_[0], &encrypted_data_length);
+      if(status!=THEMIS_SUCCESS){
+        throw themispp::exception_t("Secure Message failed to sign message", status);
+      }
       return res_;
     }
 
@@ -89,12 +119,20 @@ namespace themispp {
     }
 
     const data_t& verify(data_t::const_iterator data_begin, data_t::const_iterator data_end){
+      if(peer_public_key_.empty()){
+        throw themispp::exception_t("Secure Message failed to verify signature: public key not set");
+      }
+      themis_status_t status=THEMIS_FAIL;
       size_t decrypted_data_length=0;
-      if(themis_secure_message_unwrap(NULL, 0, &peer_public_key_[0], peer_public_key_.size(), &(*data_begin), data_end-data_begin, NULL, &decrypted_data_length)!=THEMIS_BUFFER_TOO_SMALL)
-	throw themispp::exception_t("Secure Message failed verifying");
+      status=themis_secure_message_unwrap(NULL, 0, &peer_public_key_[0], peer_public_key_.size(), &(*data_begin), data_end-data_begin, NULL, &decrypted_data_length);
+      if(status!=THEMIS_BUFFER_TOO_SMALL){
+        throw themispp::exception_t("Secure Message failed to verify signature", status);
+      }
       res_.resize(decrypted_data_length);
-      if(themis_secure_message_unwrap(NULL, 0, &peer_public_key_[0], peer_public_key_.size(), &(*data_begin), data_end-data_begin, &res_[0], &decrypted_data_length)!=THEMIS_SUCCESS)
-	throw themispp::exception_t("Secure Message failed verifying");
+      status=themis_secure_message_unwrap(NULL, 0, &peer_public_key_[0], peer_public_key_.size(), &(*data_begin), data_end-data_begin, &res_[0], &decrypted_data_length);
+      if(status!=THEMIS_SUCCESS){
+        throw themispp::exception_t("Secure Message failed to verify signature", status);
+      }
       return res_;
     }
 

--- a/src/wrappers/themis/themispp/secure_message.hpp
+++ b/src/wrappers/themis/themispp/secure_message.hpp
@@ -53,6 +53,9 @@ namespace themispp {
       if(peer_public_key_.empty()){
         throw themispp::exception_t("Secure Message failed to encrypt message: public key not set");
       }
+      if(data_end-data_begin==0){
+        throw themispp::exception_t("Secure Message failed to encrypt message: data must be non-empty");
+      }
       themis_status_t status=THEMIS_FAIL;
       size_t encrypted_data_length=0;
       status=themis_secure_message_wrap(&private_key_[0], private_key_.size(), &peer_public_key_[0], peer_public_key_.size(), &(*data_begin), data_end-data_begin, NULL, &encrypted_data_length);
@@ -78,6 +81,9 @@ namespace themispp {
       if(peer_public_key_.empty()){
         throw themispp::exception_t("Secure Message failed to decrypt message: public key not set");
       }
+      if(data_end-data_begin==0){
+        throw themispp::exception_t("Secure Message failed to decrypt message: data must be non-empty");
+      }
       themis_status_t status=THEMIS_FAIL;
       size_t decrypted_data_length=0;
       status=themis_secure_message_unwrap(&private_key_[0], private_key_.size(), &peer_public_key_[0], peer_public_key_.size(), &(*data_begin), data_end-data_begin, NULL, &decrypted_data_length);
@@ -100,6 +106,9 @@ namespace themispp {
       if(private_key_.empty()){
         throw themispp::exception_t("Secure Message failed to sign message: private key not set");
       }
+      if(data_end-data_begin==0){
+        throw themispp::exception_t("Secure Message failed to sign message: data must be non-empty");
+      }
       themis_status_t status=THEMIS_FAIL;
       size_t encrypted_data_length=0;
       status=themis_secure_message_wrap(&private_key_[0], private_key_.size(), NULL, 0, &(*data_begin), data_end-data_begin, NULL, &encrypted_data_length);
@@ -121,6 +130,9 @@ namespace themispp {
     const data_t& verify(data_t::const_iterator data_begin, data_t::const_iterator data_end){
       if(peer_public_key_.empty()){
         throw themispp::exception_t("Secure Message failed to verify signature: public key not set");
+      }
+      if(data_end-data_begin==0){
+        throw themispp::exception_t("Secure Message failed to verify signature: data must be non-empty");
       }
       themis_status_t status=THEMIS_FAIL;
       size_t decrypted_data_length=0;

--- a/src/wrappers/themis/themispp/secure_message.hpp
+++ b/src/wrappers/themis/themispp/secure_message.hpp
@@ -53,7 +53,7 @@ namespace themispp {
       if(peer_public_key_.empty()){
         throw themispp::exception_t("Secure Message failed to encrypt message: public key not set");
       }
-      if(data_end-data_begin==0){
+      if(data_end<=data_begin){
         throw themispp::exception_t("Secure Message failed to encrypt message: data must be non-empty");
       }
       themis_status_t status=THEMIS_FAIL;
@@ -81,7 +81,7 @@ namespace themispp {
       if(peer_public_key_.empty()){
         throw themispp::exception_t("Secure Message failed to decrypt message: public key not set");
       }
-      if(data_end-data_begin==0){
+      if(data_end<=data_begin){
         throw themispp::exception_t("Secure Message failed to decrypt message: data must be non-empty");
       }
       themis_status_t status=THEMIS_FAIL;
@@ -106,7 +106,7 @@ namespace themispp {
       if(private_key_.empty()){
         throw themispp::exception_t("Secure Message failed to sign message: private key not set");
       }
-      if(data_end-data_begin==0){
+      if(data_end<=data_begin){
         throw themispp::exception_t("Secure Message failed to sign message: data must be non-empty");
       }
       themis_status_t status=THEMIS_FAIL;
@@ -131,7 +131,7 @@ namespace themispp {
       if(peer_public_key_.empty()){
         throw themispp::exception_t("Secure Message failed to verify signature: public key not set");
       }
-      if(data_end-data_begin==0){
+      if(data_end<=data_begin){
         throw themispp::exception_t("Secure Message failed to verify signature: data must be non-empty");
       }
       themis_status_t status=THEMIS_FAIL;

--- a/src/wrappers/themis/themispp/secure_session.hpp
+++ b/src/wrappers/themis/themispp/secure_session.hpp
@@ -136,16 +136,24 @@ namespace themispp{
       if(!_session){
         throw themispp::exception_t("uninitialized Secure Session");
       }
+      themis_status_t status=THEMIS_FAIL;
       size_t unwrapped_data_length=0;
-      themis_status_t r=secure_session_unwrap(_session, &data[0],data.size(), NULL, &unwrapped_data_length);
-      if(r==THEMIS_SUCCESS){_res.resize(0); return _res;}
-      if(r!=THEMIS_BUFFER_TOO_SMALL)
-	throw themispp::exception_t("Secure Session failed decrypting");
+      status=secure_session_unwrap(_session, &data[0],data.size(), NULL, &unwrapped_data_length);
+      if(status==THEMIS_SUCCESS){
+        _res.resize(0);
+        return _res;
+      }
+      if(status!=THEMIS_BUFFER_TOO_SMALL){
+        throw themispp::exception_t("Secure Session failed to unwrap message", status);
+      }
       _res.resize(unwrapped_data_length);
-      r=secure_session_unwrap(_session, &data[0],data.size(), &_res[0], &unwrapped_data_length);
-      if(r==THEMIS_SSESSION_SEND_OUTPUT_TO_PEER){return _res;}
-      if(r!=THEMIS_SUCCESS)
-	throw themispp::exception_t("Secure Session failed decrypting");
+      status=secure_session_unwrap(_session, &data[0],data.size(), &_res[0], &unwrapped_data_length);
+      if(status==THEMIS_SSESSION_SEND_OUTPUT_TO_PEER){
+        return _res;
+      }
+      if(status!=THEMIS_SUCCESS){
+        throw themispp::exception_t("Secure Session failed to unwrap message", status);
+      }
       return _res;
     }
 
@@ -153,12 +161,17 @@ namespace themispp{
       if(!_session){
         throw themispp::exception_t("uninitialized Secure Session");
       }
+      themis_status_t status=THEMIS_FAIL;
       size_t wrapped_message_length=0;
-      if(secure_session_wrap(_session, &data[0], data.size(), NULL, &wrapped_message_length)!=THEMIS_BUFFER_TOO_SMALL)
-	throw themispp::exception_t("Secure Session failed encrypting");
+      status=secure_session_wrap(_session, &data[0], data.size(), NULL, &wrapped_message_length);
+      if(status!=THEMIS_BUFFER_TOO_SMALL){
+        throw themispp::exception_t("Secure Session failed to wrap message", status);
+      }
       _res.resize(wrapped_message_length);
-      if(secure_session_wrap(_session, &data[0], data.size(), &_res[0], &wrapped_message_length)!=THEMIS_SUCCESS)
-	throw themispp::exception_t("Secure Session failed encrypting");
+      status=secure_session_wrap(_session, &data[0], data.size(), &_res[0], &wrapped_message_length);
+      if(status!=THEMIS_SUCCESS){
+        throw themispp::exception_t("Secure Session failed to wrap message", status);
+      }
       return _res;
     }
     
@@ -166,12 +179,17 @@ namespace themispp{
       if(!_session){
         throw themispp::exception_t("uninitialized Secure Session");
       }
+      themis_status_t status=THEMIS_FAIL;
       size_t init_data_length=0;
-      if(secure_session_generate_connect_request(_session, NULL, &init_data_length)!=THEMIS_BUFFER_TOO_SMALL)
-	throw themispp::exception_t("Secure Session failed making connection request");
+      status=secure_session_generate_connect_request(_session, NULL, &init_data_length);
+      if(status!=THEMIS_BUFFER_TOO_SMALL){
+        throw themispp::exception_t("Secure Session failed to initialize", status);
+      }
       _res.resize(init_data_length);
-      if(secure_session_generate_connect_request(_session, &_res.front(), &init_data_length)!=THEMIS_SUCCESS)
-	throw themispp::exception_t("Secure Session failed making connection request");
+      status=secure_session_generate_connect_request(_session, &_res.front(), &init_data_length);
+      if(status!=THEMIS_SUCCESS){
+        throw themispp::exception_t("Secure Session failed to initialize", status);
+      }
       return _res;
     }
     
@@ -186,8 +204,10 @@ namespace themispp{
       if(!_session){
         throw themispp::exception_t("uninitialized Secure Session");
       }
-      if(secure_session_connect(_session)!=THEMIS_SUCCESS)
-	throw themispp::exception_t("Secure Session failed connecting");
+      themis_status_t status=secure_session_connect(_session);
+      if(status!=THEMIS_SUCCESS){
+        throw themispp::exception_t("Secure Session failed to connect", status);
+      }
     }
 
     const data_t& receive(){
@@ -196,8 +216,9 @@ namespace themispp{
       }
       _res.resize(THEMISPP_SECURE_SESSION_MAX_MESSAGE_SIZE);
       ssize_t recv_size=secure_session_receive(_session, &_res[0], _res.size());
-      if(recv_size<=0)
-	throw themispp::exception_t("Secure Session failed receiving");
+      if(recv_size<=0){
+        throw themispp::exception_t("Secure Session failed to receive", THEMIS_SSESSION_TRANSPORT_ERROR);
+      }
       _res.resize(recv_size);
       return _res;
     }
@@ -207,12 +228,22 @@ namespace themispp{
         throw themispp::exception_t("uninitialized Secure Session");
       }
       ssize_t send_size=secure_session_send(_session, &data[0], data.size());
-      if(send_size<=0)
-	throw themispp::exception_t("Secure Session failed sending");
+      if(send_size<=0){
+        throw themispp::exception_t("Secure Session failed to send", THEMIS_SSESSION_TRANSPORT_ERROR);
+      }
     }
 
   private:
     void initialize_session(const data_t& id, const data_t& priv_key, secure_session_callback_interface_t* callbacks){
+      if(id.empty()){
+        throw themispp::exception_t("Secure Session construction failed: client ID must be non-empty");
+      }
+      if(priv_key.empty()){
+        throw themispp::exception_t("Secure Session construction failed: private key must be non-empty");
+      }
+      if(!callbacks){
+        throw themispp::exception_t("Secure Session construction failed: callbacks must be non-NULL");
+      }
       _callback=new secure_session_user_callbacks_t();
       _callback->get_public_key_for_id=themispp::get_public_key_for_id_callback;
       _callback->send_data=themispp::send_callback;
@@ -222,7 +253,7 @@ namespace themispp{
       _session=secure_session_create(&id[0], id.size(), &priv_key[0], priv_key.size(), _callback);
       if(!_session){
         delete _callback;
-        throw themispp::exception_t("Secure Session failed creating");
+        throw themispp::exception_t("Secure Session construction failed");
       }
     }
 

--- a/tests/themispp/secure_cell_test.hpp
+++ b/tests/themispp/secure_cell_test.hpp
@@ -34,6 +34,34 @@ namespace themispp {
         static std::string context1("secure cell test context1 message");
         static std::string context2("secure cell test context2 message");
 
+        static void secure_cell_construction_test() {
+            std::vector<uint8_t> empty;
+
+            try {
+                themispp::secure_cell_seal_t seal(empty);
+                sput_fail_unless(false, "empty password (seal)", __LINE__);
+            }
+            catch (const themispp::exception_t&) {
+                sput_fail_unless(true, "empty password (seal)", __LINE__);
+            }
+
+            try {
+                themispp::secure_cell_token_protect_t seal(empty);
+                sput_fail_unless(false, "empty password (token protect)", __LINE__);
+            }
+            catch (const themispp::exception_t&) {
+                sput_fail_unless(true, "empty password (token protect)", __LINE__);
+            }
+
+            try {
+                themispp::secure_cell_context_imprint_t seal(empty);
+                sput_fail_unless(false, "empty password (context imprint)", __LINE__);
+            }
+            catch (const themispp::exception_t&) {
+                sput_fail_unless(true, "empty password (context imprint)", __LINE__);
+            }
+        }
+
         static void secure_cell_seal_test() {
             //construction
             std::vector<uint8_t> pass1_vector(password1.c_str(), password1.c_str() + password1.length());
@@ -213,6 +241,7 @@ namespace themispp {
 
         void run_secure_cell_test() {
             sput_enter_suite("ThemisPP secure cell seal mode test:");
+            sput_run_test(secure_cell_construction_test, "secure_cell_construction_test", __FILE__);
             sput_run_test(secure_cell_seal_test, "secure_cell_seal_test", __FILE__);
             sput_run_test(secure_cell_seal_context_test, "secure_cell_seal_context_test", __FILE__);
             sput_run_test(secure_cell_token_protect_test, "secure_cell_token_protect_test", __FILE__);

--- a/tests/themispp/secure_message_test.hpp
+++ b/tests/themispp/secure_message_test.hpp
@@ -55,7 +55,7 @@ namespace themispp {
                     decrypted_message = c.decrypt(encrypted_message);
                     sput_fail_unless(false, "decryption fail", __LINE__);
                 } catch (themispp::exception_t &e) {
-                    sput_fail_unless(true, "decryption by intruder", __LINE__);
+                    sput_fail_unless(e.status()==THEMIS_FAIL, "decryption by intruder", __LINE__);
                 }
             } catch (themispp::exception_t &e) {
                 sput_fail_unless(false, e.what(), __LINE__);
@@ -97,7 +97,7 @@ namespace themispp {
                     verified_message = c.verify(a_signed_message);
                     sput_fail_unless(false, "verification fail", __LINE__);
                 } catch (themispp::exception_t &e) {
-                    sput_fail_unless(true, "verification by intruder", __LINE__);
+                    sput_fail_unless(e.status()==THEMIS_INVALID_PARAMETER, "verification by intruder", __LINE__);
                 }
             } catch (themispp::exception_t &e) {
                 sput_fail_unless(false, e.what(), __LINE__);

--- a/tests/themispp/secure_session_test.hpp
+++ b/tests/themispp/secure_session_test.hpp
@@ -53,6 +53,38 @@ namespace themispp{
       }
     };
 
+    void secure_session_invalid_arguments(){
+      std::string client_id("client");
+      std::vector<uint8_t> empty;
+      std::vector<uint8_t> valid_id(client_id.c_str(), client_id.c_str()+client_id.length());
+      std::vector<uint8_t> valid_key(client_priv, client_priv+sizeof(client_priv));
+      callback valid_callbacks;
+
+      try{
+        themispp::secure_session_t client(empty, valid_key, &valid_callbacks);
+        sput_fail_unless(false, "empty client ID", __LINE__);
+      }
+      catch (const themispp::exception_t&){
+        sput_fail_unless(true, "empty client ID", __LINE__);
+      }
+
+      try{
+        themispp::secure_session_t client(valid_id, empty, &valid_callbacks);
+        sput_fail_unless(false, "empty private key", __LINE__);
+      }
+      catch (const themispp::exception_t&){
+        sput_fail_unless(true, "empty private key", __LINE__);
+      }
+
+      try{
+        themispp::secure_session_t client(valid_id, valid_key, 0);
+        sput_fail_unless(false, "empty callback", __LINE__);
+      }
+      catch (const themispp::exception_t&){
+        sput_fail_unless(true, "empty callbacks", __LINE__);
+      }
+    }
+
     void secure_session_test(){
       std::string mes("the test message");
       callback client_callbacks;
@@ -164,6 +196,7 @@ namespace themispp{
 
     int run_secure_session_test(){
       sput_enter_suite("ThemisPP secure session test");
+      sput_run_test(secure_session_invalid_arguments, "secure_session_invalid_arguments", __FILE__);
       sput_run_test(secure_session_test, "secure_session_test", __FILE__);
       sput_run_test(secure_session_uninitialized, "secure_session_uninitialized", __FILE__);
       sput_run_test(secure_session_moved, "secure_session_moved", __FILE__);


### PR DESCRIPTION
This is a change set similar to #384 but for ThemisPP which updates error reporting.

- Added original Themis status codes to exceptions where appropriate
- Added checks for empty keys and IDs where appropriate (especially Secure Message)
- Updated the messages to use similar wording to JsThemis
- Updated tests to verify the new behavior (some constructors throw more exceptions now)