### PR TITLE
Additional safety checks for Secure Session

### DIFF
--- a/src/themis/secure_session_peer.c
+++ b/src/themis/secure_session_peer.c
@@ -33,6 +33,11 @@ themis_status_t secure_session_peer_init(secure_session_peer_t *peer, const void
 {
 	size_t total_len = id_len + sign_key_len;
 
+	if (!id || !id_len || !sign_key || !sign_key_len)
+	{
+		return THEMIS_INVALID_PARAMETER;
+	}
+
 	if (ecdh_key)
 	{
 		total_len += ecdh_key_len;


### PR DESCRIPTION
It turns out that Secure Session breaks in a subtle and non-obvious way if it is created with empty client ID or missing private key. The user callbacks are also not thoroughly validated and may cause a crash if the user forgets to fill them in.

Add checks for client ID and private key length as well as NULL checks for pointers involved with user context and its callbacks.