### PR TITLE
Fix a warning about memory leak in Secure Message

### DIFF
--- a/src/themis/secure_message_wrapper.c
+++ b/src/themis/secure_message_wrapper.c
@@ -487,9 +487,8 @@ themis_secure_message_encrypter_init(const uint8_t* private_key, const size_t pr
         THEMIS_IF_FAIL_(ctx->ctx.rsa_encrypter, free(ctx));
         ctx->alg = alg;
         return ctx;
-    default:
-        return NULL;
     }
+    free(ctx);
     return NULL;
 }
 themis_status_t themis_secure_message_encrypter_proceed(themis_secure_message_encrypter_t* ctx,
@@ -558,9 +557,8 @@ themis_secure_message_decrypter_init(const uint8_t* private_key, const size_t pr
         THEMIS_CHECK__(ctx->ctx.rsa_encrypter, free(ctx); return NULL);
         ctx->alg = alg;
         return ctx;
-    default:
-        return NULL;
     }
+    free(ctx);
     return NULL;
 }
 


### PR DESCRIPTION
clang-tidy is being cautious about allocations. Calm it down by freeing the allocated context if we're going to return NULL.

This actually cannot happen because we check the key type earlier and return before allocating a crypto context. However, clang-tidy is not that smart to see through five layers or preprocessor macros. I'd bet that developers aren't that smart either.