### PR TITLE
Automate C code formatting [1/3]

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,19 @@
+﻿---
+BasedOnStyle: LLVM
+AccessModifierOffset: -4
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakTemplateDeclarations: true
+BreakBeforeBraces: Linux
+BreakConstructorInitializersBeforeComma: true
+ColumnLimit: 100
+IndentWidth: 4
+ObjCSpaceAfterProperty: true
+PointerAlignment: Left
+TabWidth: 8
+UseTab: Never
+...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,4 @@
+---
+Checks: 'readability-*'
+FormatStyle: none
+...

--- a/src/soter/boringssl/soter.mk
+++ b/src/soter/boringssl/soter.mk
@@ -14,7 +14,8 @@
 # limitations under the License.
 #
 
-SOTER_SRC += $(wildcard $(CRYPTO_ENGINE)/*.c)
+CRYPTO_ENGINE_SOURCES += $(wildcard $(CRYPTO_ENGINE)/*.c)
+CRYPTO_ENGINE_HEADERS += $(wildcard $(CRYPTO_ENGINE)/*.h)
 
 # Put path to your OpenSSL/LibreSSL here
 OPENSSL_DIR = libs/librebin

--- a/src/soter/openssl/soter.mk
+++ b/src/soter/openssl/soter.mk
@@ -14,9 +14,9 @@
 # limitations under the License.
 #
 
-SOTER_SRC += $(wildcard $(CRYPTO_ENGINE)/*.c)
-SOTER_AUD_SRC += $(wildcard $(CRYPTO_ENGINE)/*.c)
-SOTER_AUD_SRC += $(wildcard $(CRYPTO_ENGINE)/*.h)
+CRYPTO_ENGINE_SOURCES += $(wildcard $(CRYPTO_ENGINE)/*.c)
+CRYPTO_ENGINE_HEADERS += $(wildcard $(CRYPTO_ENGINE)/*.h)
+
 # Put path to your OpenSSL/LibreSSL here
 OPENSSL_DIR = libs/librebin
 

--- a/src/soter/soter.mk
+++ b/src/soter/soter.mk
@@ -14,19 +14,28 @@
 # limitations under the License.
 #
 
-SOTER_SRC = $(wildcard $(SRC_PATH)/soter/*.c)
-SOTER_AUD_SRC = $(wildcard $(SRC_PATH)/soter/*.c)
-SOTER_AUD_SRC += $(wildcard $(SRC_PATH)/soter/*.h)
-# ed25519 we specify here, because it should be portable and does not depend on $(CRYPTO_ENGINE)
-SOTER_SRC += $(wildcard $(SRC_PATH)/soter/ed25519/*.c)
-SOTER_AUD_SRC += $(wildcard $(SRC_PATH)/soter/ed25519/*.c)
-SOTER_AUD_SRC += $(wildcard $(SRC_PATH)/soter/ed25519/*.h)
+SOTER_SOURCES = $(wildcard $(SRC_PATH)/soter/*.c)
+SOTER_HEADERS = $(wildcard $(SRC_PATH)/soter/*.h)
+ED25519_SOURCES = $(wildcard $(SRC_PATH)/soter/ed25519/*.c)
+ED25519_HEADERS = $(wildcard $(SRC_PATH)/soter/ed25519/*.h)
+
+SOTER_SRC = $(SOTER_SOURCES) $(ED25519_SOURCES) $(CRYPTO_ENGINE_SOURCES)
+
+SOTER_AUD_SRC += $(SOTER_SOURCES) $(ED25519_SOURCES) $(CRYPTO_ENGINE_SOURCES)
+SOTER_AUD_SRC += $(SOTER_HEADERS) $(ED25519_HEADERS) $(CRYPTO_ENGINE_HEADERS)
+
+# Ignore ed25519 during code reformatting as it is 3rd-party code (and it breaks clang-tidy)
+SOTER_FMT_SRC += $(SOTER_SOURCES) $(CRYPTO_ENGINE_SOURCES)
+SOTER_FMT_SRC += $(SOTER_HEADERS) $(CRYPTO_ENGINE_HEADERS)
 
 include $(CRYPTO_ENGINE)/soter.mk
 
 SOTER_OBJ = $(patsubst $(SRC_PATH)/%.c,$(OBJ_PATH)/%.o, $(SOTER_SRC))
 
 SOTER_AUD = $(patsubst $(SRC_PATH)/%,$(AUD_PATH)/%, $(SOTER_AUD_SRC))
+
+SOTER_FMT_FIXUP = $(patsubst $(SRC_PATH)/%,$(OBJ_PATH)/%.fmt_fixup,$(SOTER_FMT_SRC))
+SOTER_FMT_CHECK = $(patsubst $(SRC_PATH)/%,$(OBJ_PATH)/%.fmt_check,$(SOTER_FMT_SRC))
 
 SOTER_BIN = soter
 

--- a/src/themis/themis.mk
+++ b/src/themis/themis.mk
@@ -14,13 +14,19 @@
 # limitations under the License.
 #
 
-THEMIS_SRC = $(wildcard $(SRC_PATH)/themis/*.c)
-THEMIS_AUD_SRC = $(wildcard $(SRC_PATH)/themis/*.c)
-THEMIS_AUD_SRC += $(wildcard $(SRC_PATH)/themis/*.h)
+THEMIS_SOURCES = $(wildcard $(SRC_PATH)/themis/*.c)
+THEMIS_HEADERS = $(wildcard $(SRC_PATH)/themis/*.h)
+
+THEMIS_SRC = $(THEMIS_SOURCES)
+THEMIS_AUD_SRC = $(THEMIS_SOURCES) $(THEMIS_HEADERS)
+THEMIS_FMT_SRC = $(THEMIS_SOURCES) $(THEMIS_HEADERS)
 
 THEMIS_OBJ = $(patsubst $(SRC_PATH)/%.c,$(OBJ_PATH)/%.o, $(THEMIS_SRC))
 
 THEMIS_AUD = $(patsubst $(SRC_PATH)/%,$(AUD_PATH)/%, $(THEMIS_AUD_SRC))
+
+THEMIS_FMT_FIXUP = $(patsubst $(SRC_PATH)/%,$(OBJ_PATH)/%.fmt_fixup,$(THEMIS_FMT_SRC))
+THEMIS_FMT_CHECK = $(patsubst $(SRC_PATH)/%,$(OBJ_PATH)/%.fmt_check,$(THEMIS_FMT_SRC))
 
 THEMIS_BIN = themis
 

--- a/tests/soter/nist-sts/.clang-format
+++ b/tests/soter/nist-sts/.clang-format
@@ -1,0 +1,4 @@
+---
+DisableFormat: true
+SortIncludes: false
+...


### PR DESCRIPTION
Let's introduce an automatic code style formatting and checks for Themis. We use **clang-format** and **clang-tidy** tools as they are generally available and gives reasonable results.

Introduce two new targets for Makefile:

  - make fmt
  - make fmt_check

**fmt** is intended for humans to reformat the code before submitting changes for review. Currently it formats only C code but it may be extended to other languages as well.

**fmt_check** is intended for CI to do format checks to ensure that the code is formatted accordingly. Unfortunately, clang-format does not have a convenient check mode so we hack one with git diff.

clang-tidy requires the compilation flags so we integrate the format checking into the build pipeline. It's a bit repetetive, but also gives up a chance to cleanup the build system. And it uses Make features nicely so we don't have to recheck and reformat the files which are okay.

We start by formatting only Soter and Themis source code. Other parts will be added later.

Supersedes #391, relates to #270