### PR TITLE
Cleanup header includes

### DIFF
--- a/jni/themis_keygen.c
+++ b/jni/themis_keygen.c
@@ -16,7 +16,7 @@
 
 #include <jni.h>
 #include <themis/themis_error.h>
-#include <themis/secure_message.h>
+#include <themis/secure_keygen.h>
 
 /* Should be same as in AsymmetricKey.java */
 #define KEYTYPE_EC 0

--- a/src/soter/boringssl/soter_asym_cipher.c
+++ b/src/soter/boringssl/soter_asym_cipher.c
@@ -14,14 +14,15 @@
 * limitations under the License.
 */
 
-#include <soter/soter.h>
-#include <soter/soter_rsa_key.h>
-#include "soter_engine.h"
+#include "soter/soter_asym_cipher.h"
+
 #include <openssl/evp.h>
 #include <openssl/rsa.h>
 
-#define OAEP_HASH_SIZE 20
+#include "soter/soter_rsa_key.h"
+#include "soter/boringssl/soter_engine.h"
 
+#define OAEP_HASH_SIZE 20
 
 #ifndef SOTER_RSA_KEY_LENGTH
 #define SOTER_RSA_KEY_LENGTH 2048

--- a/src/soter/boringssl/soter_asym_ka.c
+++ b/src/soter/boringssl/soter_asym_ka.c
@@ -14,10 +14,12 @@
 * limitations under the License.
 */
 
-#include <soter/soter_error.h>
-#include "soter_engine.h"
-#include <soter/soter_ec_key.h>
+#include "soter/soter_asym_ka.h"
+
 #include <openssl/ec.h>
+
+#include "soter/soter_ec_key.h"
+#include "soter/boringssl/soter_engine.h"
 
 static int soter_alg_to_curve_nid(soter_asym_ka_alg_t alg)
 {

--- a/src/soter/boringssl/soter_ec_key.c
+++ b/src/soter/boringssl/soter_ec_key.c
@@ -14,14 +14,13 @@
 * limitations under the License.
 */
 
-#include <soter/soter_error.h>
-#include <soter/soter_ec_key.h>
-
-#include <openssl/evp.h>
-#include <openssl/bn.h>
-#include <openssl/ec.h>
+#include "soter/soter_ec_key.h"
 
 #include <string.h>
+
+#include <openssl/bn.h>
+#include <openssl/ec.h>
+#include <openssl/evp.h>
 
 static bool is_curve_supported(int curve)
 {

--- a/src/soter/boringssl/soter_ecdsa_common.c
+++ b/src/soter/boringssl/soter_ecdsa_common.c
@@ -14,11 +14,13 @@
 * limitations under the License.
 */
 
-#include <soter/soter.h>
-#include <soter/soter_ec_key.h>
-#include "soter_engine.h"
-#include <openssl/evp.h>
+#include "soter/boringssl/soter_ecdsa_common.h"
+
 #include <openssl/ec.h>
+#include <openssl/evp.h>
+
+#include "soter/soter_ec_key.h"
+#include "soter/boringssl/soter_engine.h"
 
 soter_status_t soter_ec_gen_key(EVP_PKEY_CTX *pkey_ctx)
 {

--- a/src/soter/boringssl/soter_ecdsa_common.h
+++ b/src/soter/boringssl/soter_ecdsa_common.h
@@ -17,9 +17,9 @@
 #ifndef SOTER_BORINGSSL_ECDSA_COMMON_H
 #define SOTER_BORINGSSL_ECDSA_COMMON_H
 
-#include <soter/soter_ec_key.h>
-#include <soter/soter_error.h>
-#include <soter/boringssl/soter_engine.h>
+#include "soter/soter_ec_key.h"
+#include "soter/soter_error.h"
+#include "soter/boringssl/soter_engine.h"
 
 soter_status_t soter_ec_gen_key(EVP_PKEY_CTX *pkey_ctx);
 soter_status_t soter_ec_import_key(EVP_PKEY *pkey, const void* key, const size_t key_length);

--- a/src/soter/boringssl/soter_ecdsa_common.h
+++ b/src/soter/boringssl/soter_ecdsa_common.h
@@ -14,16 +14,15 @@
 * limitations under the License.
 */
 
-#ifndef SOTER_EC_COMMON_H
-#define SOTER_EC_COMMON_H
+#ifndef SOTER_BORINGSSL_ECDSA_COMMON_H
+#define SOTER_BORINGSSL_ECDSA_COMMON_H
 
-#include <soter/soter.h>
 #include <soter/soter_ec_key.h>
-#include "soter_engine.h"
+#include <soter/soter_error.h>
+#include <soter/boringssl/soter_engine.h>
 
 soter_status_t soter_ec_gen_key(EVP_PKEY_CTX *pkey_ctx);
 soter_status_t soter_ec_import_key(EVP_PKEY *pkey, const void* key, const size_t key_length);
 soter_status_t soter_ec_export_key(soter_sign_ctx_t* ctx, void* key, size_t* key_length, bool isprivate);
 
-#endif
-
+#endif /* SOTER_BORINGSSL_ECDSA_COMMON_H */

--- a/src/soter/boringssl/soter_engine.h
+++ b/src/soter/boringssl/soter_engine.h
@@ -21,7 +21,7 @@
 
 #include <openssl/evp.h>
 
-#include <soter/soter_asym_sign.h>
+#include "soter/soter_asym_sign.h"
 
 struct soter_hash_ctx_type
 {

--- a/src/soter/boringssl/soter_engine.h
+++ b/src/soter/boringssl/soter_engine.h
@@ -14,11 +14,14 @@
 * limitations under the License.
 */
 
-#ifndef SOTER_ENGINE_H
-#define SOTER_ENGINE_H
+#ifndef SOTER_BORINGSSL_ENGINE_H
+#define SOTER_BORINGSSL_ENGINE_H
 
-#include <soter/soter.h>
+#include <stdint.h>
+
 #include <openssl/evp.h>
+
+#include <soter/soter_asym_sign.h>
 
 struct soter_hash_ctx_type
 {
@@ -51,4 +54,4 @@ struct soter_sign_ctx_type{
   soter_sign_alg_t alg;
 };
 
-#endif /* SOTER_ENGINE_H */
+#endif /* SOTER_BORINGSSL_ENGINE_H */

--- a/src/soter/boringssl/soter_hash.c
+++ b/src/soter/boringssl/soter_hash.c
@@ -14,10 +14,11 @@
 * limitations under the License.
 */
 
-#include "soter/soter.h"
-#include "soter_engine.h"
+#include "soter/soter_hash.h"
+
 #include <openssl/evp.h>
 
+#include "soter/boringssl/soter_engine.h"
 
 static const EVP_MD* soter_algo_to_evp_md(soter_hash_algo_t algo)
 {

--- a/src/soter/boringssl/soter_rand.c
+++ b/src/soter/boringssl/soter_rand.c
@@ -14,7 +14,8 @@
 * limitations under the License.
 */
 
-#include "soter/soter.h"
+#include "soter/soter_rand.h"
+
 #include <openssl/rand.h>
 
 soter_status_t soter_rand(uint8_t* buffer, size_t length)

--- a/src/soter/boringssl/soter_rsa_common.c
+++ b/src/soter/boringssl/soter_rsa_common.c
@@ -14,12 +14,11 @@
 * limitations under the License.
 */
 
-#include <soter/soter.h>
-#include <soter/soter_rsa_key.h>
-#include "soter_engine.h"
+#include "soter/boringssl/soter_rsa_common.h"
+
+#include <openssl/bn.h>
 #include <openssl/evp.h>
 #include <openssl/rsa.h>
-#include <openssl/bn.h>
 
 #ifndef SOTER_RSA_KEY_LENGTH
 #define SOTER_RSA_KEY_LENGTH 2048
@@ -113,4 +112,3 @@ soter_status_t soter_rsa_export_key(soter_sign_ctx_t* ctx, void* key, size_t* ke
       return soter_engine_specific_to_rsa_pub_key((const soter_engine_specific_rsa_key_t *)pkey, (soter_container_hdr_t *)key, key_length);
     }  
 }
-

--- a/src/soter/boringssl/soter_rsa_common.h
+++ b/src/soter/boringssl/soter_rsa_common.h
@@ -14,17 +14,16 @@
 * limitations under the License.
 */
 
-#ifndef SOTER_RSA_COMMON_H
-#define SOTER_RSA_COMMON_H
+#ifndef SOTER_BORINGSSL_RSA_COMMON_H
+#define SOTER_BORINGSSL_RSA_COMMON_H
 
-#include <soter/soter.h>
+#include <soter/soter_error.h>
 #include <soter/soter_rsa_key.h>
-#include "soter_engine.h"
+#include <soter/boringssl/soter_engine.h>
 
 unsigned rsa_key_length(const int size);
 soter_status_t soter_rsa_gen_key(EVP_PKEY_CTX *pkey_ctx, const unsigned key_length);
 soter_status_t soter_rsa_import_key(EVP_PKEY *pkey, const void* key, const size_t key_length);
 soter_status_t soter_rsa_export_key(soter_sign_ctx_t* ctx, void* key, size_t* key_length, bool isprivate);
 
-#endif
-
+#endif /* SOTER_BORINGSSL_RSA_COMMON_H */

--- a/src/soter/boringssl/soter_rsa_common.h
+++ b/src/soter/boringssl/soter_rsa_common.h
@@ -17,9 +17,9 @@
 #ifndef SOTER_BORINGSSL_RSA_COMMON_H
 #define SOTER_BORINGSSL_RSA_COMMON_H
 
-#include <soter/soter_error.h>
-#include <soter/soter_rsa_key.h>
-#include <soter/boringssl/soter_engine.h>
+#include "soter/soter_error.h"
+#include "soter/soter_rsa_key.h"
+#include "soter/boringssl/soter_engine.h"
 
 unsigned rsa_key_length(const int size);
 soter_status_t soter_rsa_gen_key(EVP_PKEY_CTX *pkey_ctx, const unsigned key_length);

--- a/src/soter/boringssl/soter_rsa_key.c
+++ b/src/soter/boringssl/soter_rsa_key.c
@@ -14,13 +14,13 @@
 * limitations under the License.
 */
 
-#include <soter/soter_error.h>
-#include <soter/soter_rsa_key.h>
+#include "soter/soter_rsa_key.h"
+
+#include <string.h>
 
 #include <openssl/bn.h>
 #include <openssl/evp.h>
 #include <openssl/rsa.h>
-#include <string.h>
 
 static size_t rsa_pub_key_size(int mod_size)
 {

--- a/src/soter/boringssl/soter_rsa_key_pair_gen.c
+++ b/src/soter/boringssl/soter_rsa_key_pair_gen.c
@@ -14,16 +14,15 @@
 * limitations under the License.
 */
 
-#include <soter/soter_error.h>
-#include "soter_engine.h"
-#include "soter_rsa_common.h"
-#include <soter/soter_rsa_key_pair_gen.h>
+#include "soter/soter_rsa_key_pair_gen.h"
+
+#include <string.h>
 
 #include <openssl/evp.h>
 #include <openssl/rsa.h>
 
-#include <string.h>
-
+#include "soter/boringssl/soter_engine.h"
+#include "soter/boringssl/soter_rsa_common.h"
 
 soter_rsa_key_pair_gen_t* soter_rsa_key_pair_gen_create(const unsigned key_length){
     SOTER_CHECK_PARAM_(rsa_key_length(key_length)>0);

--- a/src/soter/boringssl/soter_sign_ecdsa.c
+++ b/src/soter/boringssl/soter_sign_ecdsa.c
@@ -14,15 +14,15 @@
 * limitations under the License.
 */
 
-#include <soter/soter_sign_ecdsa.h>
-#include <soter/soter.h>
-#include <soter/soter_ec_key.h>
-#include "soter_engine.h"
-#include "soter_ecdsa_common.h"
-#include <openssl/evp.h>
+#include "soter/soter_sign_ecdsa.h"
+
 #include <openssl/ecdsa.h>
 #include <openssl/err.h>
+#include <openssl/evp.h>
 
+#include "soter/soter_ec_key.h"
+#include "soter/boringssl/soter_ecdsa_common.h"
+#include "soter/boringssl/soter_engine.h"
 
 soter_status_t soter_sign_init_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx, const void* private_key, const size_t private_key_length, const void* public_key, const size_t public_key_length)
 {

--- a/src/soter/boringssl/soter_sign_rsa.c
+++ b/src/soter/boringssl/soter_sign_rsa.c
@@ -14,14 +14,14 @@
 * limitations under the License.
 */
 
-#include <soter/soter_sign_rsa.h>
-#include <soter/soter.h>
-#include <soter/soter_rsa_key.h>
-#include "soter_engine.h"
-#include "soter_rsa_common.h"
+#include "soter/soter_sign_rsa.h"
+
 #include <openssl/evp.h>
 #include <openssl/rsa.h>
 
+#include "soter/soter_rsa_key.h"
+#include "soter/boringssl/soter_engine.h"
+#include "soter/boringssl/soter_rsa_common.h"
 
 soter_status_t soter_sign_init_rsa_pss_pkcs8(soter_sign_ctx_t* ctx, const void* private_key, const size_t private_key_length, const void* public_key, const size_t public_key_length)
 {

--- a/src/soter/boringssl/soter_sym.c
+++ b/src/soter/boringssl/soter_sym.c
@@ -14,11 +14,14 @@
 * limitations under the License.
 */
 
+#include "soter/soter_sym.h"
+
 #include <string.h>
-#include "soter/soter.h"
-#include "soter_engine.h"
-#include <openssl/err.h>
+
 #include <openssl/cipher.h>
+#include <openssl/err.h>
+
+#include "soter/boringssl/soter_engine.h"
 
 #define SOTER_SYM_MAX_KEY_LENGTH 128
 #define SOTER_SYM_MAX_IV_LENGTH 16

--- a/src/soter/boringssl/soter_verify_ecdsa.c
+++ b/src/soter/boringssl/soter_verify_ecdsa.c
@@ -14,13 +14,14 @@
 * limitations under the License.
 */
 
-#include <soter/soter_sign_ecdsa.h>
-#include <soter/soter.h>
-#include <soter/soter_ec_key.h>
-#include "soter_engine.h"
-#include "soter_ecdsa_common.h"
-#include <openssl/evp.h>
+#include "soter/soter_sign_ecdsa.h"
+
 #include <openssl/ecdsa.h>
+#include <openssl/evp.h>
+
+#include "soter/soter_ec_key.h"
+#include "soter/boringssl/soter_ecdsa_common.h"
+#include "soter/boringssl/soter_engine.h"
 
 soter_status_t soter_verify_init_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx, const void* private_key, const size_t private_key_length, const void* public_key, const size_t public_key_length)
 {

--- a/src/soter/boringssl/soter_verify_rsa.c
+++ b/src/soter/boringssl/soter_verify_rsa.c
@@ -14,13 +14,14 @@
 * limitations under the License.
 */
 
-#include <soter/soter_sign_rsa.h>
-#include <soter/soter.h>
-#include <soter/soter_rsa_key.h>
-#include "soter_engine.h"
-#include "soter_rsa_common.h"
+#include "soter/soter_sign_rsa.h"
+
 #include <openssl/evp.h>
 #include <openssl/rsa.h>
+
+#include "soter/soter_rsa_key.h"
+#include "soter/boringssl/soter_engine.h"
+#include "soter/boringssl/soter_rsa_common.h"
 
 soter_status_t soter_verify_init_rsa_pss_pkcs8(soter_sign_ctx_t* ctx, const void* private_key, const size_t private_key_length, const void* public_key, const size_t public_key_length)
 {

--- a/src/soter/openssl/soter_asym_cipher.c
+++ b/src/soter/openssl/soter_asym_cipher.c
@@ -14,11 +14,13 @@
 * limitations under the License.
 */
 
-#include <soter/soter.h>
-#include <soter/soter_rsa_key.h>
-#include "soter_engine.h"
+#include "soter/soter_asym_cipher.h"
+
 #include <openssl/evp.h>
 #include <openssl/rsa.h>
+
+#include "soter/soter_rsa_key.h"
+#include "soter/openssl/soter_engine.h"
 
 /* We use only SHA1 for now */
 #define OAEP_HASH_SIZE 20

--- a/src/soter/openssl/soter_asym_ka.c
+++ b/src/soter/openssl/soter_asym_ka.c
@@ -14,10 +14,12 @@
 * limitations under the License.
 */
 
-#include <soter/soter_error.h>
-#include "soter_engine.h"
-#include <soter/soter_ec_key.h>
+#include "soter/soter_asym_ka.h"
+
 #include <openssl/ec.h>
+
+#include "soter/soter_ec_key.h"
+#include "soter/openssl/soter_engine.h"
 
 static int soter_alg_to_curve_nid(soter_asym_ka_alg_t alg)
 {

--- a/src/soter/openssl/soter_ec_key.c
+++ b/src/soter/openssl/soter_ec_key.c
@@ -14,13 +14,12 @@
 * limitations under the License.
 */
 
-#include <soter/soter_error.h>
-#include <soter/soter_ec_key.h>
-
-#include <openssl/evp.h>
-#include <openssl/ec.h>
+#include "soter/soter_ec_key.h"
 
 #include <string.h>
+
+#include <openssl/ec.h>
+#include <openssl/evp.h>
 
 static bool is_curve_supported(int curve)
 {

--- a/src/soter/openssl/soter_ecdsa_common.c
+++ b/src/soter/openssl/soter_ecdsa_common.c
@@ -14,11 +14,13 @@
 * limitations under the License.
 */
 
-#include <soter/soter.h>
-#include <soter/soter_ec_key.h>
-#include "soter_engine.h"
-#include <openssl/evp.h>
+#include "soter/openssl/soter_ecdsa_common.h"
+
 #include <openssl/ec.h>
+#include <openssl/evp.h>
+
+#include "soter/soter_ec_key.h"
+#include "soter/openssl/soter_engine.h"
 
 soter_status_t soter_ec_gen_key(EVP_PKEY_CTX *pkey_ctx)
 {

--- a/src/soter/openssl/soter_ecdsa_common.h
+++ b/src/soter/openssl/soter_ecdsa_common.h
@@ -14,16 +14,15 @@
 * limitations under the License.
 */
 
-#ifndef SOTER_EC_COMMON_H
-#define SOTER_EC_COMMON_H
+#ifndef SOTER_OPENSSL_ECDSA_COMMON_H
+#define SOTER_OPENSSL_ECDSA_COMMON_H
 
-#include <soter/soter.h>
 #include <soter/soter_ec_key.h>
-#include "soter_engine.h"
+#include <soter/soter_error.h>
+#include <soter/openssl/soter_engine.h>
 
 soter_status_t soter_ec_gen_key(EVP_PKEY_CTX *pkey_ctx);
 soter_status_t soter_ec_import_key(EVP_PKEY *pkey, const void* key, const size_t key_length);
 soter_status_t soter_ec_export_key(soter_sign_ctx_t* ctx, void* key, size_t* key_length, bool isprivate);
 
-#endif
-
+#endif /* SOTER_OPENSSL_ECDSA_COMMON_H */

--- a/src/soter/openssl/soter_ecdsa_common.h
+++ b/src/soter/openssl/soter_ecdsa_common.h
@@ -17,9 +17,9 @@
 #ifndef SOTER_OPENSSL_ECDSA_COMMON_H
 #define SOTER_OPENSSL_ECDSA_COMMON_H
 
-#include <soter/soter_ec_key.h>
-#include <soter/soter_error.h>
-#include <soter/openssl/soter_engine.h>
+#include "soter/soter_ec_key.h"
+#include "soter/soter_error.h"
+#include "soter/openssl/soter_engine.h"
 
 soter_status_t soter_ec_gen_key(EVP_PKEY_CTX *pkey_ctx);
 soter_status_t soter_ec_import_key(EVP_PKEY *pkey, const void* key, const size_t key_length);

--- a/src/soter/openssl/soter_engine.h
+++ b/src/soter/openssl/soter_engine.h
@@ -21,7 +21,7 @@
 
 #include <openssl/evp.h>
 
-#include <soter/soter_asym_sign.h>
+#include "soter/soter_asym_sign.h"
 
 struct soter_hash_ctx_type
 {

--- a/src/soter/openssl/soter_engine.h
+++ b/src/soter/openssl/soter_engine.h
@@ -14,11 +14,14 @@
 * limitations under the License.
 */
 
-#ifndef SOTER_ENGINE_H
-#define SOTER_ENGINE_H
+#ifndef SOTER_OPENSSL_ENGINE_H
+#define SOTER_OPENSSL_ENGINE_H
 
-#include <soter/soter.h>
+#include <stdint.h>
+
 #include <openssl/evp.h>
+
+#include <soter/soter_asym_sign.h>
 
 struct soter_hash_ctx_type
 {
@@ -51,4 +54,4 @@ struct soter_sign_ctx_type{
   soter_sign_alg_t alg;
 };
 
-#endif /* SOTER_ENGINE_H */
+#endif /* SOTER_OPENSSL_ENGINE_H */

--- a/src/soter/openssl/soter_hash.c
+++ b/src/soter/openssl/soter_hash.c
@@ -14,10 +14,11 @@
 * limitations under the License.
 */
 
-#include "soter/soter.h"
-#include "soter_engine.h"
+#include "soter/soter_hash.h"
+
 #include <openssl/evp.h>
 
+#include "soter/openssl/soter_engine.h"
 
 static const EVP_MD* soter_algo_to_evp_md(soter_hash_algo_t algo)
 {

--- a/src/soter/openssl/soter_rand.c
+++ b/src/soter/openssl/soter_rand.c
@@ -14,7 +14,8 @@
 * limitations under the License.
 */
 
-#include "soter/soter.h"
+#include "soter/soter_rand.h"
+
 #include <openssl/rand.h>
 
 soter_status_t soter_rand(uint8_t* buffer, size_t length)

--- a/src/soter/openssl/soter_rsa_common.c
+++ b/src/soter/openssl/soter_rsa_common.c
@@ -14,9 +14,8 @@
 * limitations under the License.
 */
 
-#include <soter/soter.h>
-#include <soter/soter_rsa_key.h>
-#include "soter_engine.h"
+#include "soter/openssl/soter_rsa_common.h"
+
 #include <openssl/evp.h>
 #include <openssl/rsa.h>
 

--- a/src/soter/openssl/soter_rsa_common.h
+++ b/src/soter/openssl/soter_rsa_common.h
@@ -14,16 +14,15 @@
 * limitations under the License.
 */
 
-#ifndef SOTER_RSA_COMMON_H
-#define SOTER_RSA_COMMON_H
+#ifndef SOTER_OPENSSL_RSA_COMMON_H
+#define SOTER_OPENSSL_RSA_COMMON_H
 
-#include <soter/soter.h>
+#include <soter/soter_error.h>
 #include <soter/soter_rsa_key.h>
-#include "soter_engine.h"
+#include <soter/openssl/soter_engine.h>
 
 soter_status_t soter_rsa_gen_key(EVP_PKEY_CTX *pkey_ctx);
 soter_status_t soter_rsa_import_key(EVP_PKEY *pkey, const void* key, const size_t key_length);
 soter_status_t soter_rsa_export_key(soter_sign_ctx_t* ctx, void* key, size_t* key_length, bool isprivate);
 
-#endif
-
+#endif /* SOTER_OPENSSL_RSA_COMMON_H */

--- a/src/soter/openssl/soter_rsa_common.h
+++ b/src/soter/openssl/soter_rsa_common.h
@@ -17,9 +17,9 @@
 #ifndef SOTER_OPENSSL_RSA_COMMON_H
 #define SOTER_OPENSSL_RSA_COMMON_H
 
-#include <soter/soter_error.h>
-#include <soter/soter_rsa_key.h>
-#include <soter/openssl/soter_engine.h>
+#include "soter/soter_error.h"
+#include "soter/soter_rsa_key.h"
+#include "soter/openssl/soter_engine.h"
 
 soter_status_t soter_rsa_gen_key(EVP_PKEY_CTX *pkey_ctx);
 soter_status_t soter_rsa_import_key(EVP_PKEY *pkey, const void* key, const size_t key_length);

--- a/src/soter/openssl/soter_rsa_key.c
+++ b/src/soter/openssl/soter_rsa_key.c
@@ -14,13 +14,12 @@
 * limitations under the License.
 */
 
-#include <soter/soter_error.h>
-#include <soter/soter_rsa_key.h>
+#include "soter/soter_rsa_key.h"
+
+#include <string.h>
 
 #include <openssl/evp.h>
 #include <openssl/rsa.h>
-
-#include <string.h>
 
 static size_t rsa_pub_key_size(int mod_size)
 {

--- a/src/soter/openssl/soter_rsa_key_pair_gen.c
+++ b/src/soter/openssl/soter_rsa_key_pair_gen.c
@@ -14,14 +14,14 @@
 * limitations under the License.
 */
 
-#include <soter/soter_error.h>
-#include "soter_engine.h"
-#include <soter/soter_rsa_key_pair_gen.h>
+#include "soter/soter_rsa_key_pair_gen.h"
+
+#include <string.h>
 
 #include <openssl/evp.h>
 #include <openssl/rsa.h>
 
-#include <string.h>
+#include "soter/openssl/soter_engine.h"
 
 static unsigned rsa_key_length(const int size){
     switch (size){

--- a/src/soter/openssl/soter_sign_ecdsa.c
+++ b/src/soter/openssl/soter_sign_ecdsa.c
@@ -14,15 +14,15 @@
 * limitations under the License.
 */
 
-#include <soter/soter_sign_ecdsa.h>
-#include <soter/soter.h>
-#include <soter/soter_ec_key.h>
-#include "soter_engine.h"
-#include "soter_ecdsa_common.h"
-#include <openssl/evp.h>
+#include "soter/soter_sign_ecdsa.h"
+
 #include <openssl/ecdsa.h>
 #include <openssl/err.h>
+#include <openssl/evp.h>
 
+#include "soter/soter_ec_key.h"
+#include "soter/openssl/soter_ecdsa_common.h"
+#include "soter/openssl/soter_engine.h"
 
 soter_status_t soter_sign_init_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx, const void* private_key, const size_t private_key_length, const void* public_key, const size_t public_key_length)
 {

--- a/src/soter/openssl/soter_sign_rsa.c
+++ b/src/soter/openssl/soter_sign_rsa.c
@@ -14,14 +14,14 @@
 * limitations under the License.
 */
 
-#include <soter/soter_sign_rsa.h>
-#include <soter/soter.h>
-#include <soter/soter_rsa_key.h>
-#include "soter_engine.h"
-#include "soter_rsa_common.h"
+#include "soter/soter_sign_rsa.h"
+
 #include <openssl/evp.h>
 #include <openssl/rsa.h>
 
+#include "soter/soter_rsa_key.h"
+#include "soter/openssl/soter_engine.h"
+#include "soter/openssl/soter_rsa_common.h"
 
 soter_status_t soter_sign_init_rsa_pss_pkcs8(soter_sign_ctx_t* ctx, const void* private_key, const size_t private_key_length, const void* public_key, const size_t public_key_length)
 {

--- a/src/soter/openssl/soter_sym.c
+++ b/src/soter/openssl/soter_sym.c
@@ -14,11 +14,14 @@
 * limitations under the License.
 */
 
+#include "soter/soter_sym.h"
+
 #include <string.h>
-#include "soter/soter.h"
-#include "soter_engine.h"
+
 #include <openssl/err.h>
 #include <openssl/evp.h>
+
+#include "soter/openssl/soter_engine.h"
 
 #define SOTER_SYM_MAX_KEY_LENGTH 128
 #define SOTER_SYM_MAX_IV_LENGTH 16

--- a/src/soter/openssl/soter_verify_ecdsa.c
+++ b/src/soter/openssl/soter_verify_ecdsa.c
@@ -14,13 +14,14 @@
 * limitations under the License.
 */
 
-#include <soter/soter_sign_ecdsa.h>
-#include <soter/soter.h>
-#include <soter/soter_ec_key.h>
-#include "soter_engine.h"
-#include "soter_ecdsa_common.h"
-#include <openssl/evp.h>
+#include "soter/soter_sign_ecdsa.h"
+
 #include <openssl/ecdsa.h>
+#include <openssl/evp.h>
+
+#include "soter/soter_ec_key.h"
+#include "soter/openssl/soter_ecdsa_common.h"
+#include "soter/openssl/soter_engine.h"
 
 soter_status_t soter_verify_init_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx, const void* private_key, const size_t private_key_length, const void* public_key, const size_t public_key_length)
 {

--- a/src/soter/openssl/soter_verify_rsa.c
+++ b/src/soter/openssl/soter_verify_rsa.c
@@ -14,13 +14,14 @@
 * limitations under the License.
 */
 
-#include <soter/soter_sign_rsa.h>
-#include <soter/soter.h>
-#include <soter/soter_rsa_key.h>
-#include "soter_engine.h"
-#include "soter_rsa_common.h"
+#include "soter/soter_sign_rsa.h"
+
 #include <openssl/evp.h>
 #include <openssl/rsa.h>
+
+#include "soter/soter_rsa_key.h"
+#include "soter/openssl/soter_engine.h"
+#include "soter/openssl/soter_rsa_common.h"
 
 soter_status_t soter_verify_init_rsa_pss_pkcs8(soter_sign_ctx_t* ctx, const void* private_key, const size_t private_key_length, const void* public_key, const size_t public_key_length)
 {

--- a/src/soter/soter.h
+++ b/src/soter/soter.h
@@ -23,27 +23,26 @@
 #ifndef SOTER_H
 #define SOTER_H
 
-
 /** 
  * @defgroup SOTER Soter 
  * @brief Soter is a cross-platform multipurpose cryptographic library. It provides a set of highly secure cryptographic primitives through a well-defined, consistent and simple interface.
  * @{
  */
 
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdlib.h>
 
-#include <soter/soter_error.h>
-#include <soter/soter_rand.h>
-#include <soter/soter_hash.h>
-#include <soter/soter_hmac.h>
-#include <soter/soter_sym.h>
-#include <soter/soter_rsa_key_pair_gen.h>
 #include <soter/soter_asym_cipher.h>
 #include <soter/soter_asym_ka.h>
 #include <soter/soter_asym_sign.h>
+#include <soter/soter_error.h>
+#include <soter/soter_hash.h>
+#include <soter/soter_hmac.h>
 #include <soter/soter_kdf.h>
+#include <soter/soter_rand.h>
+#include <soter/soter_rsa_key_pair_gen.h>
+#include <soter/soter_sym.h>
 
 /**@}*/
 #endif /* SOTER_H */

--- a/src/soter/soter_asym_cipher.h
+++ b/src/soter/soter_asym_cipher.h
@@ -21,7 +21,7 @@
 #ifndef SOTER_ASYM_CIPHER_H
 #define SOTER_ASYM_CIPHER_H
 
-#include <soter/soter.h>
+#include <soter/soter_error.h>
 
 /** 
  * @addtogroup SOTER

--- a/src/soter/soter_asym_ka.h
+++ b/src/soter/soter_asym_ka.h
@@ -21,7 +21,7 @@
 #ifndef SOTER_ASYM_KA_H
 #define SOTER_ASYM_KA_H
 
-#include <soter/soter.h>
+#include <soter/soter_error.h>
 
 /** @addtogroup SOTER
  * @{

--- a/src/soter/soter_asym_sign.h
+++ b/src/soter/soter_asym_sign.h
@@ -21,7 +21,7 @@
 #ifndef SOTER_ASYM_SIGN_H
 #define SOTER_ASYM_SIGN_H
 
-#include <soter/soter.h>
+#include <soter/soter_error.h>
 
 /** @addtogroup SOTER
  * @{

--- a/src/soter/soter_container.c
+++ b/src/soter/soter_container.c
@@ -14,11 +14,12 @@
 * limitations under the License.
 */
 
-#include <soter/soter_container.h>
-#include <soter/soter.h>
-#include <soter/soter_error.h>
-#include <soter/soter_crc32.h>
+#include "soter/soter_container.h"
+
 #include <arpa/inet.h>
+
+#include "soter/soter_crc32.h"
+
 soter_status_t soter_update_container_checksum(soter_container_hdr_t *hdr)
 {
 	hdr->crc = 0;

--- a/src/soter/soter_container.h
+++ b/src/soter/soter_container.h
@@ -17,7 +17,6 @@
 #ifndef SOTER_CONTAINER_H
 #define SOTER_CONTAINER_H
 
-#include <stdint.h>
 #include <soter/soter_error.h>
 
 #define SOTER_CONTAINER_TAG_LENGTH 4

--- a/src/soter/soter_crc32.c
+++ b/src/soter/soter_crc32.c
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-#include "soter_crc32.h"
+#include "soter/soter_crc32.h"
 
 /* Taken from draft-ietf-tsvwg-sctpcsum-03.txt */
 

--- a/src/soter/soter_crc32.h
+++ b/src/soter/soter_crc32.h
@@ -17,7 +17,8 @@
 #ifndef SOTER_CRC32_H
 #define SOTER_CRC32_H
 
-#include <soter/soter.h>
+#include <stddef.h>
+#include <stdint.h>
 
 typedef uint32_t soter_crc32_t;
 

--- a/src/soter/soter_ec_key.h
+++ b/src/soter/soter_ec_key.h
@@ -17,10 +17,10 @@
 #ifndef SOTER_EC_KEY_H
 #define SOTER_EC_KEY_H
 
-#include <soter/soter_container.h>
-#include <soter/soter.h>
-
 #include <arpa/inet.h>
+
+#include <soter/soter_container.h>
+#include <soter/soter_error.h>
 
 /** private key header part */
 #define EC_PRIV_KEY_PREF "REC"

--- a/src/soter/soter_error.h
+++ b/src/soter/soter_error.h
@@ -22,9 +22,11 @@
 #ifndef SOTER_ERROR_H
 #define SOTER_ERROR_H
 
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdint.h>
 
 /** @brief return type */
 typedef int32_t soter_status_t;

--- a/src/soter/soter_hash.h
+++ b/src/soter/soter_hash.h
@@ -22,7 +22,7 @@
 #ifndef SOTER_HASH_H
 #define SOTER_HASH_H
 
-#include <soter/soter.h>
+#include <soter/soter_error.h>
 
 /**
  * @addtogroup SOTER

--- a/src/soter/soter_hmac.c
+++ b/src/soter/soter_hmac.c
@@ -14,10 +14,11 @@
 * limitations under the License.
 */
 
-#include <soter/soter_t.h>
-#include <soter/soter_error.h>
+#include "soter/soter_hmac.h"
 
 #include <string.h>
+
+#include "soter/soter_t.h"
 
 static size_t hash_block_size(soter_hash_algo_t algo)
 {

--- a/src/soter/soter_hmac.h
+++ b/src/soter/soter_hmac.h
@@ -21,6 +21,7 @@
 #ifndef SOTER_HMAC_H
 #define SOTER_HMAC_H
 
+#include <soter/soter_error.h>
 #include <soter/soter_hash.h>
 
 /**

--- a/src/soter/soter_kdf.c
+++ b/src/soter/soter_kdf.c
@@ -14,11 +14,11 @@
 * limitations under the License.
 */
 
-#include <soter/soter_kdf.h>
-#include <soter/soter_t.h>
-#include <soter/soter_error.h>
+#include "soter/soter_kdf.h"
 
 #include <string.h>
+
+#include "soter/soter_t.h"
 
 #define MAX_HMAC_SIZE 64 /* For HMAC-SHA512 */
 #define MIN_VAL(_X_, _Y_) ((_X_ < _Y_) ? (_X_) : (_Y_))

--- a/src/soter/soter_kdf.h
+++ b/src/soter/soter_kdf.h
@@ -21,7 +21,7 @@
 #ifndef SOTER_KDF_H
 #define SOTER_KDF_H
 
-#include <soter/soter.h>
+#include <soter/soter_error.h>
 
 /** @addtogroup SOTER
  * @{

--- a/src/soter/soter_rand.h
+++ b/src/soter/soter_rand.h
@@ -22,7 +22,7 @@
 #ifndef SOTER_RAND_H
 #define SOTER_RAND_H
 
-#include <soter/soter.h>
+#include <soter/soter_error.h>
 
 /**
  * @addtogroup SOTER

--- a/src/soter/soter_rsa_key.h
+++ b/src/soter/soter_rsa_key.h
@@ -17,10 +17,10 @@
 #ifndef SOTER_RSA_KEY_H
 #define SOTER_RSA_KEY_H
 
-#include <soter/soter_container.h>
-#include <soter/soter.h>
-
 #include <arpa/inet.h>
+
+#include <soter/soter_container.h>
+#include <soter/soter_error.h>
 
 #define RSA_PRIV_KEY_PREF "RRA"
 #define RSA_PUB_KEY_PREF "URA"
@@ -85,4 +85,5 @@ soter_status_t soter_rsa_pub_key_to_engine_specific(const soter_container_hdr_t 
 soter_status_t soter_rsa_priv_key_to_engine_specific(const soter_container_hdr_t *key, size_t key_length, soter_engine_specific_rsa_key_t **engine_key);
 soter_status_t soter_engine_specific_to_rsa_priv_key(const soter_engine_specific_rsa_key_t *engine_key, soter_container_hdr_t *key, size_t* key_length);
 soter_status_t soter_engine_specific_to_rsa_pub_key(const soter_engine_specific_rsa_key_t *engine_key, soter_container_hdr_t *key, size_t* key_length);
+
 #endif /* SOTER_RSA_KEY_H */

--- a/src/soter/soter_rsa_key_pair_gen.h
+++ b/src/soter/soter_rsa_key_pair_gen.h
@@ -17,6 +17,7 @@
 #ifndef SOTER_RSA_KEY_PAIR_GEN_H
 #define SOTER_RSA_KEY_PAIR_GEN_H
 
+#include <soter/soter_error.h>
 #include <soter/soter_rsa_key.h>
 
 typedef struct soter_rsa_key_pair_gen_type soter_rsa_key_pair_gen_t;
@@ -25,4 +26,5 @@ soter_rsa_key_pair_gen_t* soter_rsa_key_pair_gen_create(const unsigned key_lengt
 soter_status_t soter_rsa_key_pair_gen_init(soter_rsa_key_pair_gen_t* ctx, const unsigned key_length);
 soter_status_t soter_rsa_key_pair_gen_destroy(soter_rsa_key_pair_gen_t* ctx);
 soter_status_t soter_rsa_key_pair_gen_export_key(soter_rsa_key_pair_gen_t* ctx, void* key, size_t* key_length, bool isprivate);
+
 #endif /* SOTER_RSA_KEY_PAIR_GEN_H */

--- a/src/soter/soter_sign.c
+++ b/src/soter/soter_sign.c
@@ -14,8 +14,8 @@
 * limitations under the License.
 */
 
-#include "soter_sign_ecdsa.h"
-#include "soter_sign_rsa.h"
+#include "soter/soter_sign_ecdsa.h"
+#include "soter/soter_sign_rsa.h"
 
 #ifdef CRYPTO_ENGINE_PATH
 #define CEP <soter/CRYPTO_ENGINE_PATH/soter_engine.h>

--- a/src/soter/soter_sign.c
+++ b/src/soter/soter_sign.c
@@ -14,7 +14,8 @@
 * limitations under the License.
 */
 
-#include <soter/soter.h>
+#include "soter_sign_ecdsa.h"
+#include "soter_sign_rsa.h"
 
 #ifdef CRYPTO_ENGINE_PATH
 #define CEP <soter/CRYPTO_ENGINE_PATH/soter_engine.h>
@@ -23,9 +24,6 @@
 #else
 #include <soter/openssl/soter_engine.h>
 #endif
-
-#include <soter/soter_sign_rsa.h>
-#include <soter/soter_sign_ecdsa.h>
 
 #define SOTER_SIGN_ALGS \
     SOTER_SIGN_ALG(rsa,pss,pkcs8)	\

--- a/src/soter/soter_sign_ecdsa.h
+++ b/src/soter/soter_sign_ecdsa.h
@@ -17,7 +17,8 @@
 #ifndef SOTER_SIGN_ECDSA_H
 #define SOTER_SIGN_ECDSA_H
 
-#include "soter/soter.h"
+#include <soter/soter_asym_sign.h>
+#include <soter/soter_error.h>
 
 soter_status_t soter_sign_init_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx, const void* private_key, const size_t private_key_length, const void* public_key, const size_t public_key_length);
 soter_status_t soter_sign_update_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx, const void* data, const size_t data_length);

--- a/src/soter/soter_sign_rsa.h
+++ b/src/soter/soter_sign_rsa.h
@@ -17,7 +17,8 @@
 #ifndef SOTER_SIGN_RSA_H
 #define SOTER_SIGN_RSA_H
 
-#include "soter/soter.h"
+#include <soter/soter_asym_sign.h>
+#include <soter/soter_error.h>
 
 soter_status_t soter_sign_init_rsa_pss_pkcs8(soter_sign_ctx_t* ctx, const void* private_key, const size_t private_key_length, const void* public_key, const size_t public_key_length);
 soter_status_t soter_sign_update_rsa_pss_pkcs8(soter_sign_ctx_t* ctx, const void* data, const size_t data_length);

--- a/src/soter/soter_sym.h
+++ b/src/soter/soter_sym.h
@@ -22,7 +22,7 @@
 #ifndef SOTER_SYM_H
 #define SOTER_SYM_H
 
-#include <soter/soter.h>
+#include <soter/soter_error.h>
 
 /**
  * @addtogroup SOTER
@@ -336,4 +336,3 @@ soter_status_t soter_sym_aead_decrypt_destroy(soter_sym_ctx_t *ctx);
 /** @}@} */
 
 #endif /* SOTER_SYM_H */
-

--- a/src/soter/soter_t.h
+++ b/src/soter/soter_t.h
@@ -16,7 +16,13 @@
 
 #ifndef SOTER_T_H
 #define SOTER_T_H
-#include <soter/soter.h>
+
+#include <soter/soter_asym_cipher.h>
+#include <soter/soter_asym_ka.h>
+#include <soter/soter_asym_sign.h>
+#include <soter/soter_error.h>
+#include <soter/soter_hash.h>
+#include <soter/soter_hmac.h>
 
 #ifdef CRYPTO_ENGINE_PATH
 #define CEP <soter/CRYPTO_ENGINE_PATH/soter_engine.h>

--- a/src/themis/message.c
+++ b/src/themis/message.c
@@ -14,9 +14,9 @@
 * limitations under the License.
 */
 
+#include "themis/message.h"
+
 #include <string.h>
-#include <themis/themis_error.h>
-#include <themis/message.h>
 
 themis_message_t* themis_message_init(const uint8_t* message, const size_t message_length){
   themis_message_t* msg=malloc(sizeof(themis_message_t));
@@ -78,14 +78,3 @@ themis_status_t themis_message_destroy(themis_message_t* ctx){
   ctx=NULL;
   return THEMIS_SUCCESS;
 }
-
-
-
-
-
-
-
-
-
-
-

--- a/src/themis/message.h
+++ b/src/themis/message.h
@@ -14,10 +14,10 @@
 * limitations under the License.
 */
 
-#ifndef THEMIS_MESSAGE_H_
-#define THEMIS_MESSAGE_H_
+#ifndef THEMIS_MESSAGE_H
+#define THEMIS_MESSAGE_H
 
-#include <themis/themis.h>
+#include <themis/themis_error.h>
 
 struct themis_message_type{
   size_t length;
@@ -35,4 +35,4 @@ size_t themis_message_get_length(themis_message_t* ctx);
 
 themis_status_t themis_message_destroy(themis_message_t* ctx);
 
-#endif /* THEMIS_MESSAGE_H_ */
+#endif /* THEMIS_MESSAGE_H */

--- a/src/themis/portable_endian.h
+++ b/src/themis/portable_endian.h
@@ -14,8 +14,8 @@
 * limitations under the License.
 */
 
-#ifndef PORTABLE_ENDIAN_H__
-#define PORTABLE_ENDIAN_H__
+#ifndef THEMIS_PORTABLE_ENDIAN_H
+#define THEMIS_PORTABLE_ENDIAN_H
  
 #if (defined(_WIN16) || defined(_WIN32) || defined(_WIN64)) && !defined(__WINDOWS__)
  
@@ -125,4 +125,4 @@
  
 #endif
  
-#endif 
+#endif /* THEMIS_PORTABLE_ENDIAN_H */

--- a/src/themis/secure_cell.c
+++ b/src/themis/secure_cell.c
@@ -14,9 +14,9 @@
 * limitations under the License.
 */
 
-#include <themis/secure_cell.h>
-#include <themis/themis_error.h>
-#include "sym_enc_message.h"
+#include "themis/secure_cell.h"
+
+#include "themis/sym_enc_message.h"
 
 themis_status_t themis_secure_cell_encrypt_seal(const uint8_t* master_key,
 						const size_t master_key_length,

--- a/src/themis/secure_cell.h
+++ b/src/themis/secure_cell.h
@@ -18,10 +18,11 @@
  * @file secure_cell.h
  * @brief Secure cell is a high-level cryptographic service which can protect arbitrary data being stored in various types of storages (like databases, document archives, cloud storage etc)
  */
-#include <themis/themis.h>
 
-#ifndef _SECURE_CELL_H_
-#define _SECURE_CELL_H_
+#ifndef THEMIS_SECURE_CELL_H
+#define THEMIS_SECURE_CELL_H
+
+#include <themis/themis_error.h>
 
 #ifdef __cplusplus
 extern "C"{
@@ -202,4 +203,5 @@ themis_status_t themis_secure_cell_decrypt_context_imprint(const uint8_t* master
 #ifdef __cplusplus
 }
 #endif
-#endif /* _SECURE_CELL_H_ */
+
+#endif /* THEMIS_SECURE_CELL_H */

--- a/src/themis/secure_cell_alg.h
+++ b/src/themis/secure_cell_alg.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef _SECURE_CELL_ALG_H_
-#define _SECURE_CELL_ALG_H_
+#ifndef THEMIS_SECURE_CELL_ALG_H
+#define THEMIS_SECURE_CELL_ALG_H
 
 #ifdef THEMIS_AUTH_SYM_ALG_AES_256_GCM
 #define THEMIS_AUTH_SYM_KEY_LENGTH SOTER_SYM_256_KEY_LENGTH
@@ -72,4 +72,4 @@
 #define THEMIS_SYM_IV_LENGTH 16
 #endif
 
-#endif /* _SECURE_CELL_ALG_H_ */
+#endif /* THEMIS_SECURE_CELL_ALG_H */

--- a/src/themis/secure_comparator.c
+++ b/src/themis/secure_comparator.c
@@ -48,8 +48,11 @@
  * 
  */
 
-#include "secure_comparator_t.h"
+#include "themis/secure_comparator.h"
+
 #include <string.h>
+
+#include "themis/secure_comparator_t.h"
 
 static themis_status_t secure_comparator_alice_step1(secure_comparator_t *comp_ctx, void *output, size_t *output_length);
 static themis_status_t secure_comparator_bob_step2(secure_comparator_t *comp_ctx, const void *input, size_t input_length, void *output, size_t *output_length);

--- a/src/themis/secure_comparator.h
+++ b/src/themis/secure_comparator.h
@@ -17,7 +17,7 @@
 #ifndef THEMIS_SECURE_COMPARATOR_H
 #define THEMIS_SECURE_COMPARATOR_H
 
-#include <themis/themis.h>
+#include <themis/themis_error.h>
 
 #define THEMIS_SCOMPARE_MATCH 		21
 #define THEMIS_SCOMPARE_NO_MATCH 	22
@@ -42,4 +42,5 @@ themis_status_t secure_comparator_get_result(const secure_comparator_t *comp_ctx
 #ifdef __cplusplus
 }
 #endif
+
 #endif /* THEMIS_SECURE_COMPARATOR_H */

--- a/src/themis/secure_comparator_t.h
+++ b/src/themis/secure_comparator_t.h
@@ -19,9 +19,9 @@
 
 #include "themis/secure_comparator.h"
 
-#include <soter/ed25519/ge_utils.h>
-#include <soter/ed25519/sc.h>
-#include <soter/soter_t.h>
+#include "soter/ed25519/ge_utils.h"
+#include "soter/ed25519/sc.h"
+#include "soter/soter_t.h"
 
 typedef themis_status_t (*secure_compare_handler)(secure_comparator_t *comp_ctx, const void *input, size_t input_length, void *output, size_t *output_length);
 

--- a/src/themis/secure_comparator_t.h
+++ b/src/themis/secure_comparator_t.h
@@ -17,7 +17,8 @@
 #ifndef THEMIS_SECURE_COMPARATOR_T_H
 #define THEMIS_SECURE_COMPARATOR_T_H
 
-#include "secure_comparator.h"
+#include "themis/secure_comparator.h"
+
 #include <soter/ed25519/ge_utils.h>
 #include <soter/ed25519/sc.h>
 #include <soter/soter_t.h>

--- a/src/themis/secure_keygen.c
+++ b/src/themis/secure_keygen.c
@@ -14,16 +14,16 @@
 * limitations under the License.
 */
 
-#include "secure_keygen.h"
+#include "themis/secure_keygen.h"
 
 #include <string.h>
 #include <arpa/inet.h>
 
-#include <themis/themis_error.h>
-#include <soter/soter_t.h>
 #include <soter/soter_container.h>
 #include <soter/soter_ec_key.h>
 #include <soter/soter_rsa_key.h>
+#include <soter/soter_rsa_key_pair_gen.h>
+#include <soter/soter_t.h>
 
 #ifndef THEMIS_RSA_KEY_LENGTH
 #define THEMIS_RSA_KEY_LENGTH RSA_KEY_LENGTH_2048

--- a/src/themis/secure_keygen.c
+++ b/src/themis/secure_keygen.c
@@ -19,11 +19,11 @@
 #include <string.h>
 #include <arpa/inet.h>
 
-#include <soter/soter_container.h>
-#include <soter/soter_ec_key.h>
-#include <soter/soter_rsa_key.h>
-#include <soter/soter_rsa_key_pair_gen.h>
-#include <soter/soter_t.h>
+#include "soter/soter_container.h"
+#include "soter/soter_ec_key.h"
+#include "soter/soter_rsa_key.h"
+#include "soter/soter_rsa_key_pair_gen.h"
+#include "soter/soter_t.h"
 
 #ifndef THEMIS_RSA_KEY_LENGTH
 #define THEMIS_RSA_KEY_LENGTH RSA_KEY_LENGTH_2048

--- a/src/themis/secure_keygen.h
+++ b/src/themis/secure_keygen.h
@@ -19,10 +19,10 @@
  * @brief secure key generation
  */
 
-#ifndef _THEMIS_SECURE_KEYGEN_H_
-#define _THEMIS_SECURE_KEYGEN_H_
+#ifndef THEMIS_SECURE_KEYGEN_H
+#define THEMIS_SECURE_KEYGEN_H
 
-#include <themis/themis.h>
+#include <themis/themis_error.h>
 
 #ifdef __cplusplus
 extern "C"{
@@ -98,5 +98,4 @@ themis_status_t themis_is_valid_asym_key(const uint8_t* key, size_t length);
 }
 #endif
 
-
-#endif /* _THEMIS_SECURE_KEYGEN_H_ */
+#endif /* THEMIS_SECURE_KEYGEN_H */

--- a/src/themis/secure_message.c
+++ b/src/themis/secure_message.c
@@ -14,11 +14,10 @@
 * limitations under the License.
 */
 
-#include "secure_message.h"
+#include "themis/secure_message.h"
 
-#include <themis/themis_error.h>
-#include <themis/secure_message.h>
-#include <themis/secure_message_wrapper.h>
+#include "themis/secure_keygen.h"
+#include "themis/secure_message_wrapper.h"
 
 static bool valid_private_key(const uint8_t* private_key, size_t private_key_length){
   if(themis_is_valid_asym_key(private_key, private_key_length)==THEMIS_SUCCESS){

--- a/src/themis/secure_message.h
+++ b/src/themis/secure_message.h
@@ -19,10 +19,10 @@
  * @brief main Secure Session interface
  */
 
-#ifndef _THEMIS_SECURE_MESSAGE_H_
-#define _THEMIS_SECURE_MESSAGE_H_
+#ifndef THEMIS_SECURE_MESSAGE_H
+#define THEMIS_SECURE_MESSAGE_H
 
-#include <themis/themis.h>
+#include <themis/themis_error.h>
 
 #ifdef __cplusplus
 extern "C"{
@@ -180,21 +180,4 @@ themis_status_t themis_secure_message_unwrap(const uint8_t* private_key,
 }
 #endif
 
-
-#endif /* _THEMIS_SECURE_MESSAGE_H_ */
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+#endif /* THEMIS_SECURE_MESSAGE_H */

--- a/src/themis/secure_message_wrapper.c
+++ b/src/themis/secure_message_wrapper.c
@@ -14,17 +14,15 @@
 * limitations under the License.
 */
 
+#include "themis/secure_message_wrapper.h"
+
 #include <string.h>
 
-
-#include <themis/themis_error.h>
 #include <soter/soter.h>
-#include <soter/soter_rsa_key.h>
 #include <soter/soter_ec_key.h>
-#include <soter/soter_asym_sign.h>
-#include <soter/soter_asym_ka.h>
-#include <themis/secure_message_wrapper.h>
+#include <soter/soter_rsa_key.h>
 
+#include "themis/secure_cell.h"
 
 #define THEMIS_RSA_SYM_ALG (SOTER_SYM_AES_CTR|SOTER_SYM_256_KEY_LENGTH|SOTER_SYM_PBKDF2)
 #define THEMIS_RSA_SYMM_PASSWD_LENGTH 70 //!!! need to aprove
@@ -444,12 +442,3 @@ themis_status_t themis_secure_message_decrypter_destroy(themis_secure_message_de
     }
   return res;
 }
-
-
-
-
-
-
-
-
-

--- a/src/themis/secure_message_wrapper.c
+++ b/src/themis/secure_message_wrapper.c
@@ -18,9 +18,9 @@
 
 #include <string.h>
 
-#include <soter/soter.h>
-#include <soter/soter_ec_key.h>
-#include <soter/soter_rsa_key.h>
+#include "soter/soter.h"
+#include "soter/soter_ec_key.h"
+#include "soter/soter_rsa_key.h"
 
 #include "themis/secure_cell.h"
 

--- a/src/themis/secure_message_wrapper.h
+++ b/src/themis/secure_message_wrapper.h
@@ -14,11 +14,12 @@
 * limitations under the License.
 */
 
-#ifndef _THEMIS_SECURE_MESSAGE_WRAPPER_H_
-#define _THEMIS_SECURE_MESSAGE_WRAPPER_H_
+#ifndef THEMIS_SECURE_MESSAGE_WRAPPER_H
+#define THEMIS_SECURE_MESSAGE_WRAPPER_H
 
-#include <themis/themis.h>
 #include <soter/soter.h>
+
+#include <themis/themis_error.h>
 
 #define THEMIS_SECURE_MESSAGE                      0x26040000
 
@@ -91,16 +92,4 @@ themis_secure_message_decrypter_t* themis_secure_message_decrypter_init(const ui
 themis_status_t themis_secure_message_decrypter_proceed(themis_secure_message_decrypter_t* ctx, const uint8_t* message, const size_t message_length, uint8_t* wrapped_message, size_t* wrapped_message_length);
 themis_status_t themis_secure_message_decrypter_destroy(themis_secure_message_decrypter_t* ctx);
 
-
-
-#endif /* _THEMIS_SECURE_MESSAGE_WRAPPER_H_ */
-
-
-
-
-
-
-
-
-
-
+#endif /* THEMIS_SECURE_MESSAGE_WRAPPER_H */

--- a/src/themis/secure_session.c
+++ b/src/themis/secure_session.c
@@ -18,9 +18,9 @@
 
 #include <string.h>
 
-#include <soter/soter_ec_key.h>
-#include <soter/soter_rsa_key.h>
-#include <soter/soter_t.h>
+#include "soter/soter_ec_key.h"
+#include "soter/soter_rsa_key.h"
+#include "soter/soter_t.h"
 
 #include "themis/secure_session_t.h"
 #include "themis/secure_session_utils.h"

--- a/src/themis/secure_session.c
+++ b/src/themis/secure_session.c
@@ -14,16 +14,16 @@
 * limitations under the License.
 */
 
-#include <themis/secure_session.h>
-#include <themis/secure_session_t.h>
-#include <themis/themis_error.h>
-#include <soter/soter_rsa_key.h>
-#include <soter/soter_ec_key.h>
+#include "themis/secure_session.h"
 
 #include <string.h>
 
-#include <themis/secure_session_utils.h>
+#include <soter/soter_ec_key.h>
+#include <soter/soter_rsa_key.h>
 #include <soter/soter_t.h>
+
+#include "themis/secure_session_t.h"
+#include "themis/secure_session_utils.h"
 
 #define SESSION_ID_GENERATION_LABEL "Themis secure session unique identifier"
 #define SESSION_MASTER_KEY_GENERATION_LABEL "Themis secure session master key"

--- a/src/themis/secure_session.h
+++ b/src/themis/secure_session.h
@@ -21,10 +21,11 @@
 #ifndef THEMIS_SECURE_SESSION_H
 #define THEMIS_SECURE_SESSION_H
 
-#include <themis/themis.h>
-
 #include <sys/types.h>
+
 #include <soter/soter.h>
+
+#include <themis/themis_error.h>
 
 #ifdef __cplusplus
 extern "C"{
@@ -150,4 +151,5 @@ themis_status_t secure_session_get_remote_id(const secure_session_t* session_ctx
 #ifdef __cplusplus
 }
 #endif
+
 #endif /* THEMIS_SECURE_SESSION_H */

--- a/src/themis/secure_session_message.c
+++ b/src/themis/secure_session_message.c
@@ -14,18 +14,16 @@
 * limitations under the License.
 */
 
-#include <themis/secure_session.h>
-#include <themis/secure_session_t.h>
-#include <themis/secure_session_utils.h>
-#include <themis/themis_error.h>
+#include <string.h>
+#include <time.h>
+#include <arpa/inet.h>
 
 #include <soter/soter_container.h>
 
-#include <string.h>
-#include <time.h>
-
-#include <arpa/inet.h>
-#include "portable_endian.h"
+#include "themis/portable_endian.h"
+#include "themis/secure_session.h"
+#include "themis/secure_session_t.h"
+#include "themis/secure_session_utils.h"
 
 #define THEMIS_SESSION_WRAP_TAG "TSWM"
 

--- a/src/themis/secure_session_message.c
+++ b/src/themis/secure_session_message.c
@@ -18,7 +18,7 @@
 #include <time.h>
 #include <arpa/inet.h>
 
-#include <soter/soter_container.h>
+#include "soter/soter_container.h"
 
 #include "themis/portable_endian.h"
 #include "themis/secure_session.h"

--- a/src/themis/secure_session_peer.c
+++ b/src/themis/secure_session_peer.c
@@ -14,8 +14,7 @@
 * limitations under the License.
 */
 
-#include <themis/secure_session_peer.h>
-#include <themis/themis_error.h>
+#include "themis/secure_session_peer.h"
 
 #include <string.h>
 

--- a/src/themis/secure_session_peer.h
+++ b/src/themis/secure_session_peer.h
@@ -22,5 +22,4 @@
 
 #include <themis/secure_session.h>
 
-
 #endif /* THEMIS_SECURE_SESSION_PEER_H */

--- a/src/themis/secure_session_serialize.c
+++ b/src/themis/secure_session_serialize.c
@@ -17,7 +17,7 @@
 #include <string.h>
 #include <arpa/inet.h>
 
-#include <soter/soter_container.h>
+#include "soter/soter_container.h"
 
 #include "themis/secure_session.h"
 #include "themis/secure_session_t.h"

--- a/src/themis/secure_session_serialize.c
+++ b/src/themis/secure_session_serialize.c
@@ -14,15 +14,14 @@
 * limitations under the License.
 */
 
-#include <themis/secure_session_utils.h>
-#include <themis/secure_session_t.h>
-#include <themis/themis_error.h>
+#include <string.h>
+#include <arpa/inet.h>
 
 #include <soter/soter_container.h>
 
-#include <string.h>
-
-#include <arpa/inet.h>
+#include "themis/secure_session.h"
+#include "themis/secure_session_t.h"
+#include "themis/secure_session_utils.h"
 
 #define THEMIS_SESSION_CONTEXT_TAG "TSSC"
 

--- a/src/themis/secure_session_t.h
+++ b/src/themis/secure_session_t.h
@@ -18,7 +18,8 @@
 #define THEMIS_SECURE_SESSION_T_H
 
 #include <soter/soter_t.h>
-#include <themis/themis.h>
+
+#include <themis/secure_session.h>
 
 struct secure_session_type
 {
@@ -44,6 +45,5 @@ struct secure_session_type
 
 themis_status_t secure_session_init(secure_session_t *session_ctx, const void *id, size_t id_length, const void *sign_key, size_t sign_key_length, const secure_session_user_callbacks_t *user_callbacks);
 themis_status_t secure_session_cleanup(secure_session_t *session_ctx);
-
 
 #endif /* THEMIS_SECURE_SESSION_T_H */

--- a/src/themis/secure_session_utils.c
+++ b/src/themis/secure_session_utils.c
@@ -16,9 +16,9 @@
 
 #include "themis/secure_session_utils.h"
 
-#include <soter/soter_ec_key.h>
-#include <soter/soter_rsa_key.h>
-#include <soter/soter_t.h>
+#include "soter/soter_ec_key.h"
+#include "soter/soter_rsa_key.h"
+#include "soter/soter_t.h"
 
 #include "themis/secure_session.h"
 #include "themis/secure_session_t.h"

--- a/src/themis/secure_session_utils.c
+++ b/src/themis/secure_session_utils.c
@@ -14,15 +14,14 @@
 * limitations under the License.
 */
 
-#include <themis/secure_session_utils.h>
-#include <themis/secure_session.h>
-#include <themis/secure_session_t.h>
+#include "themis/secure_session_utils.h"
 
-#include <soter/soter_t.h>
-#include <soter/soter_rsa_key.h>
 #include <soter/soter_ec_key.h>
+#include <soter/soter_rsa_key.h>
+#include <soter/soter_t.h>
 
-#include <themis/themis_error.h>
+#include "themis/secure_session.h"
+#include "themis/secure_session_t.h"
 
 #define MAX_HMAC_SIZE 64 /* For HMAC-SHA512 */
 
@@ -358,4 +357,3 @@ themis_status_t secure_session_derive_message_keys(secure_session_t *session_ctx
 
 	return res;
 }
-

--- a/src/themis/secure_session_utils.h
+++ b/src/themis/secure_session_utils.h
@@ -21,7 +21,7 @@
 #include <string.h>
 
 #include <soter/soter.h>
-#include <themis/themis.h>
+
 #include <themis/secure_session.h>
 
 #define CIPHER_MAX_BLOCK_SIZE 16

--- a/src/themis/sym_enc_message.c
+++ b/src/themis/sym_enc_message.c
@@ -14,11 +14,13 @@
 * limitations under the License.
 */
 
-#include <themis/themis_error.h>
-#include <themis/sym_enc_message.h>
-#include <soter/soter.h>
+#include "themis/sym_enc_message.h"
+
 #include <string.h>
-#include <themis/secure_cell_alg.h>
+
+#include <soter/soter.h>
+
+#include "themis/secure_cell_alg.h"
 
 #define THEMIS_SYM_KDF_KEY_LABEL "Themis secure cell message key"
 #define THEMIS_SYM_KDF_IV_LABEL "Themis secure cell message iv"

--- a/src/themis/sym_enc_message.h
+++ b/src/themis/sym_enc_message.h
@@ -14,10 +14,10 @@
 * limitations under the License.
 */
 
-#ifndef _SYM_ENC_MESSAGE_H_
-#define _SYM_ENC_MESSAGE_H_
+#ifndef THEMIS_SYM_ENC_MESSAGE_H
+#define THEMIS_SYM_ENC_MESSAGE_H
 
-#include <themis/themis.h>
+#include <themis/themis_error.h>
 
 themis_status_t themis_auth_sym_encrypt_message(const uint8_t* key,
 						const size_t key_length,
@@ -58,4 +58,4 @@ themis_status_t themis_sym_decrypt_message_u(const uint8_t* key,
     					     const size_t encrypted_message_length,
     					     uint8_t* message,
     					     size_t* message_length);
-#endif /* _SYM_ENC_MESSAGE_H_ */
+#endif /* THEMIS_SYM_ENC_MESSAGE_H */

--- a/src/themis/themis.h
+++ b/src/themis/themis.h
@@ -21,8 +21,8 @@
 #ifndef THEMIS_H
 #define THEMIS_H
 
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 
 /**
  * @defgroup THEMIS Themis
@@ -30,31 +30,12 @@
  * @{
  */
 
-#include <themis/themis_error.h>
+#include <themis/secure_cell.h>
+#include <themis/secure_comparator.h>
 #include <themis/secure_keygen.h>
 #include <themis/secure_message.h>
-#include <themis/secure_cell.h>
 #include <themis/secure_session.h>
-#include <themis/secure_comparator.h>
+#include <themis/themis_error.h>
 
 /** @} */
 #endif /* THEMIS_H */
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/themis/themis_error.h
+++ b/src/themis/themis_error.h
@@ -22,9 +22,12 @@
 #ifndef THEMIS_ERROR_H
 #define THEMIS_ERROR_H
 
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdint.h>
+
 #include <soter/soter_error.h>
 
 /** @brief return type */

--- a/tests/soter/soter_asym_cipher_test.c
+++ b/tests/soter/soter_asym_cipher_test.c
@@ -14,7 +14,8 @@
 * limitations under the License.
 */
 
-#include "soter_test.h"
+#include "soter/soter_test.h"
+
 #include <string.h>
 
 #define TEST_DATA_SIZE 70

--- a/tests/soter/soter_asym_ka_test.c
+++ b/tests/soter/soter_asym_ka_test.c
@@ -14,7 +14,8 @@
 * limitations under the License.
 */
 
-#include "soter_test.h"
+#include "soter/soter_test.h"
+
 #include <string.h>
 
 #define KEY_BUFFER_SIZE 2048

--- a/tests/soter/soter_hash_test.c
+++ b/tests/soter/soter_hash_test.c
@@ -14,7 +14,8 @@
 * limitations under the License.
 */
 
-#include "soter_test.h"
+#include "soter/soter_test.h"
+
 #include <string.h>
 
 typedef struct test_vector_type test_vector_t;

--- a/tests/soter/soter_hmac_test.c
+++ b/tests/soter/soter_hmac_test.c
@@ -14,7 +14,8 @@
 * limitations under the License.
 */
 
-#include "soter_test.h"
+#include "soter/soter_test.h"
+
 #include <string.h>
 
 typedef struct test_vector_type test_vector_t;

--- a/tests/soter/soter_rand_test.c
+++ b/tests/soter/soter_rand_test.c
@@ -14,10 +14,11 @@
 * limitations under the License.
 */
 
-#include "soter_test.h"
+#include "soter/soter_test.h"
+
 #include <stdio.h>
-#include <unistd.h>
 #include <string.h>
+#include <unistd.h>
 
 #ifdef NIST_STS_EXE_PATH
 

--- a/tests/soter/soter_sign_test.c
+++ b/tests/soter/soter_sign_test.c
@@ -14,8 +14,9 @@
 * limitations under the License.
 */
 
+#include "soter/soter_test.h"
+
 #include <string.h>
-#include "soter_test.h"
 
 #define MAX_TEST_DATA 2048
 #define MAX_TEST_KEY MAX_TEST_DATA

--- a/tests/soter/soter_sym_test.c
+++ b/tests/soter/soter_sym_test.c
@@ -14,9 +14,10 @@
 * limitations under the License.
 */
 
-#include <string.h>
+#include "soter/soter_test.h"
+
 #include <stdio.h>
-#include "soter_test.h"
+#include <string.h>
 
 struct test_vector_type
 {

--- a/tests/soter/soter_test.c
+++ b/tests/soter/soter_test.c
@@ -14,7 +14,8 @@
 * limitations under the License.
 */
 
-#include "soter_test.h"
+#include "soter/soter_test.h"
+
 #include <stdio.h>
 
 int main(int argc, char *argv[])

--- a/tests/soter/soter_test.h
+++ b/tests/soter/soter_test.h
@@ -17,9 +17,10 @@
 #ifndef SOTER_TEST_H
 #define SOTER_TEST_H
 
-#include <soter/soter_error.h>
-#include "../common/test_utils.h"
+#include <soter/soter.h>
 #include <soter/soter_t.h>
+
+#include <common/test_utils.h>
 
 void run_soter_hash_tests(void);
 void run_soter_asym_cipher_tests(void);

--- a/tests/themis/themis_seccure_message.c
+++ b/tests/themis/themis_seccure_message.c
@@ -14,10 +14,11 @@
 * limitations under the License.
 */
 
+#include "themis/themis_test.h"
 
 #include <string.h>
-#include <common/test_utils.h>
-#include <themis/secure_message.h>
+
+#include <soter/soter_rand.h>
 
 /* Fuzz parameters */
 #define MAX_MESSAGE_SIZE 2048

--- a/tests/themis/themis_secure_cell.c
+++ b/tests/themis/themis_secure_cell.c
@@ -14,9 +14,11 @@
 * limitations under the License.
 */
 
+#include "themis/themis_test.h"
+
 #include <string.h>
-#include <common/test_utils.h>
-#include <themis/secure_cell.h>
+
+#include <soter/soter_rand.h>
 
 /* Fuzz parameters */
 #define MAX_KEY_SIZE 256

--- a/tests/themis/themis_secure_comparator.c
+++ b/tests/themis/themis_secure_comparator.c
@@ -14,11 +14,10 @@
 * limitations under the License.
 */
 
-#include <themis/secure_comparator.h>
-#include <themis/secure_comparator_t.h>
+#include "themis/themis_test.h"
+
 #include <stdio.h>
 #include <string.h>
-#include "themis_test.h"
 
 /* Implemented in themis_secure_comparator_security.c */
 void secure_comparator_security_test(void);

--- a/tests/themis/themis_secure_comparator_security.c
+++ b/tests/themis/themis_secure_comparator_security.c
@@ -5,11 +5,12 @@
  *      Author: ignat
  */
 
-#include <themis/secure_comparator.h>
-#include <themis/secure_comparator_t.h>
+#include "themis/themis_test.h"
+
 #include <stdio.h>
 #include <string.h>
-#include "themis_test.h"
+
+#include <themis/secure_comparator_t.h>
 
 /* Peers will communicate using shared memory */
 static uint8_t shared_mem[512];

--- a/tests/themis/themis_secure_session.c
+++ b/tests/themis/themis_secure_session.c
@@ -14,11 +14,10 @@
 * limitations under the License.
 */
 
-#include <themis/secure_session.h>
-#include <string.h>
-#include "themis_test.h"
+#include "themis/themis_test.h"
 
 #include <assert.h>
+#include <string.h>
 
 /* Fuzz parameters */
 #define MAX_MESSAGE_SIZE 2048

--- a/tests/themis/themis_test.c
+++ b/tests/themis/themis_test.c
@@ -16,7 +16,8 @@
 
 #include <stdio.h>
 #include <string.h>
-#include "themis_test.h"
+
+#include "themis/themis_test.h"
 
 int main(int argc, char* argv[])
 {
@@ -32,4 +33,3 @@ int main(int argc, char* argv[])
   testsuite_finish_testing();
   return testsuite_get_return_value();
 }
-

--- a/tests/themis/themis_test.h
+++ b/tests/themis/themis_test.h
@@ -14,15 +14,16 @@
 * limitations under the License.
 */
 
-#ifndef _THEMIS_TEST_H_
-#define _THEMIS_TEST_H_
+#ifndef THEMIS_TEST_H
+#define THEMIS_TEST_H
 
-#include <themis/themis_error.h>
-#include <common/test_utils.h>
 #include <themis/themis.h>
+
+#include <common/test_utils.h>
+
 void run_secure_message_test(void);
 void run_secure_session_test(void);
 void run_secure_cell_test(void);
 void run_secure_comparator_test(void);
 
-#endif /* _THEMIS_TEST_H_ */
+#endif /* THEMIS_TEST_H */


### PR DESCRIPTION
The main issue addressed by this PR are circular dependencies in header files. Many of them include _umrella headers_ (`<soter/soter.h>`, `<themis/themis.h>`) which creates a circular dependency in other headers included from umrella headers. This prevents individual headers from compiled and analyzed separate by the tools. It also introduces hidden dependency on the inclusion order. To resolve issue avoid using umbrella headers in library code: include specific headers where necessary. Umbrella headers should be used only for the user code (and tests).

While we're here, do some cosmetic improvement as well:

- unify include guard style to be `<PROJECT>_<HEADER>_H` everywhere
- sort included headers alphabetically
- group headers in the meaningful groups
- use proper relative paths in headers
- consistently use quotes `"soter/soter_rsa_key.h"` for internal inclusions
- consistently use angle brackets `<soter/soter.h>` for public inclusions

These changes are inspired and rationalized by [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html#Names_and_Order_of_Includes).