### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,8 @@
 # Default reviewer set
 *                   @vixentael @Lagovas
-/src/soter/              @vixentael @Lagovas @ilammy @storojs72 @secumod 
-/src/themis/             @vixentael @Lagovas @ilammy @storojs72 @secumod
+/src/soter/         @vixentael @Lagovas @ilammy @storojs72 @secumod
+/src/themis/        @vixentael @Lagovas @ilammy @storojs72 @secumod
+
 # Build system
 Makefile            @vixentael @Lagovas @shadinua
 *.mk                @vixentael @Lagovas @shadinua

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,7 @@
 # Default reviewer set
 *                   @vixentael @Lagovas
-
+/src/soter/              @vixentael @Lagovas @ilammy @storojs72 @secumod 
+/src/themis/             @vixentael @Lagovas @ilammy @storojs72 @secumod
 # Build system
 Makefile            @vixentael @Lagovas @shadinua
 *.mk                @vixentael @Lagovas @shadinua

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,11 @@
+# Default reviewer set
+*                   @vixentael @Lagovas
+
+# Build system
+Makefile            @vixentael @Lagovas @shadinua
+*.mk                @vixentael @Lagovas @shadinua
+*.sh                @vixentael @Lagovas @shadinua
+
+# rust-themis
+Cargo.toml          @vixentael @Lagovas @ilammy
+*.rs                @vixentael @Lagovas @ilammy


### PR DESCRIPTION
I've become too lazy to add people for code review manually. Let's offload some of this work to GitHub by adding [a CODEOWNERS file](https://github.blog/2017-07-06-introducing-code-owners/).

Any suggestions for the list?