### PR TITLE
Update Themis iOS wrapper for new SecureMessage API (1 Part)

### DIFF
--- a/src/wrappers/themis/Obj-C/objcthemis/scell.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell.h
@@ -48,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** @brief store master key
 */
-@property (nonatomic, readonly) NSData * key;
+@property(nonatomic, readonly) NSData *key;
 
 /** @brief Initialize Secure Cell object
 * @param [in] key master key

--- a/src/wrappers/themis/Obj-C/objcthemis/scell.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell.m
@@ -22,7 +22,7 @@
 
 /** @brief store master key, rewrite
 */
-@property (nonatomic, readwrite) NSData * key;
+@property(nonatomic, readwrite) NSData *key;
 
 @end
 

--- a/src/wrappers/themis/Obj-C/objcthemis/scell_context_imprint.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_context_imprint.m
@@ -37,7 +37,7 @@
         return nil;
     }
 
-    unsigned char * wrappedMessage = malloc(wrappedMessageLength);
+    unsigned char *wrappedMessage = malloc(wrappedMessageLength);
     if (!wrappedMessage) {
         *error = SCERROR(encryptionResult, @"Secure Cell (Context Imprint) encryption failed, not enough memory");
         return nil;
@@ -60,21 +60,21 @@
     size_t unwrappedMessageLength = 0;
 
     int decryptionResult = themis_secure_cell_decrypt_context_imprint([self.key bytes], [self.key length],
-        [message bytes], [message length], [context bytes], [context length], NULL, &unwrappedMessageLength);
+            [message bytes], [message length], [context bytes], [context length], NULL, &unwrappedMessageLength);
 
     if (decryptionResult != TSErrorTypeBufferTooSmall) {
         *error = SCERROR(decryptionResult, @"Secure Cell (Context Imprint) decrypted message length determination failed");
         return nil;
     }
 
-    unsigned char * unwrappedMessage = malloc(unwrappedMessageLength);
+    unsigned char *unwrappedMessage = malloc(unwrappedMessageLength);
     if (!unwrappedMessage) {
         *error = SCERROR(decryptionResult, @"Secure Cell (Context Imprint) decryption failed, not enough memory");
         return nil;
     }
 
     decryptionResult = themis_secure_cell_decrypt_context_imprint([self.key bytes], [self.key length],
-        [message bytes], [message length], [context bytes], [context length], unwrappedMessage, &unwrappedMessageLength);
+            [message bytes], [message length], [context bytes], [context length], unwrappedMessage, &unwrappedMessageLength);
 
     if (decryptionResult != TSErrorTypeSuccess) {
         free(unwrappedMessage);

--- a/src/wrappers/themis/Obj-C/objcthemis/scell_seal.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_seal.h
@@ -59,7 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
 * @param [in] error pointer to Error on failure
 * @return Wrapped message as NSData object on success or nil on failure
 */
-- (nullable NSData *)wrapData:(NSData *)message error:(NSError * __autoreleasing *)error;
+- (nullable NSData *)wrapData:(NSData *)message error:(NSError *__autoreleasing *)error;
 
 /**
 * @brief Unwrap message
@@ -67,7 +67,7 @@ NS_ASSUME_NONNULL_BEGIN
 * @param [in] error pointer to Error on failure
 * @return Unwrapped message as NSData object on success or nil on failure
 */
-- (nullable NSData *)unwrapData:(NSData *)message error:(NSError * __autoreleasing *)error;
+- (nullable NSData *)unwrapData:(NSData *)message error:(NSError *__autoreleasing *)error;
 
 /**
 * @brief Wrap message with context
@@ -76,7 +76,7 @@ NS_ASSUME_NONNULL_BEGIN
 * @param [in] error pointer to Error on failure
 * @return Wrapped message as NSData object on success or nil on failure
 */
-- (nullable NSData *)wrapData:(NSData *)message context:(nullable NSData *)context error:(NSError * __autoreleasing *)error;
+- (nullable NSData *)wrapData:(NSData *)message context:(nullable NSData *)context error:(NSError *__autoreleasing *)error;
 
 /**
 * @brief Unwrap message
@@ -84,7 +84,7 @@ NS_ASSUME_NONNULL_BEGIN
 * @param [in] error pointer to Error on failure
 * @return Unwrapped message as NSData object on success or nil on failure
 */
-- (nullable NSData *)unwrapData:(NSData *)message context:(nullable NSData *)context error:(NSError * __autoreleasing *)error;
+- (nullable NSData *)unwrapData:(NSData *)message context:(nullable NSData *)context error:(NSError *__autoreleasing *)error;
 
 @end
 

--- a/src/wrappers/themis/Obj-C/objcthemis/scell_seal.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_seal.m
@@ -26,46 +26,46 @@
 }
 
 
-- (nullable NSData *)wrapData:(NSData *)message error:(NSError * __autoreleasing *)error {
+- (nullable NSData *)wrapData:(NSData *)message error:(NSError *__autoreleasing *)error {
     return [self wrapData:message context:nil error:error];
 }
 
 
-- (nullable NSData *)unwrapData:(NSData *)message error:(NSError * __autoreleasing *)error {
+- (nullable NSData *)unwrapData:(NSData *)message error:(NSError *__autoreleasing *)error {
     return [self unwrapData:message context:nil error:error];
 }
 
 
-- (nullable NSData *)wrapData:(NSData *)message context:(nullable NSData *)context error:(NSError * __autoreleasing *)error {
+- (nullable NSData *)wrapData:(NSData *)message context:(nullable NSData *)context error:(NSError *__autoreleasing *)error {
     size_t wrappedMessageLength = 0;
 
-    const void * contextData = [context bytes];
+    const void *contextData = [context bytes];
     size_t contextLength = [context length];
 
     TSErrorType result = (TSErrorType) themis_secure_cell_encrypt_seal([self.key bytes], [self.key length],
-        contextData, contextLength, [message bytes], [message length], NULL, &wrappedMessageLength);
+            contextData, contextLength, [message bytes], [message length], NULL, &wrappedMessageLength);
 
     if (result != TSErrorTypeBufferTooSmall) {
-		if (error) {
-        	*error = SCERROR(result, @"Secure Cell (Seal) encrypted message length determination failed");
-		}
+        if (error) {
+            *error = SCERROR(result, @"Secure Cell (Seal) encrypted message length determination failed");
+        }
         return nil;
     }
 
-    unsigned char * wrappedMessage = malloc(wrappedMessageLength);
+    unsigned char *wrappedMessage = malloc(wrappedMessageLength);
     if (!wrappedMessage) {
-		if (error) {
-        	*error = SCERROR(result, @"Secure Cell (Seal) encryption failed, not enough memory");
-		}
+        if (error) {
+            *error = SCERROR(result, @"Secure Cell (Seal) encryption failed, not enough memory");
+        }
         return nil;
     }
     result = (TSErrorType) themis_secure_cell_encrypt_seal([self.key bytes], [self.key length],
-        contextData, contextLength, [message bytes], [message length], wrappedMessage, &wrappedMessageLength);
+            contextData, contextLength, [message bytes], [message length], wrappedMessage, &wrappedMessageLength);
 
     if (result != TSErrorTypeSuccess) {
-		if (error) {
-        	*error = SCERROR(result, @"Secure Cell (Seal) encryption failed");
-		}
+        if (error) {
+            *error = SCERROR(result, @"Secure Cell (Seal) encryption failed");
+        }
         free(wrappedMessage);
         return nil;
     }
@@ -73,37 +73,37 @@
     return [NSData dataWithBytesNoCopy:wrappedMessage length:wrappedMessageLength];
 }
 
-- (nullable NSData *)unwrapData:(NSData *)message context:(nullable NSData *)context error:(NSError * __autoreleasing *)error {
+- (nullable NSData *)unwrapData:(NSData *)message context:(nullable NSData *)context error:(NSError *__autoreleasing *)error {
     size_t unwrappedMessageLength = 0;
 
-    const void * contextData = [context bytes];
+    const void *contextData = [context bytes];
     size_t contextLength = [context length];
 
     TSErrorType result = (TSErrorType) themis_secure_cell_decrypt_seal([self.key bytes], [self.key length],
-        contextData, contextLength, [message bytes], [message length], NULL, &unwrappedMessageLength);
+            contextData, contextLength, [message bytes], [message length], NULL, &unwrappedMessageLength);
 
     if (result != TSErrorTypeBufferTooSmall) {
-		if (error) {
-        	*error = SCERROR(result, @"Secure Cell (Seal) decrypted message length determination failed");
-		}
+        if (error) {
+            *error = SCERROR(result, @"Secure Cell (Seal) decrypted message length determination failed");
+        }
         return nil;
     }
 
-    unsigned char * unwrappedMessage = malloc(unwrappedMessageLength);
+    unsigned char *unwrappedMessage = malloc(unwrappedMessageLength);
     if (!unwrappedMessage) {
-		if (error) {
-        	*error = SCERROR(result, @"Secure Cell (Seal) decryption failed, not enough memory");
-		}
+        if (error) {
+            *error = SCERROR(result, @"Secure Cell (Seal) decryption failed, not enough memory");
+        }
         return nil;
     }
 
     result = (TSErrorType) themis_secure_cell_decrypt_seal([self.key bytes], [self.key length],
-        contextData, contextLength, [message bytes], [message length], unwrappedMessage, &unwrappedMessageLength);
+            contextData, contextLength, [message bytes], [message length], unwrappedMessage, &unwrappedMessageLength);
 
     if (result != TSErrorTypeSuccess) {
-		if (error) {
-        	*error = SCERROR(result, @"Secure Cell (Seal) decryption failed");
-		}
+        if (error) {
+            *error = SCERROR(result, @"Secure Cell (Seal) decryption failed");
+        }
         free(unwrappedMessage);
         return nil;
     }

--- a/src/wrappers/themis/Obj-C/objcthemis/scell_token.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_token.h
@@ -35,10 +35,10 @@ NS_ASSUME_NONNULL_BEGIN
 @interface TSCellTokenEncryptedData : NSObject
 
 /**< @breaf cipher text */
-@property (nonatomic, strong) NSMutableData * cipherText;
+@property(nonatomic, strong) NSMutableData *cipherText;
 
 /**< @breaf token */
-@property (nonatomic, strong) NSMutableData * token;
+@property(nonatomic, strong) NSMutableData *token;
 
 @end
 
@@ -71,7 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
 * @param [in] error pointer to Error on failure
 * @return Wrapped message as NSData object on success or nil on failure
 */
-- (nullable TSCellTokenEncryptedData *)wrapData:(NSData *)message error:(NSError * __autoreleasing *)error;
+- (nullable TSCellTokenEncryptedData *)wrapData:(NSData *)message error:(NSError *__autoreleasing *)error;
 
 /**
 * @brief Unwrap message
@@ -79,7 +79,7 @@ NS_ASSUME_NONNULL_BEGIN
 * @param [in] error pointer to Error on failure
 * @return Unwrapped message as NSData object on success or nil on failure
 */
-- (nullable NSData *)unwrapData:(TSCellTokenEncryptedData *)message error:(NSError * __autoreleasing *)error;
+- (nullable NSData *)unwrapData:(TSCellTokenEncryptedData *)message error:(NSError *__autoreleasing *)error;
 
 /**
 * @brief Wrap message with context
@@ -88,7 +88,7 @@ NS_ASSUME_NONNULL_BEGIN
 * @param [in] error pointer to Error on failure
 * @return Wrapped message as NSData object on success or nil on failure
 */
-- (nullable TSCellTokenEncryptedData *)wrapData:(NSData *)message context:(nullable NSData *)context error:(NSError * __autoreleasing *)error;
+- (nullable TSCellTokenEncryptedData *)wrapData:(NSData *)message context:(nullable NSData *)context error:(NSError *__autoreleasing *)error;
 
 /**
 * @brief Unwrap message with context
@@ -97,7 +97,7 @@ NS_ASSUME_NONNULL_BEGIN
 * @param [in] error pointer to Error on failure
 * @return Unwrapped message as NSData object on success or nil on failure
 */
-- (nullable NSData *)unwrapData:(TSCellTokenEncryptedData *)message context:(nullable NSData *)context error:(NSError * __autoreleasing *)error;
+- (nullable NSData *)unwrapData:(TSCellTokenEncryptedData *)message context:(nullable NSData *)context error:(NSError *__autoreleasing *)error;
 
 @end
 

--- a/src/wrappers/themis/Obj-C/objcthemis/scell_token.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_token.m
@@ -31,32 +31,32 @@
 }
 
 
-- (nullable TSCellTokenEncryptedData *)wrapData:(NSData *)message error:(NSError * __autoreleasing *)error {
+- (nullable TSCellTokenEncryptedData *)wrapData:(NSData *)message error:(NSError *__autoreleasing *)error {
     return [self wrapData:message context:nil error:error];
 }
 
 
-- (nullable NSData *)unwrapData:(TSCellTokenEncryptedData *)message error:(NSError * __autoreleasing *)error {
+- (nullable NSData *)unwrapData:(TSCellTokenEncryptedData *)message error:(NSError *__autoreleasing *)error {
     return [self unwrapData:message context:nil error:error];
 }
 
 
-- (nullable TSCellTokenEncryptedData *)wrapData:(NSData *)message context:(nullable NSData *)context error:(NSError * __autoreleasing *)error {
+- (nullable TSCellTokenEncryptedData *)wrapData:(NSData *)message context:(nullable NSData *)context error:(NSError *__autoreleasing *)error {
     size_t wrappedMessageLength = 0;
     size_t tokenLength = 0;
 
-    const void * contextData = [context bytes];
+    const void *contextData = [context bytes];
     size_t contextLength = [context length];
 
-    TSCellTokenEncryptedData * encryptedMessage = [[TSCellTokenEncryptedData alloc] init];
+    TSCellTokenEncryptedData *encryptedMessage = [[TSCellTokenEncryptedData alloc] init];
     TSErrorType result = (TSErrorType) themis_secure_cell_encrypt_token_protect([self.key bytes], [self.key length],
             contextData, contextLength, [message bytes], [message length], NULL, &tokenLength,
             NULL, &wrappedMessageLength);
 
     if (result != TSErrorTypeBufferTooSmall) {
-		if (error) {
-        	*error = SCERROR(result, @"Secure Cell (Token Protect) encrypted message length determination failed");
-		}
+        if (error) {
+            *error = SCERROR(result, @"Secure Cell (Token Protect) encrypted message length determination failed");
+        }
         return nil;
     }
 
@@ -68,18 +68,18 @@
             [encryptedMessage.cipherText mutableBytes], &wrappedMessageLength);
 
     if (result != TSErrorTypeSuccess) {
-		if (error) {
-        	*error = SCERROR(result, @"Secure Cell (Token Protect) encryption failed");
-		}
+        if (error) {
+            *error = SCERROR(result, @"Secure Cell (Token Protect) encryption failed");
+        }
         return nil;
     }
     return encryptedMessage;
 }
 
 
-- (nullable NSData *)unwrapData:(TSCellTokenEncryptedData *)message context:(nullable NSData *)context error:(NSError * __autoreleasing *)error {
+- (nullable NSData *)unwrapData:(TSCellTokenEncryptedData *)message context:(nullable NSData *)context error:(NSError *__autoreleasing *)error {
     size_t unwrappedMessageLength = 0;
-    const void * contextData = [context bytes];
+    const void *contextData = [context bytes];
     size_t contextLength = [context length];
 
     TSErrorType result = (TSErrorType) themis_secure_cell_decrypt_token_protect([self.key bytes], [self.key length], contextData, contextLength,
@@ -87,21 +87,21 @@
             NULL, &unwrappedMessageLength);
 
     if (result != TSErrorTypeBufferTooSmall) {
-		if (error) {
-        	*error = SCERROR(result, @"Secure Cell (Token Protect) decrypted message length determination failed");
-		}
+        if (error) {
+            *error = SCERROR(result, @"Secure Cell (Token Protect) decrypted message length determination failed");
+        }
         return nil;
     }
 
-    NSMutableData * unwrapped_message = [[NSMutableData alloc] initWithLength:unwrappedMessageLength];
+    NSMutableData *unwrapped_message = [[NSMutableData alloc] initWithLength:unwrappedMessageLength];
     result = (TSErrorType) themis_secure_cell_decrypt_token_protect([self.key bytes], [self.key length], contextData, contextLength,
             [message.cipherText bytes], [message.cipherText length], [message.token bytes], [message.token length],
             [unwrapped_message mutableBytes], &unwrappedMessageLength);
 
     if (result != TSErrorTypeSuccess) {
-		if (error) {
-        	*error = SCERROR(result, @"Secure Cell (Token Protect) decryption failed");
-		}
+        if (error) {
+            *error = SCERROR(result, @"Secure Cell (Token Protect) decryption failed");
+        }
         return nil;
     }
     return [unwrapped_message copy];

--- a/src/wrappers/themis/Obj-C/objcthemis/scomparator.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/scomparator.h
@@ -31,11 +31,12 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /** @brief Secure comparator states */
-typedef NS_ENUM(NSInteger, TSComparatorStateType){
-  TSComparatorNotReady = 0,
-  TSComparatorNotMatch = 22,
-  TSComparatorMatch = 21
+typedef NS_ENUM(NSInteger, TSComparatorStateType) {
+    TSComparatorNotReady = 0,
+    TSComparatorNotMatch = 22,
+    TSComparatorMatch = 21
 };
+
 /** @brief Secure comparator interface
 *
 * Secure comparator is a lightweight mechanism
@@ -54,7 +55,7 @@ typedef NS_ENUM(NSInteger, TSComparatorStateType){
 * @param [in] error pointer to Error on failure
 * @return Comparation initialization message on success or nil on failure
 */
-- (nullable NSData *)beginCompare:(NSError * __autoreleasing *)error;
+- (nullable NSData *)beginCompare:(NSError *__autoreleasing *)error;
 
 
 /** @brief Proceed comparation message 
@@ -62,7 +63,7 @@ typedef NS_ENUM(NSInteger, TSComparatorStateType){
 * @param [in] error pointer to Error on failure
 * @return Next comparation message in NSData object on success or nil on failure.
 */
-- (nullable NSData *)proceedCompare:(nullable NSData *)message error:(NSError * __autoreleasing *)error;
+- (nullable NSData *)proceedCompare:(nullable NSData *)message error:(NSError *__autoreleasing *)error;
 
 /** @brief indicate comparation state.
 * @return comparation state.

--- a/src/wrappers/themis/Obj-C/objcthemis/scomparator.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/scomparator.m
@@ -20,7 +20,7 @@
 
 @interface TSComparator ()
 
-@property (nonatomic) secure_comparator_t * comparator;
+@property(nonatomic) secure_comparator_t *comparator;
 
 @end
 
@@ -43,36 +43,36 @@
 
 // TODO: check for memory leak?
 - (void)dealloc {
-    if(self.comparator) {
+    if (self.comparator) {
         secure_comparator_destroy(self.comparator);
     }
 }
 
 
-- (nullable NSData *)beginCompare:(NSError * __autoreleasing *)error {
+- (nullable NSData *)beginCompare:(NSError *__autoreleasing *)error {
     size_t comparationRequestLength = 0;
     TSErrorType result = (TSErrorType) secure_comparator_begin_compare(self.comparator, NULL, &comparationRequestLength);
 
     if (result != TSErrorTypeBufferTooSmall) {
         if (error) {
-        	*error = SCERROR(result, @"Secure Comparator failed making initialisation message");
-		}
+            *error = SCERROR(result, @"Secure Comparator failed making initialisation message");
+        }
         return nil;
     }
 
-    NSMutableData * requestData = [[NSMutableData alloc] initWithLength:comparationRequestLength];
+    NSMutableData *requestData = [[NSMutableData alloc] initWithLength:comparationRequestLength];
     result = (TSErrorType) secure_comparator_begin_compare(self.comparator, [requestData mutableBytes], &comparationRequestLength);
 
-    if (result != TSErrorTypeSuccess && result !=TSErrorTypeSendAsIs) {
-		if (error) {
-        	*error = SCERROR(result, @"Secure Comparator failed making initialisation message");
-		}
+    if (result != TSErrorTypeSuccess && result != TSErrorTypeSendAsIs) {
+        if (error) {
+            *error = SCERROR(result, @"Secure Comparator failed making initialisation message");
+        }
         return nil;
     }
     return [requestData copy];
 }
 
-- (nullable NSData *)proceedCompare:(nullable NSData *)message error:(NSError * __autoreleasing *)error {
+- (nullable NSData *)proceedCompare:(nullable NSData *)message error:(NSError *__autoreleasing *)error {
     size_t unwrappedMessageLength = 0;
     TSErrorType result = (TSErrorType) secure_comparator_proceed_compare(self.comparator, [message bytes], [message length], NULL, &unwrappedMessageLength);
 
@@ -80,23 +80,22 @@
         if (result == TSErrorTypeSuccess) {
             return nil;
         }
-		if (error) {
-        	*error = SCERROR(result, @"Secure Comparator failed proceeding message");
-		}
+        if (error) {
+            *error = SCERROR(result, @"Secure Comparator failed proceeding message");
+        }
         return nil;
     }
 
-    NSMutableData * unwrappedMessage = [[NSMutableData alloc] initWithLength:unwrappedMessageLength];
+    NSMutableData *unwrappedMessage = [[NSMutableData alloc] initWithLength:unwrappedMessageLength];
     result = (TSErrorType) secure_comparator_proceed_compare(self.comparator, [message bytes], [message length], [unwrappedMessage mutableBytes], &unwrappedMessageLength);
 
     if (result != TSErrorTypeSuccess) {
         if (result == TSErrorTypeSendAsIs) {
             return unwrappedMessage;
-        }
-        else {
-			if (error) {
-            	*error = SCERROR(result, @"Secure Comparator failed proceeding message");
-			}
+        } else {
+            if (error) {
+                *error = SCERROR(result, @"Secure Comparator failed proceeding message");
+            }
             return nil;
         }
     }

--- a/src/wrappers/themis/Obj-C/objcthemis/skeygen.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/skeygen.h
@@ -43,10 +43,10 @@ typedef NS_ENUM(NSInteger, TSKeyGenAsymmetricAlgorithm) {
 
 
 /** @brief private key */
-@property (nonatomic, readonly) NSMutableData * privateKey;
+@property(nonatomic, readonly) NSMutableData *privateKey;
 
 /** @brief public key */
-@property (nonatomic, readonly) NSMutableData * publicKey;
+@property(nonatomic, readonly) NSMutableData *publicKey;
 
 /**
 * @brief initialise key pair generator, generates privateKey and publicKey

--- a/src/wrappers/themis/Obj-C/objcthemis/skeygen.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/skeygen.m
@@ -20,12 +20,12 @@
 
 @interface TSKeyGen ()
 
-@property (nonatomic, readwrite) TSKeyGenAsymmetricAlgorithm algorithm;
+@property(nonatomic, readwrite) TSKeyGenAsymmetricAlgorithm algorithm;
 
 /** @brief private key */
-@property (nonatomic, readwrite) NSMutableData * privateKey;
+@property(nonatomic, readwrite) NSMutableData *privateKey;
 /** @brief public key */
-@property (nonatomic, readwrite) NSMutableData * publicKey;
+@property(nonatomic, readwrite) NSMutableData *publicKey;
 
 @end
 
@@ -70,11 +70,11 @@
     switch (self.algorithm) {
         case TSKeyGenAsymmetricAlgorithmEC:
             result = (TSErrorType) themis_gen_ec_key_pair([self.privateKey mutableBytes], &privateKeyLength,
-                            [self.publicKey mutableBytes], &publicKeyLength);
+                    [self.publicKey mutableBytes], &publicKeyLength);
             break;
         case TSKeyGenAsymmetricAlgorithmRSA:
             result = (TSErrorType) themis_gen_rsa_key_pair([self.privateKey mutableBytes], &privateKeyLength,
-                            [self.publicKey mutableBytes], &publicKeyLength);
+                    [self.publicKey mutableBytes], &publicKeyLength);
     }
     return result;
 }

--- a/src/wrappers/themis/Obj-C/objcthemis/smessage.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/smessage.h
@@ -41,7 +41,7 @@ typedef NS_ENUM(NSInteger, TSMessageMode) {
     * protection.
     * @image html encrypted_message.png Secure Encrypted message
     */
-        TSMessageModeEncryptDecrypt,
+            TSMessageModeEncryptDecrypt,
 
     /** @brief Signed message
     *
@@ -50,7 +50,7 @@ typedef NS_ENUM(NSInteger, TSMessageMode) {
     * (for example, route data based on its type).
     * @image html signed_message.png Secure Signed message
     */
-        TSMessageModeSignVerify
+            TSMessageModeSignVerify
 };
 
 
@@ -75,13 +75,13 @@ typedef NS_ENUM(NSInteger, TSMessageMode) {
 
 
 /** @brief private key */
-@property (nonatomic, readonly) NSData * privateKey;
+@property(nonatomic, readonly) NSData *privateKey;
 
 /** @brief public key */
-@property (nonatomic, readonly) NSData * publicKey;
+@property(nonatomic, readonly) NSData *publicKey;
 
 /** @brief mode */
-@property (nonatomic, readonly) TSMessageMode mode;
+@property(nonatomic, readonly) TSMessageMode mode;
 
 
 /**
@@ -104,7 +104,7 @@ typedef NS_ENUM(NSInteger, TSMessageMode) {
 * @param [in] error pointer to Error on failure
 * @return Wrapped message as NSData object on success or nil on failure
  */
-- (nullable NSData *)wrapData:(nullable NSData *)message error:(NSError * __autoreleasing *)error;
+- (nullable NSData *)wrapData:(nullable NSData *)message error:(NSError *__autoreleasing *)error;
 
 /**
 * @brief Unwrap message (decrypt using both keys or verify using peer's public key)
@@ -112,7 +112,7 @@ typedef NS_ENUM(NSInteger, TSMessageMode) {
 * @param [in] error pointer to Error on failure
 * @return Unwrapped message as NSData object on success or nil on failure
 */
-- (nullable NSData *)unwrapData:(nullable NSData *)message error:(NSError * __autoreleasing *)error;
+- (nullable NSData *)unwrapData:(nullable NSData *)message error:(NSError *__autoreleasing *)error;
 
 @end
 

--- a/src/wrappers/themis/Obj-C/objcthemis/smessage.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/smessage.h
@@ -89,17 +89,17 @@ typedef NS_ENUM(NSInteger, TSMessageMode) {
 * @param [in] privateKey Private key
 * @param [in] peerPublicKey Peer public key
 */
-- (nullable instancetype)initInEncryptModeWithPrivateKey:(NSData *)privateKey peerPublicKey:(NSData *)peerPublicKey;
+- (nullable instancetype)initInEncryptModeWithPrivateKey:(nonnull NSData *)privateKey peerPublicKey:(nonnull NSData *)peerPublicKey;
 
 /**
-* @brief Initialize Secure message object in sign/verify mode
+* @brief Initialize Secure message object in sign/verify mode.
 * @param [in] privateKey Private key
 * @param [in] peerPublicKey Peer public key
 */
-- (nullable instancetype)initInSignVerifyModeWithPrivateKey:(NSData *)privateKey peerPublicKey:(NSData *)peerPublicKey;
+- (nullable instancetype)initInSignVerifyModeWithPrivateKey:(nullable NSData *)privateKey peerPublicKey:(nullable NSData *)peerPublicKey;
 
 /**
-* @brief Wrap message
+* @brief Wrap message (encrypt using both keys or sign using own private key)
 * @param [in] message message to wrap
 * @param [in] error pointer to Error on failure
 * @return Wrapped message as NSData object on success or nil on failure
@@ -107,7 +107,7 @@ typedef NS_ENUM(NSInteger, TSMessageMode) {
 - (nullable NSData *)wrapData:(nullable NSData *)message error:(NSError * __autoreleasing *)error;
 
 /**
-* @brief Unwrap message
+* @brief Unwrap message (decrypt using both keys or verify using peer's public key)
 * @param [in] message message to unwrap
 * @param [in] error pointer to Error on failure
 * @return Unwrapped message as NSData object on success or nil on failure

--- a/src/wrappers/themis/Obj-C/objcthemis/smessage.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/smessage.m
@@ -79,7 +79,7 @@
             if (!(self.privateKey) || [self.privateKey length] == 0) {
                 NSLog(@"Error during signing: private key is missing");
                 if (error) {
-                    *error = SCERROR(TSErrorTypeFail, @"Secure Message failed wraping");
+                    *error = SCERROR(TSErrorTypeFail, @"Secure Message failed signing message");
                 }
                 return nil;
             }
@@ -88,15 +88,15 @@
             break;
         default:
             if (error) {
-                *error = SCERROR(TSErrorTypeFail, @"Secure Message failed wraping, mode unknown");
+                *error = SCERROR(TSErrorTypeFail, @"Secure Message failed wrapping, mode unknown");
             }
             return nil;
     }
 
     if (result != TSErrorTypeBufferTooSmall) {
-        NSLog(@"Error during wrapping data: either key is invalid of message is empty");
+        NSLog(@"Error during wrapping data: either keys are invalid or message is empty");
         if (error) {
-            *error = SCERROR(result, @"Secure Message failed wraping");
+            *error = SCERROR(result, @"Secure Message failed");
         }
         return nil;
     }
@@ -122,15 +122,16 @@
             break;
         default:
             if (error) {
-                *error = SCERROR(TSErrorTypeFail, @"Secure Message failed wraping, mode unknown");
+                *error = SCERROR(TSErrorTypeFail, @"Secure Message failed wrapping, mode unknown");
             }
             free(wrappedMessage);
             return NULL;
     }
 
     if (result != TSErrorTypeSuccess) {
+        NSLog(@"Error during wrapping data: either keys are invalid or message is empty");
         if (error) {
-            *error = SCERROR(result, @"Secure Message failed wrapping");
+            *error = SCERROR(result, @"Secure Message failed");
         }
         free(wrappedMessage);
         return NULL;
@@ -155,7 +156,7 @@
             if (!(self.publicKey) || [self.publicKey length] == 0) {
                 NSLog(@"Error during verifying: public key is missing");
                 if (error) {
-                    *error = SCERROR(TSErrorTypeFail, @"Secure Message failed wraping");
+                    *error = SCERROR(TSErrorTypeFail, @"Secure Message failed verifying");
                 }
                 return nil;
             }
@@ -164,15 +165,15 @@
             break;
         default:
             if (error) {
-                *error = SCERROR(TSErrorTypeFail, @"Secure Message failed wraping, mode unknown");
+                *error = SCERROR(TSErrorTypeFail, @"Secure Message failed wrapping, mode unknown");
             }
             return nil;
     }
 
     if (result != TSErrorTypeBufferTooSmall) {
-        NSLog(@"Error during wrapping data: either key is invalid of message is empty");
+        NSLog(@"Error during wrapping data: either keys are invalid or message is empty");
         if (error) {
-            *error = SCERROR(result, @"Secure Message failed unwraping");
+            *error = SCERROR(result, @"Secure Message failed");
         }
         return nil;
     }
@@ -198,14 +199,15 @@
             break;
         default:
             if (error) {
-                *error = SCERROR(TSErrorTypeFail, @"Secure Message failed wraping, mode unknown");
+                *error = SCERROR(TSErrorTypeFail, @"Secure Message failed wrapping, mode unknown");
             }
             return nil;
     }
 
     if (result != TSErrorTypeSuccess) {
+        NSLog(@"Error during unwrapping data: either keys are invalid or message is empty");
         if (error) {
-            *error = SCERROR(result, @"Secure Message failed unwraping");
+            *error = SCERROR(result, @"Secure Message failed");
         }
         free(unwrappedMessage);
         return nil;

--- a/src/wrappers/themis/Obj-C/objcthemis/smessage.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/smessage.m
@@ -34,10 +34,11 @@
 
 @implementation TSMessage
 
-- (nullable instancetype)initInEncryptModeWithPrivateKey:(NSData *)privateKey peerPublicKey:(NSData *)peerPublicKey {
+- (nullable instancetype)initInEncryptModeWithPrivateKey:(nonnull NSData *)privateKey peerPublicKey:(nonnull NSData *)peerPublicKey {
     self = [super init];
     if (self) {
         if (!privateKey || [privateKey length] == 0 || !peerPublicKey || [peerPublicKey length] == 0) {
+            NSLog(@"Error during init: Secure Message in Encrypt/Decrypt mode requires both private and public keys to be set");
             return nil;
         }
         self.privateKey = [privateKey copy];
@@ -48,10 +49,11 @@
 }
 
 
-- (nullable instancetype)initInSignVerifyModeWithPrivateKey:(NSData *)privateKey peerPublicKey:(NSData *)peerPublicKey {
+- (nullable instancetype)initInSignVerifyModeWithPrivateKey:(nullable NSData *)privateKey peerPublicKey:(nullable NSData *)peerPublicKey {
     self = [super init];
     if (self) {
-        if (!privateKey || [privateKey length] == 0 || !peerPublicKey || [peerPublicKey length] == 0) {
+        if ((!privateKey || [privateKey length] == 0) && (!peerPublicKey || [peerPublicKey length] == 0)) {
+            NSLog(@"Error during init: Secure Message in Sign/Verify mode requires either private or public key to be set");
             return nil;
         }
         self.privateKey = [privateKey copy];
@@ -68,19 +70,20 @@
 
     switch (self.mode) {
         case TSMessageModeEncryptDecrypt:
-            result = (TSErrorType) themis_secure_message_wrap([self.privateKey bytes], [self.privateKey length],
+            result = (TSErrorType) themis_secure_message_encrypt([self.privateKey bytes], [self.privateKey length],
                 [self.publicKey bytes], [self.publicKey length], [message bytes], [message length],
                 NULL, &wrappedMessageLength);
             break;
 
         case TSMessageModeSignVerify:
             if (!(self.privateKey) || [self.privateKey length] == 0) {
+              NSLog(@"Error during signing: private key is missing");
 				if (error) {
                 	*error = SCERROR(TSErrorTypeFail, @"Secure Message failed wraping");
 				}
                 return nil;
             }
-            result = (TSErrorType) themis_secure_message_wrap([self.privateKey bytes], [self.privateKey length], NULL, 0,
+            result = (TSErrorType) themis_secure_message_sign([self.privateKey bytes], [self.privateKey length],
                 [message bytes], [message length], NULL, &wrappedMessageLength);
             break;
         default:
@@ -91,6 +94,7 @@
     }
 
     if (result != TSErrorTypeBufferTooSmall) {
+      NSLog(@"Error during wrapping data: either key is invalid of message is empty");
 		if (error) {
         	*error = SCERROR(result, @"Secure Message failed wraping");
 		}
@@ -107,13 +111,13 @@
 
     switch (self.mode) {
         case TSMessageModeEncryptDecrypt:
-            result = (TSErrorType) themis_secure_message_wrap([self.privateKey bytes], [self.privateKey length],
+            result = (TSErrorType) themis_secure_message_encrypt([self.privateKey bytes], [self.privateKey length],
                 [self.publicKey bytes], [self.publicKey length], [message bytes], [message length],
                 wrappedMessage, &wrappedMessageLength);
             break;
 
         case TSMessageModeSignVerify:
-            result = (TSErrorType) themis_secure_message_wrap([self.privateKey bytes], [self.privateKey length], NULL, 0,
+            result = (TSErrorType) themis_secure_message_sign([self.privateKey bytes], [self.privateKey length],
                 [message bytes], [message length], wrappedMessage, &wrappedMessageLength);
             break;
         default:
@@ -138,12 +142,35 @@
 
 - (nullable NSData *)unwrapData:(nullable NSData *)message error:(NSError * __autoreleasing *)error {
     size_t unwrappedMessageLength = 0;
-
-    TSErrorType result = (TSErrorType) themis_secure_message_unwrap([self.privateKey bytes], [self.privateKey length],
-        [self.publicKey bytes], [self.publicKey length], [message bytes], [message length],
-        NULL, &unwrappedMessageLength);
+    TSErrorType result = TSErrorTypeFail;
+  
+    switch (self.mode) {
+      case TSMessageModeEncryptDecrypt:
+        result = (TSErrorType) themis_secure_message_decrypt([self.privateKey bytes], [self.privateKey length],
+                                                             [self.publicKey bytes], [self.publicKey length], [message bytes], [message length],
+                                                             NULL, &unwrappedMessageLength);
+        break;
+        
+      case TSMessageModeSignVerify:
+        if (!(self.publicKey) || [self.publicKey length] == 0) {
+          NSLog(@"Error during verifying: public key is missing");
+          if (error) {
+            *error = SCERROR(TSErrorTypeFail, @"Secure Message failed wraping");
+          }
+          return nil;
+        }
+        result = (TSErrorType) themis_secure_message_verify([self.publicKey bytes], [self.publicKey length],
+                                                          [message bytes], [message length], NULL, &unwrappedMessageLength);
+        break;
+      default:
+        if (error) {
+          *error = SCERROR(TSErrorTypeFail, @"Secure Message failed wraping, mode unknown");
+        }
+        return nil;
+    }
 
     if (result != TSErrorTypeBufferTooSmall) {
+      NSLog(@"Error during wrapping data: either key is invalid of message is empty");
 		if (error) {
         	*error = SCERROR(result, @"Secure Message failed unwraping");
 		}
@@ -158,10 +185,24 @@
         return nil;
     }
 
-    result = (TSErrorType) themis_secure_message_unwrap([self.privateKey bytes], [self.privateKey length],
-        [self.publicKey bytes], [self.publicKey length], [message bytes], [message length],
-        unwrappedMessage, &unwrappedMessageLength);
-
+    switch (self.mode) {
+      case TSMessageModeEncryptDecrypt:
+        result = (TSErrorType) themis_secure_message_decrypt([self.privateKey bytes], [self.privateKey length],
+                                                             [self.publicKey bytes], [self.publicKey length], [message bytes], [message length],
+                                                             unwrappedMessage, &unwrappedMessageLength);
+        break;
+        
+      case TSMessageModeSignVerify:
+        result = (TSErrorType) themis_secure_message_verify([self.publicKey bytes], [self.publicKey length],
+                                                            [message bytes], [message length], unwrappedMessage, &unwrappedMessageLength);
+        break;
+      default:
+        if (error) {
+          *error = SCERROR(TSErrorTypeFail, @"Secure Message failed wraping, mode unknown");
+        }
+        return nil;
+    }
+  
     if (result != TSErrorTypeSuccess) {
 		if (error) {
         	*error = SCERROR(result, @"Secure Message failed unwraping");

--- a/src/wrappers/themis/Obj-C/objcthemis/smessage.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/smessage.m
@@ -21,13 +21,13 @@
 @interface TSMessage ()
 
 /** @brief private key */
-@property (nonatomic, readwrite) NSData * privateKey;
+@property(nonatomic, readwrite) NSData *privateKey;
 
 /** @brief public key */
-@property (nonatomic, readwrite) NSData * publicKey;
+@property(nonatomic, readwrite) NSData *publicKey;
 
 /** @brief mode */
-@property (nonatomic, readwrite) TSMessageMode mode;
+@property(nonatomic, readwrite) TSMessageMode mode;
 
 @end
 
@@ -64,74 +64,74 @@
 }
 
 
-- (nullable NSData *)wrapData:(nullable NSData *)message error:(NSError * __autoreleasing *)error {
+- (nullable NSData *)wrapData:(nullable NSData *)message error:(NSError *__autoreleasing *)error {
     size_t wrappedMessageLength = 0;
     TSErrorType result = TSErrorTypeFail;
 
     switch (self.mode) {
         case TSMessageModeEncryptDecrypt:
             result = (TSErrorType) themis_secure_message_encrypt([self.privateKey bytes], [self.privateKey length],
-                [self.publicKey bytes], [self.publicKey length], [message bytes], [message length],
-                NULL, &wrappedMessageLength);
+                    [self.publicKey bytes], [self.publicKey length], [message bytes], [message length],
+                    NULL, &wrappedMessageLength);
             break;
 
         case TSMessageModeSignVerify:
             if (!(self.privateKey) || [self.privateKey length] == 0) {
-              NSLog(@"Error during signing: private key is missing");
-				if (error) {
-                	*error = SCERROR(TSErrorTypeFail, @"Secure Message failed wraping");
-				}
+                NSLog(@"Error during signing: private key is missing");
+                if (error) {
+                    *error = SCERROR(TSErrorTypeFail, @"Secure Message failed wraping");
+                }
                 return nil;
             }
             result = (TSErrorType) themis_secure_message_sign([self.privateKey bytes], [self.privateKey length],
-                [message bytes], [message length], NULL, &wrappedMessageLength);
+                    [message bytes], [message length], NULL, &wrappedMessageLength);
             break;
         default:
-			if (error) {
-            	*error = SCERROR(TSErrorTypeFail, @"Secure Message failed wraping, mode unknown");
-			}
+            if (error) {
+                *error = SCERROR(TSErrorTypeFail, @"Secure Message failed wraping, mode unknown");
+            }
             return nil;
     }
 
     if (result != TSErrorTypeBufferTooSmall) {
-      NSLog(@"Error during wrapping data: either key is invalid of message is empty");
-		if (error) {
-        	*error = SCERROR(result, @"Secure Message failed wraping");
-		}
+        NSLog(@"Error during wrapping data: either key is invalid of message is empty");
+        if (error) {
+            *error = SCERROR(result, @"Secure Message failed wraping");
+        }
         return nil;
     }
 
-    unsigned char * wrappedMessage = malloc(wrappedMessageLength);
+    unsigned char *wrappedMessage = malloc(wrappedMessageLength);
     if (!wrappedMessage) {
-		if (error) {
-        	*error = SCERROR(TSErrorTypeFail, @"Secure Message failed, not enough memory");
-		}
+        if (error) {
+            *error = SCERROR(TSErrorTypeFail, @"Secure Message failed, not enough memory");
+        }
         return nil;
     }
 
     switch (self.mode) {
         case TSMessageModeEncryptDecrypt:
             result = (TSErrorType) themis_secure_message_encrypt([self.privateKey bytes], [self.privateKey length],
-                [self.publicKey bytes], [self.publicKey length], [message bytes], [message length],
-                wrappedMessage, &wrappedMessageLength);
+                    [self.publicKey bytes], [self.publicKey length], [message bytes], [message length],
+                    wrappedMessage, &wrappedMessageLength);
             break;
 
         case TSMessageModeSignVerify:
             result = (TSErrorType) themis_secure_message_sign([self.privateKey bytes], [self.privateKey length],
-                [message bytes], [message length], wrappedMessage, &wrappedMessageLength);
+                    [message bytes], [message length], wrappedMessage, &wrappedMessageLength);
             break;
         default:
-			if (error) {
-            	*error = SCERROR(TSErrorTypeFail, @"Secure Message failed wraping, mode unknown");
-			}
+            if (error) {
+                *error = SCERROR(TSErrorTypeFail, @"Secure Message failed wraping, mode unknown");
+            }
             free(wrappedMessage);
             return NULL;
     }
 
     if (result != TSErrorTypeSuccess) {
-		if (error) {
-        	*error = SCERROR(result, @"Secure Message failed wrapping");
-		}
+        if (error) {
+            *error = SCERROR(result, @"Secure Message failed wrapping");
+        }
         free(wrappedMessage);
         return NULL;
     }
@@ -140,73 +140,73 @@
 }
 
 
-- (nullable NSData *)unwrapData:(nullable NSData *)message error:(NSError * __autoreleasing *)error {
+- (nullable NSData *)unwrapData:(nullable NSData *)message error:(NSError *__autoreleasing *)error {
     size_t unwrappedMessageLength = 0;
     TSErrorType result = TSErrorTypeFail;
-  
+
     switch (self.mode) {
-      case TSMessageModeEncryptDecrypt:
-        result = (TSErrorType) themis_secure_message_decrypt([self.privateKey bytes], [self.privateKey length],
-                                                             [self.publicKey bytes], [self.publicKey length], [message bytes], [message length],
-                                                             NULL, &unwrappedMessageLength);
-        break;
-        
-      case TSMessageModeSignVerify:
-        if (!(self.publicKey) || [self.publicKey length] == 0) {
-          NSLog(@"Error during verifying: public key is missing");
-          if (error) {
-            *error = SCERROR(TSErrorTypeFail, @"Secure Message failed wraping");
-          }
-          return nil;
-        }
-        result = (TSErrorType) themis_secure_message_verify([self.publicKey bytes], [self.publicKey length],
-                                                          [message bytes], [message length], NULL, &unwrappedMessageLength);
-        break;
-      default:
-        if (error) {
-          *error = SCERROR(TSErrorTypeFail, @"Secure Message failed wraping, mode unknown");
-        }
-        return nil;
+        case TSMessageModeEncryptDecrypt:
+            result = (TSErrorType) themis_secure_message_decrypt([self.privateKey bytes], [self.privateKey length],
+                    [self.publicKey bytes], [self.publicKey length], [message bytes], [message length],
+                    NULL, &unwrappedMessageLength);
+            break;
+
+        case TSMessageModeSignVerify:
+            if (!(self.publicKey) || [self.publicKey length] == 0) {
+                NSLog(@"Error during verifying: public key is missing");
+                if (error) {
+                    *error = SCERROR(TSErrorTypeFail, @"Secure Message failed wraping");
+                }
+                return nil;
+            }
+            result = (TSErrorType) themis_secure_message_verify([self.publicKey bytes], [self.publicKey length],
+                    [message bytes], [message length], NULL, &unwrappedMessageLength);
+            break;
+        default:
+            if (error) {
+                *error = SCERROR(TSErrorTypeFail, @"Secure Message failed wraping, mode unknown");
+            }
+            return nil;
     }
 
     if (result != TSErrorTypeBufferTooSmall) {
-      NSLog(@"Error during wrapping data: either key is invalid of message is empty");
-		if (error) {
-        	*error = SCERROR(result, @"Secure Message failed unwraping");
-		}
+        NSLog(@"Error during wrapping data: either key is invalid of message is empty");
+        if (error) {
+            *error = SCERROR(result, @"Secure Message failed unwraping");
+        }
         return nil;
     }
 
-    unsigned char * unwrappedMessage = malloc(unwrappedMessageLength);
+    unsigned char *unwrappedMessage = malloc(unwrappedMessageLength);
     if (!unwrappedMessage) {
-		if (error) {
-        	*error = SCERROR(TSErrorTypeFail, @"Secure Message failed, not enough memory");
-		}
+        if (error) {
+            *error = SCERROR(TSErrorTypeFail, @"Secure Message failed, not enough memory");
+        }
         return nil;
     }
 
     switch (self.mode) {
-      case TSMessageModeEncryptDecrypt:
-        result = (TSErrorType) themis_secure_message_decrypt([self.privateKey bytes], [self.privateKey length],
-                                                             [self.publicKey bytes], [self.publicKey length], [message bytes], [message length],
-                                                             unwrappedMessage, &unwrappedMessageLength);
-        break;
-        
-      case TSMessageModeSignVerify:
-        result = (TSErrorType) themis_secure_message_verify([self.publicKey bytes], [self.publicKey length],
-                                                            [message bytes], [message length], unwrappedMessage, &unwrappedMessageLength);
-        break;
-      default:
-        if (error) {
-          *error = SCERROR(TSErrorTypeFail, @"Secure Message failed wraping, mode unknown");
-        }
-        return nil;
+        case TSMessageModeEncryptDecrypt:
+            result = (TSErrorType) themis_secure_message_decrypt([self.privateKey bytes], [self.privateKey length],
+                    [self.publicKey bytes], [self.publicKey length], [message bytes], [message length],
+                    unwrappedMessage, &unwrappedMessageLength);
+            break;
+
+        case TSMessageModeSignVerify:
+            result = (TSErrorType) themis_secure_message_verify([self.publicKey bytes], [self.publicKey length],
+                    [message bytes], [message length], unwrappedMessage, &unwrappedMessageLength);
+            break;
+        default:
+            if (error) {
+                *error = SCERROR(TSErrorTypeFail, @"Secure Message failed wraping, mode unknown");
+            }
+            return nil;
     }
-  
+
     if (result != TSErrorTypeSuccess) {
-		if (error) {
-        	*error = SCERROR(result, @"Secure Message failed unwraping");
-		}
+        if (error) {
+            *error = SCERROR(result, @"Secure Message failed unwraping");
+        }
         free(unwrappedMessage);
         return nil;
     }

--- a/src/wrappers/themis/Obj-C/objcthemis/ssession.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/ssession.h
@@ -56,7 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
 * @param [in] callbacks Reference to TSSessionTransportInterface object
 */
 - (nullable instancetype)initWithUserId:(NSData *)userId
-                                privateKey:(NSData *)privateKey
+                             privateKey:(NSData *)privateKey
                               callbacks:(TSSessionTransportInterface *)callbacks;
 
 
@@ -65,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
 * @return Connection initialization message on success or nil on failure
 */
 // TODO: rename method to reflect it's goal
-- (nullable NSData *)connectRequest:(NSError * __autoreleasing *)error;
+- (nullable NSData *)connectRequest:(NSError *__autoreleasing *)error;
 
 
 /**
@@ -74,7 +74,7 @@ NS_ASSUME_NONNULL_BEGIN
 * @return YES if success, NO if fail.
 */
 // TODO: rename method to reflect it's goal
-- (BOOL)connect:(NSError * __autoreleasing *)error;
+- (BOOL)connect:(NSError *__autoreleasing *)error;
 
 
 /**
@@ -83,7 +83,7 @@ NS_ASSUME_NONNULL_BEGIN
 * @param [in] error pointer to Error on failure
 * @return Wrapped message in NSData object on success or nil on failure.
 */
-- (nullable NSData *)wrapData:(nullable NSData *)message error:(NSError * __autoreleasing *)error;
+- (nullable NSData *)wrapData:(nullable NSData *)message error:(NSError *__autoreleasing *)error;
 
 
 /** @brief Unwrap message
@@ -91,7 +91,7 @@ NS_ASSUME_NONNULL_BEGIN
 * @param [in] error pointer to Error on failure
 * @return Unwrapped message in NSData object on success or nil on failure.
 */
-- (nullable NSData *)unwrapData:(nullable NSData *)message error:(NSError * __autoreleasing *)error;
+- (nullable NSData *)unwrapData:(nullable NSData *)message error:(NSError *__autoreleasing *)error;
 
 
 /** @brief Wrap message and sent it to peer by \b send method from callbacks object.
@@ -101,7 +101,7 @@ NS_ASSUME_NONNULL_BEGIN
 * @return YES if success, NO if fail.
 */
 // TODO: rename method to reflect it's goal
-- (BOOL)wrapAndSend:(nullable NSData *)message error:(NSError * __autoreleasing *)error;
+- (BOOL)wrapAndSend:(nullable NSData *)message error:(NSError *__autoreleasing *)error;
 
 
 /** @brief Unwrap received from peer by \b receive method from callbacks object message.
@@ -111,7 +111,7 @@ NS_ASSUME_NONNULL_BEGIN
 * @return Plain message in NSData object on success or nil on failure.
 */
 // TODO: rename method to reflect it's goal
-- (nullable NSData *)unwrapAndReceive:(NSUInteger)length error:(NSError * __autoreleasing *)error;
+- (nullable NSData *)unwrapAndReceive:(NSUInteger)length error:(NSError *__autoreleasing *)error;
 
 
 /** @brief indicate session established state.

--- a/src/wrappers/themis/Obj-C/objcthemis/ssession.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/ssession.m
@@ -20,7 +20,7 @@
 
 @interface TSSession ()
 
-@property (nonatomic) secure_session_t * session;
+@property(nonatomic) secure_session_t *session;
 
 @end
 
@@ -33,102 +33,101 @@
     self = [super init];
     if (self) {
         self.session = secure_session_create([userId bytes], [userId length],
-            [privateKey bytes], [privateKey length], [callbacks callbacks]);
+                [privateKey bytes], [privateKey length], [callbacks callbacks]);
     }
     return self;
 }
 
 
-- (BOOL)connect:(NSError * __autoreleasing *)error {
+- (BOOL)connect:(NSError *__autoreleasing *)error {
     TSErrorType result = (TSErrorType) secure_session_connect(self.session);
     if (result != TSErrorTypeSuccess) {
-		if (error) {
-        	*error = SCERROR(result, @"Secure Session failed connection");
-		}
-		return NO;
+        if (error) {
+            *error = SCERROR(result, @"Secure Session failed connection");
+        }
+        return NO;
     }
-	return YES;
+    return YES;
 }
 
 
-- (nullable NSData *)connectRequest:(NSError * __autoreleasing *)error {
+- (nullable NSData *)connectRequest:(NSError *__autoreleasing *)error {
     size_t connectRequestLength = 0;
     TSErrorType result = (TSErrorType) secure_session_generate_connect_request(self.session, NULL, &connectRequestLength);
 
     if (result != TSErrorTypeBufferTooSmall) {
-		if (error) {
-        	*error = SCERROR(result, @"Secure Session failed making connection request");
-		}
+        if (error) {
+            *error = SCERROR(result, @"Secure Session failed making connection request");
+        }
         return nil;
     }
 
-    NSMutableData * requestData = [[NSMutableData alloc] initWithLength:connectRequestLength];
+    NSMutableData *requestData = [[NSMutableData alloc] initWithLength:connectRequestLength];
     result = (TSErrorType) secure_session_generate_connect_request(self.session, [requestData mutableBytes], &connectRequestLength);
 
     if (result != TSErrorTypeSuccess) {
-		if (error) {
-        	*error = SCERROR(result, @"Secure Session failed making connection request");
-		}
+        if (error) {
+            *error = SCERROR(result, @"Secure Session failed making connection request");
+        }
         return nil;
     }
     return [requestData copy];
 }
 
 
-- (nullable NSData *)wrapData:(nullable NSData *)message error:(NSError * __autoreleasing *)error {
+- (nullable NSData *)wrapData:(nullable NSData *)message error:(NSError *__autoreleasing *)error {
     size_t wrappedMessageLength = 0;
 
     TSErrorType result = (TSErrorType) secure_session_wrap(self.session, [message bytes], [message length],
-        NULL, &wrappedMessageLength);
+            NULL, &wrappedMessageLength);
 
     if (result != TSErrorTypeBufferTooSmall) {
-		if (error) {
-        	*error = SCERROR(result, @"Secure Session failed encryption");
-		}
+        if (error) {
+            *error = SCERROR(result, @"Secure Session failed encryption");
+        }
         return nil;
     }
 
-    NSMutableData * wrappedMessage = [[NSMutableData alloc] initWithLength:wrappedMessageLength];
+    NSMutableData *wrappedMessage = [[NSMutableData alloc] initWithLength:wrappedMessageLength];
     result = (TSErrorType) secure_session_wrap(self.session, [message bytes], [message length],
-        [wrappedMessage mutableBytes], &wrappedMessageLength);
+            [wrappedMessage mutableBytes], &wrappedMessageLength);
 
     if (result != TSErrorTypeSuccess) {
-		if (error) {
-        	*error = SCERROR(result, @"Secure Session failed encryption");
-		}
+        if (error) {
+            *error = SCERROR(result, @"Secure Session failed encryption");
+        }
         return nil;
     }
     return [wrappedMessage copy];
 }
 
 
-- (nullable NSData *)unwrapData:(nullable NSData *)message error:(NSError * __autoreleasing *)error {
+- (nullable NSData *)unwrapData:(nullable NSData *)message error:(NSError *__autoreleasing *)error {
     size_t unwrappedMessageLength = 0;
     TSErrorType result = (TSErrorType) secure_session_unwrap(self.session, [message bytes], [message length],
-        NULL, &unwrappedMessageLength);
+            NULL, &unwrappedMessageLength);
 
     if (result != TSErrorTypeBufferTooSmall) {
         if (result == TSErrorTypeSuccess) {
-			return nil; // TODO: This is really strange! Success and returning nil???
+            return nil; // TODO: This is really strange! Success and returning nil???
         }
-		if (error) {
-        	*error = SCERROR(result, @"Secure Session failed decryption");
-		}
+        if (error) {
+            *error = SCERROR(result, @"Secure Session failed decryption");
+        }
         return nil;
     }
 
-    NSMutableData * unwrappedMessage = [[NSMutableData alloc] initWithLength:unwrappedMessageLength];
+    NSMutableData *unwrappedMessage = [[NSMutableData alloc] initWithLength:unwrappedMessageLength];
     result = (TSErrorType) secure_session_unwrap(self.session, [message bytes], [message length],
-        [unwrappedMessage mutableBytes], &unwrappedMessageLength);
+            [unwrappedMessage mutableBytes], &unwrappedMessageLength);
 
     if (result != TSErrorTypeSuccess) {
         if (result == TSErrorTypeSendAsIs) {
             return unwrappedMessage;
-        }
-        else {
-			if (error) {
-            	*error = SCERROR(result, @"Secure Session failed decryption");
-			}
+        } else {
+            if (error) {
+                *error = SCERROR(result, @"Secure Session failed decryption");
+            }
             return nil;
         }
     }
@@ -137,27 +136,27 @@
 }
 
 
-- (BOOL)wrapAndSend:(nullable NSData *)message error:(NSError * __autoreleasing *)error {
+- (BOOL)wrapAndSend:(nullable NSData *)message error:(NSError *__autoreleasing *)error {
     TSErrorType result = (TSErrorType) secure_session_send(self.session, [message bytes], [message length]);
     if (result != TSErrorTypeSuccess) {
-		if (error) {
-        	*error = SCERROR(result, @"Secure Session failed sending");
-		}
-		return NO;
+        if (error) {
+            *error = SCERROR(result, @"Secure Session failed sending");
+        }
+        return NO;
     }
-	return YES;
+    return YES;
 }
 
 
-- (nullable NSData *)unwrapAndReceive:(NSUInteger)length error:(NSError * __autoreleasing *)error {
-    NSMutableData * receivedData = [[NSMutableData alloc] initWithLength:length];
+- (nullable NSData *)unwrapAndReceive:(NSUInteger)length error:(NSError *__autoreleasing *)error {
+    NSMutableData *receivedData = [[NSMutableData alloc] initWithLength:length];
     TSErrorType result = (TSErrorType) secure_session_receive(self.session, [receivedData mutableBytes],
-        [receivedData length]);
+            [receivedData length]);
 
     if (result != TSErrorTypeSuccess) {
-		if (error) {
-        	*error = SCERROR(result, @"Secure Session failed receiving");
-		}
+        if (error) {
+            *error = SCERROR(result, @"Secure Session failed receiving");
+        }
         return nil;
     }
     return [receivedData copy];

--- a/src/wrappers/themis/Obj-C/objcthemis/ssession_transport_interface.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/ssession_transport_interface.h
@@ -33,14 +33,14 @@ NS_ASSUME_NONNULL_BEGIN
 * @param [in] data binary data
 * @param [in] error pointer to Error on failure
 */
-- (void)sendData:(nullable NSData *)data error:(NSError * __autoreleasing *)error;
+- (void)sendData:(nullable NSData *)data error:(NSError *__autoreleasing *)error;
 
 
 /** @brief Receive data from peer and return it in NSData object
 * @param [in] error pointer to Error on failure
 * @return data object or nil on failure
 */
-- (nullable NSData *)receiveDataWithError:(NSError * __autoreleasing *)error;
+- (nullable NSData *)receiveDataWithError:(NSError *__autoreleasing *)error;
 
 
 /** @brief Return public key associated with binaryId as NSData object or nil on failure
@@ -48,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 * @param [in] error pointer to Error on failure
 * @return binary public key associated with binaryId or nil on failure
 */
-- (nullable NSData *)publicKeyFor:(nullable NSData *)binaryId error:(NSError * __autoreleasing *)error;
+- (nullable NSData *)publicKeyFor:(nullable NSData *)binaryId error:(NSError *__autoreleasing *)error;
 
 
 /** @brief Get callbacks */

--- a/src/wrappers/themis/Obj-C/objcthemis/ssession_transport_interface.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/ssession_transport_interface.m
@@ -18,25 +18,25 @@
 #import <objcthemis/serror.h>
 
 
-ssize_t on_send_callback(const uint8_t * data, size_t data_length, void * user_data) {
+ssize_t on_send_callback(const uint8_t *data, size_t data_length, void *user_data) {
     return TSErrorTypeFail;
 }
 
 
-ssize_t on_receive_callback(uint8_t * data, size_t data_length, void * user_data) {
+ssize_t on_receive_callback(uint8_t *data, size_t data_length, void *user_data) {
     return TSErrorTypeFail;
 }
 
 
-void on_state_changed_callback(int event, void * user_data) {
+void on_state_changed_callback(int event, void *user_data) {
     return;
 }
 
 
-int on_get_public_key_for_id_callback(const void * id, size_t id_length, void * key_buffer, size_t key_buffer_length, void * user_data) {
-    TSSessionTransportInterface * referenceObject = (__bridge TSSessionTransportInterface *) user_data;
-    NSError * error = nil;
-    NSData * publicKey = [referenceObject publicKeyFor:[[NSData alloc] initWithBytes:id length:id_length] error:&error];
+int on_get_public_key_for_id_callback(const void *id, size_t id_length, void *key_buffer, size_t key_buffer_length, void *user_data) {
+    TSSessionTransportInterface *referenceObject = (__bridge TSSessionTransportInterface *) user_data;
+    NSError *error = nil;
+    NSData *publicKey = [referenceObject publicKeyFor:[[NSData alloc] initWithBytes:id length:id_length] error:&error];
 
     if (error || key_buffer_length < [publicKey length]) {
         return TSErrorTypeFail;
@@ -62,33 +62,33 @@ int on_get_public_key_for_id_callback(const void * id, size_t id_length, void * 
 
 
 // TODO: implement
-- (void)sendData:(nullable NSData *)data error:(NSError * __autoreleasing *)error {
-	if (error) {
-    	*error = SCERROR(TSErrorTypeFail, @"secure session send callback");
-	}
+- (void)sendData:(nullable NSData *)data error:(NSError *__autoreleasing *)error {
+    if (error) {
+        *error = SCERROR(TSErrorTypeFail, @"secure session send callback");
+    }
     return;
 }
 
 
 // TODO: implement
 - (nullable NSData *)receiveDataWithError:(NSError **)error {
-	if (error) {
-    	*error = SCERROR(TSErrorTypeFail, @"secure session receive callback");
-	}
+    if (error) {
+        *error = SCERROR(TSErrorTypeFail, @"secure session receive callback");
+    }
     return nil;
 }
 
 
-- (nullable NSData *)publicKeyFor:(nullable NSData *)binaryId error:(NSError * __autoreleasing *)error {
+- (nullable NSData *)publicKeyFor:(nullable NSData *)binaryId error:(NSError *__autoreleasing *)error {
     // TODO: approve
-    NSMutableData * key = [[NSMutableData alloc] initWithLength:1024];
+    NSMutableData *key = [[NSMutableData alloc] initWithLength:1024];
     TSErrorType result = (TSErrorType) on_get_public_key_for_id_callback([binaryId bytes], [binaryId length],
-        [key mutableBytes], [key length], (__bridge void *) self);
+            [key mutableBytes], [key length], (__bridge void *) self);
 
     if (result != TSErrorTypeSuccess) {
-		if (error) {
-        	*error = SCERROR(TSErrorTypeFail, @"Secure Session failed getting of public key");
-		}
+        if (error) {
+            *error = SCERROR(TSErrorTypeFail, @"Secure Session failed getting of public key");
+        }
         return nil;
     }
     return [key copy];


### PR DESCRIPTION
This is first PR of two to update SecureMessage Themis iOS wrapper for new SecureMessage API (#389).

Please check this PR by commits.

1. Update SecureMessage wrapper to call encrypt/decrypt and sign/verify core functions instead of wrap/unwrap. This change doesn't affect SecureMessage iOS wrapper API itself (users won't notice).

2. Add more logs for developers about wrong / missing private and public keys.

3. Fix formatting of the whole Themis iOS wrapper, because it drives me crazy – this commit is about updating style only.

--

In next PR (#394): more tests on SecureMessage iOS wrapper that depends on this PR