### PR TITLE
Enforce C formatting in Soter and Themis tests

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -10,6 +10,7 @@ AllowShortLoopsOnASingleLine: false
 AlwaysBreakTemplateDeclarations: true
 BreakBeforeBraces: Linux
 BreakConstructorInitializersBeforeComma: true
+BreakStringLiterals: false
 ColumnLimit: 100
 IndentWidth: 4
 ObjCSpaceAfterProperty: true

--- a/Makefile
+++ b/Makefile
@@ -326,20 +326,6 @@ $(AUD_PATH)/%: $(SRC_PATH)/%
 	@echo -n "compile "
 	@$(BUILD_CMD)
 
-$(TEST_OBJ_PATH)/%.o: CMD = $(CC) $(CFLAGS) -DNIST_STS_EXE_PATH=$(realpath $(NIST_STS_DIR)) -I$(TEST_SRC_PATH) -c $< -o $@
-
-$(TEST_OBJ_PATH)/%.o: $(TEST_SRC_PATH)/%.c
-	@mkdir -p $(@D)
-	@echo -n "compile "
-	@$(BUILD_CMD)
-
-$(TEST_OBJ_PATH)/%.opp: CMD = $(CXX) $(CFLAGS) -I$(TEST_SRC_PATH) -c $< -o $@
-
-$(TEST_OBJ_PATH)/%.opp: $(TEST_SRC_PATH)/%.cpp
-	@mkdir -p $(@D)
-	@echo -n "compile "
-	@$(BUILD_CMD)
-
 include tests/test.mk
 include tools/afl/fuzzy.mk
 

--- a/tests/soter/soter.mk
+++ b/tests/soter/soter.mk
@@ -14,5 +14,12 @@
 # limitations under the License.
 #
 
-THEMIS_TEST_SRC = $(wildcard tests/themis/*.c)
+THEMIS_TEST_SOURCES = $(wildcard tests/themis/*.c)
+THEMIS_TEST_HEADERS = $(wildcard tests/themis/*.h)
+
+THEMIS_TEST_SRC = $(THEMIS_TEST_SOURCES)
 THEMIS_TEST_OBJ = $(patsubst $(TEST_SRC_PATH)/%.c,$(TEST_OBJ_PATH)/%.o, $(THEMIS_TEST_SRC))
+
+THEMIS_TEST_FMT_SRC = $(THEMIS_TEST_SOURCES) $(THEMIS_TEST_HEADERS)
+THEMIS_TEST_FMT_FIXUP = $(patsubst $(TEST_SRC_PATH)/%,$(TEST_OBJ_PATH)/%.fmt_fixup, $(THEMIS_TEST_FMT_SRC))
+THEMIS_TEST_FMT_CHECK = $(patsubst $(TEST_SRC_PATH)/%,$(TEST_OBJ_PATH)/%.fmt_check, $(THEMIS_TEST_FMT_SRC))

--- a/tests/soter/soter_asym_cipher_test.c
+++ b/tests/soter/soter_asym_cipher_test.c
@@ -1,18 +1,18 @@
 /*
-* Copyright (c) 2015 Cossack Labs Limited
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2015 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "soter/soter_test.h"
 
@@ -22,232 +22,291 @@
 
 static void test_basic_encryption_flow(void)
 {
-	uint8_t test_data[TEST_DATA_SIZE];
-	uint8_t encrypted_data[4096];
-	uint8_t decrypted_data[sizeof(encrypted_data)];
-	size_t encrypted_data_length = sizeof(encrypted_data);
-	size_t decrypted_data_length = sizeof(decrypted_data);
+    uint8_t test_data[TEST_DATA_SIZE];
+    uint8_t encrypted_data[4096];
+    uint8_t decrypted_data[sizeof(encrypted_data)];
+    size_t encrypted_data_length = sizeof(encrypted_data);
+    size_t decrypted_data_length = sizeof(decrypted_data);
 
+    uint8_t key_data[8192];
+    size_t key_data_length = sizeof(key_data);
 
-	uint8_t key_data[8192];
-	size_t key_data_length = sizeof(key_data);
+    soter_asym_cipher_t* ctx;
+    soter_asym_cipher_t* decrypt_ctx;
+    soter_status_t res = soter_rand(test_data, sizeof(test_data));
 
-	soter_asym_cipher_t *ctx;
-	soter_asym_cipher_t *decrypt_ctx;
-	soter_status_t res = soter_rand(test_data, sizeof(test_data));
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_unless(SOTER_SUCCESS == res, "generate test data");
+        return;
+    }
 
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_unless(SOTER_SUCCESS == res, "generate test data");
-		return;
-	}
+    soter_rsa_key_pair_gen_t* key_pair_ctx = soter_rsa_key_pair_gen_create(RSA_KEY_LENGTH_1024);
+    if (!key_pair_ctx) {
+        testsuite_fail_if(!key_pair_ctx, "generate key test data");
+        return;
+    }
 
-	soter_rsa_key_pair_gen_t* key_pair_ctx=soter_rsa_key_pair_gen_create(RSA_KEY_LENGTH_1024);
-	if(!key_pair_ctx){
-		testsuite_fail_if(!key_pair_ctx, "generate key test data");
-		return;
-	}
-	
-	res = soter_rsa_key_pair_gen_export_key(key_pair_ctx, key_data, &key_data_length, false);
-	if(res!=SOTER_SUCCESS){
-		testsuite_fail_if(res!=SOTER_SUCCESS, "export generated public key");
-		soter_rsa_key_pair_gen_destroy(key_pair_ctx);
-		return;
-	}
+    res = soter_rsa_key_pair_gen_export_key(key_pair_ctx, key_data, &key_data_length, false);
+    if (res != SOTER_SUCCESS) {
+        testsuite_fail_if(res != SOTER_SUCCESS, "export generated public key");
+        soter_rsa_key_pair_gen_destroy(key_pair_ctx);
+        return;
+    }
 
-	ctx = soter_asym_cipher_create(key_data, key_data_length, SOTER_ASYM_CIPHER_OAEP);
-	if (NULL == ctx)
-	{
-		testsuite_fail_if(NULL == ctx, "asym_cipher_ctx != NULL");
-		soter_rsa_key_pair_gen_destroy(key_pair_ctx);
-		return;
-	}
+    ctx = soter_asym_cipher_create(key_data, key_data_length, SOTER_ASYM_CIPHER_OAEP);
+    if (NULL == ctx) {
+        testsuite_fail_if(NULL == ctx, "asym_cipher_ctx != NULL");
+        soter_rsa_key_pair_gen_destroy(key_pair_ctx);
+        return;
+    }
 
-	res = soter_asym_cipher_encrypt(ctx, test_data, sizeof(test_data), encrypted_data, &encrypted_data_length);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_cipher_encrypt fail");
-		soter_asym_cipher_destroy(ctx);
-		return;
-	}
+    res = soter_asym_cipher_encrypt(ctx, test_data, sizeof(test_data), encrypted_data,
+                                    &encrypted_data_length);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_cipher_encrypt fail");
+        soter_asym_cipher_destroy(ctx);
+        return;
+    }
 
-	/* Encrypted ciphertext for 2048 RSA key should be 256 bytes */
-	testsuite_fail_unless(128 == encrypted_data_length, "RSA OAEP encryption");
-	key_data_length = sizeof(key_data);
-	res = soter_rsa_key_pair_gen_export_key(key_pair_ctx, key_data, &key_data_length, true);
-	printf("%i\n", res);
-	if(res!=SOTER_SUCCESS){
-		testsuite_fail_if(res!=SOTER_SUCCESS, "export generated private key");
-		soter_rsa_key_pair_gen_destroy(key_pair_ctx);
-		return;
-	}
+    /* Encrypted ciphertext for 2048 RSA key should be 256 bytes */
+    testsuite_fail_unless(128 == encrypted_data_length, "RSA OAEP encryption");
+    key_data_length = sizeof(key_data);
+    res = soter_rsa_key_pair_gen_export_key(key_pair_ctx, key_data, &key_data_length, true);
+    printf("%i\n", res);
+    if (res != SOTER_SUCCESS) {
+        testsuite_fail_if(res != SOTER_SUCCESS, "export generated private key");
+        soter_rsa_key_pair_gen_destroy(key_pair_ctx);
+        return;
+    }
 
-	decrypt_ctx = soter_asym_cipher_create(key_data, key_data_length, SOTER_ASYM_CIPHER_OAEP);
-	if (NULL == decrypt_ctx)
-	{
-		testsuite_fail_if(NULL == decrypt_ctx, "asym_cipher_ctx != NULL");
-		soter_asym_cipher_destroy(ctx);
-		soter_rsa_key_pair_gen_destroy(key_pair_ctx);
-		return;
-	}
+    decrypt_ctx = soter_asym_cipher_create(key_data, key_data_length, SOTER_ASYM_CIPHER_OAEP);
+    if (NULL == decrypt_ctx) {
+        testsuite_fail_if(NULL == decrypt_ctx, "asym_cipher_ctx != NULL");
+        soter_asym_cipher_destroy(ctx);
+        soter_rsa_key_pair_gen_destroy(key_pair_ctx);
+        return;
+    }
 
-	res = soter_asym_cipher_decrypt(decrypt_ctx, encrypted_data, encrypted_data_length, decrypted_data, &decrypted_data_length);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_cipher_decrypt fail");
-		soter_asym_cipher_destroy(ctx);
-		soter_asym_cipher_destroy(decrypt_ctx);
-		soter_rsa_key_pair_gen_destroy(key_pair_ctx);
-		return;
-	}
+    res = soter_asym_cipher_decrypt(decrypt_ctx, encrypted_data, encrypted_data_length,
+                                    decrypted_data, &decrypted_data_length);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_cipher_decrypt fail");
+        soter_asym_cipher_destroy(ctx);
+        soter_asym_cipher_destroy(decrypt_ctx);
+        soter_rsa_key_pair_gen_destroy(key_pair_ctx);
+        return;
+    }
 
-	testsuite_fail_unless((sizeof(test_data) == decrypted_data_length) && !(memcmp(test_data, decrypted_data, sizeof(test_data))), "RSA OAEP decryption");
+    testsuite_fail_unless((sizeof(test_data) == decrypted_data_length) &&
+                              !(memcmp(test_data, decrypted_data, sizeof(test_data))),
+                          "RSA OAEP decryption");
 
-	key_data_length = sizeof(key_data);
+    key_data_length = sizeof(key_data);
 
-	res = soter_asym_cipher_destroy(ctx);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_cipher_destroy fail");
-		return;
-	}
+    res = soter_asym_cipher_destroy(ctx);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_cipher_destroy fail");
+        return;
+    }
 
-	res = soter_asym_cipher_destroy(decrypt_ctx);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_cipher_destroy fail");
-		return;
-	}
-	res = soter_rsa_key_pair_gen_destroy(key_pair_ctx);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_unless(SOTER_SUCCESS == res, "soter_rsa_key_pair_gen_destroy fail");
-		return;
-	}
+    res = soter_asym_cipher_destroy(decrypt_ctx);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_cipher_destroy fail");
+        return;
+    }
+    res = soter_rsa_key_pair_gen_destroy(key_pair_ctx);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_unless(SOTER_SUCCESS == res, "soter_rsa_key_pair_gen_destroy fail");
+        return;
+    }
 }
 
 void test_api(int key_length)
 {
-	soter_status_t res;
-	soter_asym_cipher_t ctx, decrypt_ctx;
+    soter_status_t res;
+    soter_asym_cipher_t ctx, decrypt_ctx;
 
-	uint8_t test_data[TEST_DATA_SIZE];
-	uint8_t encrypted_data[4096];
-	uint8_t decrypted_data[sizeof(encrypted_data)];
-	size_t encrypted_data_length = sizeof(encrypted_data);
-	size_t decrypted_data_length = sizeof(decrypted_data);
+    uint8_t test_data[TEST_DATA_SIZE];
+    uint8_t encrypted_data[4096];
+    uint8_t decrypted_data[sizeof(encrypted_data)];
+    size_t encrypted_data_length = sizeof(encrypted_data);
+    size_t decrypted_data_length = sizeof(decrypted_data);
 
-	uint8_t key_data[8192];
-	size_t key_data_length = sizeof(key_data);
+    uint8_t key_data[8192];
+    size_t key_data_length = sizeof(key_data);
 
-	memset(&ctx, 0, sizeof(soter_asym_cipher_t));
+    memset(&ctx, 0, sizeof(soter_asym_cipher_t));
 
-	soter_rsa_key_pair_gen_t* key_pair_ctx=soter_rsa_key_pair_gen_create((unsigned)key_length);
-	if(!key_pair_ctx){
-		testsuite_fail_if(!key_pair_ctx, "generate key test data");
-		return;
-	}
-	
+    soter_rsa_key_pair_gen_t* key_pair_ctx = soter_rsa_key_pair_gen_create((unsigned)key_length);
+    if (!key_pair_ctx) {
+        testsuite_fail_if(!key_pair_ctx, "generate key test data");
+        return;
+    }
 
-	res = soter_rand(test_data, sizeof(test_data));
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_unless(SOTER_SUCCESS == res, "generate test data");
-		return;
-	}
+    res = soter_rand(test_data, sizeof(test_data));
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_unless(SOTER_SUCCESS == res, "generate test data");
+        return;
+    }
 
-	testsuite_fail_unless(SOTER_SUCCESS==soter_rsa_key_pair_gen_export_key(key_pair_ctx, key_data, &key_data_length, false), "export private_key failed");	
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_cipher_init(NULL, key_data, key_data_length, SOTER_ASYM_CIPHER_OAEP), "soter_asym_cipher_init: invalid context");
-	testsuite_fail_unless(SOTER_FAIL == soter_asym_cipher_init(&ctx, NULL, key_data_length, SOTER_ASYM_CIPHER_OAEP), "soter_asym_cipher_init: invalid key");
-	testsuite_fail_unless(SOTER_FAIL == soter_asym_cipher_init(&ctx, key_data, 0, SOTER_ASYM_CIPHER_OAEP), "soter_asym_cipher_init: invalid key length");
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_cipher_init(&ctx, key_data, key_data_length, (soter_asym_cipher_padding_t)0xffffffff), "soter_asym_cipher_init: invalid algorithm type");
-	testsuite_fail_unless(NULL == soter_asym_cipher_create(key_data, key_data_length, (soter_asym_cipher_padding_t)0xffffffff), "soter_asym_cipher_create: invalid algorithm type");
+    testsuite_fail_unless(SOTER_SUCCESS == soter_rsa_key_pair_gen_export_key(
+                                               key_pair_ctx, key_data, &key_data_length, false),
+                          "export private_key failed");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_cipher_init(NULL, key_data,
+                                                                            key_data_length,
+                                                                            SOTER_ASYM_CIPHER_OAEP),
+                          "soter_asym_cipher_init: invalid context");
+    testsuite_fail_unless(
+        SOTER_FAIL == soter_asym_cipher_init(&ctx, NULL, key_data_length, SOTER_ASYM_CIPHER_OAEP),
+        "soter_asym_cipher_init: invalid key");
+    testsuite_fail_unless(SOTER_FAIL ==
+                              soter_asym_cipher_init(&ctx, key_data, 0, SOTER_ASYM_CIPHER_OAEP),
+                          "soter_asym_cipher_init: invalid key length");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER ==
+                              soter_asym_cipher_init(&ctx, key_data, key_data_length,
+                                                     (soter_asym_cipher_padding_t)0xffffffff),
+                          "soter_asym_cipher_init: invalid algorithm type");
+    testsuite_fail_unless(NULL == soter_asym_cipher_create(key_data, key_data_length,
+                                                           (soter_asym_cipher_padding_t)0xffffffff),
+                          "soter_asym_cipher_create: invalid algorithm type");
 
-	res = soter_asym_cipher_init(&ctx, key_data, key_data_length, SOTER_ASYM_CIPHER_OAEP);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_cipher_init fail");
-		return;
-	}
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_cipher_encrypt(NULL, test_data, sizeof(test_data), encrypted_data, &encrypted_data_length), "soter_asym_cipher_encrypt: invalid context");
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_cipher_encrypt(&ctx, NULL, sizeof(test_data), encrypted_data, &encrypted_data_length), "soter_asym_cipher_encrypt: invalid input data");
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_cipher_encrypt(&ctx, test_data, 0, encrypted_data, &encrypted_data_length), "soter_asym_cipher_encrypt: invalid input data length");
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_cipher_encrypt(&ctx, test_data, sizeof(test_data), encrypted_data, NULL), "soter_asym_cipher_encrypt: invalid output data length");
+    res = soter_asym_cipher_init(&ctx, key_data, key_data_length, SOTER_ASYM_CIPHER_OAEP);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_cipher_init fail");
+        return;
+    }
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER ==
+                              soter_asym_cipher_encrypt(NULL, test_data, sizeof(test_data),
+                                                        encrypted_data, &encrypted_data_length),
+                          "soter_asym_cipher_encrypt: invalid context");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER ==
+                              soter_asym_cipher_encrypt(&ctx, NULL, sizeof(test_data),
+                                                        encrypted_data, &encrypted_data_length),
+                          "soter_asym_cipher_encrypt: invalid input data");
+    testsuite_fail_unless(
+        SOTER_INVALID_PARAMETER ==
+            soter_asym_cipher_encrypt(&ctx, test_data, 0, encrypted_data, &encrypted_data_length),
+        "soter_asym_cipher_encrypt: invalid input data length");
+    testsuite_fail_unless(
+        SOTER_INVALID_PARAMETER ==
+            soter_asym_cipher_encrypt(&ctx, test_data, sizeof(test_data), encrypted_data, NULL),
+        "soter_asym_cipher_encrypt: invalid output data length");
 
-	encrypted_data_length = 0;
-	res = soter_asym_cipher_encrypt(&ctx, test_data, sizeof(test_data), NULL, &encrypted_data_length);
-	testsuite_fail_unless((SOTER_BUFFER_TOO_SMALL == res) && (encrypted_data_length > 0), "soter_asym_cipher_encrypt: get output size (NULL out buffer)");
+    encrypted_data_length = 0;
+    res =
+        soter_asym_cipher_encrypt(&ctx, test_data, sizeof(test_data), NULL, &encrypted_data_length);
+    testsuite_fail_unless((SOTER_BUFFER_TOO_SMALL == res) && (encrypted_data_length > 0),
+                          "soter_asym_cipher_encrypt: get output size (NULL out buffer)");
 
-	encrypted_data_length--;
-	res = soter_asym_cipher_encrypt(&ctx, test_data, sizeof(test_data), encrypted_data, &encrypted_data_length);
-	testsuite_fail_unless((SOTER_BUFFER_TOO_SMALL == res) && (encrypted_data_length > 0), "soter_asym_cipher_encrypt: get output size (small out buffer)");
+    encrypted_data_length--;
+    res = soter_asym_cipher_encrypt(&ctx, test_data, sizeof(test_data), encrypted_data,
+                                    &encrypted_data_length);
+    testsuite_fail_unless((SOTER_BUFFER_TOO_SMALL == res) && (encrypted_data_length > 0),
+                          "soter_asym_cipher_encrypt: get output size (small out buffer)");
 
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_cipher_encrypt(&ctx, test_data, 2048, encrypted_data, &encrypted_data_length), "soter_asym_cipher_encrypt: plaintext too large");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER ==
+                              soter_asym_cipher_encrypt(&ctx, test_data, 2048, encrypted_data,
+                                                        &encrypted_data_length),
+                          "soter_asym_cipher_encrypt: plaintext too large");
 
-	res = soter_asym_cipher_encrypt(&ctx, test_data, sizeof(test_data), encrypted_data, &encrypted_data_length);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_cipher_encrypt fail");
-		return;
-	}
+    res = soter_asym_cipher_encrypt(&ctx, test_data, sizeof(test_data), encrypted_data,
+                                    &encrypted_data_length);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_cipher_encrypt fail");
+        return;
+    }
 
+    key_data_length = sizeof(key_data);
+    testsuite_fail_unless(SOTER_SUCCESS == soter_rsa_key_pair_gen_export_key(
+                                               key_pair_ctx, key_data, &key_data_length, true),
+                          "export private_key failed");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_cipher_init(NULL, key_data,
+                                                                            key_data_length,
+                                                                            SOTER_ASYM_CIPHER_OAEP),
+                          "soter_asym_cipher_init: invalid context");
+    testsuite_fail_unless(SOTER_FAIL == soter_asym_cipher_init(&decrypt_ctx, NULL, key_data_length,
+                                                               SOTER_ASYM_CIPHER_OAEP),
+                          "soter_asym_cipher_init: invalid key");
+    testsuite_fail_unless(
+        SOTER_FAIL == soter_asym_cipher_init(&decrypt_ctx, key_data, 0, SOTER_ASYM_CIPHER_OAEP),
+        "soter_asym_cipher_init: invalid key length");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER ==
+                              soter_asym_cipher_init(&decrypt_ctx, key_data, key_data_length,
+                                                     (soter_asym_cipher_padding_t)0xffffffff),
+                          "soter_asym_cipher_init: invalid algorithm type");
+    testsuite_fail_unless(NULL == soter_asym_cipher_create(key_data, key_data_length,
+                                                           (soter_asym_cipher_padding_t)0xffffffff),
+                          "soter_asym_cipher_create: invalid algorithm type");
 
-	key_data_length = sizeof(key_data);
-	testsuite_fail_unless(SOTER_SUCCESS==soter_rsa_key_pair_gen_export_key(key_pair_ctx, key_data, &key_data_length, true), "export private_key failed");
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_cipher_init(NULL, key_data, key_data_length, SOTER_ASYM_CIPHER_OAEP), "soter_asym_cipher_init: invalid context");
-	testsuite_fail_unless(SOTER_FAIL == soter_asym_cipher_init(&decrypt_ctx, NULL, key_data_length, SOTER_ASYM_CIPHER_OAEP), "soter_asym_cipher_init: invalid key");
-	testsuite_fail_unless(SOTER_FAIL == soter_asym_cipher_init(&decrypt_ctx, key_data, 0, SOTER_ASYM_CIPHER_OAEP), "soter_asym_cipher_init: invalid key length");
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_cipher_init(&decrypt_ctx, key_data, key_data_length, (soter_asym_cipher_padding_t)0xffffffff), "soter_asym_cipher_init: invalid algorithm type");
-	testsuite_fail_unless(NULL == soter_asym_cipher_create(key_data, key_data_length, (soter_asym_cipher_padding_t)0xffffffff), "soter_asym_cipher_create: invalid algorithm type");
+    res = soter_asym_cipher_init(&decrypt_ctx, key_data, key_data_length, SOTER_ASYM_CIPHER_OAEP);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_cipher_init fail");
+        return;
+    }
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER ==
+                              soter_asym_cipher_decrypt(NULL, encrypted_data, encrypted_data_length,
+                                                        decrypted_data, &decrypted_data_length),
+                          "soter_asym_cipher_decrypt: invalid context");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER ==
+                              soter_asym_cipher_decrypt(&decrypt_ctx, NULL, encrypted_data_length,
+                                                        decrypted_data, &decrypted_data_length),
+                          "soter_asym_cipher_decrypt: invalid input data");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER ==
+                              soter_asym_cipher_decrypt(&decrypt_ctx, encrypted_data, 0,
+                                                        decrypted_data, &decrypted_data_length),
+                          "soter_asym_cipher_decrypt: invalid input data length");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER ==
+                              soter_asym_cipher_decrypt(&decrypt_ctx, encrypted_data,
+                                                        encrypted_data_length, decrypted_data,
+                                                        NULL),
+                          "soter_asym_cipher_decrypt: invalid output data length");
 
-	res = soter_asym_cipher_init(&decrypt_ctx, key_data, key_data_length, SOTER_ASYM_CIPHER_OAEP);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_cipher_init fail");
-		return;
-	}
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_cipher_decrypt(NULL, encrypted_data, encrypted_data_length, decrypted_data, &decrypted_data_length), "soter_asym_cipher_decrypt: invalid context");
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_cipher_decrypt(&decrypt_ctx, NULL, encrypted_data_length, decrypted_data, &decrypted_data_length), "soter_asym_cipher_decrypt: invalid input data");
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_cipher_decrypt(&decrypt_ctx, encrypted_data, 0, decrypted_data, &decrypted_data_length), "soter_asym_cipher_decrypt: invalid input data length");
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_cipher_decrypt(&decrypt_ctx, encrypted_data, encrypted_data_length, decrypted_data, NULL), "soter_asym_cipher_decrypt: invalid output data length");
+    decrypted_data_length = 0;
+    res = soter_asym_cipher_decrypt(&decrypt_ctx, encrypted_data, encrypted_data_length, NULL,
+                                    &decrypted_data_length);
+    testsuite_fail_unless((SOTER_BUFFER_TOO_SMALL == res) && (decrypted_data_length > 0),
+                          "soter_asym_cipher_decrypt: get output size (NULL out buffer)");
 
-	decrypted_data_length = 0;
-	res = soter_asym_cipher_decrypt(&decrypt_ctx, encrypted_data, encrypted_data_length, NULL, &decrypted_data_length);
-	testsuite_fail_unless((SOTER_BUFFER_TOO_SMALL == res) && (decrypted_data_length > 0), "soter_asym_cipher_decrypt: get output size (NULL out buffer)");
+    decrypted_data_length = 0;
+    res = soter_asym_cipher_decrypt(&decrypt_ctx, encrypted_data, encrypted_data_length,
+                                    decrypted_data, &decrypted_data_length);
+    testsuite_fail_unless((SOTER_BUFFER_TOO_SMALL == res) && (decrypted_data_length > 0),
+                          "soter_asym_cipher_decrypt: get output size (small out buffer)");
 
-	decrypted_data_length = 0;
-	res = soter_asym_cipher_decrypt(&decrypt_ctx, encrypted_data, encrypted_data_length, decrypted_data, &decrypted_data_length);
-	testsuite_fail_unless((SOTER_BUFFER_TOO_SMALL == res) && (decrypted_data_length > 0), "soter_asym_cipher_decrypt: get output size (small out buffer)");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER ==
+                              soter_asym_cipher_decrypt(&decrypt_ctx, encrypted_data,
+                                                        encrypted_data_length - 1, decrypted_data,
+                                                        &decrypted_data_length),
+                          "soter_asym_cipher_decrypt: ciphertext too small");
 
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_cipher_decrypt(&decrypt_ctx, encrypted_data, encrypted_data_length - 1, decrypted_data, &decrypted_data_length), "soter_asym_cipher_decrypt: ciphertext too small");
+    res = soter_asym_cipher_decrypt(&decrypt_ctx, encrypted_data, encrypted_data_length,
+                                    decrypted_data, &decrypted_data_length);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_cipher_decrypt fail");
+        return;
+    }
 
-	res = soter_asym_cipher_decrypt(&decrypt_ctx, encrypted_data, encrypted_data_length, decrypted_data, &decrypted_data_length);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_cipher_decrypt fail");
-		return;
-	}
+    testsuite_fail_if((sizeof(test_data) != decrypted_data_length) ||
+                          (memcmp(test_data, decrypted_data, sizeof(test_data))),
+                      "soter_asym_cipher: normal value");
 
-	testsuite_fail_if((sizeof(test_data) != decrypted_data_length) || (memcmp(test_data, decrypted_data, sizeof(test_data))), "soter_asym_cipher: normal value");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_cipher_cleanup(NULL),
+                          "soter_asym_cipher_cleanup: invalid context");
 
+    res = soter_asym_cipher_cleanup(&ctx);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_cipher_cleanup fail");
+        return;
+    }
 
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_cipher_cleanup(NULL), "soter_asym_cipher_cleanup: invalid context");
-
-	res = soter_asym_cipher_cleanup(&ctx);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_cipher_cleanup fail");
-		return;
-	}
-
-	res = soter_asym_cipher_cleanup(&decrypt_ctx);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_cipher_cleanup fail");
-		return;
-	}
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_cipher_destroy(NULL), "soter_asym_cipher_destroy: invalid context");
-	soter_rsa_key_pair_gen_destroy(key_pair_ctx);
+    res = soter_asym_cipher_cleanup(&decrypt_ctx);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_cipher_cleanup fail");
+        return;
+    }
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_cipher_destroy(NULL),
+                          "soter_asym_cipher_destroy: invalid context");
+    soter_rsa_key_pair_gen_destroy(key_pair_ctx);
 }
 
 void test_api_all()
@@ -255,13 +314,13 @@ void test_api_all()
     test_api(RSA_KEY_LENGTH_1024);
     test_api(RSA_KEY_LENGTH_2048);
     test_api(RSA_KEY_LENGTH_4096);
-//    test_api(RSA_KEY_LENGTH_8192);
+    //    test_api(RSA_KEY_LENGTH_8192);
 }
 void run_soter_asym_cipher_tests(void)
 {
-	testsuite_enter_suite("soter asym cipher: basic flow");
-	testsuite_run_test(test_basic_encryption_flow);
+    testsuite_enter_suite("soter asym cipher: basic flow");
+    testsuite_run_test(test_basic_encryption_flow);
 
-	testsuite_enter_suite("soter asym cipher: api");
-	testsuite_run_test(test_api_all);
+    testsuite_enter_suite("soter asym cipher: api");
+    testsuite_run_test(test_api_all);
 }

--- a/tests/soter/soter_asym_ka_test.c
+++ b/tests/soter/soter_asym_ka_test.c
@@ -1,18 +1,18 @@
 /*
-* Copyright (c) 2015 Cossack Labs Limited
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2015 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "soter/soter_test.h"
 
@@ -23,224 +23,247 @@
 
 static void test_basic_ka_flow(void)
 {
-	uint8_t key_buffer[KEY_BUFFER_SIZE];
-	size_t key_buffer_length = sizeof(key_buffer);
+    uint8_t key_buffer[KEY_BUFFER_SIZE];
+    size_t key_buffer_length = sizeof(key_buffer);
 
-	uint8_t peer1_shared_secret[SHARED_SECRET_BUFFER_SIZE];
-	size_t peer1_shared_secret_length = sizeof(peer1_shared_secret);
+    uint8_t peer1_shared_secret[SHARED_SECRET_BUFFER_SIZE];
+    size_t peer1_shared_secret_length = sizeof(peer1_shared_secret);
 
-	uint8_t peer2_shared_secret[SHARED_SECRET_BUFFER_SIZE];
-	size_t peer2_shared_secret_length = sizeof(peer2_shared_secret);
+    uint8_t peer2_shared_secret[SHARED_SECRET_BUFFER_SIZE];
+    size_t peer2_shared_secret_length = sizeof(peer2_shared_secret);
 
-	uint8_t peer2_private[SHARED_SECRET_BUFFER_SIZE];
-	size_t peer2_private_length = sizeof(peer2_private);
+    uint8_t peer2_private[SHARED_SECRET_BUFFER_SIZE];
+    size_t peer2_private_length = sizeof(peer2_private);
 
-	soter_status_t res;
-	soter_asym_ka_t *peer1 = soter_asym_ka_create(SOTER_ASYM_KA_EC_P256);
-	soter_asym_ka_t *peer2 = soter_asym_ka_create(SOTER_ASYM_KA_EC_P256);
+    soter_status_t res;
+    soter_asym_ka_t* peer1 = soter_asym_ka_create(SOTER_ASYM_KA_EC_P256);
+    soter_asym_ka_t* peer2 = soter_asym_ka_create(SOTER_ASYM_KA_EC_P256);
 
-	if ((!peer1) || (!peer2))
-	{
-		goto err;
-	}
+    if ((!peer1) || (!peer2)) {
+        goto err;
+    }
 
-	res = soter_asym_ka_gen_key(peer1);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_gen_key fail");
-		goto err;
-	}
+    res = soter_asym_ka_gen_key(peer1);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_gen_key fail");
+        goto err;
+    }
 
-	res = soter_asym_ka_gen_key(peer2);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_gen_key fail");
-		goto err;
-	}
+    res = soter_asym_ka_gen_key(peer2);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_gen_key fail");
+        goto err;
+    }
 
-	res = soter_asym_ka_export_key(peer2, key_buffer, &key_buffer_length, false);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_export_key fail");
-		goto err;
-	}
+    res = soter_asym_ka_export_key(peer2, key_buffer, &key_buffer_length, false);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_export_key fail");
+        goto err;
+    }
 
-	res = soter_asym_ka_derive(peer1, key_buffer, key_buffer_length, peer1_shared_secret, &peer1_shared_secret_length);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_derive fail");
-		goto err;
-	}
+    res = soter_asym_ka_derive(peer1, key_buffer, key_buffer_length, peer1_shared_secret,
+                               &peer1_shared_secret_length);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_derive fail");
+        goto err;
+    }
 
-	key_buffer_length = sizeof(key_buffer);
+    key_buffer_length = sizeof(key_buffer);
 
-	res = soter_asym_ka_export_key(peer1, key_buffer, &key_buffer_length, false);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_export_key fail");
-		goto err;
-	}
+    res = soter_asym_ka_export_key(peer1, key_buffer, &key_buffer_length, false);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_export_key fail");
+        goto err;
+    }
 
-	res = soter_asym_ka_derive(peer2, key_buffer, key_buffer_length, peer2_shared_secret, &peer2_shared_secret_length);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_derive fail");
-		goto err;
-	}
+    res = soter_asym_ka_derive(peer2, key_buffer, key_buffer_length, peer2_shared_secret,
+                               &peer2_shared_secret_length);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_derive fail");
+        goto err;
+    }
 
-	testsuite_fail_unless((peer1_shared_secret_length == peer2_shared_secret_length) && !memcmp(peer1_shared_secret, peer2_shared_secret, peer1_shared_secret_length), "Basic ECDH");
+    testsuite_fail_unless(
+        (peer1_shared_secret_length == peer2_shared_secret_length) &&
+            !memcmp(peer1_shared_secret, peer2_shared_secret, peer1_shared_secret_length),
+        "Basic ECDH");
 
-	res = soter_asym_ka_export_key(peer2, peer2_private, &peer2_private_length, true);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_export_key fail");
-		goto err;
-	}
+    res = soter_asym_ka_export_key(peer2, peer2_private, &peer2_private_length, true);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_export_key fail");
+        goto err;
+    }
 
-	res = soter_asym_ka_destroy(peer2);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_destroy fail");
-		goto err;
-	}
+    res = soter_asym_ka_destroy(peer2);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_destroy fail");
+        goto err;
+    }
 
-	peer2 = soter_asym_ka_create(SOTER_ASYM_KA_EC_P256);
-	if (!peer2)
-	{
-		testsuite_fail_if(NULL == peer2, "soter_asym_ka_create fail");
-		goto err;
-	}
+    peer2 = soter_asym_ka_create(SOTER_ASYM_KA_EC_P256);
+    if (!peer2) {
+        testsuite_fail_if(NULL == peer2, "soter_asym_ka_create fail");
+        goto err;
+    }
 
-	res = soter_asym_ka_import_key(peer2, peer2_private, peer2_private_length);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_import_key fail");
-		goto err;
-	}
+    res = soter_asym_ka_import_key(peer2, peer2_private, peer2_private_length);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_import_key fail");
+        goto err;
+    }
 
-	peer2_shared_secret_length = sizeof(peer2_shared_secret);
+    peer2_shared_secret_length = sizeof(peer2_shared_secret);
 
-	res = soter_asym_ka_derive(peer2, key_buffer, key_buffer_length, peer2_shared_secret, &peer2_shared_secret_length);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_derive fail");
-		goto err;
-	}
+    res = soter_asym_ka_derive(peer2, key_buffer, key_buffer_length, peer2_shared_secret,
+                               &peer2_shared_secret_length);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_derive fail");
+        goto err;
+    }
 
-	testsuite_fail_unless((peer1_shared_secret_length == peer2_shared_secret_length) && !memcmp(peer1_shared_secret, peer2_shared_secret, peer1_shared_secret_length), "Basic ECDH with imported key");
+    testsuite_fail_unless(
+        (peer1_shared_secret_length == peer2_shared_secret_length) &&
+            !memcmp(peer1_shared_secret, peer2_shared_secret, peer1_shared_secret_length),
+        "Basic ECDH with imported key");
 
 err:
-	if (peer1)
-	{
-		res = soter_asym_ka_destroy(peer1);
-		if (SOTER_SUCCESS != res)
-		{
-			testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_destroy fail");
-		}
-	}
+    if (peer1) {
+        res = soter_asym_ka_destroy(peer1);
+        if (SOTER_SUCCESS != res) {
+            testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_destroy fail");
+        }
+    }
 
-	if (peer2)
-	{
-		res = soter_asym_ka_destroy(peer2);
-		if (SOTER_SUCCESS != res)
-		{
-			testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_destroy fail");
-		}
-	}
+    if (peer2) {
+        res = soter_asym_ka_destroy(peer2);
+        if (SOTER_SUCCESS != res) {
+            testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_destroy fail");
+        }
+    }
 }
 
 static void test_api(void)
 {
-	soter_status_t res;
-	soter_asym_ka_t ctx;
+    soter_status_t res;
+    soter_asym_ka_t ctx;
 
-	uint8_t key_buffer[KEY_BUFFER_SIZE];
-	size_t key_buffer_length = sizeof(key_buffer);
+    uint8_t key_buffer[KEY_BUFFER_SIZE];
+    size_t key_buffer_length = sizeof(key_buffer);
 
-	uint8_t shared_secret[SHARED_SECRET_BUFFER_SIZE];
-	size_t shared_secret_length = sizeof(shared_secret);
+    uint8_t shared_secret[SHARED_SECRET_BUFFER_SIZE];
+    size_t shared_secret_length = sizeof(shared_secret);
 
-	memset(&ctx, 0, sizeof(soter_asym_ka_t));
+    memset(&ctx, 0, sizeof(soter_asym_ka_t));
 
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_ka_init(NULL, SOTER_ASYM_KA_EC_P256), "soter_asym_ka_init: invalid context");
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_ka_init(&ctx, (soter_asym_ka_alg_t)0xffffffff), "soter_asym_ka_init: invalid algorithm type");
-	testsuite_fail_unless(NULL == soter_asym_ka_create((soter_asym_ka_alg_t)0xffffffff), "soter_asym_ka_create: invalid algorithm type");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER ==
+                              soter_asym_ka_init(NULL, SOTER_ASYM_KA_EC_P256),
+                          "soter_asym_ka_init: invalid context");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER ==
+                              soter_asym_ka_init(&ctx, (soter_asym_ka_alg_t)0xffffffff),
+                          "soter_asym_ka_init: invalid algorithm type");
+    testsuite_fail_unless(NULL == soter_asym_ka_create((soter_asym_ka_alg_t)0xffffffff),
+                          "soter_asym_ka_create: invalid algorithm type");
 
-	res = soter_asym_ka_init(&ctx, SOTER_ASYM_KA_EC_P256);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_init fail");
-		return;
-	}
+    res = soter_asym_ka_init(&ctx, SOTER_ASYM_KA_EC_P256);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_init fail");
+        return;
+    }
 
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_ka_gen_key(NULL), "soter_asym_ka_gen_key: invalid context");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_ka_gen_key(NULL),
+                          "soter_asym_ka_gen_key: invalid context");
 
-	res = soter_asym_ka_gen_key(&ctx);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_gen_key fail");
-		return;
-	}
+    res = soter_asym_ka_gen_key(&ctx);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_gen_key fail");
+        return;
+    }
 
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_ka_export_key(NULL, key_buffer, &key_buffer_length, true), "soter_asym_ka_export_key: invalid context");
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_ka_export_key(&ctx, key_buffer, NULL, false), "soter_asym_ka_export_key: invalid output data length");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER ==
+                              soter_asym_ka_export_key(NULL, key_buffer, &key_buffer_length, true),
+                          "soter_asym_ka_export_key: invalid context");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER ==
+                              soter_asym_ka_export_key(&ctx, key_buffer, NULL, false),
+                          "soter_asym_ka_export_key: invalid output data length");
 
-	key_buffer_length = 0;
-	res = soter_asym_ka_export_key(&ctx, NULL, &key_buffer_length, false);
-	testsuite_fail_unless((SOTER_BUFFER_TOO_SMALL == res) && (key_buffer_length > 0), "soter_asym_ka_export_key: get output size (NULL out buffer)");
+    key_buffer_length = 0;
+    res = soter_asym_ka_export_key(&ctx, NULL, &key_buffer_length, false);
+    testsuite_fail_unless((SOTER_BUFFER_TOO_SMALL == res) && (key_buffer_length > 0),
+                          "soter_asym_ka_export_key: get output size (NULL out buffer)");
 
-	key_buffer_length--;
-	res = soter_asym_ka_export_key(&ctx, key_buffer, &key_buffer_length, false);
-	testsuite_fail_unless((SOTER_BUFFER_TOO_SMALL == res) && (key_buffer_length > 0), "soter_asym_ka_export_key: get output size (small out buffer)");
+    key_buffer_length--;
+    res = soter_asym_ka_export_key(&ctx, key_buffer, &key_buffer_length, false);
+    testsuite_fail_unless((SOTER_BUFFER_TOO_SMALL == res) && (key_buffer_length > 0),
+                          "soter_asym_ka_export_key: get output size (small out buffer)");
 
-	res = soter_asym_ka_export_key(&ctx, key_buffer, &key_buffer_length, false);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_export_key fail");
-		return;
-	}
+    res = soter_asym_ka_export_key(&ctx, key_buffer, &key_buffer_length, false);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_export_key fail");
+        return;
+    }
 
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_ka_import_key(NULL, key_buffer, key_buffer_length), "soter_asym_ka_import_key: invalid context");
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_ka_import_key(&ctx, NULL, key_buffer_length), "soter_asym_ka_import_key: invalid input data");
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_ka_import_key(NULL, key_buffer, 0), "soter_asym_ka_import_key: invalid input data length");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER ==
+                              soter_asym_ka_import_key(NULL, key_buffer, key_buffer_length),
+                          "soter_asym_ka_import_key: invalid context");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER ==
+                              soter_asym_ka_import_key(&ctx, NULL, key_buffer_length),
+                          "soter_asym_ka_import_key: invalid input data");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_ka_import_key(NULL, key_buffer, 0),
+                          "soter_asym_ka_import_key: invalid input data length");
 
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_ka_derive(NULL, key_buffer, key_buffer_length, shared_secret, &shared_secret_length), "soter_asym_ka_derive: invalid context");
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_ka_derive(&ctx, NULL, key_buffer_length, shared_secret, &shared_secret_length), "soter_asym_ka_derive: invalid input data");
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_ka_derive(&ctx, key_buffer, 0, shared_secret, &shared_secret_length), "soter_asym_ka_derive: invalid input data length");
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_ka_derive(&ctx, key_buffer, key_buffer_length, shared_secret, NULL), "soter_asym_ka_derive: invalid output data length");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER ==
+                              soter_asym_ka_derive(NULL, key_buffer, key_buffer_length,
+                                                   shared_secret, &shared_secret_length),
+                          "soter_asym_ka_derive: invalid context");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER ==
+                              soter_asym_ka_derive(&ctx, NULL, key_buffer_length, shared_secret,
+                                                   &shared_secret_length),
+                          "soter_asym_ka_derive: invalid input data");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_ka_derive(&ctx, key_buffer, 0,
+                                                                          shared_secret,
+                                                                          &shared_secret_length),
+                          "soter_asym_ka_derive: invalid input data length");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_ka_derive(&ctx, key_buffer,
+                                                                          key_buffer_length,
+                                                                          shared_secret, NULL),
+                          "soter_asym_ka_derive: invalid output data length");
 
-	shared_secret_length = 0;
-	res = soter_asym_ka_derive(&ctx, key_buffer, key_buffer_length, NULL, &shared_secret_length);
-	testsuite_fail_unless((SOTER_BUFFER_TOO_SMALL == res) && (shared_secret_length > 0), "soter_asym_ka_derive: get output size (NULL out buffer)");
+    shared_secret_length = 0;
+    res = soter_asym_ka_derive(&ctx, key_buffer, key_buffer_length, NULL, &shared_secret_length);
+    testsuite_fail_unless((SOTER_BUFFER_TOO_SMALL == res) && (shared_secret_length > 0),
+                          "soter_asym_ka_derive: get output size (NULL out buffer)");
 
-	shared_secret_length--;
-	res = soter_asym_ka_derive(&ctx, key_buffer, key_buffer_length, shared_secret, &shared_secret_length);
-	testsuite_fail_unless((SOTER_BUFFER_TOO_SMALL == res) && (shared_secret_length > 0), "soter_asym_ka_derive: get output size (small out buffer)");
+    shared_secret_length--;
+    res = soter_asym_ka_derive(&ctx, key_buffer, key_buffer_length, shared_secret,
+                               &shared_secret_length);
+    testsuite_fail_unless((SOTER_BUFFER_TOO_SMALL == res) && (shared_secret_length > 0),
+                          "soter_asym_ka_derive: get output size (small out buffer)");
 
-	res = soter_asym_ka_derive(&ctx, key_buffer, key_buffer_length, shared_secret, &shared_secret_length);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_derive fail");
-		return;
-	}
+    res = soter_asym_ka_derive(&ctx, key_buffer, key_buffer_length, shared_secret,
+                               &shared_secret_length);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_derive fail");
+        return;
+    }
 
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_ka_cleanup(NULL), "soter_asym_ka_cleanup: invalid context");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_ka_cleanup(NULL),
+                          "soter_asym_ka_cleanup: invalid context");
 
-	res = soter_asym_ka_cleanup(&ctx);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_cleanup fail");
-		return;
-	}
+    res = soter_asym_ka_cleanup(&ctx);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_unless(SOTER_SUCCESS == res, "soter_asym_ka_cleanup fail");
+        return;
+    }
 
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_ka_destroy(NULL), "soter_asym_ka_destroy: invalid context");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_asym_ka_destroy(NULL),
+                          "soter_asym_ka_destroy: invalid context");
 }
 
 void run_soter_asym_ka_tests(void)
 {
-	testsuite_enter_suite("soter asym ka: basic flow");
-	testsuite_run_test(test_basic_ka_flow);
+    testsuite_enter_suite("soter asym ka: basic flow");
+    testsuite_run_test(test_basic_ka_flow);
 
-	testsuite_enter_suite("soter asym ka: api");
-	testsuite_run_test(test_api);
+    testsuite_enter_suite("soter asym ka: api");
+    testsuite_run_test(test_api);
 }

--- a/tests/soter/soter_hash_test.c
+++ b/tests/soter/soter_hash_test.c
@@ -1,18 +1,18 @@
 /*
-* Copyright (c) 2015 Cossack Labs Limited
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2015 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "soter/soter_test.h"
 
@@ -20,179 +20,187 @@
 
 typedef struct test_vector_type test_vector_t;
 
-struct test_vector_type
-{
-	char *input;
-	char *result;
+struct test_vector_type {
+    char* input;
+    char* result;
 };
 
 /* Taken from NIST test suite */
-static test_vector_t vectors[] =
-{
-	{"", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
-	{"74cb9381d89f5aa73368", "73d6fad1caaa75b43b21733561fd3958bdc555194a037c2addec19dc2d7a52bd"},
-	{"09fc1accc230a205e4a208e64a8f204291f581a12756392da4b8c0cf5ef02b95", "4f44c1c7fbebb6f9601829f3897bfd650c56fa07844be76489076356ac1886a4"},
-	{"5a86b737eaea8ee976a0a24da63e7ed7eefad18a101c1211e2b3650c5187c2a8a650547208251f6d4237e661c7bf4c77f335390394c37fa1a9f9be836ac28509", "42e61e174fbb3897d6dd6cef3dd2802fe67b331953b06114a65c772859dfc1aa"},
-	{"451101250ec6f26652249d59dc974b7361d571a8101cdfd36aba3b5854d3ae086b5fdd4597721b66e3c0dc5d8c606d9657d0e323283a5217d1f53f2f284f57b85c8a61ac8924711f895c5ed90ef17745ed2d728abd22a5f7a13479a462d71b56c19a74a40b655c58edfe0a188ad2cf46cbf30524f65d423c837dd1ff2bf462ac4198007345bb44dbb7b1c861298cdf61982a833afc728fae1eda2f87aa2c9480858bec", "3c593aa539fdcdae516cdf2f15000f6634185c88f505b39775fb9ab137a10aa2"}
-};
+static test_vector_t vectors[] = {
+    {"", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+    {"74cb9381d89f5aa73368", "73d6fad1caaa75b43b21733561fd3958bdc555194a037c2addec19dc2d7a52bd"},
+    {"09fc1accc230a205e4a208e64a8f204291f581a12756392da4b8c0cf5ef02b95",
+     "4f44c1c7fbebb6f9601829f3897bfd650c56fa07844be76489076356ac1886a4"},
+    {"5a86b737eaea8ee976a0a24da63e7ed7eefad18a101c1211e2b3650c5187c2a8a650547208251f6d4237e661c7bf4c77f335390394c37fa1a9f9be836ac28509",
+     "42e61e174fbb3897d6dd6cef3dd2802fe67b331953b06114a65c772859dfc1aa"},
+    {"451101250ec6f26652249d59dc974b7361d571a8101cdfd36aba3b5854d3ae086b5fdd4597721b66e3c0dc5d8c606d9657d0e323283a5217d1f53f2f284f57b85c8a61ac8924711f895c5ed90ef17745ed2d728abd22a5f7a13479a462d71b56c19a74a40b655c58edfe0a188ad2cf46cbf30524f65d423c837dd1ff2bf462ac4198007345bb44dbb7b1c861298cdf61982a833afc728fae1eda2f87aa2c9480858bec",
+     "3c593aa539fdcdae516cdf2f15000f6634185c88f505b39775fb9ab137a10aa2"}};
 
 #define MAX_TEST_INPUT 2048
 
 static void test_known_values(void)
 {
-	soter_hash_ctx_t *ctx;
-	uint8_t input[MAX_TEST_INPUT];
-	uint8_t hash[32], result[32]; /* TODO: define this and also consider whole SHA-2, not only SHA-256 */
-	size_t i, input_len, hash_len = sizeof(hash);
-	test_utils_status_t res;
+    soter_hash_ctx_t* ctx;
+    uint8_t input[MAX_TEST_INPUT];
+    uint8_t hash[32],
+        result[32]; /* TODO: define this and also consider whole SHA-2, not only SHA-256 */
+    size_t i, input_len, hash_len = sizeof(hash);
+    test_utils_status_t res;
 
-	for (i = 0; i < (sizeof(vectors) / sizeof(test_vector_t)); i++)
-	{
-		input_len = strlen(vectors[i].input) / 2;
-		if (input_len > MAX_TEST_INPUT)
-		{
-			testsuite_fail_if(input_len > MAX_TEST_INPUT, "input_len > MAX_TEST_INPUT");
-			continue;
-		}
+    for (i = 0; i < (sizeof(vectors) / sizeof(test_vector_t)); i++) {
+        input_len = strlen(vectors[i].input) / 2;
+        if (input_len > MAX_TEST_INPUT) {
+            testsuite_fail_if(input_len > MAX_TEST_INPUT, "input_len > MAX_TEST_INPUT");
+            continue;
+        }
 
-		res = string_to_bytes(vectors[i].input, input, sizeof(input));
-		if (res)
-		{
-			testsuite_fail_if(res, "input read fail");
-			continue;
-		}
+        res = string_to_bytes(vectors[i].input, input, sizeof(input));
+        if (res) {
+            testsuite_fail_if(res, "input read fail");
+            continue;
+        }
 
-		res = string_to_bytes(vectors[i].result, result, sizeof(result));
-		if (res)
-		{
-			testsuite_fail_if(res, "result read fail");
-			continue;
-		}
+        res = string_to_bytes(vectors[i].result, result, sizeof(result));
+        if (res) {
+            testsuite_fail_if(res, "result read fail");
+            continue;
+        }
 
-		ctx = soter_hash_create(SOTER_HASH_SHA256);
-		if (!ctx)
-		{
-			testsuite_fail_if(NULL == ctx, "hash_ctx != NULL");
-			continue;
-		}
+        ctx = soter_hash_create(SOTER_HASH_SHA256);
+        if (!ctx) {
+            testsuite_fail_if(NULL == ctx, "hash_ctx != NULL");
+            continue;
+        }
 
-		res = soter_hash_update(ctx, input, input_len);
-		if (res)
-		{
-			testsuite_fail_if(res, "soter_hash_update fail");
-			soter_hash_destroy(ctx);
-			continue;
-		}
+        res = soter_hash_update(ctx, input, input_len);
+        if (res) {
+            testsuite_fail_if(res, "soter_hash_update fail");
+            soter_hash_destroy(ctx);
+            continue;
+        }
 
-		res = soter_hash_final(ctx, hash, &hash_len);
-		if (res)
-		{
-			testsuite_fail_if(res, "soter_hash_final fail");
-			soter_hash_destroy(ctx);
-			continue;
-		}
+        res = soter_hash_final(ctx, hash, &hash_len);
+        if (res) {
+            testsuite_fail_if(res, "soter_hash_final fail");
+            soter_hash_destroy(ctx);
+            continue;
+        }
 
-		soter_hash_destroy(ctx);
+        soter_hash_destroy(ctx);
 
-		testsuite_fail_if((hash_len != sizeof(result)) || (memcmp(hash, result, hash_len)), "hash == know value");
-	}
+        testsuite_fail_if((hash_len != sizeof(result)) || (memcmp(hash, result, hash_len)),
+                          "hash == know value");
+    }
 }
 
 static void test_api_(soter_hash_ctx_t* ctx)
 {
-	soter_status_t res;
-	uint8_t input[MAX_TEST_INPUT];
-	uint8_t hash[32], result[32]; /* TODO: define this and also consider whole SHA-2, not only SHA-256 */
-	size_t input_len, hash_len = sizeof(hash);
-	test_utils_status_t util_res;
+    soter_status_t res;
+    uint8_t input[MAX_TEST_INPUT];
+    uint8_t hash[32],
+        result[32]; /* TODO: define this and also consider whole SHA-2, not only SHA-256 */
+    size_t input_len, hash_len = sizeof(hash);
+    test_utils_status_t util_res;
 
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_hash_init(NULL, SOTER_HASH_SHA256), "soter_hash_init: invalid context");
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_hash_init(ctx, (soter_hash_algo_t)0xffffffff), "soter_hash_init: invalid algorithm type");
-	testsuite_fail_unless(NULL == soter_hash_create((soter_hash_algo_t)0xffffffff), "soter_hash_create: invalid algorithm type");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_hash_init(NULL, SOTER_HASH_SHA256),
+                          "soter_hash_init: invalid context");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER ==
+                              soter_hash_init(ctx, (soter_hash_algo_t)0xffffffff),
+                          "soter_hash_init: invalid algorithm type");
+    testsuite_fail_unless(NULL == soter_hash_create((soter_hash_algo_t)0xffffffff),
+                          "soter_hash_create: invalid algorithm type");
 
-	input_len = strlen(vectors[4].input) / 2;
-	if (input_len > MAX_TEST_INPUT)
-	{
-		testsuite_fail_if(input_len > MAX_TEST_INPUT, "input_len > MAX_TEST_INPUT");
-		return;
-	}
+    input_len = strlen(vectors[4].input) / 2;
+    if (input_len > MAX_TEST_INPUT) {
+        testsuite_fail_if(input_len > MAX_TEST_INPUT, "input_len > MAX_TEST_INPUT");
+        return;
+    }
 
-	util_res = string_to_bytes(vectors[4].input, input, sizeof(input));
-	if (util_res)
-	{
-		testsuite_fail_if(util_res, "input read fail");
-		return;
-	}
+    util_res = string_to_bytes(vectors[4].input, input, sizeof(input));
+    if (util_res) {
+        testsuite_fail_if(util_res, "input read fail");
+        return;
+    }
 
-	res = soter_hash_init(ctx, SOTER_HASH_SHA256);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_if(SOTER_SUCCESS != res, "soter_hash_init failed");
-		return;
-	}
+    res = soter_hash_init(ctx, SOTER_HASH_SHA256);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_if(SOTER_SUCCESS != res, "soter_hash_init failed");
+        return;
+    }
 
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_hash_update(NULL, input, input_len), "soter_hash_update: invalid context");
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_hash_update(ctx, NULL, input_len), "soter_hash_update: invalid data");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_hash_update(NULL, input, input_len),
+                          "soter_hash_update: invalid context");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_hash_update(ctx, NULL, input_len),
+                          "soter_hash_update: invalid data");
 
-	res = soter_hash_update(ctx, input, input_len);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_if(SOTER_SUCCESS != res, "soter_hash_update failed");
-		return;
-	}
+    res = soter_hash_update(ctx, input, input_len);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_if(SOTER_SUCCESS != res, "soter_hash_update failed");
+        return;
+    }
 
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_hash_final(NULL, hash, &hash_len), "soter_hash_final: invalid context");
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_hash_final(ctx, hash, NULL), "soter_hash_final: invalid size pointer");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_hash_final(NULL, hash, &hash_len),
+                          "soter_hash_final: invalid context");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_hash_final(ctx, hash, NULL),
+                          "soter_hash_final: invalid size pointer");
 
-	res = soter_hash_final(ctx, NULL, &hash_len);
-	testsuite_fail_unless((SOTER_BUFFER_TOO_SMALL == res) && (32 == hash_len), "soter_hash_final: get output size (NULL out buffer)");
+    res = soter_hash_final(ctx, NULL, &hash_len);
+    testsuite_fail_unless((SOTER_BUFFER_TOO_SMALL == res) && (32 == hash_len),
+                          "soter_hash_final: get output size (NULL out buffer)");
 
-	hash_len--;
-	res = soter_hash_final(ctx, hash, &hash_len);
-	testsuite_fail_unless((SOTER_BUFFER_TOO_SMALL == res) && (32 == hash_len), "soter_hash_final: get output size (small out buffer)");
+    hash_len--;
+    res = soter_hash_final(ctx, hash, &hash_len);
+    testsuite_fail_unless((SOTER_BUFFER_TOO_SMALL == res) && (32 == hash_len),
+                          "soter_hash_final: get output size (small out buffer)");
 
-	util_res = string_to_bytes(vectors[4].result, result, sizeof(result));
-	if (util_res)
-	{
-		testsuite_fail_if(util_res, "result read fail");
-		return;
-	}
+    util_res = string_to_bytes(vectors[4].result, result, sizeof(result));
+    if (util_res) {
+        testsuite_fail_if(util_res, "result read fail");
+        return;
+    }
 
-	res = soter_hash_final(ctx, hash, &hash_len);
-	testsuite_fail_unless((SOTER_SUCCESS == res) && (32 == hash_len) && !memcmp(hash, result, hash_len), "soter_hash_final: normal value");
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_hash_update(ctx, input, input_len), "soter_hash_update: use after final");
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_hash_destroy(NULL), "soter_hash_destroy: invalid context");
-    testsuite_fail_unless(SOTER_SUCCESS == soter_hash_cleanup(ctx), "soter_hash_cleanup: can't cleanup");
+    res = soter_hash_final(ctx, hash, &hash_len);
+    testsuite_fail_unless((SOTER_SUCCESS == res) && (32 == hash_len) &&
+                              !memcmp(hash, result, hash_len),
+                          "soter_hash_final: normal value");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_hash_update(ctx, input, input_len),
+                          "soter_hash_update: use after final");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_hash_destroy(NULL),
+                          "soter_hash_destroy: invalid context");
+    testsuite_fail_unless(SOTER_SUCCESS == soter_hash_cleanup(ctx),
+                          "soter_hash_cleanup: can't cleanup");
 }
 
-static void test_api(void){
+static void test_api(void)
+{
     soter_hash_ctx_t* ctx = soter_hash_create(SOTER_HASH_SHA256);
-    if (!ctx){
+    if (!ctx) {
         testsuite_fail_if(true, "soter_hash_create failed");
         return;
     }
     soter_status_t res = soter_hash_cleanup(ctx);
-    if (SOTER_SUCCESS != res)
-    {
+    if (SOTER_SUCCESS != res) {
         testsuite_fail_if(SOTER_SUCCESS != res, "soter_hash_cleanup failed");
         return;
     }
     test_api_(ctx);
-    testsuite_fail_unless(SOTER_SUCCESS == soter_hash_destroy(ctx), "soter_hash_destroy: can't destroy");
+    testsuite_fail_unless(SOTER_SUCCESS == soter_hash_destroy(ctx),
+                          "soter_hash_destroy: can't destroy");
 }
 
-static void test_api_stack_struct(void){
+static void test_api_stack_struct(void)
+{
     soter_hash_ctx_t ctx;
     test_api_(&ctx);
 }
 
 void run_soter_hash_tests(void)
 {
-	testsuite_enter_suite("soter hash: known values");
-	testsuite_run_test(test_known_values);
+    testsuite_enter_suite("soter hash: known values");
+    testsuite_run_test(test_known_values);
 
-	testsuite_enter_suite("soter hash: api");
-	testsuite_run_test(test_api);
+    testsuite_enter_suite("soter hash: api");
+    testsuite_run_test(test_api);
 
     testsuite_enter_suite("soter hash: stack struct");
     testsuite_run_test(test_api_stack_struct);

--- a/tests/soter/soter_hmac_test.c
+++ b/tests/soter/soter_hmac_test.c
@@ -1,18 +1,18 @@
 /*
-* Copyright (c) 2015 Cossack Labs Limited
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2015 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "soter/soter_test.h"
 
@@ -20,24 +20,37 @@
 
 typedef struct test_vector_type test_vector_t;
 
-struct test_vector_type
-{
-	char *key;
-	char *data;
-	char *hmac_sha256;
-	char *hmac_sha512;
+struct test_vector_type {
+    char* key;
+    char* data;
+    char* hmac_sha256;
+    char* hmac_sha512;
 };
 
 /* Taken from RFC 4231 */
-static test_vector_t vectors[] =
-{
-	{"0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b", "4869205468657265", "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7", "87aa7cdea5ef619d4ff0b4241a1d6cb02379f4e2ce4ec2787ad0b30545e17cdedaa833b7d6b8a702038b274eaea3f4e4be9d914eeb61f1702e696c203a126854"},
-	{"4a656665", "7768617420646f2079612077616e7420666f72206e6f7468696e673f", "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843", "164b7a7bfcf819e2e395fbe73b56e0a387bd64222e831fd610270cd7ea2505549758bf75c05a994a6d034f65f8f0e6fdcaeab1a34d4a6b4b636e070a38bce737"},
-	{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", "773ea91e36800e46854db8ebd09181a72959098b3ef8c122d9635514ced565fe", "fa73b0089d56a284efb0f0756c890be9b1b5dbdd8ee81a3655f83e33b2279d39bf3e848279a722c806b485a47e67c807b946a337bee8942674278859e13292fb"},
-	{"0102030405060708090a0b0c0d0e0f10111213141516171819", "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd", "82558a389a443c0ea4cc819899f2083a85f0faa3e578f8077a2e3ff46729665b", "b0ba465637458c6990e5a8c5f61d4af7e576d97ff94b872de76f8050361ee3dba91ca5c11aa25eb4d679275cc5788063a5f19741120c4f2de2adebeb10a298dd"},
-	{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "54657374205573696e67204c6172676572205468616e20426c6f636b2d53697a65204b6579202d2048617368204b6579204669727374", "60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54", "80b24263c7c1a3ebb71493c1dd7be8b49b46d1f41b4aeec1121b013783f8f3526b56d037e05f2598bd0fd2215d6a1e5295e64f73f63f0aec8b915a985d786598"},
-	{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "5468697320697320612074657374207573696e672061206c6172676572207468616e20626c6f636b2d73697a65206b657920616e642061206c6172676572207468616e20626c6f636b2d73697a6520646174612e20546865206b6579206e6565647320746f20626520686173686564206265666f7265206265696e6720757365642062792074686520484d414320616c676f726974686d2e", "9b09ffa71b942fcb27635fbcd5b0e944bfdc63644f0713938a7f51535c3a35e2", "e37b6a775dc87dbaa4dfa9f96e5e3ffddebd71f8867289865df5a32d20cdc944b6022cac3c4982b10d5eeb55c3e4de15134676fb6de0446065c97440fa8c6a58"}
-};
+static test_vector_t vectors[] = {
+    {"0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b", "4869205468657265",
+     "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7",
+     "87aa7cdea5ef619d4ff0b4241a1d6cb02379f4e2ce4ec2787ad0b30545e17cdedaa833b7d6b8a702038b274eaea3f4e4be9d914eeb61f1702e696c203a126854"},
+    {"4a656665", "7768617420646f2079612077616e7420666f72206e6f7468696e673f",
+     "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843",
+     "164b7a7bfcf819e2e395fbe73b56e0a387bd64222e831fd610270cd7ea2505549758bf75c05a994a6d034f65f8f0e6fdcaeab1a34d4a6b4b636e070a38bce737"},
+    {"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+     "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+     "773ea91e36800e46854db8ebd09181a72959098b3ef8c122d9635514ced565fe",
+     "fa73b0089d56a284efb0f0756c890be9b1b5dbdd8ee81a3655f83e33b2279d39bf3e848279a722c806b485a47e67c807b946a337bee8942674278859e13292fb"},
+    {"0102030405060708090a0b0c0d0e0f10111213141516171819",
+     "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd",
+     "82558a389a443c0ea4cc819899f2083a85f0faa3e578f8077a2e3ff46729665b",
+     "b0ba465637458c6990e5a8c5f61d4af7e576d97ff94b872de76f8050361ee3dba91ca5c11aa25eb4d679275cc5788063a5f19741120c4f2de2adebeb10a298dd"},
+    {"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+     "54657374205573696e67204c6172676572205468616e20426c6f636b2d53697a65204b6579202d2048617368204b6579204669727374",
+     "60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54",
+     "80b24263c7c1a3ebb71493c1dd7be8b49b46d1f41b4aeec1121b013783f8f3526b56d037e05f2598bd0fd2215d6a1e5295e64f73f63f0aec8b915a985d786598"},
+    {"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+     "5468697320697320612074657374207573696e672061206c6172676572207468616e20626c6f636b2d73697a65206b657920616e642061206c6172676572207468616e20626c6f636b2d73697a6520646174612e20546865206b6579206e6565647320746f20626520686173686564206265666f7265206265696e6720757365642062792074686520484d414320616c676f726974686d2e",
+     "9b09ffa71b942fcb27635fbcd5b0e944bfdc63644f0713938a7f51535c3a35e2",
+     "e37b6a775dc87dbaa4dfa9f96e5e3ffddebd71f8867289865df5a32d20cdc944b6022cac3c4982b10d5eeb55c3e4de15134676fb6de0446065c97440fa8c6a58"}};
 
 #define MAX_TEST_DATA 2048
 #define MAX_TEST_KEY 256
@@ -45,241 +58,245 @@ static test_vector_t vectors[] =
 
 static void test_known_values(void)
 {
-	soter_hmac_ctx_t *ctx;
-	uint8_t data[MAX_TEST_DATA];
-	uint8_t key[MAX_TEST_KEY];
-	uint8_t hmac[HMAC_SIZE], result[HMAC_SIZE];
-	size_t i, data_len, key_len, hmac_len = sizeof(hmac);
-	test_utils_status_t res;
+    soter_hmac_ctx_t* ctx;
+    uint8_t data[MAX_TEST_DATA];
+    uint8_t key[MAX_TEST_KEY];
+    uint8_t hmac[HMAC_SIZE], result[HMAC_SIZE];
+    size_t i, data_len, key_len, hmac_len = sizeof(hmac);
+    test_utils_status_t res;
 
-	for (i = 0; i < (sizeof(vectors) / sizeof(test_vector_t)); i++)
-	{
-		data_len = strlen(vectors[i].data) / 2;
-		if (data_len > MAX_TEST_DATA)
-		{
-			testsuite_fail_if(data_len > MAX_TEST_DATA, "data_len > MAX_TEST_DATA");
-			continue;
-		}
+    for (i = 0; i < (sizeof(vectors) / sizeof(test_vector_t)); i++) {
+        data_len = strlen(vectors[i].data) / 2;
+        if (data_len > MAX_TEST_DATA) {
+            testsuite_fail_if(data_len > MAX_TEST_DATA, "data_len > MAX_TEST_DATA");
+            continue;
+        }
 
-		key_len = strlen(vectors[i].key) / 2;
-		if (key_len > MAX_TEST_KEY)
-		{
-			testsuite_fail_if(key_len > MAX_TEST_KEY, "key_len > MAX_TEST_KEY");
-			continue;
-		}
+        key_len = strlen(vectors[i].key) / 2;
+        if (key_len > MAX_TEST_KEY) {
+            testsuite_fail_if(key_len > MAX_TEST_KEY, "key_len > MAX_TEST_KEY");
+            continue;
+        }
 
-		res = string_to_bytes(vectors[i].data, data, sizeof(data));
-		if (res)
-		{
-			testsuite_fail_if(res, "data read fail");
-			continue;
-		}
+        res = string_to_bytes(vectors[i].data, data, sizeof(data));
+        if (res) {
+            testsuite_fail_if(res, "data read fail");
+            continue;
+        }
 
-		res = string_to_bytes(vectors[i].key, key, sizeof(key));
-		if (res)
-		{
-			testsuite_fail_if(res, "key read fail");
-			continue;
-		}
+        res = string_to_bytes(vectors[i].key, key, sizeof(key));
+        if (res) {
+            testsuite_fail_if(res, "key read fail");
+            continue;
+        }
 
-		res = string_to_bytes(vectors[i].hmac_sha256, result, sizeof(result));
-		if (res)
-		{
-			testsuite_fail_if(res, "result read fail");
-			continue;
-		}
+        res = string_to_bytes(vectors[i].hmac_sha256, result, sizeof(result));
+        if (res) {
+            testsuite_fail_if(res, "result read fail");
+            continue;
+        }
 
-		ctx = soter_hmac_create(SOTER_HASH_SHA256, key, key_len);
-		if (!ctx)
-		{
-			testsuite_fail_if(NULL == ctx, "hash_ctx != NULL");
-			continue;
-		}
+        ctx = soter_hmac_create(SOTER_HASH_SHA256, key, key_len);
+        if (!ctx) {
+            testsuite_fail_if(NULL == ctx, "hash_ctx != NULL");
+            continue;
+        }
 
-		res = soter_hmac_update(ctx, data, data_len);
-		if (res)
-		{
-			testsuite_fail_if(res, "soter_hmac_update fail");
-			soter_hmac_destroy(ctx);
-			continue;
-		}
+        res = soter_hmac_update(ctx, data, data_len);
+        if (res) {
+            testsuite_fail_if(res, "soter_hmac_update fail");
+            soter_hmac_destroy(ctx);
+            continue;
+        }
 
-		res = soter_hmac_final(ctx, hmac, &hmac_len);
-		if (res)
-		{
-			testsuite_fail_if(res, "soter_hmac_final fail");
-			soter_hmac_destroy(ctx);
-			continue;
-		}
+        res = soter_hmac_final(ctx, hmac, &hmac_len);
+        if (res) {
+            testsuite_fail_if(res, "soter_hmac_final fail");
+            soter_hmac_destroy(ctx);
+            continue;
+        }
 
-		soter_hmac_destroy(ctx);
+        soter_hmac_destroy(ctx);
 
-		testsuite_fail_if(memcmp(hmac, result, hmac_len), "hmac == know value");
+        testsuite_fail_if(memcmp(hmac, result, hmac_len), "hmac == know value");
 
-		hmac_len = sizeof(hmac);
+        hmac_len = sizeof(hmac);
 
-		res = string_to_bytes(vectors[i].hmac_sha512, result, sizeof(result));
-		if (res)
-		{
-			testsuite_fail_if(res, "result read fail");
-			continue;
-		}
+        res = string_to_bytes(vectors[i].hmac_sha512, result, sizeof(result));
+        if (res) {
+            testsuite_fail_if(res, "result read fail");
+            continue;
+        }
 
-		ctx = soter_hmac_create(SOTER_HASH_SHA512, key, key_len);
-		if (!ctx)
-		{
-			testsuite_fail_if(NULL == ctx, "hash_ctx != NULL");
-			continue;
-		}
+        ctx = soter_hmac_create(SOTER_HASH_SHA512, key, key_len);
+        if (!ctx) {
+            testsuite_fail_if(NULL == ctx, "hash_ctx != NULL");
+            continue;
+        }
 
-		res = soter_hmac_update(ctx, data, data_len);
-		if (res)
-		{
-			testsuite_fail_if(res, "soter_hmac_update fail");
-			soter_hmac_destroy(ctx);
-			continue;
-		}
+        res = soter_hmac_update(ctx, data, data_len);
+        if (res) {
+            testsuite_fail_if(res, "soter_hmac_update fail");
+            soter_hmac_destroy(ctx);
+            continue;
+        }
 
-		res = soter_hmac_final(ctx, hmac, &hmac_len);
-		if (res)
-		{
-			testsuite_fail_if(res, "soter_hmac_final fail");
-			soter_hmac_destroy(ctx);
-			continue;
-		}
+        res = soter_hmac_final(ctx, hmac, &hmac_len);
+        if (res) {
+            testsuite_fail_if(res, "soter_hmac_final fail");
+            soter_hmac_destroy(ctx);
+            continue;
+        }
 
-		soter_hmac_destroy(ctx);
+        soter_hmac_destroy(ctx);
 
-		testsuite_fail_if(memcmp(hmac, result, hmac_len), "hmac == know value");
-	}
+        testsuite_fail_if(memcmp(hmac, result, hmac_len), "hmac == know value");
+    }
 }
 
 static void test_api_(soter_hmac_ctx_t* ctx, uint8_t* data, uint8_t* key)
 {
-	soter_status_t res;
-	uint8_t hmac[HMAC_SIZE], result[HMAC_SIZE];
-	size_t data_len, key_len, hmac_len = sizeof(hmac);
-	test_utils_status_t util_res;
+    soter_status_t res;
+    uint8_t hmac[HMAC_SIZE], result[HMAC_SIZE];
+    size_t data_len, key_len, hmac_len = sizeof(hmac);
+    test_utils_status_t util_res;
 
-	data_len = strlen(vectors[4].data) / 2;
-	if (data_len > MAX_TEST_DATA)
-	{
-		testsuite_fail_if(data_len > MAX_TEST_DATA, "data_len > MAX_TEST_DATA");
-		return;
-	}
+    data_len = strlen(vectors[4].data) / 2;
+    if (data_len > MAX_TEST_DATA) {
+        testsuite_fail_if(data_len > MAX_TEST_DATA, "data_len > MAX_TEST_DATA");
+        return;
+    }
 
-	util_res = string_to_bytes(vectors[4].data, data, MAX_TEST_DATA);
-	if (util_res)
-	{
-		testsuite_fail_if(util_res, "data read fail");
-		return;
-	}
+    util_res = string_to_bytes(vectors[4].data, data, MAX_TEST_DATA);
+    if (util_res) {
+        testsuite_fail_if(util_res, "data read fail");
+        return;
+    }
 
-	key_len = strlen(vectors[4].key) / 2;
-	if (key_len > MAX_TEST_KEY)
-	{
-		testsuite_fail_if(key_len > MAX_TEST_KEY, "key_len > MAX_TEST_KEY");
-		return;
-	}
+    key_len = strlen(vectors[4].key) / 2;
+    if (key_len > MAX_TEST_KEY) {
+        testsuite_fail_if(key_len > MAX_TEST_KEY, "key_len > MAX_TEST_KEY");
+        return;
+    }
 
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_hmac_init(NULL, SOTER_HASH_SHA256, key, key_len), "soter_hmac_init: invalid context");
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_hmac_init(ctx, (soter_hash_algo_t)0xffffffff, key, key_len), "soter_hmac_init: invalid algorithm type");
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_hmac_init(ctx, SOTER_HASH_SHA256, NULL, key_len), "soter_hmac_init: invalid key");
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_hmac_init(ctx, SOTER_HASH_SHA256, key, 0), "soter_hmac_init: invalid key length");
-	testsuite_fail_unless(NULL == soter_hmac_create((soter_hash_algo_t)0xffffffff, key, key_len), "soter_hmac_create: invalid algorithm type");
-	testsuite_fail_unless(NULL == soter_hmac_create(SOTER_HASH_SHA256, NULL, key_len), "soter_hmac_create: invalid key");
-	testsuite_fail_unless(NULL == soter_hmac_create(SOTER_HASH_SHA256, key, 0), "soter_hmac_create: invalid key length");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER ==
+                              soter_hmac_init(NULL, SOTER_HASH_SHA256, key, key_len),
+                          "soter_hmac_init: invalid context");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER ==
+                              soter_hmac_init(ctx, (soter_hash_algo_t)0xffffffff, key, key_len),
+                          "soter_hmac_init: invalid algorithm type");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER ==
+                              soter_hmac_init(ctx, SOTER_HASH_SHA256, NULL, key_len),
+                          "soter_hmac_init: invalid key");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER ==
+                              soter_hmac_init(ctx, SOTER_HASH_SHA256, key, 0),
+                          "soter_hmac_init: invalid key length");
+    testsuite_fail_unless(NULL == soter_hmac_create((soter_hash_algo_t)0xffffffff, key, key_len),
+                          "soter_hmac_create: invalid algorithm type");
+    testsuite_fail_unless(NULL == soter_hmac_create(SOTER_HASH_SHA256, NULL, key_len),
+                          "soter_hmac_create: invalid key");
+    testsuite_fail_unless(NULL == soter_hmac_create(SOTER_HASH_SHA256, key, 0),
+                          "soter_hmac_create: invalid key length");
 
-	res = soter_hmac_init(ctx, SOTER_HASH_SHA256, key, key_len);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_if(SOTER_SUCCESS != res, "soter_hmac_init failed");
-		return;
-	}
+    res = soter_hmac_init(ctx, SOTER_HASH_SHA256, key, key_len);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_if(SOTER_SUCCESS != res, "soter_hmac_init failed");
+        return;
+    }
 
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_hmac_update(NULL, data, data_len), "soter_hmac_update: invalid context");
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_hmac_update(ctx, NULL, data_len), "soter_hmac_update: invalid data");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_hmac_update(NULL, data, data_len),
+                          "soter_hmac_update: invalid context");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_hmac_update(ctx, NULL, data_len),
+                          "soter_hmac_update: invalid data");
 
-	res = soter_hmac_update(ctx, data, data_len);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_if(SOTER_SUCCESS != res, "soter_hmac_update failed");
-		return;
-	}
+    res = soter_hmac_update(ctx, data, data_len);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_if(SOTER_SUCCESS != res, "soter_hmac_update failed");
+        return;
+    }
 
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_hmac_final(NULL, hmac, &hmac_len), "soter_hmac_final: invalid context");
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_hmac_final(ctx, hmac, NULL), "soter_hmac_final: invalid size pointer");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_hmac_final(NULL, hmac, &hmac_len),
+                          "soter_hmac_final: invalid context");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_hmac_final(ctx, hmac, NULL),
+                          "soter_hmac_final: invalid size pointer");
 
-	res = soter_hmac_final(ctx, NULL, &hmac_len);
-	testsuite_fail_unless((SOTER_BUFFER_TOO_SMALL == res) && (32 == hmac_len), "soter_hmac_final: get output size (NULL out buffer)");
+    res = soter_hmac_final(ctx, NULL, &hmac_len);
+    testsuite_fail_unless((SOTER_BUFFER_TOO_SMALL == res) && (32 == hmac_len),
+                          "soter_hmac_final: get output size (NULL out buffer)");
 
-	hmac_len--;
-	res = soter_hmac_final(ctx, hmac, &hmac_len);
-	testsuite_fail_unless((SOTER_BUFFER_TOO_SMALL == res) && (32 == hmac_len), "soter_hmac_final: get output size (small out buffer)");
+    hmac_len--;
+    res = soter_hmac_final(ctx, hmac, &hmac_len);
+    testsuite_fail_unless((SOTER_BUFFER_TOO_SMALL == res) && (32 == hmac_len),
+                          "soter_hmac_final: get output size (small out buffer)");
 
-	util_res = string_to_bytes(vectors[4].hmac_sha256, result, sizeof(result));
-	if (util_res)
-	{
-		testsuite_fail_if(util_res, "result read fail");
-		return;
-	}
+    util_res = string_to_bytes(vectors[4].hmac_sha256, result, sizeof(result));
+    if (util_res) {
+        testsuite_fail_if(util_res, "result read fail");
+        return;
+    }
 
-	res = soter_hmac_final(ctx, hmac, &hmac_len);
-	testsuite_fail_unless((SOTER_SUCCESS == res) && (32 == hmac_len) && !memcmp(hmac, result, hmac_len), "soter_hmac_final: normal value");
+    res = soter_hmac_final(ctx, hmac, &hmac_len);
+    testsuite_fail_unless((SOTER_SUCCESS == res) && (32 == hmac_len) &&
+                              !memcmp(hmac, result, hmac_len),
+                          "soter_hmac_final: normal value");
 
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_hmac_cleanup(NULL), "soter_hmac_cleanup: invalid context");
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_hmac_destroy(NULL), "soter_hash_destroy: invalid context");
-	testsuite_fail_unless(SOTER_SUCCESS == soter_hmac_cleanup(ctx), "soter_hmac_cleanup: can't cleanup");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_hmac_cleanup(NULL),
+                          "soter_hmac_cleanup: invalid context");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_hmac_destroy(NULL),
+                          "soter_hash_destroy: invalid context");
+    testsuite_fail_unless(SOTER_SUCCESS == soter_hmac_cleanup(ctx),
+                          "soter_hmac_cleanup: can't cleanup");
 }
 
-static void test_api(void){
-	uint8_t data[MAX_TEST_DATA];
-	uint8_t key[MAX_TEST_KEY];
+static void test_api(void)
+{
+    uint8_t data[MAX_TEST_DATA];
+    uint8_t key[MAX_TEST_KEY];
 
-	test_utils_status_t util_res = string_to_bytes(vectors[4].key, key, sizeof(key));
-	if (util_res)
-	{
-		testsuite_fail_if(util_res, "key read fail");
-		return;
-	}
+    test_utils_status_t util_res = string_to_bytes(vectors[4].key, key, sizeof(key));
+    if (util_res) {
+        testsuite_fail_if(util_res, "key read fail");
+        return;
+    }
 
-	soter_hmac_ctx_t* ctx = soter_hmac_create(SOTER_HASH_SHA256, key, HMAC_SIZE);
-	if(!ctx){
-		testsuite_fail_if(!ctx, "soter_hmac_create: can't create");
-		return;
-	}
-	soter_status_t res = soter_hmac_cleanup(ctx);
-	if(SOTER_SUCCESS != res){
-		testsuite_fail_if(true, "soter_hmac_cleanup: error");
-		return;
-	}
-	test_api_(ctx, &data[0], &key[0]);
-	testsuite_fail_unless(SOTER_SUCCESS == soter_hmac_destroy(ctx), "soter_hmac_destroy: can't destroy");
+    soter_hmac_ctx_t* ctx = soter_hmac_create(SOTER_HASH_SHA256, key, HMAC_SIZE);
+    if (!ctx) {
+        testsuite_fail_if(!ctx, "soter_hmac_create: can't create");
+        return;
+    }
+    soter_status_t res = soter_hmac_cleanup(ctx);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_if(true, "soter_hmac_cleanup: error");
+        return;
+    }
+    test_api_(ctx, &data[0], &key[0]);
+    testsuite_fail_unless(SOTER_SUCCESS == soter_hmac_destroy(ctx),
+                          "soter_hmac_destroy: can't destroy");
 }
 
-static void test_api_stack_struct(void){
-	uint8_t data[MAX_TEST_DATA];
-	uint8_t key[MAX_TEST_KEY];
+static void test_api_stack_struct(void)
+{
+    uint8_t data[MAX_TEST_DATA];
+    uint8_t key[MAX_TEST_KEY];
 
-	test_utils_status_t util_res = string_to_bytes(vectors[4].key, key, sizeof(key));
-	if (util_res)
-	{
-		testsuite_fail_if(util_res, "key read fail");
-		return;
-	}
+    test_utils_status_t util_res = string_to_bytes(vectors[4].key, key, sizeof(key));
+    if (util_res) {
+        testsuite_fail_if(util_res, "key read fail");
+        return;
+    }
 
-	soter_hmac_ctx_t ctx;
-	test_api_(&ctx, &data[0], &key[0]);
+    soter_hmac_ctx_t ctx;
+    test_api_(&ctx, &data[0], &key[0]);
 }
 
 void run_soter_hmac_tests(void)
 {
-	testsuite_enter_suite("soter hmac: known values");
-	testsuite_run_test(test_known_values);
+    testsuite_enter_suite("soter hmac: known values");
+    testsuite_run_test(test_known_values);
 
-	testsuite_enter_suite("soter hmac: api");
-	testsuite_run_test(test_api);
+    testsuite_enter_suite("soter hmac: api");
+    testsuite_run_test(test_api);
 
-	testsuite_enter_suite("soter hmac: api with stack initialization");
-	testsuite_run_test(test_api_stack_struct);
+    testsuite_enter_suite("soter hmac: api with stack initialization");
+    testsuite_run_test(test_api_stack_struct);
 }

--- a/tests/soter/soter_rand_test.c
+++ b/tests/soter/soter_rand_test.c
@@ -1,18 +1,18 @@
 /*
-* Copyright (c) 2015 Cossack Labs Limited
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2015 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "soter/soter_test.h"
 
@@ -36,160 +36,147 @@
 
 static bool generate_test_data(void)
 {
-	FILE *test_file = fopen(TEST_DATA_FILE_NAME, "wb");
-	uint8_t rand_buf[1024];
-	soter_status_t res;
-	size_t bytes_written;
-	size_t i;
+    FILE* test_file = fopen(TEST_DATA_FILE_NAME, "wb");
+    uint8_t rand_buf[1024];
+    soter_status_t res;
+    size_t bytes_written;
+    size_t i;
 
-	if (!test_file)
-	{
-		return false;
-	}
+    if (!test_file) {
+        return false;
+    }
 
-	for (i = 0; i < ((TEST_BIT_STREAM_SAMPLE_LENGTH * TEST_BIT_STREAM_SAMPLE_COUNT) / 8); )
-	{
-		res = soter_rand(rand_buf, sizeof(rand_buf));
-		if (SOTER_SUCCESS != res)
-		{
-			fclose(test_file);
-			return false;
-		}
+    for (i = 0; i < ((TEST_BIT_STREAM_SAMPLE_LENGTH * TEST_BIT_STREAM_SAMPLE_COUNT) / 8);) {
+        res = soter_rand(rand_buf, sizeof(rand_buf));
+        if (SOTER_SUCCESS != res) {
+            fclose(test_file);
+            return false;
+        }
 
-		bytes_written = fwrite(rand_buf, 1, sizeof(rand_buf), test_file);
-		if (bytes_written != sizeof(rand_buf))
-		{
-			fclose(test_file);
-			return false;
-		}
+        bytes_written = fwrite(rand_buf, 1, sizeof(rand_buf), test_file);
+        if (bytes_written != sizeof(rand_buf)) {
+            fclose(test_file);
+            return false;
+        }
 
-		i += bytes_written;
-	}
+        i += bytes_written;
+    }
 
-	fclose(test_file);
-	return true;
+    fclose(test_file);
+    return true;
 }
 
 static bool run_nist_suite(void)
 {
-	FILE *nist_file = popen("./assess 1000000 > /dev/null", "w");
-	char cmd[128];
+    FILE* nist_file = popen("./assess 1000000 > /dev/null", "w");
+    char cmd[128];
 
-	if (!nist_file)
-	{
-		return false;
-	}
+    if (!nist_file) {
+        return false;
+    }
 
-	sprintf(cmd, "0\n%s\n1\n0\n%d\n1\n", TEST_DATA_FILE_NAME, TEST_BIT_STREAM_SAMPLE_COUNT);
-	fputs(cmd, nist_file);
+    sprintf(cmd, "0\n%s\n1\n0\n%d\n1\n", TEST_DATA_FILE_NAME, TEST_BIT_STREAM_SAMPLE_COUNT);
+    fputs(cmd, nist_file);
 
-	if (-1 == pclose(nist_file))
-	{
-		return false;
-	}
+    if (-1 == pclose(nist_file)) {
+        return false;
+    }
 
-	return true;
+    return true;
 }
 
 static bool get_result_from_report(void)
 {
-	FILE *report_file = fopen(REPORT_FILE_PATH, "r");
-	char report_line[256];
-	bool is_file_correct = false;
-	bool failed_samples = false;
+    FILE* report_file = fopen(REPORT_FILE_PATH, "r");
+    char report_line[256];
+    bool is_file_correct = false;
+    bool failed_samples = false;
 
-	if (!report_file)
-	{
-		return false;
-	}
+    if (!report_file) {
+        return false;
+    }
 
-	while (fgets(report_line, sizeof(report_line), report_file))
-	{
-		if (!is_file_correct)
-		{
-			/* Sanity check: if we used correct input */
-			if (strstr(report_line, TEST_DATA_FILE_NAME))
-			{
-				is_file_correct = true;
-			}
-		}
+    while (fgets(report_line, sizeof(report_line), report_file)) {
+        if (!is_file_correct) {
+            /* Sanity check: if we used correct input */
+            if (strstr(report_line, TEST_DATA_FILE_NAME)) {
+                is_file_correct = true;
+            }
+        }
 
-		/* Failed tests are marked with '*' in the report */
-		if (strchr(report_line, '*'))
-		{
-			failed_samples = true;
-		}
-	}
+        /* Failed tests are marked with '*' in the report */
+        if (strchr(report_line, '*')) {
+            failed_samples = true;
+        }
+    }
 
-	fclose(report_file);
+    fclose(report_file);
 
-	return (is_file_correct && !failed_samples);
+    return (is_file_correct && !failed_samples);
 }
 
 /* NIST test suite should be launched from its root directory */
 static void test_rand_with_nist(void)
 {
-	int path_max = (int)pathconf("/", _PC_PATH_MAX);;
-	char curr_work_dir[path_max];
+    int path_max = (int)pathconf("/", _PC_PATH_MAX);
+    ;
+    char curr_work_dir[path_max];
 
-	/* Store current work dir */
-	if (NULL == getcwd(curr_work_dir, sizeof(curr_work_dir)))
-	{
-		testsuite_fail_if(true, "getcwd failed");
-		return;
-	}
+    /* Store current work dir */
+    if (NULL == getcwd(curr_work_dir, sizeof(curr_work_dir))) {
+        testsuite_fail_if(true, "getcwd failed");
+        return;
+    }
 
-	/* Change to NIST directory */
-	if (0 != chdir(TO_STRING(NIST_STS_EXE_PATH)))
-	{
-		testsuite_fail_if(true, "chdir failed");
-		return;
-	}
+    /* Change to NIST directory */
+    if (0 != chdir(TO_STRING(NIST_STS_EXE_PATH))) {
+        testsuite_fail_if(true, "chdir failed");
+        return;
+    }
 
-	if (!generate_test_data())
-	{
-		testsuite_fail_if(true, "generate_test_data failed");
-		return;
-	}
+    if (!generate_test_data()) {
+        testsuite_fail_if(true, "generate_test_data failed");
+        return;
+    }
 
-	if (!run_nist_suite())
-	{
-		testsuite_fail_if(true, "run_nist_suite failed");
-		return;
-	}
+    if (!run_nist_suite()) {
+        testsuite_fail_if(true, "run_nist_suite failed");
+        return;
+    }
 
-	testsuite_fail_unless(get_result_from_report(), "NIST tests");
+    testsuite_fail_unless(get_result_from_report(), "NIST tests");
 
-	/* Change back to original directory */
-	if (0 != chdir(curr_work_dir))
-	{
-		testsuite_fail_if(true, "chdir failed");
-		return;
-	}
+    /* Change back to original directory */
+    if (0 != chdir(curr_work_dir)) {
+        testsuite_fail_if(true, "chdir failed");
+        return;
+    }
 }
 
 #else
 
 static void test_rand_with_nist(void)
 {
-	testsuite_fail_if(true, "NIST tests");
+    testsuite_fail_if(true, "NIST tests");
 }
 
 #endif
 
 static void test_api(void)
 {
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_rand(NULL, 32), "soter_rand: invalid out buffer");
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_rand((uint8_t *)0x1, 0), "soter_rand: invalid buffer length");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_rand(NULL, 32),
+                          "soter_rand: invalid out buffer");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_rand((uint8_t*)0x1, 0),
+                          "soter_rand: invalid buffer length");
 }
 
 void run_soter_rand_tests(void)
 {
-	testsuite_enter_suite("soter rand: api");
-	testsuite_run_test(test_api);
+    testsuite_enter_suite("soter rand: api");
+    testsuite_run_test(test_api);
 // always fail under ci
 #ifndef CIRICLE_TEST
-	testsuite_enter_suite("soter rand: NIST STS (make take some time...)");
-	testsuite_run_test(test_rand_with_nist);
+    testsuite_enter_suite("soter rand: NIST STS (make take some time...)");
+    testsuite_run_test(test_rand_with_nist);
 #endif
 }

--- a/tests/soter/soter_sign_test.c
+++ b/tests/soter/soter_sign_test.c
@@ -1,18 +1,18 @@
 /*
-* Copyright (c) 2015 Cossack Labs Limited
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2015 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "soter/soter_test.h"
 
@@ -23,300 +23,319 @@
 
 static int sign_test(soter_sign_alg_t alg)
 {
-  char test_data[]="test message";
-  size_t test_data_length=strlen(test_data);
-  
-  soter_sign_ctx_t* ctx=NULL;
+    char test_data[] = "test message";
+    size_t test_data_length = strlen(test_data);
 
-  uint8_t* signature=NULL;
-  size_t signature_length=0;
+    soter_sign_ctx_t* ctx = NULL;
 
-  ctx=soter_sign_create(alg,NULL,0,NULL,0);
-  if(!ctx){
-    testsuite_fail_if(!ctx, "soter_sign_ctx_t == NULL");
-    return -1;
-  }
+    uint8_t* signature = NULL;
+    size_t signature_length = 0;
 
-  uint8_t private_key[8192];
-  size_t private_key_length=sizeof(private_key);
+    ctx = soter_sign_create(alg, NULL, 0, NULL, 0);
+    if (!ctx) {
+        testsuite_fail_if(!ctx, "soter_sign_ctx_t == NULL");
+        return -1;
+    }
 
-  uint8_t public_key[8192];
-  size_t public_key_length=sizeof(public_key);
+    uint8_t private_key[8192];
+    size_t private_key_length = sizeof(private_key);
 
-  soter_status_t res;
-  res=soter_sign_export_key(ctx, private_key, &private_key_length, true);
-  if(res!=SOTER_SUCCESS){
-    testsuite_fail_if(res!=SOTER_SUCCESS,"soter_sign_export_key (private key) fail");
-    soter_sign_destroy(ctx);
-    return -6;
-  }
+    uint8_t public_key[8192];
+    size_t public_key_length = sizeof(public_key);
 
-  res=soter_sign_export_key(ctx, public_key, &public_key_length, false);
-  if(res!=SOTER_SUCCESS){
-    testsuite_fail_if(res!=SOTER_SUCCESS,"soter_sign_export_key (public key) fail");
-    soter_sign_destroy(ctx);
-    return -7;
-  }
+    soter_status_t res;
+    res = soter_sign_export_key(ctx, private_key, &private_key_length, true);
+    if (res != SOTER_SUCCESS) {
+        testsuite_fail_if(res != SOTER_SUCCESS, "soter_sign_export_key (private key) fail");
+        soter_sign_destroy(ctx);
+        return -6;
+    }
 
-  res=soter_sign_destroy(ctx);
-  if(res!=SOTER_SUCCESS){
-    testsuite_fail_if(res!=SOTER_SUCCESS,"soter_sign_destroy fail");
-    return -8;
-  }
-  
-  soter_sign_ctx_t* sctx=NULL;
+    res = soter_sign_export_key(ctx, public_key, &public_key_length, false);
+    if (res != SOTER_SUCCESS) {
+        testsuite_fail_if(res != SOTER_SUCCESS, "soter_sign_export_key (public key) fail");
+        soter_sign_destroy(ctx);
+        return -7;
+    }
 
-  sctx=soter_sign_create(alg,private_key,private_key_length,NULL,0);
-  if(!sctx){
-    testsuite_fail_if(!sctx, "soter_sign_ctx_t == NULL 2");
-    return -1;
-  }
+    res = soter_sign_destroy(ctx);
+    if (res != SOTER_SUCCESS) {
+        testsuite_fail_if(res != SOTER_SUCCESS, "soter_sign_destroy fail");
+        return -8;
+    }
 
-  res=soter_sign_update(sctx, test_data, test_data_length);
-  if(res!=SOTER_SUCCESS){
-    testsuite_fail_if(res!=SOTER_SUCCESS, "soter_sign_update fail");
-    soter_sign_destroy(sctx);
-    return -2;
-  }
+    soter_sign_ctx_t* sctx = NULL;
 
-  res=soter_sign_final(sctx, signature, &signature_length);
-  if(res!=SOTER_BUFFER_TOO_SMALL){
-    testsuite_fail_if(res!=SOTER_BUFFER_TOO_SMALL, "soter_sign_final (signature length determine) fail");
-    soter_sign_destroy(sctx);
-    return -3;
-  }
+    sctx = soter_sign_create(alg, private_key, private_key_length, NULL, 0);
+    if (!sctx) {
+        testsuite_fail_if(!sctx, "soter_sign_ctx_t == NULL 2");
+        return -1;
+    }
 
-  signature=malloc(signature_length);
-  if(!signature){
-    testsuite_fail_if(!signature, "out of memory");
-    soter_sign_destroy(ctx);
-    return -4;
-  }
+    res = soter_sign_update(sctx, test_data, test_data_length);
+    if (res != SOTER_SUCCESS) {
+        testsuite_fail_if(res != SOTER_SUCCESS, "soter_sign_update fail");
+        soter_sign_destroy(sctx);
+        return -2;
+    }
 
-  res=soter_sign_final(sctx, signature, &signature_length);
-  if(res!=SOTER_SUCCESS){
-    testsuite_fail_if(res!=SOTER_SUCCESS, "soter_sign_final fail");
-    soter_sign_destroy(sctx);
-    return -5;
-  }
-  res=soter_sign_destroy(sctx);
-  if(res!=SOTER_SUCCESS){
-    testsuite_fail_if(res!=SOTER_SUCCESS,"soter_sign_destroy fail");
-    return -8;
-  }
-  
-  soter_verify_ctx_t* vctx=NULL;
+    res = soter_sign_final(sctx, signature, &signature_length);
+    if (res != SOTER_BUFFER_TOO_SMALL) {
+        testsuite_fail_if(res != SOTER_BUFFER_TOO_SMALL,
+                          "soter_sign_final (signature length determine) fail");
+        soter_sign_destroy(sctx);
+        return -3;
+    }
 
-  vctx=soter_verify_create(alg, NULL, 0, public_key, public_key_length);
-  if(!vctx){
-    testsuite_fail_if(!vctx, "soter_verify_ctx_t == NULL");
-    return -9;
-  }
+    signature = malloc(signature_length);
+    if (!signature) {
+        testsuite_fail_if(!signature, "out of memory");
+        soter_sign_destroy(ctx);
+        return -4;
+    }
 
-  res=soter_verify_update(vctx, test_data, test_data_length);
-  if(res!=SOTER_SUCCESS){
-    testsuite_fail_if(res!=SOTER_SUCCESS, "soter_verify_update fail");
-    soter_verify_destroy(vctx);
-    return -10;
-  }
+    res = soter_sign_final(sctx, signature, &signature_length);
+    if (res != SOTER_SUCCESS) {
+        testsuite_fail_if(res != SOTER_SUCCESS, "soter_sign_final fail");
+        soter_sign_destroy(sctx);
+        return -5;
+    }
+    res = soter_sign_destroy(sctx);
+    if (res != SOTER_SUCCESS) {
+        testsuite_fail_if(res != SOTER_SUCCESS, "soter_sign_destroy fail");
+        return -8;
+    }
 
-  res=soter_verify_final(vctx, signature, signature_length);
-  if(res!=SOTER_SUCCESS){
-    testsuite_fail_if(res!=SOTER_SUCCESS, "soter_verify_final fail");
-    soter_verify_destroy(vctx);
-    return -11;
-  }
+    soter_verify_ctx_t* vctx = NULL;
 
-  res=soter_verify_destroy(vctx);
-  if(res!=SOTER_SUCCESS){
-    testsuite_fail_if(res!=SOTER_SUCCESS,"soter_sign_destroy fail");
-    return -12;
-  }
-  free(signature);
-  return 0;
+    vctx = soter_verify_create(alg, NULL, 0, public_key, public_key_length);
+    if (!vctx) {
+        testsuite_fail_if(!vctx, "soter_verify_ctx_t == NULL");
+        return -9;
+    }
+
+    res = soter_verify_update(vctx, test_data, test_data_length);
+    if (res != SOTER_SUCCESS) {
+        testsuite_fail_if(res != SOTER_SUCCESS, "soter_verify_update fail");
+        soter_verify_destroy(vctx);
+        return -10;
+    }
+
+    res = soter_verify_final(vctx, signature, signature_length);
+    if (res != SOTER_SUCCESS) {
+        testsuite_fail_if(res != SOTER_SUCCESS, "soter_verify_final fail");
+        soter_verify_destroy(vctx);
+        return -11;
+    }
+
+    res = soter_verify_destroy(vctx);
+    if (res != SOTER_SUCCESS) {
+        testsuite_fail_if(res != SOTER_SUCCESS, "soter_sign_destroy fail");
+        return -12;
+    }
+    free(signature);
+    return 0;
 }
 
 static void soter_sign_test()
 {
-  testsuite_fail_if(sign_test(SOTER_SIGN_rsa_pss_pkcs8),"soter sign SOTER_SIGN_rsa_pss_pkcs8");
-  testsuite_fail_if(sign_test(SOTER_SIGN_ecdsa_none_pkcs8),"soter sign SOTER_SIGN_ecdsa_none_pkcs8");
+    testsuite_fail_if(sign_test(SOTER_SIGN_rsa_pss_pkcs8), "soter sign SOTER_SIGN_rsa_pss_pkcs8");
+    testsuite_fail_if(sign_test(SOTER_SIGN_ecdsa_none_pkcs8),
+                      "soter sign SOTER_SIGN_ecdsa_none_pkcs8");
 }
 
 static void soter_sign_api_test()
 {
-	uint8_t priv[MAX_TEST_KEY];
-	size_t priv_length = sizeof(priv);
+    uint8_t priv[MAX_TEST_KEY];
+    size_t priv_length = sizeof(priv);
 
-	uint8_t pub[MAX_TEST_KEY];
-	size_t pub_length = sizeof(pub);
+    uint8_t pub[MAX_TEST_KEY];
+    size_t pub_length = sizeof(pub);
 
-	uint8_t message[MAX_TEST_DATA];
-	size_t message_length = rand_int(MAX_TEST_DATA);
+    uint8_t message[MAX_TEST_DATA];
+    size_t message_length = rand_int(MAX_TEST_DATA);
 
-	uint8_t signature[MAX_TEST_DATA];
-	size_t signature_length = sizeof(signature);
+    uint8_t signature[MAX_TEST_DATA];
+    size_t signature_length = sizeof(signature);
 
-	soter_status_t res;
+    soter_status_t res;
 
-	if (soter_rand(message, message_length))
-	{
-		testsuite_fail_if(true, "soter_rand failed");
-		return;
-	}
+    if (soter_rand(message, message_length)) {
+        testsuite_fail_if(true, "soter_rand failed");
+        return;
+    }
 
-	soter_sign_ctx_t *sign_ctx = soter_sign_create(SOTER_SIGN_ecdsa_none_pkcs8, NULL, 0, NULL, 0);
-	if (!sign_ctx)
-	{
-		testsuite_fail_if(true, "soter_sign_create failed");
-		return;
-	}
+    soter_sign_ctx_t* sign_ctx = soter_sign_create(SOTER_SIGN_ecdsa_none_pkcs8, NULL, 0, NULL, 0);
+    if (!sign_ctx) {
+        testsuite_fail_if(true, "soter_sign_create failed");
+        return;
+    }
 
-	res = soter_sign_export_key(sign_ctx, priv, &priv_length, true);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_if(true, "soter_sign_export_key failed");
-		soter_sign_destroy(sign_ctx);
-		return;
-	}
+    res = soter_sign_export_key(sign_ctx, priv, &priv_length, true);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_if(true, "soter_sign_export_key failed");
+        soter_sign_destroy(sign_ctx);
+        return;
+    }
 
-	res = soter_sign_export_key(sign_ctx, pub, &pub_length, false);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_if(true, "soter_sign_export_key failed");
-		soter_sign_destroy(sign_ctx);
-		return;
-	}
+    res = soter_sign_export_key(sign_ctx, pub, &pub_length, false);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_if(true, "soter_sign_export_key failed");
+        soter_sign_destroy(sign_ctx);
+        return;
+    }
 
-	soter_sign_destroy(sign_ctx);
+    soter_sign_destroy(sign_ctx);
 
-	sign_ctx = soter_sign_create((soter_sign_alg_t)-1, priv, priv_length, NULL, 0);
-	testsuite_fail_if(sign_ctx, "soter_sign_create: invalid algorithm");
+    sign_ctx = soter_sign_create((soter_sign_alg_t)-1, priv, priv_length, NULL, 0);
+    testsuite_fail_if(sign_ctx, "soter_sign_create: invalid algorithm");
 
-	sign_ctx = soter_sign_create(SOTER_SIGN_ecdsa_none_pkcs8, priv, priv_length - 1, NULL, 0);
-	testsuite_fail_if(sign_ctx, "soter_sign_create: invalid private key length");
+    sign_ctx = soter_sign_create(SOTER_SIGN_ecdsa_none_pkcs8, priv, priv_length - 1, NULL, 0);
+    testsuite_fail_if(sign_ctx, "soter_sign_create: invalid private key length");
 
-	sign_ctx = soter_sign_create(SOTER_SIGN_ecdsa_none_pkcs8, priv, priv_length, NULL, 0);
-	if (!sign_ctx)
-	{
-		testsuite_fail_if(true, "soter_sign_create failed");
-		return;
-	}
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_sign_update(NULL, message, message_length), "soter_sign_update: invalid context");
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_sign_update(sign_ctx, NULL, message_length), "soter_sign_update: invalid message");
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_sign_update(sign_ctx, message, 0), "soter_sign_update: invalid message length");
+    sign_ctx = soter_sign_create(SOTER_SIGN_ecdsa_none_pkcs8, priv, priv_length, NULL, 0);
+    if (!sign_ctx) {
+        testsuite_fail_if(true, "soter_sign_create failed");
+        return;
+    }
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER ==
+                              soter_sign_update(NULL, message, message_length),
+                          "soter_sign_update: invalid context");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER ==
+                              soter_sign_update(sign_ctx, NULL, message_length),
+                          "soter_sign_update: invalid message");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_sign_update(sign_ctx, message, 0),
+                          "soter_sign_update: invalid message length");
 
-	res = soter_sign_update(sign_ctx, message, message_length);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_if(true, "soter_sign_update failed");
-		soter_sign_destroy(sign_ctx);
-		return;
-	}
+    res = soter_sign_update(sign_ctx, message, message_length);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_if(true, "soter_sign_update failed");
+        soter_sign_destroy(sign_ctx);
+        return;
+    }
 
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_sign_final(NULL, signature, &signature_length), "soter_sign_final: invalid context");
-	testsuite_fail_unless(SOTER_BUFFER_TOO_SMALL == soter_sign_final(sign_ctx, NULL, &signature_length), "soter_sign_final: get output size (NULL out buffer)");
-	signature_length--;
-	testsuite_fail_unless(SOTER_BUFFER_TOO_SMALL == soter_sign_final(sign_ctx, signature, &signature_length), "soter_sign_final: get output size (small out buffer)");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER ==
+                              soter_sign_final(NULL, signature, &signature_length),
+                          "soter_sign_final: invalid context");
+    testsuite_fail_unless(SOTER_BUFFER_TOO_SMALL ==
+                              soter_sign_final(sign_ctx, NULL, &signature_length),
+                          "soter_sign_final: get output size (NULL out buffer)");
+    signature_length--;
+    testsuite_fail_unless(SOTER_BUFFER_TOO_SMALL ==
+                              soter_sign_final(sign_ctx, signature, &signature_length),
+                          "soter_sign_final: get output size (small out buffer)");
 
-	res = soter_sign_final(sign_ctx, signature, &signature_length);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_if(true, "soter_sign_final failed");
-		soter_sign_destroy(sign_ctx);
-		return;
-	}
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_sign_destroy(NULL), "soter_sign_destroy: invalid context");
-	res = soter_sign_destroy(sign_ctx);
-	if (SOTER_SUCCESS != res){
-		testsuite_fail_if(true, "soter_sign_destroy failed");
-		return;
-	}
+    res = soter_sign_final(sign_ctx, signature, &signature_length);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_if(true, "soter_sign_final failed");
+        soter_sign_destroy(sign_ctx);
+        return;
+    }
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_sign_destroy(NULL),
+                          "soter_sign_destroy: invalid context");
+    res = soter_sign_destroy(sign_ctx);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_if(true, "soter_sign_destroy failed");
+        return;
+    }
 
-	sign_ctx = soter_verify_create((soter_sign_alg_t)-1, NULL, 0, pub, pub_length);
-	testsuite_fail_if(sign_ctx, "soter_verify_create: invalid algorithm");
+    sign_ctx = soter_verify_create((soter_sign_alg_t)-1, NULL, 0, pub, pub_length);
+    testsuite_fail_if(sign_ctx, "soter_verify_create: invalid algorithm");
 
-	sign_ctx = soter_verify_create(SOTER_SIGN_ecdsa_none_pkcs8, NULL, 0, pub, pub_length - 1);
-	testsuite_fail_if(sign_ctx, "soter_verify_create: invalid public key length");
+    sign_ctx = soter_verify_create(SOTER_SIGN_ecdsa_none_pkcs8, NULL, 0, pub, pub_length - 1);
+    testsuite_fail_if(sign_ctx, "soter_verify_create: invalid public key length");
 
-	sign_ctx = soter_verify_create(SOTER_SIGN_ecdsa_none_pkcs8, NULL, 0, pub, pub_length);
-	if (!sign_ctx)
-	{
-		testsuite_fail_if(true, "soter_verify_create failed");
-		return;
-	}
+    sign_ctx = soter_verify_create(SOTER_SIGN_ecdsa_none_pkcs8, NULL, 0, pub, pub_length);
+    if (!sign_ctx) {
+        testsuite_fail_if(true, "soter_verify_create failed");
+        return;
+    }
 
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_verify_update(NULL, message, message_length), "soter_verify_update: invalid context");
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_verify_update(sign_ctx, NULL, message_length), "soter_verify_update: invalid message");
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_verify_update(sign_ctx, message, 0), "soter_verify_update: invalid message length");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER ==
+                              soter_verify_update(NULL, message, message_length),
+                          "soter_verify_update: invalid context");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER ==
+                              soter_verify_update(sign_ctx, NULL, message_length),
+                          "soter_verify_update: invalid message");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_verify_update(sign_ctx, message, 0),
+                          "soter_verify_update: invalid message length");
 
-	res = soter_verify_update(sign_ctx, message, message_length);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_if(true, "soter_verify_update failed");
-		soter_verify_destroy(sign_ctx);
-		return;
-	}
+    res = soter_verify_update(sign_ctx, message, message_length);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_if(true, "soter_verify_update failed");
+        soter_verify_destroy(sign_ctx);
+        return;
+    }
 
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_verify_final(NULL, signature, signature_length), "soter_verify_final: invalid context");
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_verify_final(sign_ctx, NULL, signature_length), "soter_verify_final: invalid signature buffer");
-	testsuite_fail_unless(SOTER_INVALID_SIGNATURE == soter_verify_final(sign_ctx, signature, signature_length - 1), "soter_verify_final: invalid signature length");
-	signature[signature_length / 2]++;
-	testsuite_fail_unless(SOTER_INVALID_SIGNATURE == soter_verify_final(sign_ctx, signature, signature_length), "soter_verify_final: invalid signature value");
-	signature[signature_length / 2]--;
-	testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_verify_destroy(NULL), "soter_verify_destroy: invalid context");
-	res = soter_verify_destroy(sign_ctx);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_if(true, "soter_verify_destroy failed");
-		return;
-	}
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER ==
+                              soter_verify_final(NULL, signature, signature_length),
+                          "soter_verify_final: invalid context");
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER ==
+                              soter_verify_final(sign_ctx, NULL, signature_length),
+                          "soter_verify_final: invalid signature buffer");
+    testsuite_fail_unless(SOTER_INVALID_SIGNATURE ==
+                              soter_verify_final(sign_ctx, signature, signature_length - 1),
+                          "soter_verify_final: invalid signature length");
+    signature[signature_length / 2]++;
+    testsuite_fail_unless(SOTER_INVALID_SIGNATURE ==
+                              soter_verify_final(sign_ctx, signature, signature_length),
+                          "soter_verify_final: invalid signature value");
+    signature[signature_length / 2]--;
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER == soter_verify_destroy(NULL),
+                          "soter_verify_destroy: invalid context");
+    res = soter_verify_destroy(sign_ctx);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_if(true, "soter_verify_destroy failed");
+        return;
+    }
 
-	sign_ctx = soter_verify_create(SOTER_SIGN_ecdsa_none_pkcs8, NULL, 0, pub, pub_length);
-	if (!sign_ctx)
-	{
-		testsuite_fail_if(true, "soter_verify_create failed");
-		return;
-	}
+    sign_ctx = soter_verify_create(SOTER_SIGN_ecdsa_none_pkcs8, NULL, 0, pub, pub_length);
+    if (!sign_ctx) {
+        testsuite_fail_if(true, "soter_verify_create failed");
+        return;
+    }
 
-	message[message_length / 2]++;
+    message[message_length / 2]++;
 
-	res = soter_verify_update(sign_ctx, message, message_length);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_if(true, "soter_verify_update failed");
-		soter_verify_destroy(sign_ctx);
-		return;
-	}
+    res = soter_verify_update(sign_ctx, message, message_length);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_if(true, "soter_verify_update failed");
+        soter_verify_destroy(sign_ctx);
+        return;
+    }
 
-	message[message_length / 2]--;
+    message[message_length / 2]--;
 
-	testsuite_fail_unless(SOTER_INVALID_SIGNATURE == soter_verify_final(sign_ctx, signature, signature_length), "soter_verify_final: wrong signed message");
+    testsuite_fail_unless(SOTER_INVALID_SIGNATURE ==
+                              soter_verify_final(sign_ctx, signature, signature_length),
+                          "soter_verify_final: wrong signed message");
 
-	soter_verify_destroy(sign_ctx);
+    soter_verify_destroy(sign_ctx);
 
-	sign_ctx = soter_verify_create(SOTER_SIGN_ecdsa_none_pkcs8, NULL, 0, pub, pub_length);
-	if (!sign_ctx)
-	{
-		testsuite_fail_if(true, "soter_verify_create failed");
-		return;
-	}
+    sign_ctx = soter_verify_create(SOTER_SIGN_ecdsa_none_pkcs8, NULL, 0, pub, pub_length);
+    if (!sign_ctx) {
+        testsuite_fail_if(true, "soter_verify_create failed");
+        return;
+    }
 
-	res = soter_verify_update(sign_ctx, message, message_length);
-	if (SOTER_SUCCESS != res)
-	{
-		testsuite_fail_if(true, "soter_verify_update failed");
-		soter_verify_destroy(sign_ctx);
-		return;
-	}
+    res = soter_verify_update(sign_ctx, message, message_length);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_if(true, "soter_verify_update failed");
+        soter_verify_destroy(sign_ctx);
+        return;
+    }
 
-	testsuite_fail_unless(SOTER_SUCCESS == soter_verify_final(sign_ctx, signature, signature_length), "soter_verify_final: normal flow");
-	soter_verify_destroy(sign_ctx);
+    testsuite_fail_unless(SOTER_SUCCESS ==
+                              soter_verify_final(sign_ctx, signature, signature_length),
+                          "soter_verify_final: normal flow");
+    soter_verify_destroy(sign_ctx);
 }
 
-void run_soter_sign_test(){
-  testsuite_enter_suite("soter sign: basic flow");
-  testsuite_run_test(soter_sign_test);
+void run_soter_sign_test()
+{
+    testsuite_enter_suite("soter sign: basic flow");
+    testsuite_run_test(soter_sign_test);
 
-  testsuite_enter_suite("soter sign: api");
-  testsuite_run_test(soter_sign_api_test);
+    testsuite_enter_suite("soter sign: api");
+    testsuite_run_test(soter_sign_api_test);
 }

--- a/tests/soter/soter_sym_test.c
+++ b/tests/soter/soter_sym_test.c
@@ -1,119 +1,89 @@
 /*
-* Copyright (c) 2015 Cossack Labs Limited
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2015 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "soter/soter_test.h"
 
 #include <stdio.h>
 #include <string.h>
 
-struct test_vector_type
-{
-  uint32_t alg;
-  char *key;
-  char *iv;
-  char *plaintext;
-  char *ciphertext;
+struct test_vector_type {
+    uint32_t alg;
+    char* key;
+    char* iv;
+    char* plaintext;
+    char* ciphertext;
 };
 
 typedef struct test_vector_type test_vector_t;
 
-struct test_vector_aead_type
-{
-  uint32_t alg;
-  char *key;
-  char *iv;
-  char *aad;
-  char *plaintext;
-  char *ciphertext;
-  char *authtag;
+struct test_vector_aead_type {
+    uint32_t alg;
+    char* key;
+    char* iv;
+    char* aad;
+    char* plaintext;
+    char* ciphertext;
+    char* authtag;
 };
 
 typedef struct test_vector_aead_type test_vector_aead_t;
 
 /* taken from NIST SP800-38A */
 static test_vector_t vectors[] = {
-  {
-    SOTER_SYM_AES_ECB_PKCS7|SOTER_SYM_128_KEY_LENGTH,
-    "2b7e151628aed2a6abf7158809cf4f3c",
-    "",
-    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e5130c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710",
-    "3ad77bb40d7a3660a89ecaf32466ef97f5d3d58503b9699de785895a96fdbaaf43b1cd7f598ece23881b00e3ed0306887b0c785e27e8ad3f8223207104725dd4a254be88e037ddd9d79fb6411c3f9df8"
-  },
-  {
-    SOTER_SYM_AES_ECB_PKCS7|SOTER_SYM_256_KEY_LENGTH,
-    "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4",
-    "",
-    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e5130c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710",
-    "f3eed1bdb5d2a03c064b5a7e3db181f8591ccb10d410ed26dc5ba74a31362870b6ed21b99ca6f4f9f153e7b1beafed1d23304b7a39f9f3ff067d8d8f9e24ecc74c45dfb3b3b484ec35b0512dc8c1c4d6"
-  },
-  {
-    SOTER_SYM_AES_CTR|SOTER_SYM_128_KEY_LENGTH,
-    "2b7e151628aed2a6abf7158809cf4f3c",
-    "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
-    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e5130c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710",
-    "874d6191b620e3261bef6864990db6ce9806f66b7970fdff8617187bb9fffdff5ae4df3edbd5d35e5b4f09020db03eab1e031dda2fbe03d1792170a0f3009cee"
-  },
-  {
-    SOTER_SYM_AES_CTR|SOTER_SYM_256_KEY_LENGTH,
-    "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4",
-    "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
-    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e5130c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710",
-    "601ec313775789a5b7a7f504bbf3d228f443e3ca4d62b59aca84e990cacaf5c52b0930daa23de94ce87017ba2d84988ddfc9c58db67aada613c2dd08457941a6"
-  }
-};
+    {SOTER_SYM_AES_ECB_PKCS7 | SOTER_SYM_128_KEY_LENGTH, "2b7e151628aed2a6abf7158809cf4f3c", "",
+     "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e5130c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710",
+     "3ad77bb40d7a3660a89ecaf32466ef97f5d3d58503b9699de785895a96fdbaaf43b1cd7f598ece23881b00e3ed0306887b0c785e27e8ad3f8223207104725dd4a254be88e037ddd9d79fb6411c3f9df8"},
+    {SOTER_SYM_AES_ECB_PKCS7 | SOTER_SYM_256_KEY_LENGTH,
+     "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4", "",
+     "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e5130c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710",
+     "f3eed1bdb5d2a03c064b5a7e3db181f8591ccb10d410ed26dc5ba74a31362870b6ed21b99ca6f4f9f153e7b1beafed1d23304b7a39f9f3ff067d8d8f9e24ecc74c45dfb3b3b484ec35b0512dc8c1c4d6"},
+    {SOTER_SYM_AES_CTR | SOTER_SYM_128_KEY_LENGTH, "2b7e151628aed2a6abf7158809cf4f3c",
+     "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+     "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e5130c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710",
+     "874d6191b620e3261bef6864990db6ce9806f66b7970fdff8617187bb9fffdff5ae4df3edbd5d35e5b4f09020db03eab1e031dda2fbe03d1792170a0f3009cee"},
+    {SOTER_SYM_AES_CTR | SOTER_SYM_256_KEY_LENGTH,
+     "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4",
+     "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+     "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e5130c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710",
+     "601ec313775789a5b7a7f504bbf3d228f443e3ca4d62b59aca84e990cacaf5c52b0930daa23de94ce87017ba2d84988ddfc9c58db67aada613c2dd08457941a6"}};
 
 /* GCM - taken from The Galois/Counter Mode of Operation (GCM) by David A. McGrew and John Viega */
-static test_vector_aead_t vectors_aead[] =  {
-  {
-    SOTER_SYM_AES_GCM|SOTER_SYM_128_KEY_LENGTH,
-    "feffe9928665731c6d6a8f9467308308",
-    "cafebabefacedbaddecaf888",
-    "",
-    "d9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b391aafd255",
-    "42831ec2217774244b7221b784d0d49ce3aa212f2c02a4e035c17e2329aca12e21d514b25466931c7d8f6a5aac84aa051ba30b396a0aac973d58e091473f5985",
-    "4d5c2af327cd64a62cf35abd2ba6fab4"
-  },
-  {
-    SOTER_SYM_AES_GCM|SOTER_SYM_128_KEY_LENGTH,
-    "feffe9928665731c6d6a8f9467308308",
-    "cafebabefacedbaddecaf888",
-    "feedfacedeadbeeffeedfacedeadbeefabaddad2",
-    "d9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b39",
-    "42831ec2217774244b7221b784d0d49ce3aa212f2c02a4e035c17e2329aca12e21d514b25466931c7d8f6a5aac84aa051ba30b396a0aac973d58e091",
-    "5bc94fbc3221a5db94fae95ae7121a47"
-  },
-  {
-    SOTER_SYM_AES_GCM|SOTER_SYM_256_KEY_LENGTH,
-    "feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308308",
-    "cafebabefacedbaddecaf888",
-    "",
-    "d9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b391aafd255",
-    "522dc1f099567d07f47f37a32a84427d643a8cdcbfe5c0c97598a2bd2555d1aa8cb08e48590dbb3da7b08b1056828838c5f61e6393ba7a0abcc9f662898015ad",
-    "b094dac5d93471bdec1a502270e3cc6c"
-  },
-  {
-    SOTER_SYM_AES_GCM|SOTER_SYM_256_KEY_LENGTH,
-    "feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308308",
-    "cafebabefacedbaddecaf888",
-    "feedfacedeadbeeffeedfacedeadbeefabaddad2",
-    "d9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b39",
-    "522dc1f099567d07f47f37a32a84427d643a8cdcbfe5c0c97598a2bd2555d1aa8cb08e48590dbb3da7b08b1056828838c5f61e6393ba7a0abcc9f662",
-    "76fc6ece0f4e1768cddf8853bb2d551b"
-  }
-};
+static test_vector_aead_t vectors_aead[] = {
+    {SOTER_SYM_AES_GCM | SOTER_SYM_128_KEY_LENGTH, "feffe9928665731c6d6a8f9467308308",
+     "cafebabefacedbaddecaf888", "",
+     "d9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b391aafd255",
+     "42831ec2217774244b7221b784d0d49ce3aa212f2c02a4e035c17e2329aca12e21d514b25466931c7d8f6a5aac84aa051ba30b396a0aac973d58e091473f5985",
+     "4d5c2af327cd64a62cf35abd2ba6fab4"},
+    {SOTER_SYM_AES_GCM | SOTER_SYM_128_KEY_LENGTH, "feffe9928665731c6d6a8f9467308308",
+     "cafebabefacedbaddecaf888", "feedfacedeadbeeffeedfacedeadbeefabaddad2",
+     "d9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b39",
+     "42831ec2217774244b7221b784d0d49ce3aa212f2c02a4e035c17e2329aca12e21d514b25466931c7d8f6a5aac84aa051ba30b396a0aac973d58e091",
+     "5bc94fbc3221a5db94fae95ae7121a47"},
+    {SOTER_SYM_AES_GCM | SOTER_SYM_256_KEY_LENGTH,
+     "feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308308", "cafebabefacedbaddecaf888",
+     "",
+     "d9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b391aafd255",
+     "522dc1f099567d07f47f37a32a84427d643a8cdcbfe5c0c97598a2bd2555d1aa8cb08e48590dbb3da7b08b1056828838c5f61e6393ba7a0abcc9f662898015ad",
+     "b094dac5d93471bdec1a502270e3cc6c"},
+    {SOTER_SYM_AES_GCM | SOTER_SYM_256_KEY_LENGTH,
+     "feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308308", "cafebabefacedbaddecaf888",
+     "feedfacedeadbeeffeedfacedeadbeefabaddad2",
+     "d9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b39",
+     "522dc1f099567d07f47f37a32a84427d643a8cdcbfe5c0c97598a2bd2555d1aa8cb08e48590dbb3da7b08b1056828838c5f61e6393ba7a0abcc9f662",
+     "76fc6ece0f4e1768cddf8853bb2d551b"}};
 
 #define MAX_KEY_LENGTH 32
 #define MAX_DATA_LENGTH 1024
@@ -121,128 +91,121 @@ static test_vector_aead_t vectors_aead[] =  {
 
 static void test_known_values(void)
 {
-  soter_sym_ctx_t *ctx;
-  int i;
-  
-  uint8_t key[MAX_KEY_LENGTH];
-  uint8_t iv[MAX_IV_LENGTH];
-  uint8_t plaintext[MAX_DATA_LENGTH];
-  uint8_t ciphertext[MAX_DATA_LENGTH];
-  
-  uint8_t computed[MAX_DATA_LENGTH];
-  size_t computed_length;
-  uint8_t computed2[MAX_DATA_LENGTH];  
-  size_t computed_length2=MAX_DATA_LENGTH;
-  
-  uint8_t pad[MAX_IV_LENGTH];
-  size_t pad_length = sizeof(pad);
-  
-  soter_status_t res;
-  
-  for (i = 0; i < (int)(sizeof(vectors) / sizeof(test_vector_t)); i++)
-    {
-      res = string_to_bytes(vectors[i].key, key, sizeof(key));
-      if (SOTER_SUCCESS != res)
-	{
-	  testsuite_fail_if(res, "string_to_bytes");
-	  continue;
-	}
-      
-      res = string_to_bytes(vectors[i].iv, iv, sizeof(iv));
-      if (SOTER_SUCCESS != res)
-	{
-	  testsuite_fail_if(res, "string_to_bytes");
-	  continue;
-	}
-      
-      res = string_to_bytes(vectors[i].plaintext, plaintext, sizeof(plaintext));
-      if (SOTER_SUCCESS != res)
-	{
-	  testsuite_fail_if(res, "string_to_bytes");
-	  continue;
-	}
-      
-      res = string_to_bytes(vectors[i].ciphertext, ciphertext, sizeof(ciphertext));
-      if (SOTER_SUCCESS != res)
-	{
-	  testsuite_fail_if(res, "string_to_bytes");
-	  continue;
-	}
-      
-      /* Encryption */
-      if(strlen(vectors[i].iv)==0){
-	ctx = soter_sym_encrypt_create(vectors[i].alg, key, strlen(vectors[i].key) / 2, NULL, 0, NULL, 0);
-      }else{
-	ctx = soter_sym_encrypt_create(vectors[i].alg, key, strlen(vectors[i].key) / 2, NULL, 0, iv, strlen(vectors[i].iv) / 2);
-      }
-      if (NULL == ctx)
-	{
-	  testsuite_fail_unless(ctx, "soter_sym_create");
-	  continue;
-	}
-      
-      computed_length = sizeof(computed);
-      res = soter_sym_encrypt_update(ctx, plaintext, strlen(vectors[i].plaintext) / 2, computed, &computed_length);
-      if (SOTER_SUCCESS != res)
-	{
-	  testsuite_fail_if(SOTER_SUCCESS != res, "soter_sym_update");
-	  soter_sym_encrypt_destroy(ctx);
-	  continue;
-	}
-      
-      pad_length=sizeof(pad);
-      res = soter_sym_encrypt_final(ctx, computed+computed_length, &pad_length);
-      if (SOTER_SUCCESS != res)
-	{
-	  testsuite_fail_if(SOTER_SUCCESS != res, "soter_sym_final");
-	  soter_sym_encrypt_destroy(ctx);
- 	  continue;
-	}
-        computed_length+=pad_length;
-      res = soter_sym_encrypt_destroy(ctx);
-      if (SOTER_SUCCESS != res)
-	{
-	  testsuite_fail_if(SOTER_SUCCESS != res, "soter_sym_destroy");
-	}
+    soter_sym_ctx_t* ctx;
+    int i;
 
-      testsuite_fail_if(memcmp(computed, ciphertext, computed_length)!=0, "known encryption");
+    uint8_t key[MAX_KEY_LENGTH];
+    uint8_t iv[MAX_IV_LENGTH];
+    uint8_t plaintext[MAX_DATA_LENGTH];
+    uint8_t ciphertext[MAX_DATA_LENGTH];
 
-      /* Decryption */
-      if(strlen(vectors[i].iv)==0){
-	ctx = soter_sym_decrypt_create(vectors[i].alg, key, strlen(vectors[i].key) / 2, NULL, 0, NULL, 0);
-      }else{
-	ctx = soter_sym_decrypt_create(vectors[i].alg, key, strlen(vectors[i].key) / 2, NULL, 0, iv, strlen(vectors[i].iv) / 2);
-      }
-      if (NULL == ctx)
-	{
-	  testsuite_fail_unless(ctx, "soter_sym_create");
-	  continue;
-	}
-      computed_length2=MAX_DATA_LENGTH;
-      res = soter_sym_decrypt_update(ctx, computed, computed_length, computed2, &computed_length2);
-      if (SOTER_SUCCESS != res)
-	{
-	  testsuite_fail_if(res, "soter_sym_update");
-	  soter_sym_decrypt_destroy(ctx);
-	  continue;
-	}
-      pad_length=sizeof(pad);
-      res = soter_sym_decrypt_final(ctx, computed2+computed_length2, &pad_length);
-      if (SOTER_SUCCESS != res)
-	{
-	  testsuite_fail_if(res, "soter_sym_final");
-	  soter_sym_decrypt_destroy(ctx);
-	  continue;
-	}
-      computed_length2+=pad_length;
-      res = soter_sym_decrypt_destroy(ctx);
-      if (SOTER_SUCCESS != res)
-	{
-	  testsuite_fail_if(res, "soter_sym_destroy");
-	  soter_sym_decrypt_destroy(ctx);
-	  continue;
-	}
-      testsuite_fail_if(memcmp(computed2, plaintext, computed_length2), "known decryption");
+    uint8_t computed[MAX_DATA_LENGTH];
+    size_t computed_length;
+    uint8_t computed2[MAX_DATA_LENGTH];
+    size_t computed_length2 = MAX_DATA_LENGTH;
+
+    uint8_t pad[MAX_IV_LENGTH];
+    size_t pad_length = sizeof(pad);
+
+    soter_status_t res;
+
+    for (i = 0; i < (int)(sizeof(vectors) / sizeof(test_vector_t)); i++) {
+        res = string_to_bytes(vectors[i].key, key, sizeof(key));
+        if (SOTER_SUCCESS != res) {
+            testsuite_fail_if(res, "string_to_bytes");
+            continue;
+        }
+
+        res = string_to_bytes(vectors[i].iv, iv, sizeof(iv));
+        if (SOTER_SUCCESS != res) {
+            testsuite_fail_if(res, "string_to_bytes");
+            continue;
+        }
+
+        res = string_to_bytes(vectors[i].plaintext, plaintext, sizeof(plaintext));
+        if (SOTER_SUCCESS != res) {
+            testsuite_fail_if(res, "string_to_bytes");
+            continue;
+        }
+
+        res = string_to_bytes(vectors[i].ciphertext, ciphertext, sizeof(ciphertext));
+        if (SOTER_SUCCESS != res) {
+            testsuite_fail_if(res, "string_to_bytes");
+            continue;
+        }
+
+        /* Encryption */
+        if (strlen(vectors[i].iv) == 0) {
+            ctx = soter_sym_encrypt_create(vectors[i].alg, key, strlen(vectors[i].key) / 2, NULL, 0,
+                                           NULL, 0);
+        } else {
+            ctx = soter_sym_encrypt_create(vectors[i].alg, key, strlen(vectors[i].key) / 2, NULL, 0,
+                                           iv, strlen(vectors[i].iv) / 2);
+        }
+        if (NULL == ctx) {
+            testsuite_fail_unless(ctx, "soter_sym_create");
+            continue;
+        }
+
+        computed_length = sizeof(computed);
+        res = soter_sym_encrypt_update(ctx, plaintext, strlen(vectors[i].plaintext) / 2, computed,
+                                       &computed_length);
+        if (SOTER_SUCCESS != res) {
+            testsuite_fail_if(SOTER_SUCCESS != res, "soter_sym_update");
+            soter_sym_encrypt_destroy(ctx);
+            continue;
+        }
+
+        pad_length = sizeof(pad);
+        res = soter_sym_encrypt_final(ctx, computed + computed_length, &pad_length);
+        if (SOTER_SUCCESS != res) {
+            testsuite_fail_if(SOTER_SUCCESS != res, "soter_sym_final");
+            soter_sym_encrypt_destroy(ctx);
+            continue;
+        }
+        computed_length += pad_length;
+        res = soter_sym_encrypt_destroy(ctx);
+        if (SOTER_SUCCESS != res) {
+            testsuite_fail_if(SOTER_SUCCESS != res, "soter_sym_destroy");
+        }
+
+        testsuite_fail_if(memcmp(computed, ciphertext, computed_length) != 0, "known encryption");
+
+        /* Decryption */
+        if (strlen(vectors[i].iv) == 0) {
+            ctx = soter_sym_decrypt_create(vectors[i].alg, key, strlen(vectors[i].key) / 2, NULL, 0,
+                                           NULL, 0);
+        } else {
+            ctx = soter_sym_decrypt_create(vectors[i].alg, key, strlen(vectors[i].key) / 2, NULL, 0,
+                                           iv, strlen(vectors[i].iv) / 2);
+        }
+        if (NULL == ctx) {
+            testsuite_fail_unless(ctx, "soter_sym_create");
+            continue;
+        }
+        computed_length2 = MAX_DATA_LENGTH;
+        res =
+            soter_sym_decrypt_update(ctx, computed, computed_length, computed2, &computed_length2);
+        if (SOTER_SUCCESS != res) {
+            testsuite_fail_if(res, "soter_sym_update");
+            soter_sym_decrypt_destroy(ctx);
+            continue;
+        }
+        pad_length = sizeof(pad);
+        res = soter_sym_decrypt_final(ctx, computed2 + computed_length2, &pad_length);
+        if (SOTER_SUCCESS != res) {
+            testsuite_fail_if(res, "soter_sym_final");
+            soter_sym_decrypt_destroy(ctx);
+            continue;
+        }
+        computed_length2 += pad_length;
+        res = soter_sym_decrypt_destroy(ctx);
+        if (SOTER_SUCCESS != res) {
+            testsuite_fail_if(res, "soter_sym_destroy");
+            soter_sym_decrypt_destroy(ctx);
+            continue;
+        }
+        testsuite_fail_if(memcmp(computed2, plaintext, computed_length2), "known decryption");
     }
 }
 
@@ -251,351 +214,331 @@ static void test_known_values(void)
 
 static void test_known_values_gcm(void)
 {
-  soter_sym_ctx_t *ctx;
-  int i;
-  
-  uint8_t key[MAX_KEY_LENGTH];
-  uint8_t iv[MAX_IV_LENGTH];
-  uint8_t plaintext[MAX_DATA_LENGTH];
-  uint8_t ciphertext[MAX_DATA_LENGTH];
-  
-  uint8_t computed[MAX_DATA_LENGTH];
-  size_t computed_length;
+    soter_sym_ctx_t* ctx;
+    int i;
 
-  uint8_t computed2[MAX_DATA_LENGTH];
-  size_t computed_length2;
+    uint8_t key[MAX_KEY_LENGTH];
+    uint8_t iv[MAX_IV_LENGTH];
+    uint8_t plaintext[MAX_DATA_LENGTH];
+    uint8_t ciphertext[MAX_DATA_LENGTH];
 
-  uint8_t aad[MAX_AAD_LENGTH];
+    uint8_t computed[MAX_DATA_LENGTH];
+    size_t computed_length;
 
+    uint8_t computed2[MAX_DATA_LENGTH];
+    size_t computed_length2;
 
-  uint8_t auth_tag[MAX_AUTH_TAG_LENGTH];
-  uint8_t expected_auth_tag[MAX_AUTH_TAG_LENGTH];
-  size_t auth_tag_length=sizeof(auth_tag);
-  soter_status_t res;
-  
-  for (i = 0; i < (int)(sizeof(vectors_aead) / sizeof(test_vector_aead_t)); i++)
-    {
-      res = string_to_bytes(vectors_aead[i].key, key, sizeof(key));
-      if (SOTER_SUCCESS != res)
-	{
-	  testsuite_fail_if(res, "string_to_bytes");
-	  continue;
-	}
-      
-      res = string_to_bytes(vectors_aead[i].iv, iv, sizeof(iv));
-      if (SOTER_SUCCESS != res)
-	{
-	  testsuite_fail_if(res, "string_to_bytes");
-	  continue;
-	}
-      
-      res = string_to_bytes(vectors_aead[i].plaintext, plaintext, sizeof(plaintext));
-      if (SOTER_SUCCESS != res)
-	{
-	  testsuite_fail_if(res, "string_to_bytes");
-	  continue;
-	}
+    uint8_t aad[MAX_AAD_LENGTH];
 
-      res = string_to_bytes(vectors_aead[i].ciphertext, ciphertext, sizeof(ciphertext));
-      if (SOTER_SUCCESS != res)
-	{
-	  testsuite_fail_if(res, "string_to_bytes");
-	  continue;
-	}
+    uint8_t auth_tag[MAX_AUTH_TAG_LENGTH];
+    uint8_t expected_auth_tag[MAX_AUTH_TAG_LENGTH];
+    size_t auth_tag_length = sizeof(auth_tag);
+    soter_status_t res;
 
-      res = string_to_bytes(vectors_aead[i].aad, aad, sizeof(aad));
-      if (SOTER_SUCCESS != res)
-	{
-	  testsuite_fail_if(res, "string_to_bytes");
-	  continue;
-	}
-	
-      res = string_to_bytes(vectors_aead[i].authtag, expected_auth_tag, MAX_AUTH_TAG_LENGTH);
-      if (SOTER_SUCCESS != res)
-	{
-	  testsuite_fail_if(res, "string_to_bytes");
-	  continue;
-	}
+    for (i = 0; i < (int)(sizeof(vectors_aead) / sizeof(test_vector_aead_t)); i++) {
+        res = string_to_bytes(vectors_aead[i].key, key, sizeof(key));
+        if (SOTER_SUCCESS != res) {
+            testsuite_fail_if(res, "string_to_bytes");
+            continue;
+        }
 
-      /* Encryption */
-      ctx = soter_sym_aead_encrypt_create(vectors_aead[i].alg, key, strlen(vectors_aead[i].key) / 2, NULL,0,iv, strlen(vectors_aead[i].iv) / 2);
-      if (NULL == ctx)
-	{
-	  testsuite_fail_unless(ctx, "soter_sym_create");
-	  continue;
-	}
-      if(strlen(vectors_aead[i].aad)!=0){
-	computed_length = sizeof(computed);     
-	res = soter_sym_aead_encrypt_aad(ctx, aad, strlen(vectors_aead[i].aad) / 2);
-	if (SOTER_SUCCESS != res)
-	  {
-	    testsuite_fail_if(res, "soter_sym_update aad");
-	    soter_sym_encrypt_destroy(ctx);
-	    continue;
-	  }
-      }
+        res = string_to_bytes(vectors_aead[i].iv, iv, sizeof(iv));
+        if (SOTER_SUCCESS != res) {
+            testsuite_fail_if(res, "string_to_bytes");
+            continue;
+        }
 
-      computed_length = sizeof(computed);
-      
-      res = soter_sym_aead_encrypt_update(ctx, plaintext, strlen(vectors_aead[i].plaintext) / 2, computed, &computed_length);
-      if (SOTER_SUCCESS != res)
-	{
-	  testsuite_fail_if(res, "soter_sym_update");
-	  soter_sym_aead_encrypt_destroy(ctx);
-	  continue;
-	}
+        res = string_to_bytes(vectors_aead[i].plaintext, plaintext, sizeof(plaintext));
+        if (SOTER_SUCCESS != res) {
+            testsuite_fail_if(res, "string_to_bytes");
+            continue;
+        }
 
-      res = soter_sym_aead_encrypt_final(ctx, auth_tag, &auth_tag_length);
-      if (SOTER_SUCCESS != res)
-	{
-	  testsuite_fail_if(res, "soter_sym_final");
-	  soter_sym_aead_encrypt_destroy(ctx);
- 	  continue;
-	}
-      
-      res = soter_sym_aead_encrypt_destroy(ctx);
-      if (SOTER_SUCCESS != res)
-	{
-	  testsuite_fail_if(res, "soter_sym_destroy");
-	}
+        res = string_to_bytes(vectors_aead[i].ciphertext, ciphertext, sizeof(ciphertext));
+        if (SOTER_SUCCESS != res) {
+            testsuite_fail_if(res, "string_to_bytes");
+            continue;
+        }
 
-      testsuite_fail_if(memcmp(computed, ciphertext, computed_length), "known encryption");
+        res = string_to_bytes(vectors_aead[i].aad, aad, sizeof(aad));
+        if (SOTER_SUCCESS != res) {
+            testsuite_fail_if(res, "string_to_bytes");
+            continue;
+        }
 
-      testsuite_fail_if(memcmp(auth_tag, expected_auth_tag, auth_tag_length), "known encryption (auth tag value)");
+        res = string_to_bytes(vectors_aead[i].authtag, expected_auth_tag, MAX_AUTH_TAG_LENGTH);
+        if (SOTER_SUCCESS != res) {
+            testsuite_fail_if(res, "string_to_bytes");
+            continue;
+        }
 
-      /* Decryption */
-      ctx = soter_sym_aead_decrypt_create(vectors_aead[i].alg, key, strlen(vectors_aead[i].key) / 2, NULL, 0, iv, strlen(vectors_aead[i].iv) / 2);
-      if (NULL == ctx)
-	{
-	  testsuite_fail_unless(ctx, "soter_sym_create");
-	  continue;
-	}
+        /* Encryption */
+        ctx =
+            soter_sym_aead_encrypt_create(vectors_aead[i].alg, key, strlen(vectors_aead[i].key) / 2,
+                                          NULL, 0, iv, strlen(vectors_aead[i].iv) / 2);
+        if (NULL == ctx) {
+            testsuite_fail_unless(ctx, "soter_sym_create");
+            continue;
+        }
+        if (strlen(vectors_aead[i].aad) != 0) {
+            computed_length = sizeof(computed);
+            res = soter_sym_aead_encrypt_aad(ctx, aad, strlen(vectors_aead[i].aad) / 2);
+            if (SOTER_SUCCESS != res) {
+                testsuite_fail_if(res, "soter_sym_update aad");
+                soter_sym_encrypt_destroy(ctx);
+                continue;
+            }
+        }
 
-      if(strlen(vectors_aead[i].aad)!=0){
-	computed_length2 = sizeof(computed2);     
-	res = soter_sym_aead_decrypt_aad(ctx, aad, strlen(vectors_aead[i].aad) / 2);
-	if (SOTER_SUCCESS != res)
-	  {
-	    testsuite_fail_if(res, "soter_sym_update aad");
-	    soter_sym_aead_encrypt_destroy(ctx);
-	    continue;
-	}
-      }
+        computed_length = sizeof(computed);
 
-      computed_length2= sizeof(computed2);     
-      res = soter_sym_aead_decrypt_update(ctx, computed, computed_length, computed2, &computed_length2);
-      if (SOTER_SUCCESS != res)
-	{
-	  testsuite_fail_if(res, "soter_sym_decrypt_update");
-	  soter_sym_aead_decrypt_destroy(ctx);
-	  continue;
-	}
+        res = soter_sym_aead_encrypt_update(ctx, plaintext, strlen(vectors_aead[i].plaintext) / 2,
+                                            computed, &computed_length);
+        if (SOTER_SUCCESS != res) {
+            testsuite_fail_if(res, "soter_sym_update");
+            soter_sym_aead_encrypt_destroy(ctx);
+            continue;
+        }
 
-      res = soter_sym_aead_decrypt_final(ctx, auth_tag, auth_tag_length);
-      if (SOTER_SUCCESS != res)
-	{
-	  testsuite_fail_if(res, "soter_sym_final");
-	  soter_sym_aead_decrypt_destroy(ctx);
-	  continue;
-	}
-      res = soter_sym_aead_decrypt_destroy(ctx);
-      if (SOTER_SUCCESS != res)
-	{
-	  testsuite_fail_if(res, "soter_sym_destroy");
-	  soter_sym_aead_decrypt_destroy(ctx);
-	  continue;
-	}
+        res = soter_sym_aead_encrypt_final(ctx, auth_tag, &auth_tag_length);
+        if (SOTER_SUCCESS != res) {
+            testsuite_fail_if(res, "soter_sym_final");
+            soter_sym_aead_encrypt_destroy(ctx);
+            continue;
+        }
 
-      testsuite_fail_if(memcmp(computed2, plaintext, computed_length2), "known decryption");
+        res = soter_sym_aead_encrypt_destroy(ctx);
+        if (SOTER_SUCCESS != res) {
+            testsuite_fail_if(res, "soter_sym_destroy");
+        }
+
+        testsuite_fail_if(memcmp(computed, ciphertext, computed_length), "known encryption");
+
+        testsuite_fail_if(memcmp(auth_tag, expected_auth_tag, auth_tag_length),
+                          "known encryption (auth tag value)");
+
+        /* Decryption */
+        ctx =
+            soter_sym_aead_decrypt_create(vectors_aead[i].alg, key, strlen(vectors_aead[i].key) / 2,
+                                          NULL, 0, iv, strlen(vectors_aead[i].iv) / 2);
+        if (NULL == ctx) {
+            testsuite_fail_unless(ctx, "soter_sym_create");
+            continue;
+        }
+
+        if (strlen(vectors_aead[i].aad) != 0) {
+            computed_length2 = sizeof(computed2);
+            res = soter_sym_aead_decrypt_aad(ctx, aad, strlen(vectors_aead[i].aad) / 2);
+            if (SOTER_SUCCESS != res) {
+                testsuite_fail_if(res, "soter_sym_update aad");
+                soter_sym_aead_encrypt_destroy(ctx);
+                continue;
+            }
+        }
+
+        computed_length2 = sizeof(computed2);
+        res = soter_sym_aead_decrypt_update(ctx, computed, computed_length, computed2,
+                                            &computed_length2);
+        if (SOTER_SUCCESS != res) {
+            testsuite_fail_if(res, "soter_sym_decrypt_update");
+            soter_sym_aead_decrypt_destroy(ctx);
+            continue;
+        }
+
+        res = soter_sym_aead_decrypt_final(ctx, auth_tag, auth_tag_length);
+        if (SOTER_SUCCESS != res) {
+            testsuite_fail_if(res, "soter_sym_final");
+            soter_sym_aead_decrypt_destroy(ctx);
+            continue;
+        }
+        res = soter_sym_aead_decrypt_destroy(ctx);
+        if (SOTER_SUCCESS != res) {
+            testsuite_fail_if(res, "soter_sym_destroy");
+            soter_sym_aead_decrypt_destroy(ctx);
+            continue;
+        }
+
+        testsuite_fail_if(memcmp(computed2, plaintext, computed_length2), "known decryption");
     }
 }
 
 static void test_auth_tag(void)
 {
-	  uint8_t key[MAX_KEY_LENGTH];
-	  uint8_t iv[MAX_IV_LENGTH];
-	  uint8_t plaintext[MAX_DATA_LENGTH];
-	  uint8_t aad[MAX_KEY_LENGTH];
-	  uint8_t ciphertext[MAX_DATA_LENGTH];
-	  uint8_t decrypted[MAX_DATA_LENGTH];
-	  size_t bytes_processed = sizeof(ciphertext);
+    uint8_t key[MAX_KEY_LENGTH];
+    uint8_t iv[MAX_IV_LENGTH];
+    uint8_t plaintext[MAX_DATA_LENGTH];
+    uint8_t aad[MAX_KEY_LENGTH];
+    uint8_t ciphertext[MAX_DATA_LENGTH];
+    uint8_t decrypted[MAX_DATA_LENGTH];
+    size_t bytes_processed = sizeof(ciphertext);
 
-	  uint8_t tag[MAX_AUTH_TAG_LENGTH];
-	  size_t tag_length = sizeof(tag);
+    uint8_t tag[MAX_AUTH_TAG_LENGTH];
+    size_t tag_length = sizeof(tag);
 
-	  soter_sym_ctx_t *ctx;
-	  soter_status_t res;
+    soter_sym_ctx_t* ctx;
+    soter_status_t res;
 
-	  res = soter_rand(key, sizeof(key));
-	  if (SOTER_SUCCESS != res)
-	  {
-		  testsuite_fail_if(res, "key gen");
-		  return;
-	  }
+    res = soter_rand(key, sizeof(key));
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_if(res, "key gen");
+        return;
+    }
 
-	  res = soter_rand(iv, sizeof(iv));
-	  if (SOTER_SUCCESS != res)
-	  {
-		  testsuite_fail_if(res, "iv gen");
-		  return;
-	  }
+    res = soter_rand(iv, sizeof(iv));
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_if(res, "iv gen");
+        return;
+    }
 
-	  res = soter_rand(plaintext, sizeof(plaintext));
-	  if (SOTER_SUCCESS != res)
-	  {
-		  testsuite_fail_if(res, "plaintext gen");
-		  return;
-	  }
+    res = soter_rand(plaintext, sizeof(plaintext));
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_if(res, "plaintext gen");
+        return;
+    }
 
-	  res = soter_rand(aad, sizeof(aad));
-	  if (SOTER_SUCCESS != res)
-	  {
-		  testsuite_fail_if(res, "aad gen");
-		  return;
-	  }
+    res = soter_rand(aad, sizeof(aad));
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_if(res, "aad gen");
+        return;
+    }
 
-	  ctx = soter_sym_aead_encrypt_create(SOTER_SYM_AES_GCM | SOTER_SYM_256_KEY_LENGTH, key, sizeof(key), NULL, 0, iv, sizeof(iv));
-	  if (NULL == ctx)
-	  {
-		  testsuite_fail_if(NULL == ctx, "soter_sym_aead_encrypt_create");
-		  return;
-	  }
+    ctx = soter_sym_aead_encrypt_create(SOTER_SYM_AES_GCM | SOTER_SYM_256_KEY_LENGTH, key,
+                                        sizeof(key), NULL, 0, iv, sizeof(iv));
+    if (NULL == ctx) {
+        testsuite_fail_if(NULL == ctx, "soter_sym_aead_encrypt_create");
+        return;
+    }
 
-	  res = soter_sym_aead_encrypt_aad(ctx, aad, sizeof(aad));
-	  if (SOTER_SUCCESS != res)
-	  {
-		  testsuite_fail_if(res, "soter_sym_aead_encrypt_aad");
-		  soter_sym_aead_encrypt_destroy(ctx);
-		  return;
-	  }
+    res = soter_sym_aead_encrypt_aad(ctx, aad, sizeof(aad));
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_if(res, "soter_sym_aead_encrypt_aad");
+        soter_sym_aead_encrypt_destroy(ctx);
+        return;
+    }
 
-	  res = soter_sym_aead_encrypt_update(ctx, plaintext, sizeof(plaintext), ciphertext, &bytes_processed);
-	  if (SOTER_SUCCESS != res)
-	  {
-		  testsuite_fail_if(res, "soter_sym_aead_encrypt_update");
-		  soter_sym_aead_encrypt_destroy(ctx);
-		  return;
-	  }
+    res = soter_sym_aead_encrypt_update(ctx, plaintext, sizeof(plaintext), ciphertext,
+                                        &bytes_processed);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_if(res, "soter_sym_aead_encrypt_update");
+        soter_sym_aead_encrypt_destroy(ctx);
+        return;
+    }
 
-	  res = soter_sym_aead_encrypt_final(ctx, tag, &tag_length);
-	  if (SOTER_SUCCESS != res)
-	  {
-		  testsuite_fail_if(res, "soter_sym_aead_encrypt_final");
-		  soter_sym_aead_encrypt_destroy(ctx);
-		  return;
-	  }
+    res = soter_sym_aead_encrypt_final(ctx, tag, &tag_length);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_if(res, "soter_sym_aead_encrypt_final");
+        soter_sym_aead_encrypt_destroy(ctx);
+        return;
+    }
 
-	  soter_sym_aead_encrypt_destroy(ctx);
+    soter_sym_aead_encrypt_destroy(ctx);
 
-	  ctx = soter_sym_aead_decrypt_create(SOTER_SYM_AES_GCM | SOTER_SYM_256_KEY_LENGTH, key, sizeof(key), NULL, 0, iv, sizeof(iv));
-	  if (NULL == ctx)
-	  {
-		  testsuite_fail_if(NULL == ctx, "soter_sym_aead_decrypt_create");
-		  return;
-	  }
+    ctx = soter_sym_aead_decrypt_create(SOTER_SYM_AES_GCM | SOTER_SYM_256_KEY_LENGTH, key,
+                                        sizeof(key), NULL, 0, iv, sizeof(iv));
+    if (NULL == ctx) {
+        testsuite_fail_if(NULL == ctx, "soter_sym_aead_decrypt_create");
+        return;
+    }
 
-	  /* Tamper with AAD */
-	  aad[2] ^= 0xff;
+    /* Tamper with AAD */
+    aad[2] ^= 0xff;
 
-	  res = soter_sym_aead_decrypt_aad(ctx, aad, sizeof(aad));
-	  if (SOTER_SUCCESS != res)
-	  {
-		  testsuite_fail_if(res, "soter_sym_aead_decrypt_aad");
-		  soter_sym_aead_decrypt_destroy(ctx);
-		  return;
-	  }
+    res = soter_sym_aead_decrypt_aad(ctx, aad, sizeof(aad));
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_if(res, "soter_sym_aead_decrypt_aad");
+        soter_sym_aead_decrypt_destroy(ctx);
+        return;
+    }
 
-	  res = soter_sym_aead_decrypt_update(ctx, ciphertext, sizeof(ciphertext), decrypted, &bytes_processed);
-	  if (SOTER_SUCCESS != res)
-	  {
-		  testsuite_fail_if(res, "soter_sym_aead_decrypt_update");
-		  soter_sym_aead_decrypt_destroy(ctx);
-		  return;
-	  }
+    res = soter_sym_aead_decrypt_update(ctx, ciphertext, sizeof(ciphertext), decrypted,
+                                        &bytes_processed);
+    if (SOTER_SUCCESS != res) {
+        testsuite_fail_if(res, "soter_sym_aead_decrypt_update");
+        soter_sym_aead_decrypt_destroy(ctx);
+        return;
+    }
 
-	  res = soter_sym_aead_decrypt_final(ctx, tag, tag_length);
+    res = soter_sym_aead_decrypt_final(ctx, tag, tag_length);
 
-	  soter_sym_aead_decrypt_destroy(ctx);
+    soter_sym_aead_decrypt_destroy(ctx);
 
-	  if (memcmp(plaintext, decrypted, sizeof(plaintext)))
-	  {
-		  testsuite_fail_if(true, "decrypted date does not match plaintext");
-		  return;
-	  }
+    if (memcmp(plaintext, decrypted, sizeof(plaintext))) {
+        testsuite_fail_if(true, "decrypted date does not match plaintext");
+        return;
+    }
 
-	  testsuite_fail_unless(SOTER_FAIL == res, "detect data tamper");
+    testsuite_fail_unless(SOTER_FAIL == res, "detect data tamper");
 }
 
 static void test_invalid_params(void)
 {
-	soter_sym_ctx_t *ctx = NULL;
-	uint8_t key[MAX_KEY_LENGTH] = {0};
-	uint8_t iv[MAX_IV_LENGTH] = {0};
+    soter_sym_ctx_t* ctx = NULL;
+    uint8_t key[MAX_KEY_LENGTH] = {0};
+    uint8_t iv[MAX_IV_LENGTH] = {0};
 
-	ctx = soter_sym_encrypt_create(0xFFFFFFFF, key, sizeof(key), NULL, 0, iv, sizeof(iv));
-	testsuite_fail_if(ctx != NULL, "encrypt_create: invalid algorithm");
-	if (ctx != NULL)
-	{
-		soter_sym_encrypt_destroy(ctx);
-	}
+    ctx = soter_sym_encrypt_create(0xFFFFFFFF, key, sizeof(key), NULL, 0, iv, sizeof(iv));
+    testsuite_fail_if(ctx != NULL, "encrypt_create: invalid algorithm");
+    if (ctx != NULL) {
+        soter_sym_encrypt_destroy(ctx);
+    }
 
-	ctx = soter_sym_encrypt_create(SOTER_SYM_AES_GCM | SOTER_SYM_256_KEY_LENGTH, key, 0, NULL, 0, iv, sizeof(iv));
-	testsuite_fail_if(ctx != NULL, "encrypt_create: invalid key length");
-	if (ctx != NULL)
-	{
-		soter_sym_encrypt_destroy(ctx);
-	}
+    ctx = soter_sym_encrypt_create(SOTER_SYM_AES_GCM | SOTER_SYM_256_KEY_LENGTH, key, 0, NULL, 0,
+                                   iv, sizeof(iv));
+    testsuite_fail_if(ctx != NULL, "encrypt_create: invalid key length");
+    if (ctx != NULL) {
+        soter_sym_encrypt_destroy(ctx);
+    }
 
-	ctx = soter_sym_encrypt_create(SOTER_SYM_AES_GCM | SOTER_SYM_256_KEY_LENGTH | SOTER_SYM_PBKDF2, key, sizeof(key), NULL, 1, NULL, 0);
-	testsuite_fail_if(ctx != NULL, "encrypt_create: invalid salt length");
-	if (ctx != NULL)
-	{
-		soter_sym_encrypt_destroy(ctx);
-	}
+    ctx = soter_sym_encrypt_create(SOTER_SYM_AES_GCM | SOTER_SYM_256_KEY_LENGTH | SOTER_SYM_PBKDF2,
+                                   key, sizeof(key), NULL, 1, NULL, 0);
+    testsuite_fail_if(ctx != NULL, "encrypt_create: invalid salt length");
+    if (ctx != NULL) {
+        soter_sym_encrypt_destroy(ctx);
+    }
 
-	ctx = soter_sym_encrypt_create(SOTER_SYM_AES_GCM | SOTER_SYM_256_KEY_LENGTH, key, sizeof(key), NULL, 0, iv, 0);
-	testsuite_fail_if(ctx != NULL, "encrypt_create: invalid IV length");
-	if (ctx != NULL)
-	{
-		soter_sym_encrypt_destroy(ctx);
-	}
+    ctx = soter_sym_encrypt_create(SOTER_SYM_AES_GCM | SOTER_SYM_256_KEY_LENGTH, key, sizeof(key),
+                                   NULL, 0, iv, 0);
+    testsuite_fail_if(ctx != NULL, "encrypt_create: invalid IV length");
+    if (ctx != NULL) {
+        soter_sym_encrypt_destroy(ctx);
+    }
 
-	ctx = soter_sym_aead_encrypt_create(0xFFFFFFFF, key, sizeof(key), NULL, 0, iv, sizeof(iv));
-	testsuite_fail_if(ctx != NULL, "aead_encrypt_create: invalid algorithm");
-	if (ctx != NULL)
-	{
-		soter_sym_aead_encrypt_destroy(ctx);
-	}
+    ctx = soter_sym_aead_encrypt_create(0xFFFFFFFF, key, sizeof(key), NULL, 0, iv, sizeof(iv));
+    testsuite_fail_if(ctx != NULL, "aead_encrypt_create: invalid algorithm");
+    if (ctx != NULL) {
+        soter_sym_aead_encrypt_destroy(ctx);
+    }
 
-	ctx = soter_sym_aead_encrypt_create(SOTER_SYM_AES_GCM | SOTER_SYM_256_KEY_LENGTH, key, 0, NULL, 0, iv, sizeof(iv));
-	testsuite_fail_if(ctx != NULL, "aead_encrypt_create: invalid key length");
-	if (ctx != NULL)
-	{
-		soter_sym_aead_encrypt_destroy(ctx);
-	}
+    ctx = soter_sym_aead_encrypt_create(SOTER_SYM_AES_GCM | SOTER_SYM_256_KEY_LENGTH, key, 0, NULL,
+                                        0, iv, sizeof(iv));
+    testsuite_fail_if(ctx != NULL, "aead_encrypt_create: invalid key length");
+    if (ctx != NULL) {
+        soter_sym_aead_encrypt_destroy(ctx);
+    }
 
-	ctx = soter_sym_aead_encrypt_create(SOTER_SYM_AES_GCM | SOTER_SYM_256_KEY_LENGTH | SOTER_SYM_PBKDF2, key, sizeof(key), NULL, 1, NULL, 0);
-	testsuite_fail_if(ctx != NULL, "aead_encrypt_create: invalid salt length");
-	if (ctx != NULL)
-	{
-		soter_sym_aead_encrypt_destroy(ctx);
-	}
+    ctx = soter_sym_aead_encrypt_create(SOTER_SYM_AES_GCM | SOTER_SYM_256_KEY_LENGTH |
+                                            SOTER_SYM_PBKDF2,
+                                        key, sizeof(key), NULL, 1, NULL, 0);
+    testsuite_fail_if(ctx != NULL, "aead_encrypt_create: invalid salt length");
+    if (ctx != NULL) {
+        soter_sym_aead_encrypt_destroy(ctx);
+    }
 
-	ctx = soter_sym_aead_encrypt_create(SOTER_SYM_AES_GCM | SOTER_SYM_256_KEY_LENGTH, key, sizeof(key), NULL, 0, iv, 0);
-	testsuite_fail_if(ctx != NULL, "aead_encrypt_create: invalid IV length");
-	if (ctx != NULL)
-	{
-		soter_sym_aead_encrypt_destroy(ctx);
-	}
+    ctx = soter_sym_aead_encrypt_create(SOTER_SYM_AES_GCM | SOTER_SYM_256_KEY_LENGTH, key,
+                                        sizeof(key), NULL, 0, iv, 0);
+    testsuite_fail_if(ctx != NULL, "aead_encrypt_create: invalid IV length");
+    if (ctx != NULL) {
+        soter_sym_aead_encrypt_destroy(ctx);
+    }
 }
 
 void run_soter_sym_test()
 {
-  testsuite_enter_suite("soter sym");
-  //  testsuite_run_test(soter_sym_test);
-  testsuite_run_test(test_known_values);
-  testsuite_run_test(test_known_values_gcm);
-  testsuite_run_test(test_auth_tag);
-  testsuite_run_test(test_invalid_params);
-  //  soter_sym_test();
+    testsuite_enter_suite("soter sym");
+    //  testsuite_run_test(soter_sym_test);
+    testsuite_run_test(test_known_values);
+    testsuite_run_test(test_known_values_gcm);
+    testsuite_run_test(test_auth_tag);
+    testsuite_run_test(test_invalid_params);
+    //  soter_sym_test();
 }

--- a/tests/soter/soter_test.c
+++ b/tests/soter/soter_test.c
@@ -1,36 +1,36 @@
 /*
-* Copyright (c) 2015 Cossack Labs Limited
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2015 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "soter/soter_test.h"
 
 #include <stdio.h>
 
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
-	UNUSED(argc);
-	UNUSED(argv);
+    UNUSED(argc);
+    UNUSED(argv);
     testsuite_start_testing();
 
-	run_soter_hash_tests();
-	run_soter_hmac_tests();
-	run_soter_asym_cipher_tests();
-	run_soter_asym_ka_tests();
-	run_soter_sym_test();
-	run_soter_sign_test();
-	run_soter_rand_tests();
+    run_soter_hash_tests();
+    run_soter_hmac_tests();
+    run_soter_asym_cipher_tests();
+    run_soter_asym_ka_tests();
+    run_soter_sym_test();
+    run_soter_sign_test();
+    run_soter_rand_tests();
 
     testsuite_finish_testing();
 

--- a/tests/soter/soter_test.h
+++ b/tests/soter/soter_test.h
@@ -1,18 +1,18 @@
 /*
-* Copyright (c) 2015 Cossack Labs Limited
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2015 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #ifndef SOTER_TEST_H
 #define SOTER_TEST_H

--- a/tests/test.mk
+++ b/tests/test.mk
@@ -26,6 +26,39 @@ include tests/tools/tools.mk
 include tests/themis/themis.mk
 include tests/themispp/themispp.mk
 
+$(TEST_OBJ_PATH)/%.o: CMD = $(CC) $(CFLAGS) -DNIST_STS_EXE_PATH=$(realpath $(NIST_STS_DIR)) -I$(TEST_SRC_PATH) -c $< -o $@
+
+$(TEST_OBJ_PATH)/%.o: $(TEST_SRC_PATH)/%.c
+	@mkdir -p $(@D)
+	@echo -n "compile "
+	@$(BUILD_CMD)
+
+$(TEST_OBJ_PATH)/%.opp: CMD = $(CXX) $(CFLAGS) -I$(TEST_SRC_PATH) -c $< -o $@
+
+$(TEST_OBJ_PATH)/%.opp: $(TEST_SRC_PATH)/%.cpp
+	@mkdir -p $(@D)
+	@echo -n "compile "
+	@$(BUILD_CMD)
+
+FMT_FIXUP += $(THEMIS_TEST_FMT_FIXUP) $(SOTER_TEST_FMT_FIXUP)
+FMT_CHECK += $(THEMIS_TEST_FMT_CHECK) $(SOTER_TEST_FMT_CHECK)
+
+$(TEST_OBJ_PATH)/%.c.fmt_fixup $(TEST_OBJ_PATH)/%.h.fmt_fixup: \
+    CMD = $(CLANG_TIDY) -fix $< -- $(CFLAGS) -I$(TEST_SRC_PATH) 2>/dev/null && $(CLANG_FORMAT) -i $< && touch $@
+
+$(TEST_OBJ_PATH)/%.c.fmt_check $(TEST_OBJ_PATH)/%.h.fmt_check: \
+    CMD = $(CLANG_FORMAT) $< | diff -u $< - && $(CLANG_TIDY) $< -- $(CFLAGS) -I$(TEST_SRC_PATH) 2>/dev/null && touch $@
+
+$(TEST_OBJ_PATH)/%.fmt_fixup: $(TEST_SRC_PATH)/%
+	@mkdir -p $(@D)
+	@echo -n "fixup $< "
+	@$(BUILD_CMD_)
+
+$(TEST_OBJ_PATH)/%.fmt_check: $(TEST_SRC_PATH)/%
+	@mkdir -p $(@D)
+	@echo -n "check $< "
+	@$(BUILD_CMD_)
+
 PYTHON2_TEST_SCRIPT=$(BIN_PATH)/tests/pythemis2_test.sh
 PYTHON3_TEST_SCRIPT=$(BIN_PATH)/tests/pythemis3_test.sh
 

--- a/tests/themis/themis.mk
+++ b/tests/themis/themis.mk
@@ -14,5 +14,12 @@
 # limitations under the License.
 #
 
+SOTER_TEST_SOURCES = $(wildcard tests/soter/*.c)
+SOTER_TEST_HEADERS = $(wildcard tests/soter/*.h)
+
 SOTER_TEST_SRC = $(wildcard tests/soter/*.c)
 SOTER_TEST_OBJ = $(patsubst $(TEST_SRC_PATH)/%.c,$(TEST_OBJ_PATH)/%.o, $(SOTER_TEST_SRC))
+
+SOTER_TEST_FMT_SRC = $(SOTER_TEST_SOURCES) $(SOTER_TEST_HEADERS)
+SOTER_TEST_FMT_FIXUP = $(patsubst $(TEST_SRC_PATH)/%,$(TEST_OBJ_PATH)/%.fmt_fixup, $(SOTER_TEST_FMT_SRC))
+SOTER_TEST_FMT_CHECK = $(patsubst $(TEST_SRC_PATH)/%,$(TEST_OBJ_PATH)/%.fmt_check, $(SOTER_TEST_FMT_SRC))

--- a/tests/themis/themis_seccure_message.c
+++ b/tests/themis/themis_seccure_message.c
@@ -1,18 +1,18 @@
 /*
-* Copyright (c) 2015 Cossack Labs Limited
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2015 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "themis/themis_test.h"
 
@@ -22,26 +22,30 @@
 
 /* Fuzz parameters */
 #define MAX_MESSAGE_SIZE 2048
-#define MAX_ENCRYPTED_MESSAGE_SIZE (MAX_MESSAGE_SIZE+1024)
+#define MAX_ENCRYPTED_MESSAGE_SIZE (MAX_MESSAGE_SIZE + 1024)
 #define MESSAGES_TO_SEND 3
 
 #define MAX_KEY_SIZE 4096
 #define RSA_ALG 1
-#define EC_ALG  2
-#define test_check(function_call, success_res, msg) {			\
-  themis_status_t res=function_call;					\
-  if(res!=success_res){							\
-    testsuite_fail_if(true, msg);					\
-    return -1;								\
-  }}
+#define EC_ALG 2
+#define test_check(function_call, success_res, msg)                                                \
+    {                                                                                              \
+        themis_status_t res = function_call;                                                       \
+        if (res != success_res) {                                                                  \
+            testsuite_fail_if(true, msg);                                                          \
+            return -1;                                                                             \
+        }                                                                                          \
+    }
 
-#define test_check_free(function_call, success_res, msg, free_condition) {		\
-  themis_status_t res=function_call;					\
-  if(res!=success_res){							\
-    testsuite_fail_if(true, msg);					\
-    free_condition;							\
-    return -1;								\
-  }}
+#define test_check_free(function_call, success_res, msg, free_condition)                           \
+    {                                                                                              \
+        themis_status_t res = function_call;                                                       \
+        if (res != success_res) {                                                                  \
+            testsuite_fail_if(true, msg);                                                          \
+            free_condition;                                                                        \
+            return -1;                                                                             \
+        }                                                                                          \
+    }
 
 /*
  * Allow usage of deprecated Secure Message interface:
@@ -52,711 +56,1072 @@
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-static themis_status_t themis_gen_key_pair(int alg, uint8_t* private_key, size_t* private_key_length, uint8_t* public_key, size_t* public_key_length){
-  themis_status_t res=THEMIS_FAIL;
-  if(alg==RSA_ALG){
-    res=themis_gen_rsa_key_pair(private_key, private_key_length, public_key, public_key_length);
-  }
-  else if(alg==EC_ALG){
-    res=themis_gen_ec_key_pair(private_key, private_key_length, public_key, public_key_length);
-  }
-  return res;
+static themis_status_t themis_gen_key_pair(int alg, uint8_t* private_key,
+                                           size_t* private_key_length, uint8_t* public_key,
+                                           size_t* public_key_length)
+{
+    themis_status_t res = THEMIS_FAIL;
+    if (alg == RSA_ALG) {
+        res =
+            themis_gen_rsa_key_pair(private_key, private_key_length, public_key, public_key_length);
+    } else if (alg == EC_ALG) {
+        res =
+            themis_gen_ec_key_pair(private_key, private_key_length, public_key, public_key_length);
+    }
+    return res;
 }
 
-static int generic_themis_secure_message_encrypt_decrypt_test(int alg, const uint8_t* message, const size_t message_length){
-  int res=-1;
-  themis_status_t status=THEMIS_FAIL;
+static int generic_themis_secure_message_encrypt_decrypt_test(int alg, const uint8_t* message,
+                                                              const size_t message_length)
+{
+    int res = -1;
+    themis_status_t status = THEMIS_FAIL;
 
-  uint8_t private_key[MAX_KEY_SIZE]={0};
-  uint8_t public_key[MAX_KEY_SIZE]={0};
-  size_t private_key_length=sizeof(private_key);
-  size_t public_key_length=sizeof(public_key);
+    uint8_t private_key[MAX_KEY_SIZE] = {0};
+    uint8_t public_key[MAX_KEY_SIZE] = {0};
+    size_t private_key_length = sizeof(private_key);
+    size_t public_key_length = sizeof(public_key);
 
-  uint8_t* encrypted_message=NULL;
-  uint8_t* decrypted_message=NULL;
-  size_t encrypted_message_length=0;
-  size_t decrypted_message_length=0;
+    uint8_t* encrypted_message = NULL;
+    uint8_t* decrypted_message = NULL;
+    size_t encrypted_message_length = 0;
+    size_t decrypted_message_length = 0;
 
-  status=themis_gen_key_pair(alg, private_key, &private_key_length, public_key, &public_key_length);
-  if(status!=THEMIS_SUCCESS){
-    testsuite_fail_if(true, "themis_gen_key_pair failed");
-    goto out;
-  }
+    status =
+        themis_gen_key_pair(alg, private_key, &private_key_length, public_key, &public_key_length);
+    if (status != THEMIS_SUCCESS) {
+        testsuite_fail_if(true, "themis_gen_key_pair failed");
+        goto out;
+    }
 
-  status=themis_secure_message_encrypt(private_key, private_key_length, public_key, public_key_length, message, message_length, NULL, &encrypted_message_length);
-  if(status!=THEMIS_BUFFER_TOO_SMALL){
-    testsuite_fail_if(true, "themis_secure_message_encrypt failed to determine encrypted message length");
-    goto out;
-  }
+    status = themis_secure_message_encrypt(private_key, private_key_length, public_key,
+                                           public_key_length, message, message_length, NULL,
+                                           &encrypted_message_length);
+    if (status != THEMIS_BUFFER_TOO_SMALL) {
+        testsuite_fail_if(
+            true, "themis_secure_message_encrypt failed to determine encrypted message length");
+        goto out;
+    }
 
-  encrypted_message=malloc(encrypted_message_length);
-  if(!encrypted_message){
-    testsuite_fail_if(true, "failed to allocate memory for encrypted message");
-    goto out;
-  }
+    encrypted_message = malloc(encrypted_message_length);
+    if (!encrypted_message) {
+        testsuite_fail_if(true, "failed to allocate memory for encrypted message");
+        goto out;
+    }
 
-  status=themis_secure_message_encrypt(private_key, private_key_length, public_key, public_key_length, message, message_length, encrypted_message, &encrypted_message_length);
-  if(status!=THEMIS_SUCCESS){
-    testsuite_fail_if(true, "themis_secure_message_encrypt failed to encrypt message");
-    goto out;
-  }
+    status = themis_secure_message_encrypt(private_key, private_key_length, public_key,
+                                           public_key_length, message, message_length,
+                                           encrypted_message, &encrypted_message_length);
+    if (status != THEMIS_SUCCESS) {
+        testsuite_fail_if(true, "themis_secure_message_encrypt failed to encrypt message");
+        goto out;
+    }
 
-  status=themis_secure_message_decrypt(private_key, private_key_length, public_key, public_key_length, encrypted_message, encrypted_message_length, NULL, &decrypted_message_length);
-  if(status!=THEMIS_BUFFER_TOO_SMALL){
-    testsuite_fail_if(true, "themis_secure_message_decrypt failed to determine decrypted message length");
-    goto out;
-  }
+    status = themis_secure_message_decrypt(
+        private_key, private_key_length, public_key, public_key_length, encrypted_message,
+        encrypted_message_length, NULL, &decrypted_message_length);
+    if (status != THEMIS_BUFFER_TOO_SMALL) {
+        testsuite_fail_if(
+            true, "themis_secure_message_decrypt failed to determine decrypted message length");
+        goto out;
+    }
 
-  decrypted_message=malloc(decrypted_message_length);
-  if(!decrypted_message){
-    testsuite_fail_if(true, "failed to allocate memory for decrypted message");
-    goto out;
-  }
+    decrypted_message = malloc(decrypted_message_length);
+    if (!decrypted_message) {
+        testsuite_fail_if(true, "failed to allocate memory for decrypted message");
+        goto out;
+    }
 
-  status=themis_secure_message_decrypt(private_key, private_key_length, public_key, public_key_length, encrypted_message, encrypted_message_length, decrypted_message, &decrypted_message_length);
-  if(status!=THEMIS_SUCCESS){
-    testsuite_fail_if(true, "themis_secure_message_decrypt failed to decrypt message");
-    goto out;
-  }
+    status = themis_secure_message_decrypt(
+        private_key, private_key_length, public_key, public_key_length, encrypted_message,
+        encrypted_message_length, decrypted_message, &decrypted_message_length);
+    if (status != THEMIS_SUCCESS) {
+        testsuite_fail_if(true, "themis_secure_message_decrypt failed to decrypt message");
+        goto out;
+    }
 
-  if(decrypted_message_length!=message_length){
-    testsuite_fail_if(true, "themis_secure_message_encrypt/decrypt does not preserve message length");
-    goto out;
-  }
+    if (decrypted_message_length != message_length) {
+        testsuite_fail_if(true,
+                          "themis_secure_message_encrypt/decrypt does not preserve message length");
+        goto out;
+    }
 
-  if(memcmp(decrypted_message, message, message_length)!=0){
-    testsuite_fail_if(true, "themis_secure_message_encrypt/decrypt does not preserve message content");
-    goto out;
-  }
+    if (memcmp(decrypted_message, message, message_length) != 0) {
+        testsuite_fail_if(
+            true, "themis_secure_message_encrypt/decrypt does not preserve message content");
+        goto out;
+    }
 
-  res=0;
+    res = 0;
 
 out:
-  free(decrypted_message);
-  free(encrypted_message);
-  return res;
+    free(decrypted_message);
+    free(encrypted_message);
+    return res;
 }
 
-static int generic_themis_secure_message_sign_verify_test(int alg, const uint8_t* message, const size_t message_length){
-   int res=-1;
-   themis_status_t status=THEMIS_FAIL;
+static int generic_themis_secure_message_sign_verify_test(int alg, const uint8_t* message,
+                                                          const size_t message_length)
+{
+    int res = -1;
+    themis_status_t status = THEMIS_FAIL;
 
-   uint8_t private_key[MAX_KEY_SIZE]={0};
-   uint8_t public_key[MAX_KEY_SIZE]={0};
-   size_t private_key_length=sizeof(private_key);
-   size_t public_key_length=sizeof(public_key);
+    uint8_t private_key[MAX_KEY_SIZE] = {0};
+    uint8_t public_key[MAX_KEY_SIZE] = {0};
+    size_t private_key_length = sizeof(private_key);
+    size_t public_key_length = sizeof(public_key);
 
-   uint8_t* signed_message=NULL;
-   uint8_t* verified_message=NULL;
-   size_t signed_message_length=0;
-   size_t verified_message_length=0;
+    uint8_t* signed_message = NULL;
+    uint8_t* verified_message = NULL;
+    size_t signed_message_length = 0;
+    size_t verified_message_length = 0;
 
-   status=themis_gen_key_pair(alg, private_key, &private_key_length, public_key, &public_key_length);
-   if(status!=THEMIS_SUCCESS){
-     testsuite_fail_if(true, "themis_gen_key_pair failed");
-     goto out;
-   }
+    status =
+        themis_gen_key_pair(alg, private_key, &private_key_length, public_key, &public_key_length);
+    if (status != THEMIS_SUCCESS) {
+        testsuite_fail_if(true, "themis_gen_key_pair failed");
+        goto out;
+    }
 
-   status=themis_secure_message_sign(private_key, private_key_length, message, message_length, NULL, &signed_message_length);
-   if(status!=THEMIS_BUFFER_TOO_SMALL){
-     testsuite_fail_if(true, "themis_secure_message_sign failed to determine signed message length");
-     goto out;
-   }
+    status = themis_secure_message_sign(private_key, private_key_length, message, message_length,
+                                        NULL, &signed_message_length);
+    if (status != THEMIS_BUFFER_TOO_SMALL) {
+        testsuite_fail_if(true,
+                          "themis_secure_message_sign failed to determine signed message length");
+        goto out;
+    }
 
-   signed_message=malloc(signed_message_length);
-   if(!signed_message){
-     testsuite_fail_if(true, "failed to allocate memory for signed message");
-     goto out;
-   }
+    signed_message = malloc(signed_message_length);
+    if (!signed_message) {
+        testsuite_fail_if(true, "failed to allocate memory for signed message");
+        goto out;
+    }
 
-   status=themis_secure_message_sign(private_key, private_key_length, message, message_length, signed_message, &signed_message_length);
-   if(status!=THEMIS_SUCCESS){
-     testsuite_fail_if(true, "themis_secure_message_sign failed to sign message");
-     goto out;
-   }
+    status = themis_secure_message_sign(private_key, private_key_length, message, message_length,
+                                        signed_message, &signed_message_length);
+    if (status != THEMIS_SUCCESS) {
+        testsuite_fail_if(true, "themis_secure_message_sign failed to sign message");
+        goto out;
+    }
 
-   status=themis_secure_message_verify(public_key, public_key_length, signed_message, signed_message_length, NULL, &verified_message_length);
-   if(status!=THEMIS_BUFFER_TOO_SMALL){
-     testsuite_fail_if(true, "themis_secure_message_verify failed to determine verified message length");
-     goto out;
-   }
+    status = themis_secure_message_verify(public_key, public_key_length, signed_message,
+                                          signed_message_length, NULL, &verified_message_length);
+    if (status != THEMIS_BUFFER_TOO_SMALL) {
+        testsuite_fail_if(
+            true, "themis_secure_message_verify failed to determine verified message length");
+        goto out;
+    }
 
-   verified_message=malloc(verified_message_length);
-   if(!verified_message){
-     testsuite_fail_if(true, "failed to allocate memory for verified message");
-     goto out;
-   }
+    verified_message = malloc(verified_message_length);
+    if (!verified_message) {
+        testsuite_fail_if(true, "failed to allocate memory for verified message");
+        goto out;
+    }
 
-   status=themis_secure_message_verify(public_key, public_key_length, signed_message, signed_message_length, verified_message, &verified_message_length);
-   if(status!=THEMIS_SUCCESS){
-     testsuite_fail_if(true, "themis_secure_message_verify failed to verify message");
-     goto out;
-   }
+    status = themis_secure_message_verify(public_key, public_key_length, signed_message,
+                                          signed_message_length, verified_message,
+                                          &verified_message_length);
+    if (status != THEMIS_SUCCESS) {
+        testsuite_fail_if(true, "themis_secure_message_verify failed to verify message");
+        goto out;
+    }
 
-   if(verified_message_length!=message_length){
-     testsuite_fail_if(true, "themis_secure_message_sign/verify does not preserve message length");
-     goto out;
-   }
+    if (verified_message_length != message_length) {
+        testsuite_fail_if(true,
+                          "themis_secure_message_sign/verify does not preserve message length");
+        goto out;
+    }
 
-   if(memcmp(verified_message, message, message_length)!=0){
-     testsuite_fail_if(true, "themis_secure_message_sign/verify does not preserve message content");
-     goto out;
-   }
+    if (memcmp(verified_message, message, message_length) != 0) {
+        testsuite_fail_if(true,
+                          "themis_secure_message_sign/verify does not preserve message content");
+        goto out;
+    }
 
-   res=0;
+    res = 0;
 
- out:
-   free(verified_message);
-   free(signed_message);
-   return res;
- }
+out:
+    free(verified_message);
+    free(signed_message);
+    return res;
+}
 
-static int themis_secure_signed_message_generic_test(int alg, const char* message, const size_t message_length){
-  uint8_t private_key[10240];
-  size_t private_key_length=10240;
-  uint8_t public_key[10240];
-  size_t public_key_length=10240;
+static int themis_secure_signed_message_generic_test(int alg, const char* message,
+                                                     const size_t message_length)
+{
+    uint8_t private_key[10240];
+    size_t private_key_length = 10240;
+    uint8_t public_key[10240];
+    size_t public_key_length = 10240;
 
-  themis_status_t res;
+    themis_status_t res;
 
-  res=themis_gen_key_pair(alg, private_key, &private_key_length, public_key, &public_key_length);
-  
-  if(res!=THEMIS_SUCCESS){
-    testsuite_fail_if(res!=THEMIS_SUCCESS, "themis_gen_key_pair fail");
-    return -1;
-  }
+    res =
+        themis_gen_key_pair(alg, private_key, &private_key_length, public_key, &public_key_length);
 
-  uint8_t* wrapped_message=NULL;
-  size_t wrapped_message_length=0;
+    if (res != THEMIS_SUCCESS) {
+        testsuite_fail_if(res != THEMIS_SUCCESS, "themis_gen_key_pair fail");
+        return -1;
+    }
 
-  res=themis_secure_message_wrap(private_key ,private_key_length+1, NULL, 0, (uint8_t*)message, message_length, NULL, &wrapped_message_length);
-  if(res!=THEMIS_FAIL){
-      testsuite_fail_if(res!=THEMIS_BUFFER_TOO_SMALL, "themis_secure_message_wrap (incorrect private key) fail");
-      return -2;
-  }
+    uint8_t* wrapped_message = NULL;
+    size_t wrapped_message_length = 0;
 
-  res=themis_secure_message_wrap(private_key ,private_key_length, NULL, 0, (uint8_t*)message, message_length, NULL, &wrapped_message_length);
-  if(res!=THEMIS_BUFFER_TOO_SMALL){
-    testsuite_fail_if(res!=THEMIS_BUFFER_TOO_SMALL, "themis_secure_message_wrap (wrapped_message_length determination) fail");
-    return -2;
-  }
+    res =
+        themis_secure_message_wrap(private_key, private_key_length + 1, NULL, 0, (uint8_t*)message,
+                                   message_length, NULL, &wrapped_message_length);
+    if (res != THEMIS_FAIL) {
+        testsuite_fail_if(res != THEMIS_BUFFER_TOO_SMALL,
+                          "themis_secure_message_wrap (incorrect private key) fail");
+        return -2;
+    }
 
-  wrapped_message=malloc(wrapped_message_length);
-  if(!wrapped_message){
-    testsuite_fail_if(!wrapped_message, "malloc fail");
-    return -3;
-  }
-  res=themis_secure_message_wrap(private_key, private_key_length, NULL, 0, (uint8_t*)message, message_length, wrapped_message, &wrapped_message_length);
-  if(res!=THEMIS_SUCCESS){
-    free(wrapped_message);
-    testsuite_fail_if(res!=THEMIS_SUCCESS, "themis_secure_message_wrap fail");
-    return -4;
-  }
+    res = themis_secure_message_wrap(private_key, private_key_length, NULL, 0, (uint8_t*)message,
+                                     message_length, NULL, &wrapped_message_length);
+    if (res != THEMIS_BUFFER_TOO_SMALL) {
+        testsuite_fail_if(res != THEMIS_BUFFER_TOO_SMALL,
+                          "themis_secure_message_wrap (wrapped_message_length determination) fail");
+        return -2;
+    }
 
-  uint8_t* unwrapped_message=NULL;
-  size_t unwrapped_message_length=0;
+    wrapped_message = malloc(wrapped_message_length);
+    if (!wrapped_message) {
+        testsuite_fail_if(!wrapped_message, "malloc fail");
+        return -3;
+    }
+    res = themis_secure_message_wrap(private_key, private_key_length, NULL, 0, (uint8_t*)message,
+                                     message_length, wrapped_message, &wrapped_message_length);
+    if (res != THEMIS_SUCCESS) {
+        free(wrapped_message);
+        testsuite_fail_if(res != THEMIS_SUCCESS, "themis_secure_message_wrap fail");
+        return -4;
+    }
 
-  res=themis_secure_message_unwrap(NULL , 0, public_key, public_key_length+1, wrapped_message, wrapped_message_length, NULL, &unwrapped_message_length);
-  if(res!=THEMIS_FAIL){
-      free(wrapped_message);
-      testsuite_fail_if(res!=THEMIS_BUFFER_TOO_SMALL, "themis_secure_message_unwrap (incorrect public key) fail");
-      return -5;
-  }
+    uint8_t* unwrapped_message = NULL;
+    size_t unwrapped_message_length = 0;
 
-  res=themis_secure_message_unwrap(NULL , 0, public_key, public_key_length, wrapped_message, wrapped_message_length, NULL, &unwrapped_message_length);
-  if(res!=THEMIS_BUFFER_TOO_SMALL){
-    free(wrapped_message);
-    testsuite_fail_if(res!=THEMIS_BUFFER_TOO_SMALL, "themis_secure_message_unwrap (unwrapped_message_length determination) fail");
-    return -5;
-  }
-  unwrapped_message=malloc(unwrapped_message_length);
-  if(!unwrapped_message){
-    free(wrapped_message);
-    testsuite_fail_if(!unwrapped_message, "malloc fail");
-    return -3;
-  }
-  res=themis_secure_message_unwrap(NULL, 0, public_key, public_key_length, wrapped_message, wrapped_message_length, unwrapped_message, &unwrapped_message_length);
-  if(res!=THEMIS_SUCCESS){
+    res = themis_secure_message_unwrap(NULL, 0, public_key, public_key_length + 1, wrapped_message,
+                                       wrapped_message_length, NULL, &unwrapped_message_length);
+    if (res != THEMIS_FAIL) {
+        free(wrapped_message);
+        testsuite_fail_if(res != THEMIS_BUFFER_TOO_SMALL,
+                          "themis_secure_message_unwrap (incorrect public key) fail");
+        return -5;
+    }
+
+    res = themis_secure_message_unwrap(NULL, 0, public_key, public_key_length, wrapped_message,
+                                       wrapped_message_length, NULL, &unwrapped_message_length);
+    if (res != THEMIS_BUFFER_TOO_SMALL) {
+        free(wrapped_message);
+        testsuite_fail_if(
+            res != THEMIS_BUFFER_TOO_SMALL,
+            "themis_secure_message_unwrap (unwrapped_message_length determination) fail");
+        return -5;
+    }
+    unwrapped_message = malloc(unwrapped_message_length);
+    if (!unwrapped_message) {
+        free(wrapped_message);
+        testsuite_fail_if(!unwrapped_message, "malloc fail");
+        return -3;
+    }
+    res = themis_secure_message_unwrap(NULL, 0, public_key, public_key_length, wrapped_message,
+                                       wrapped_message_length, unwrapped_message,
+                                       &unwrapped_message_length);
+    if (res != THEMIS_SUCCESS) {
+        free(wrapped_message);
+        free(unwrapped_message);
+        testsuite_fail_if(res != THEMIS_SUCCESS, "themis_secure_message_unwrap fail");
+        return -2;
+    }
+
+    if ((message_length != unwrapped_message_length) ||
+        (memcmp(message, unwrapped_message, message_length) != 0)) {
+        free(wrapped_message);
+        free(unwrapped_message);
+        testsuite_fail_if(true, "message not equal unwrapped_message_length");
+        return -3;
+    }
     free(wrapped_message);
     free(unwrapped_message);
-    testsuite_fail_if(res!=THEMIS_SUCCESS, "themis_secure_message_unwrap fail");
-    return -2;
-  }
+    return 0;
+}
 
-  if((message_length!=unwrapped_message_length) || (memcmp(message, unwrapped_message, message_length)!=0)){
+static int themis_secure_encrypted_message_generic_test(int alg, const char* message,
+                                                        const size_t message_length)
+{
+    uint8_t private_key[10240];
+    size_t private_key_length = 10240;
+    uint8_t public_key[10240];
+    size_t public_key_length = 10240;
+
+    uint8_t peer_private_key[10240];
+    size_t peer_private_key_length = 10240;
+    uint8_t peer_public_key[10240];
+    size_t peer_public_key_length = 10240;
+
+    test_check(
+        themis_gen_key_pair(alg, private_key, &private_key_length, public_key, &public_key_length),
+        THEMIS_SUCCESS, "gen key pair fail");
+    test_check(themis_gen_key_pair(alg, peer_private_key, &peer_private_key_length, peer_public_key,
+                                   &peer_public_key_length),
+               THEMIS_SUCCESS, "gen peer key pair fail");
+
+    uint8_t* wrapped_message = NULL;
+    size_t wrapped_message_length = 0;
+
+    // themis detect something wrong at different stage with different algorithms. that why
+    // different status
+    if (alg == EC_ALG) {
+        test_check(themis_secure_message_wrap(private_key, private_key_length + 1, peer_public_key,
+                                              peer_public_key_length, (uint8_t*)message,
+                                              message_length, NULL, &wrapped_message_length),
+                   THEMIS_INVALID_PARAMETER,
+                   "themis secure message wrap (incorrect private key) failed");
+        test_check(themis_secure_message_wrap(private_key, private_key_length, peer_public_key,
+                                              peer_public_key_length + 1, (uint8_t*)message,
+                                              message_length, NULL, &wrapped_message_length),
+                   THEMIS_INVALID_PARAMETER,
+                   "themis secure message wrap (incorrect public key) failed");
+    } else {
+        test_check(themis_secure_message_wrap(private_key, private_key_length + 1, peer_public_key,
+                                              peer_public_key_length, (uint8_t*)message,
+                                              message_length, NULL, &wrapped_message_length),
+                   THEMIS_BUFFER_TOO_SMALL,
+                   "themis secure message wrap (incorrect private key) failed");
+        test_check(themis_secure_message_wrap(private_key, private_key_length, peer_public_key,
+                                              peer_public_key_length + 1, (uint8_t*)message,
+                                              message_length, NULL, &wrapped_message_length),
+                   THEMIS_INVALID_PARAMETER,
+                   "themis secure message wrap (incorrect public key) failed");
+    }
+
+    test_check(themis_secure_message_wrap(private_key, private_key_length, peer_public_key,
+                                          peer_public_key_length, (uint8_t*)message, message_length,
+                                          NULL, &wrapped_message_length),
+               THEMIS_BUFFER_TOO_SMALL,
+               "themis secure message wrap (wrapped message length determination) failed");
+    wrapped_message = malloc(wrapped_message_length);
+    if (!wrapped_message) {
+        testsuite_fail_if(!wrapped_message, "malloc fail (wrapped_message)");
+        return -2;
+    }
+    test_check_free(themis_secure_message_wrap(private_key, private_key_length, peer_public_key,
+                                               peer_public_key_length, (uint8_t*)message,
+                                               message_length, wrapped_message,
+                                               &wrapped_message_length),
+                    THEMIS_SUCCESS, "themis secure message wrap failed", free(wrapped_message));
+
+    uint8_t* unwrapped_message = NULL;
+    size_t unwrapped_message_length = 0;
+
+    // themis detect something wrong at different stage with different algorithms. that why
+    // different status
+    if (alg == EC_ALG) {
+        test_check_free(
+            themis_secure_message_unwrap(peer_private_key, private_key_length + 1, public_key,
+                                         public_key_length, (uint8_t*)wrapped_message,
+                                         wrapped_message_length, NULL, &unwrapped_message_length),
+            THEMIS_INVALID_PARAMETER, "themis secure message unwrap (incorrect private key) failed",
+            free(wrapped_message));
+        test_check_free(
+            themis_secure_message_unwrap(peer_private_key, private_key_length, public_key,
+                                         public_key_length + 1, (uint8_t*)wrapped_message,
+                                         wrapped_message_length, NULL, &unwrapped_message_length),
+            THEMIS_INVALID_PARAMETER, "themis secure message unwrap (incorrect public key) failed",
+            free(wrapped_message));
+    } else {
+        test_check_free(
+            themis_secure_message_unwrap(peer_private_key, private_key_length + 1, public_key,
+                                         public_key_length, (uint8_t*)wrapped_message,
+                                         wrapped_message_length, NULL, &unwrapped_message_length),
+            THEMIS_INVALID_PARAMETER, "themis secure message unwrap (incorrect private key) failed",
+            free(wrapped_message));
+        test_check_free(
+            themis_secure_message_unwrap(peer_private_key, private_key_length, public_key,
+                                         public_key_length + 1, (uint8_t*)wrapped_message,
+                                         wrapped_message_length, NULL, &unwrapped_message_length),
+            THEMIS_BUFFER_TOO_SMALL, "themis secure message unwrap (incorrect public key) failed",
+            free(wrapped_message));
+    }
+    test_check_free(themis_secure_message_unwrap(peer_private_key, private_key_length, public_key,
+                                                 public_key_length, (uint8_t*)wrapped_message,
+                                                 wrapped_message_length, NULL,
+                                                 &unwrapped_message_length),
+                    THEMIS_BUFFER_TOO_SMALL,
+                    "themis secure message unwrap (unwrapped message length determination) failed",
+                    free(wrapped_message));
+    unwrapped_message = malloc(unwrapped_message_length);
+    if (!unwrapped_message) {
+        testsuite_fail_if(!unwrapped_message, "malloc fail (unwrapped_message)");
+        return -2;
+    }
+    test_check_free(themis_secure_message_unwrap(peer_private_key, peer_private_key_length,
+                                                 public_key, public_key_length,
+                                                 (uint8_t*)wrapped_message, wrapped_message_length,
+                                                 unwrapped_message, &unwrapped_message_length),
+                    THEMIS_SUCCESS, "themis secure message unwrap failed",
+                    (free(wrapped_message), free(unwrapped_message)));
+
+    if ((message_length != unwrapped_message_length) ||
+        (memcmp(message, unwrapped_message, message_length) != 0)) {
+        free(wrapped_message);
+        free(unwrapped_message);
+        testsuite_fail_if(true, "message not equal unwrapped_message");
+        return -3;
+    }
     free(wrapped_message);
     free(unwrapped_message);
-    testsuite_fail_if(true, "message not equal unwrapped_message_length");
-    return -3;
-  }
-  free(wrapped_message);
-  free(unwrapped_message);
-  return 0;
+    return 0;
 }
 
-static int themis_secure_encrypted_message_generic_test(int alg, const char* message, const size_t message_length){
-  uint8_t private_key[10240];
-  size_t private_key_length=10240;
-  uint8_t public_key[10240];
-  size_t public_key_length=10240;
+static void themis_secure_message_test()
+{
+    char message[] = "Hit http://ftp.us.debian.org[1] wheezy Release.gpg"
+                     "Hit http://ftp.us.debian.org[2] wheezy-updates Release.gpg"
+                     "Hit http://ftp.us.debian.org[3] wheezy Release"
+                     "Hit http://ftp.us.debian.org[4] wheezy-updates Release"
+                     "Hit http://ftp.us.debian.org[5] wheezy/main Sources"
+                     "Hit http://ftp.us.debian.org[6] wheezy/non-free Sources"
+                     "Hit http://ftp.us.debian.org[7] wheezy/contrib Sources"
+                     "Hit http://ftp.us.debian.org[8] wheezy/main i386 Packages"
+                     "Hit http://ftp.us.debian.org[9] wheezy/non-free i386 Packages"
+                     "Hit http://ftp.us.debian.org[10] wheezy/contrib i386 Packages"
+                     "Hit http://ftp.us.debian.org[11] wheezy/contrib Translation-en";
 
-  uint8_t peer_private_key[10240];
-  size_t peer_private_key_length=10240;
-  uint8_t peer_public_key[10240];
-  size_t peer_public_key_length=10240;
+    const uint8_t* message_bytes = (const uint8_t*)message;
+    size_t message_length = strlen(message);
 
+    testsuite_fail_if(
+        generic_themis_secure_message_encrypt_decrypt_test(RSA_ALG, message_bytes, message_length),
+        "themis secure encrypt/decrypt message (RSA)");
+    testsuite_fail_if(
+        generic_themis_secure_message_encrypt_decrypt_test(EC_ALG, message_bytes, message_length),
+        "themis secure encrypt/decrypt message (EC)");
+    testsuite_fail_if(
+        generic_themis_secure_message_sign_verify_test(RSA_ALG, message_bytes, message_length),
+        "themis secure sign/verify message (RSA)");
+    testsuite_fail_if(
+        generic_themis_secure_message_sign_verify_test(EC_ALG, message_bytes, message_length),
+        "themis secure sign/verify message (EC)");
 
-  test_check(themis_gen_key_pair(alg, private_key, &private_key_length, public_key, &public_key_length), THEMIS_SUCCESS, "gen key pair fail");
-  test_check(themis_gen_key_pair(alg, peer_private_key, &peer_private_key_length, peer_public_key, &peer_public_key_length), THEMIS_SUCCESS, "gen peer key pair fail");
-
-  uint8_t* wrapped_message=NULL;
-  size_t wrapped_message_length=0;
-
-  // themis detect something wrong at different stage with different algorithms. that why different status
-  if(alg == EC_ALG){
-      test_check(themis_secure_message_wrap(private_key ,private_key_length+1, peer_public_key, peer_public_key_length, (uint8_t*)message, message_length, NULL, &wrapped_message_length), THEMIS_INVALID_PARAMETER, "themis secure message wrap (incorrect private key) failed");
-      test_check(themis_secure_message_wrap(private_key ,private_key_length, peer_public_key, peer_public_key_length+1, (uint8_t*)message, message_length, NULL, &wrapped_message_length), THEMIS_INVALID_PARAMETER, "themis secure message wrap (incorrect public key) failed");
-  } else {
-      test_check(themis_secure_message_wrap(private_key ,private_key_length+1, peer_public_key, peer_public_key_length, (uint8_t*)message, message_length, NULL, &wrapped_message_length), THEMIS_BUFFER_TOO_SMALL, "themis secure message wrap (incorrect private key) failed");
-      test_check(themis_secure_message_wrap(private_key ,private_key_length, peer_public_key, peer_public_key_length+1, (uint8_t*)message, message_length, NULL, &wrapped_message_length), THEMIS_INVALID_PARAMETER, "themis secure message wrap (incorrect public key) failed");
-  }
-
-
-  test_check(themis_secure_message_wrap(private_key ,private_key_length, peer_public_key, peer_public_key_length, (uint8_t*)message, message_length, NULL, &wrapped_message_length), THEMIS_BUFFER_TOO_SMALL, "themis secure message wrap (wrapped message length determination) failed");
-  wrapped_message=malloc(wrapped_message_length);
-  if(!wrapped_message){
-    testsuite_fail_if(!wrapped_message, "malloc fail (wrapped_message)");
-    return -2;
-  }
-  test_check_free(themis_secure_message_wrap(private_key ,private_key_length, peer_public_key, peer_public_key_length, (uint8_t*)message, message_length, wrapped_message, &wrapped_message_length), THEMIS_SUCCESS, "themis secure message wrap failed", free(wrapped_message));
-
-  uint8_t* unwrapped_message=NULL;
-  size_t unwrapped_message_length=0;
-
-  // themis detect something wrong at different stage with different algorithms. that why different status
-  if(alg == EC_ALG){
-      test_check_free(themis_secure_message_unwrap(peer_private_key ,private_key_length+1, public_key, public_key_length, (uint8_t*)wrapped_message, wrapped_message_length, NULL, &unwrapped_message_length), THEMIS_INVALID_PARAMETER, "themis secure message unwrap (incorrect private key) failed", free(wrapped_message));
-      test_check_free(themis_secure_message_unwrap(peer_private_key ,private_key_length, public_key, public_key_length+1, (uint8_t*)wrapped_message, wrapped_message_length, NULL, &unwrapped_message_length), THEMIS_INVALID_PARAMETER, "themis secure message unwrap (incorrect public key) failed", free(wrapped_message));
-  } else {
-      test_check_free(themis_secure_message_unwrap(peer_private_key ,private_key_length+1, public_key, public_key_length, (uint8_t*)wrapped_message, wrapped_message_length, NULL, &unwrapped_message_length), THEMIS_INVALID_PARAMETER, "themis secure message unwrap (incorrect private key) failed", free(wrapped_message));
-      test_check_free(themis_secure_message_unwrap(peer_private_key ,private_key_length, public_key, public_key_length+1, (uint8_t*)wrapped_message, wrapped_message_length, NULL, &unwrapped_message_length), THEMIS_BUFFER_TOO_SMALL, "themis secure message unwrap (incorrect public key) failed", free(wrapped_message));
-  }
-  test_check_free(themis_secure_message_unwrap(peer_private_key ,private_key_length, public_key, public_key_length, (uint8_t*)wrapped_message, wrapped_message_length, NULL, &unwrapped_message_length), THEMIS_BUFFER_TOO_SMALL, "themis secure message unwrap (unwrapped message length determination) failed", free(wrapped_message));
-  unwrapped_message=malloc(unwrapped_message_length);
-  if(!unwrapped_message){
-    testsuite_fail_if(!unwrapped_message, "malloc fail (unwrapped_message)");
-    return -2;
-  }
-  test_check_free(themis_secure_message_unwrap(peer_private_key ,peer_private_key_length, public_key, public_key_length, (uint8_t*)wrapped_message, wrapped_message_length, unwrapped_message, &unwrapped_message_length), THEMIS_SUCCESS, "themis secure message unwrap failed", (free(wrapped_message), free(unwrapped_message)));
-
-  if((message_length!=unwrapped_message_length) || (memcmp(message, unwrapped_message, message_length)!=0)){
-    free(wrapped_message);
-    free(unwrapped_message);
-    testsuite_fail_if(true, "message not equal unwrapped_message");
-    return -3;
-  }
-  free(wrapped_message);
-  free(unwrapped_message);
-  return 0;
+    testsuite_fail_if(themis_secure_signed_message_generic_test(RSA_ALG, message, message_length),
+                      "(deprecated) themis secure signed message (RSA)");
+    testsuite_fail_if(themis_secure_signed_message_generic_test(EC_ALG, message, message_length),
+                      "(deprecated) themis secure signed message (EC)");
+    testsuite_fail_if(
+        themis_secure_encrypted_message_generic_test(RSA_ALG, message, message_length),
+        "(deprecated) themis secure encrypted message (RSA)");
+    testsuite_fail_if(themis_secure_encrypted_message_generic_test(EC_ALG, message, message_length),
+                      "(deprecated) themis secure encrypted message (EC)");
 }
 
-static void themis_secure_message_test(){
-  char    message[]="Hit http://ftp.us.debian.org[1] wheezy Release.gpg"
-                    "Hit http://ftp.us.debian.org[2] wheezy-updates Release.gpg"
-                    "Hit http://ftp.us.debian.org[3] wheezy Release"
-                    "Hit http://ftp.us.debian.org[4] wheezy-updates Release"
-                    "Hit http://ftp.us.debian.org[5] wheezy/main Sources"
-                    "Hit http://ftp.us.debian.org[6] wheezy/non-free Sources"
-                    "Hit http://ftp.us.debian.org[7] wheezy/contrib Sources"
-                    "Hit http://ftp.us.debian.org[8] wheezy/main i386 Packages"
-                    "Hit http://ftp.us.debian.org[9] wheezy/non-free i386 Packages"
-                    "Hit http://ftp.us.debian.org[10] wheezy/contrib i386 Packages"
-                    "Hit http://ftp.us.debian.org[11] wheezy/contrib Translation-en";
+static void themis_secure_message_encrypt_decrypt_api_test(void)
+{
+    themis_status_t status = THEMIS_FAIL;
 
-  const uint8_t* message_bytes=(const uint8_t*)message;
-  size_t message_length=strlen(message);
+    uint8_t private_key[MAX_KEY_SIZE] = {0};
+    uint8_t public_key[MAX_KEY_SIZE] = {0};
+    size_t private_key_length = sizeof(private_key);
+    size_t public_key_length = sizeof(public_key);
 
-  testsuite_fail_if(generic_themis_secure_message_encrypt_decrypt_test(RSA_ALG, message_bytes, message_length), "themis secure encrypt/decrypt message (RSA)");
-  testsuite_fail_if(generic_themis_secure_message_encrypt_decrypt_test(EC_ALG, message_bytes, message_length), "themis secure encrypt/decrypt message (EC)");
-  testsuite_fail_if(generic_themis_secure_message_sign_verify_test(RSA_ALG, message_bytes, message_length), "themis secure sign/verify message (RSA)");
-  testsuite_fail_if(generic_themis_secure_message_sign_verify_test(EC_ALG, message_bytes, message_length), "themis secure sign/verify message (EC)");
+    uint8_t plaintext[MAX_MESSAGE_SIZE] = {0};
+    uint8_t encrypted[MAX_ENCRYPTED_MESSAGE_SIZE] = {0};
+    uint8_t decrypted[MAX_MESSAGE_SIZE] = {0};
+    size_t plaintext_length = sizeof(plaintext);
+    size_t encrypted_length = sizeof(encrypted);
+    size_t decrypted_length = sizeof(decrypted);
 
-  testsuite_fail_if(themis_secure_signed_message_generic_test(RSA_ALG, message, message_length), "(deprecated) themis secure signed message (RSA)");
-  testsuite_fail_if(themis_secure_signed_message_generic_test(EC_ALG, message,message_length), "(deprecated) themis secure signed message (EC)");
-  testsuite_fail_if(themis_secure_encrypted_message_generic_test(RSA_ALG, message, message_length), "(deprecated) themis secure encrypted message (RSA)");
-  testsuite_fail_if(themis_secure_encrypted_message_generic_test(EC_ALG, message,message_length), "(deprecated) themis secure encrypted message (EC)");
+    status =
+        themis_gen_ec_key_pair(private_key, &private_key_length, public_key, &public_key_length);
+    if (status != THEMIS_SUCCESS) {
+        testsuite_fail_if(true, "themis_gen_ec_key_pair failed");
+        return;
+    }
+
+    status = soter_rand(plaintext, plaintext_length);
+    if (status != THEMIS_SUCCESS) {
+        testsuite_fail_if(true, "soter_rand failed");
+        return;
+    }
+
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_message_encrypt(
+                                  NULL, private_key_length, public_key, public_key_length,
+                                  plaintext, plaintext_length, encrypted, &encrypted_length),
+                          "themis_secure_message_encrypt: private key is NULL");
+    testsuite_fail_unless(
+        THEMIS_INVALID_PARAMETER ==
+            themis_secure_message_encrypt(private_key, 0, public_key, public_key_length, plaintext,
+                                          plaintext_length, encrypted, &encrypted_length),
+        "themis_secure_message_encrypt: private key is empty");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_message_encrypt(private_key, private_key_length - 1,
+                                                            public_key, public_key_length,
+                                                            plaintext, plaintext_length, encrypted,
+                                                            &encrypted_length),
+                          "themis_secure_message_encrypt: private key is invalid");
+
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_message_encrypt(
+                                  private_key, private_key_length, NULL, public_key_length,
+                                  plaintext, plaintext_length, encrypted, &encrypted_length),
+                          "themis_secure_message_encrypt: public key is NULL");
+    testsuite_fail_unless(
+        THEMIS_INVALID_PARAMETER ==
+            themis_secure_message_encrypt(private_key, private_key_length, public_key, 0, plaintext,
+                                          plaintext_length, encrypted, &encrypted_length),
+        "themis_secure_message_encrypt: public key is empty");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_message_encrypt(private_key, private_key_length,
+                                                            public_key, public_key_length - 1,
+                                                            plaintext, plaintext_length, encrypted,
+                                                            &encrypted_length),
+                          "themis_secure_message_encrypt: public key is invalid");
+
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_message_encrypt(
+                                  public_key, public_key_length, private_key, private_key_length,
+                                  plaintext, plaintext_length, encrypted, &encrypted_length),
+                          "themis_secure_message_encrypt: misplaced keys");
+
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_message_encrypt(
+                                  private_key, private_key_length, public_key, public_key_length,
+                                  NULL, plaintext_length, encrypted, &encrypted_length),
+                          "themis_secure_message_encrypt: plaintext is NULL");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_encrypt(
+                                                          private_key, private_key_length,
+                                                          public_key, public_key_length, plaintext,
+                                                          0, encrypted, &encrypted_length),
+                          "themis_secure_message_encrypt: plaintext is empty");
+
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_encrypt(
+                                                          private_key, private_key_length,
+                                                          public_key, public_key_length, plaintext,
+                                                          plaintext_length, NULL, NULL),
+                          "themis_secure_message_encrypt: encrypted_length is NULL");
+
+    testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL == themis_secure_message_encrypt(
+                                                         private_key, private_key_length,
+                                                         public_key, public_key_length, plaintext,
+                                                         plaintext_length, NULL, &encrypted_length),
+                          "themis_secure_message_encrypt: encrypted buffer length");
+    encrypted_length -= 1;
+    testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL ==
+                              themis_secure_message_encrypt(
+                                  private_key, private_key_length, public_key, public_key_length,
+                                  plaintext, plaintext_length, encrypted, &encrypted_length),
+                          "themis_secure_message_encrypt: encrypted buffer too small");
+
+    status = themis_secure_message_encrypt(private_key, private_key_length, public_key,
+                                           public_key_length, plaintext, plaintext_length,
+                                           encrypted, &encrypted_length);
+    if (status != THEMIS_SUCCESS) {
+        testsuite_fail_if(true, "themis_secure_message_encrypt failed to encrypt");
+        return;
+    }
+
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_message_decrypt(
+                                  NULL, private_key_length, public_key, public_key_length,
+                                  encrypted, encrypted_length, decrypted, &decrypted_length),
+                          "themis_secure_message_decrypt: private key is NULL");
+    testsuite_fail_unless(
+        THEMIS_INVALID_PARAMETER ==
+            themis_secure_message_decrypt(private_key, 0, public_key, public_key_length, encrypted,
+                                          encrypted_length, decrypted, &decrypted_length),
+        "themis_secure_message_decrypt: private key is empty");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_message_decrypt(private_key, private_key_length - 1,
+                                                            public_key, public_key_length,
+                                                            encrypted, encrypted_length, decrypted,
+                                                            &decrypted_length),
+                          "themis_secure_message_decrypt: private key is invalid");
+
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_message_decrypt(
+                                  private_key, private_key_length, NULL, public_key_length,
+                                  encrypted, encrypted_length, decrypted, &decrypted_length),
+                          "themis_secure_message_decrypt: public key is NULL");
+    testsuite_fail_unless(
+        THEMIS_INVALID_PARAMETER ==
+            themis_secure_message_decrypt(private_key, private_key_length, public_key, 0, encrypted,
+                                          encrypted_length, decrypted, &decrypted_length),
+        "themis_secure_message_decrypt: public key is empty");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_message_decrypt(private_key, private_key_length,
+                                                            public_key, public_key_length - 1,
+                                                            encrypted, encrypted_length, decrypted,
+                                                            &decrypted_length),
+                          "themis_secure_message_decrypt: public key is invalid");
+
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_message_decrypt(
+                                  public_key, public_key_length, private_key, private_key_length,
+                                  encrypted, encrypted_length, decrypted, &decrypted_length),
+                          "themis_secure_message_decrypt: misplaced keys");
+
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_message_decrypt(
+                                  private_key, private_key_length, public_key, public_key_length,
+                                  NULL, encrypted_length, decrypted, &decrypted_length),
+                          "themis_secure_message_decrypt: encrypted is NULL");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_decrypt(
+                                                          private_key, private_key_length,
+                                                          public_key, public_key_length, encrypted,
+                                                          0, decrypted, &decrypted_length),
+                          "themis_secure_message_decrypt: encrypted is empty");
+
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_decrypt(
+                                                          private_key, private_key_length,
+                                                          public_key, public_key_length, encrypted,
+                                                          encrypted_length, NULL, NULL),
+                          "themis_secure_message_decrypt: decrypted_length is NULL");
+
+    testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL == themis_secure_message_decrypt(
+                                                         private_key, private_key_length,
+                                                         public_key, public_key_length, encrypted,
+                                                         encrypted_length, NULL, &decrypted_length),
+                          "themis_secure_message_decrypt: decrypted buffer length");
+    decrypted_length -= 1;
+    testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL ==
+                              themis_secure_message_decrypt(
+                                  private_key, private_key_length, public_key, public_key_length,
+                                  encrypted, encrypted_length, decrypted, &decrypted_length),
+                          "themis_secure_message_decrypt: decrypted buffer too small");
+
+    status = themis_secure_message_decrypt(private_key, private_key_length, public_key,
+                                           public_key_length, encrypted, encrypted_length,
+                                           decrypted, &decrypted_length);
+    if (status != THEMIS_SUCCESS) {
+        testsuite_fail_if(true, "themis_secure_message_decrypt failed to decrypt");
+        return;
+    }
 }
 
-static void themis_secure_message_encrypt_decrypt_api_test(void){
-  themis_status_t status=THEMIS_FAIL;
+static void themis_secure_message_sign_verify_api_test(void)
+{
+    themis_status_t status = THEMIS_FAIL;
 
-  uint8_t private_key[MAX_KEY_SIZE]={0};
-  uint8_t public_key[MAX_KEY_SIZE]={0};
-  size_t private_key_length = sizeof(private_key);
-  size_t public_key_length = sizeof(public_key);
+    uint8_t private_key[MAX_KEY_SIZE] = {0};
+    uint8_t public_key[MAX_KEY_SIZE] = {0};
+    size_t private_key_length = sizeof(private_key);
+    size_t public_key_length = sizeof(public_key);
 
-  uint8_t plaintext[MAX_MESSAGE_SIZE]={0};
-  uint8_t encrypted[MAX_ENCRYPTED_MESSAGE_SIZE]={0};
-  uint8_t decrypted[MAX_MESSAGE_SIZE]={0};
-  size_t plaintext_length = sizeof(plaintext);
-  size_t encrypted_length = sizeof(encrypted);
-  size_t decrypted_length = sizeof(decrypted);
+    uint8_t plaintext[MAX_MESSAGE_SIZE] = {0};
+    uint8_t signed_msg[MAX_ENCRYPTED_MESSAGE_SIZE] = {0};
+    uint8_t verified[MAX_MESSAGE_SIZE] = {0};
+    size_t plaintext_length = sizeof(plaintext);
+    size_t signed_msg_length = sizeof(signed_msg);
+    size_t verified_length = sizeof(verified);
 
-  status=themis_gen_ec_key_pair(private_key, &private_key_length, public_key, &public_key_length);
-  if(status!=THEMIS_SUCCESS){
-    testsuite_fail_if(true, "themis_gen_ec_key_pair failed");
-    return;
-  }
+    status =
+        themis_gen_ec_key_pair(private_key, &private_key_length, public_key, &public_key_length);
+    if (status != THEMIS_SUCCESS) {
+        testsuite_fail_if(true, "themis_gen_ec_key_pair failed");
+        return;
+    }
 
-  status=soter_rand(plaintext, plaintext_length);
-  if(status!=THEMIS_SUCCESS){
-    testsuite_fail_if(true, "soter_rand failed");
-    return;
-  }
+    status = soter_rand(plaintext, plaintext_length);
+    if (status != THEMIS_SUCCESS) {
+        testsuite_fail_if(true, "soter_rand failed");
+        return;
+    }
 
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_encrypt(NULL, private_key_length, public_key, public_key_length, plaintext, plaintext_length, encrypted, &encrypted_length),
-                        "themis_secure_message_encrypt: private key is NULL");
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_encrypt(private_key, 0, public_key, public_key_length, plaintext, plaintext_length, encrypted, &encrypted_length),
-                        "themis_secure_message_encrypt: private key is empty");
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_encrypt(private_key, private_key_length-1, public_key, public_key_length, plaintext, plaintext_length, encrypted, &encrypted_length),
-                        "themis_secure_message_encrypt: private key is invalid");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_message_sign(NULL, private_key_length, plaintext,
+                                                         plaintext_length, signed_msg,
+                                                         &signed_msg_length),
+                          "themis_secure_message_sign: private key is NULL");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_message_sign(private_key, 0, plaintext,
+                                                         plaintext_length, signed_msg,
+                                                         &signed_msg_length),
+                          "themis_secure_message_sign: private key is empty");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_message_sign(private_key, private_key_length - 1,
+                                                         plaintext, plaintext_length, signed_msg,
+                                                         &signed_msg_length),
+                          "themis_secure_message_sign: private key is invalid");
 
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_encrypt(private_key, private_key_length, NULL, public_key_length, plaintext, plaintext_length, encrypted, &encrypted_length),
-                        "themis_secure_message_encrypt: public key is NULL");
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_encrypt(private_key, private_key_length, public_key, 0, plaintext, plaintext_length, encrypted, &encrypted_length),
-                        "themis_secure_message_encrypt: public key is empty");
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_encrypt(private_key, private_key_length, public_key, public_key_length-1, plaintext, plaintext_length, encrypted, &encrypted_length),
-                        "themis_secure_message_encrypt: public key is invalid");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_message_sign(public_key, public_key_length, plaintext,
+                                                         plaintext_length, signed_msg,
+                                                         &signed_msg_length),
+                          "themis_secure_message_sign: using public key");
 
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_encrypt(public_key, public_key_length, private_key, private_key_length, plaintext, plaintext_length, encrypted, &encrypted_length),
-                        "themis_secure_message_encrypt: misplaced keys");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_message_sign(private_key, private_key_length, NULL,
+                                                         plaintext_length, signed_msg,
+                                                         &signed_msg_length),
+                          "themis_secure_message_sign: plaintext is NULL");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_message_sign(private_key, private_key_length, plaintext,
+                                                         0, signed_msg, &signed_msg_length),
+                          "themis_secure_message_sign: plaintext is empty");
 
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_encrypt(private_key, private_key_length, public_key, public_key_length, NULL, plaintext_length, encrypted, &encrypted_length),
-                        "themis_secure_message_encrypt: plaintext is NULL");
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_encrypt(private_key, private_key_length, public_key, public_key_length, plaintext, 0, encrypted, &encrypted_length),
-                        "themis_secure_message_encrypt: plaintext is empty");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_message_sign(private_key, private_key_length, plaintext,
+                                                         plaintext_length, NULL, NULL),
+                          "themis_secure_message_sign: signed_msg_length is NULL");
 
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_encrypt(private_key, private_key_length, public_key, public_key_length, plaintext, plaintext_length, NULL, NULL),
-                        "themis_secure_message_encrypt: encrypted_length is NULL");
+    testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL ==
+                              themis_secure_message_sign(private_key, private_key_length, plaintext,
+                                                         plaintext_length, NULL,
+                                                         &signed_msg_length),
+                          "themis_secure_message_sign: signed buffer length");
+    signed_msg_length -= 1;
+    testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL ==
+                              themis_secure_message_sign(private_key, private_key_length, plaintext,
+                                                         plaintext_length, signed_msg,
+                                                         &signed_msg_length),
+                          "themis_secure_message_sign: signed buffer too small");
 
-  testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL == themis_secure_message_encrypt(private_key, private_key_length, public_key, public_key_length, plaintext, plaintext_length, NULL, &encrypted_length),
-                        "themis_secure_message_encrypt: encrypted buffer length");
-  encrypted_length -= 1;
-  testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL == themis_secure_message_encrypt(private_key, private_key_length, public_key, public_key_length, plaintext, plaintext_length, encrypted, &encrypted_length),
-                        "themis_secure_message_encrypt: encrypted buffer too small");
+    status = themis_secure_message_sign(private_key, private_key_length, plaintext,
+                                        plaintext_length, signed_msg, &signed_msg_length);
+    if (status != THEMIS_SUCCESS) {
+        testsuite_fail_if(true, "themis_secure_message_sign failed to sign");
+        return;
+    }
 
-  status=themis_secure_message_encrypt(private_key, private_key_length, public_key, public_key_length, plaintext, plaintext_length, encrypted, &encrypted_length);
-  if(status!=THEMIS_SUCCESS){
-    testsuite_fail_if(true, "themis_secure_message_encrypt failed to encrypt");
-    return;
-  }
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_message_verify(NULL, public_key_length, signed_msg,
+                                                           signed_msg_length, verified,
+                                                           &verified_length),
+                          "themis_secure_message_verify: public key is NULL");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_message_verify(public_key, 0, signed_msg,
+                                                           signed_msg_length, verified,
+                                                           &verified_length),
+                          "themis_secure_message_verify: public key is empty");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_message_verify(public_key, public_key_length - 1,
+                                                           signed_msg, signed_msg_length, verified,
+                                                           &verified_length),
+                          "themis_secure_message_verify: public key is invalid");
 
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_decrypt(NULL, private_key_length, public_key, public_key_length, encrypted, encrypted_length, decrypted, &decrypted_length),
-                        "themis_secure_message_decrypt: private key is NULL");
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_decrypt(private_key, 0, public_key, public_key_length, encrypted, encrypted_length, decrypted, &decrypted_length),
-                        "themis_secure_message_decrypt: private key is empty");
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_decrypt(private_key, private_key_length-1, public_key, public_key_length, encrypted, encrypted_length, decrypted, &decrypted_length),
-                        "themis_secure_message_decrypt: private key is invalid");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_message_verify(private_key, private_key_length,
+                                                           signed_msg, signed_msg_length, verified,
+                                                           &verified_length),
+                          "themis_secure_message_verify: using private key");
 
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_decrypt(private_key, private_key_length, NULL, public_key_length, encrypted, encrypted_length, decrypted, &decrypted_length),
-                        "themis_secure_message_decrypt: public key is NULL");
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_decrypt(private_key, private_key_length, public_key, 0, encrypted, encrypted_length, decrypted, &decrypted_length),
-                        "themis_secure_message_decrypt: public key is empty");
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_decrypt(private_key, private_key_length, public_key, public_key_length-1, encrypted, encrypted_length, decrypted, &decrypted_length),
-                        "themis_secure_message_decrypt: public key is invalid");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_message_verify(public_key, public_key_length, NULL,
+                                                           signed_msg_length, verified,
+                                                           &verified_length),
+                          "themis_secure_message_verify: signed_msg is NULL");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_verify(
+                                                          public_key, public_key_length, signed_msg,
+                                                          0, verified, &verified_length),
+                          "themis_secure_message_verify: signed_msg is empty");
 
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_decrypt(public_key, public_key_length, private_key, private_key_length, encrypted, encrypted_length, decrypted, &decrypted_length),
-                        "themis_secure_message_decrypt: misplaced keys");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_verify(
+                                                          public_key, public_key_length, signed_msg,
+                                                          signed_msg_length, NULL, NULL),
+                          "themis_secure_message_verify: verified_length is NULL");
 
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_decrypt(private_key, private_key_length, public_key, public_key_length, NULL, encrypted_length, decrypted, &decrypted_length),
-                        "themis_secure_message_decrypt: encrypted is NULL");
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_decrypt(private_key, private_key_length, public_key, public_key_length, encrypted, 0, decrypted, &decrypted_length),
-                        "themis_secure_message_decrypt: encrypted is empty");
+    testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL == themis_secure_message_verify(
+                                                         public_key, public_key_length, signed_msg,
+                                                         signed_msg_length, NULL, &verified_length),
+                          "themis_secure_message_verify: verified buffer length");
+    verified_length -= 1;
+    testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL ==
+                              themis_secure_message_verify(public_key, public_key_length,
+                                                           signed_msg, signed_msg_length, verified,
+                                                           &verified_length),
+                          "themis_secure_message_verify: verified buffer too small");
 
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_decrypt(private_key, private_key_length, public_key, public_key_length, encrypted, encrypted_length, NULL, NULL),
-                        "themis_secure_message_decrypt: decrypted_length is NULL");
-
-  testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL == themis_secure_message_decrypt(private_key, private_key_length, public_key, public_key_length, encrypted, encrypted_length, NULL, &decrypted_length),
-                        "themis_secure_message_decrypt: decrypted buffer length");
-  decrypted_length -= 1;
-  testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL == themis_secure_message_decrypt(private_key, private_key_length, public_key, public_key_length, encrypted, encrypted_length, decrypted, &decrypted_length),
-                        "themis_secure_message_decrypt: decrypted buffer too small");
-
-  status=themis_secure_message_decrypt(private_key, private_key_length, public_key, public_key_length, encrypted, encrypted_length, decrypted, &decrypted_length);
-  if(status!=THEMIS_SUCCESS){
-    testsuite_fail_if(true, "themis_secure_message_decrypt failed to decrypt");
-    return;
-  }
-}
-
-static void themis_secure_message_sign_verify_api_test(void){
-  themis_status_t status=THEMIS_FAIL;
-
-  uint8_t private_key[MAX_KEY_SIZE]={0};
-  uint8_t public_key[MAX_KEY_SIZE]={0};
-  size_t private_key_length = sizeof(private_key);
-  size_t public_key_length = sizeof(public_key);
-
-  uint8_t plaintext[MAX_MESSAGE_SIZE]={0};
-  uint8_t signed_msg[MAX_ENCRYPTED_MESSAGE_SIZE]={0};
-  uint8_t verified[MAX_MESSAGE_SIZE]={0};
-  size_t plaintext_length = sizeof(plaintext);
-  size_t signed_msg_length = sizeof(signed_msg);
-  size_t verified_length = sizeof(verified);
-
-  status=themis_gen_ec_key_pair(private_key, &private_key_length, public_key, &public_key_length);
-  if(status!=THEMIS_SUCCESS){
-    testsuite_fail_if(true, "themis_gen_ec_key_pair failed");
-    return;
-  }
-
-  status=soter_rand(plaintext, plaintext_length);
-  if(status!=THEMIS_SUCCESS){
-    testsuite_fail_if(true, "soter_rand failed");
-    return;
-  }
-
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_sign(NULL, private_key_length, plaintext, plaintext_length, signed_msg, &signed_msg_length),
-                        "themis_secure_message_sign: private key is NULL");
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_sign(private_key, 0, plaintext, plaintext_length, signed_msg, &signed_msg_length),
-                        "themis_secure_message_sign: private key is empty");
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_sign(private_key, private_key_length-1, plaintext, plaintext_length, signed_msg, &signed_msg_length),
-                        "themis_secure_message_sign: private key is invalid");
-
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_sign(public_key, public_key_length, plaintext, plaintext_length, signed_msg, &signed_msg_length),
-                        "themis_secure_message_sign: using public key");
-
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_sign(private_key, private_key_length, NULL, plaintext_length, signed_msg, &signed_msg_length),
-                        "themis_secure_message_sign: plaintext is NULL");
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_sign(private_key, private_key_length, plaintext, 0, signed_msg, &signed_msg_length),
-                        "themis_secure_message_sign: plaintext is empty");
-
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_sign(private_key, private_key_length, plaintext, plaintext_length, NULL, NULL),
-                        "themis_secure_message_sign: signed_msg_length is NULL");
-
-  testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL == themis_secure_message_sign(private_key, private_key_length, plaintext, plaintext_length, NULL, &signed_msg_length),
-                        "themis_secure_message_sign: signed buffer length");
-  signed_msg_length -= 1;
-  testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL == themis_secure_message_sign(private_key, private_key_length, plaintext, plaintext_length, signed_msg, &signed_msg_length),
-                        "themis_secure_message_sign: signed buffer too small");
-
-  status=themis_secure_message_sign(private_key, private_key_length, plaintext, plaintext_length, signed_msg, &signed_msg_length);
-  if(status!=THEMIS_SUCCESS){
-    testsuite_fail_if(true, "themis_secure_message_sign failed to sign");
-    return;
-  }
-
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_verify(NULL, public_key_length, signed_msg, signed_msg_length, verified, &verified_length),
-                        "themis_secure_message_verify: public key is NULL");
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_verify(public_key, 0, signed_msg, signed_msg_length, verified, &verified_length),
-                        "themis_secure_message_verify: public key is empty");
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_verify(public_key, public_key_length-1, signed_msg, signed_msg_length, verified, &verified_length),
-                        "themis_secure_message_verify: public key is invalid");
-
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_verify(private_key, private_key_length, signed_msg, signed_msg_length, verified, &verified_length),
-                        "themis_secure_message_verify: using private key");
-
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_verify(public_key, public_key_length, NULL, signed_msg_length, verified, &verified_length),
-                        "themis_secure_message_verify: signed_msg is NULL");
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_verify(public_key, public_key_length, signed_msg, 0, verified, &verified_length),
-                        "themis_secure_message_verify: signed_msg is empty");
-
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_verify(public_key, public_key_length, signed_msg, signed_msg_length, NULL, NULL),
-                        "themis_secure_message_verify: verified_length is NULL");
-
-  testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL == themis_secure_message_verify(public_key, public_key_length, signed_msg, signed_msg_length, NULL, &verified_length),
-                        "themis_secure_message_verify: verified buffer length");
-  verified_length -= 1;
-  testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL == themis_secure_message_verify(public_key, public_key_length, signed_msg, signed_msg_length, verified, &verified_length),
-                        "themis_secure_message_verify: verified buffer too small");
-
-  status=themis_secure_message_verify(public_key, public_key_length, signed_msg, signed_msg_length, verified, &verified_length);
-  if(status!=THEMIS_SUCCESS){
-    testsuite_fail_if(true, "themis_secure_message_verify failed to verify");
-    return;
-  }
+    status = themis_secure_message_verify(public_key, public_key_length, signed_msg,
+                                          signed_msg_length, verified, &verified_length);
+    if (status != THEMIS_SUCCESS) {
+        testsuite_fail_if(true, "themis_secure_message_verify failed to verify");
+        return;
+    }
 }
 
 static void secure_message_old_api_test(void)
 {
-	uint8_t plaintext[MAX_MESSAGE_SIZE];
-	size_t plaintext_length = 2048; //rand_int(MAX_MESSAGE_SIZE);
+    uint8_t plaintext[MAX_MESSAGE_SIZE];
+    size_t plaintext_length = 2048; // rand_int(MAX_MESSAGE_SIZE);
 
-	uint8_t ciphertext[MAX_MESSAGE_SIZE+52]; //chipther text allwais bigger then plain text (24 bytes of header + 12 bytes of iv + 16 bytes of auth_tag)
-	size_t ciphertext_length = sizeof(ciphertext);
+    uint8_t
+        ciphertext[MAX_MESSAGE_SIZE + 52]; // chipther text allwais bigger then plain text (24 bytes
+                                           // of header + 12 bytes of iv + 16 bytes of auth_tag)
+    size_t ciphertext_length = sizeof(ciphertext);
 
-	uint8_t decryptext[MAX_MESSAGE_SIZE];
-	size_t decryptext_length = sizeof(decryptext);
+    uint8_t decryptext[MAX_MESSAGE_SIZE];
+    size_t decryptext_length = sizeof(decryptext);
 
-	uint8_t priv[MAX_MESSAGE_SIZE];
-	size_t priv_length = sizeof(priv);
+    uint8_t priv[MAX_MESSAGE_SIZE];
+    size_t priv_length = sizeof(priv);
 
-	uint8_t pub[MAX_MESSAGE_SIZE];
-	size_t pub_length = sizeof(pub);
+    uint8_t pub[MAX_MESSAGE_SIZE];
+    size_t pub_length = sizeof(pub);
 
-	uint8_t peer_priv[MAX_MESSAGE_SIZE];
-	size_t peer_priv_length = sizeof(peer_priv);
+    uint8_t peer_priv[MAX_MESSAGE_SIZE];
+    size_t peer_priv_length = sizeof(peer_priv);
 
-	uint8_t peer_pub[MAX_MESSAGE_SIZE];
-	size_t peer_pub_length = sizeof(peer_pub);
+    uint8_t peer_pub[MAX_MESSAGE_SIZE];
+    size_t peer_pub_length = sizeof(peer_pub);
 
-	themis_status_t res;
+    themis_status_t res;
 
-	testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL == themis_gen_ec_key_pair(NULL, &priv_length, pub, &pub_length), "themis_gen_ec_key_pair: get output size (NULL out buffer for private key)");
-	priv_length--;
-	testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL == themis_gen_ec_key_pair(priv, &priv_length, pub, &pub_length), "themis_gen_ec_key_pair: get output size (small out buffer for private key)");
+    testsuite_fail_unless(
+        THEMIS_BUFFER_TOO_SMALL == themis_gen_ec_key_pair(NULL, &priv_length, pub, &pub_length),
+        "themis_gen_ec_key_pair: get output size (NULL out buffer for private key)");
+    priv_length--;
+    testsuite_fail_unless(
+        THEMIS_BUFFER_TOO_SMALL == themis_gen_ec_key_pair(priv, &priv_length, pub, &pub_length),
+        "themis_gen_ec_key_pair: get output size (small out buffer for private key)");
 
-	testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL == themis_gen_ec_key_pair(peer_priv, &priv_length, NULL, &pub_length), "themis_gen_ec_key_pair: get output size (NULL out buffer for public key)");
-	pub_length--;
-	testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL == themis_gen_ec_key_pair(peer_priv, &priv_length, pub, &pub_length), "themis_gen_ec_key_pair: get output size (small out buffer for public key)");
+    testsuite_fail_unless(
+        THEMIS_BUFFER_TOO_SMALL ==
+            themis_gen_ec_key_pair(peer_priv, &priv_length, NULL, &pub_length),
+        "themis_gen_ec_key_pair: get output size (NULL out buffer for public key)");
+    pub_length--;
+    testsuite_fail_unless(
+        THEMIS_BUFFER_TOO_SMALL ==
+            themis_gen_ec_key_pair(peer_priv, &priv_length, pub, &pub_length),
+        "themis_gen_ec_key_pair: get output size (small out buffer for public key)");
 
-	res = themis_gen_ec_key_pair(priv, &priv_length, pub, &pub_length);
-	if (THEMIS_SUCCESS != res)
-	{
-		testsuite_fail_if(true, "themis_gen_ec_key_pair fail");
-		return;
-	}
+    res = themis_gen_ec_key_pair(priv, &priv_length, pub, &pub_length);
+    if (THEMIS_SUCCESS != res) {
+        testsuite_fail_if(true, "themis_gen_ec_key_pair fail");
+        return;
+    }
 
-	res = themis_gen_ec_key_pair(peer_priv, &peer_priv_length, peer_pub, &peer_pub_length);
-	if (THEMIS_SUCCESS != res)
-	{
-		testsuite_fail_if(true, "themis_gen_ec_key_pair fail");
-		return;
-	}
+    res = themis_gen_ec_key_pair(peer_priv, &peer_priv_length, peer_pub, &peer_pub_length);
+    if (THEMIS_SUCCESS != res) {
+        testsuite_fail_if(true, "themis_gen_ec_key_pair fail");
+        return;
+    }
 
-	if (THEMIS_SUCCESS != soter_rand(plaintext, plaintext_length))
-	{
-		testsuite_fail_if(true, "soter_rand fail");
-		return;
-	}
+    if (THEMIS_SUCCESS != soter_rand(plaintext, plaintext_length)) {
+        testsuite_fail_if(true, "soter_rand fail");
+        return;
+    }
 
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_wrap(NULL, priv_length, peer_pub, peer_pub_length, plaintext, plaintext_length, ciphertext, &ciphertext_length), "themis_secure_message_wrap: invalid private key");
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_wrap(priv, priv_length - 1, peer_pub, peer_pub_length, plaintext, plaintext_length, ciphertext, &ciphertext_length), "themis_secure_message_wrap: invalid private key length");
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_wrap(priv, priv_length, peer_pub, peer_pub_length - 1, plaintext, plaintext_length, ciphertext, &ciphertext_length), "themis_secure_message_wrap: invalid peer public key length");
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_wrap(priv, priv_length, peer_pub, peer_pub_length, NULL, plaintext_length, ciphertext, &ciphertext_length), "themis_secure_message_wrap: invalid plaintext");
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_wrap(priv, priv_length, peer_pub, peer_pub_length, plaintext, 0, ciphertext, &ciphertext_length), "themis_secure_message_wrap: invalid plaintext length");
-	testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL == themis_secure_message_wrap(priv, priv_length, pub, pub_length, plaintext, plaintext_length, NULL, &ciphertext_length), "themis_secure_message_wrap: get output size (NULL out buffer)");
-	ciphertext_length--;
-	testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL == themis_secure_message_wrap(priv, priv_length, peer_pub, peer_pub_length, plaintext, plaintext_length, ciphertext, &ciphertext_length), "themis_secure_message_wrap: get output size (small out buffer)");
+    testsuite_fail_unless(
+        THEMIS_INVALID_PARAMETER ==
+            themis_secure_message_wrap(NULL, priv_length, peer_pub, peer_pub_length, plaintext,
+                                       plaintext_length, ciphertext, &ciphertext_length),
+        "themis_secure_message_wrap: invalid private key");
+    testsuite_fail_unless(
+        THEMIS_INVALID_PARAMETER ==
+            themis_secure_message_wrap(priv, priv_length - 1, peer_pub, peer_pub_length, plaintext,
+                                       plaintext_length, ciphertext, &ciphertext_length),
+        "themis_secure_message_wrap: invalid private key length");
+    testsuite_fail_unless(
+        THEMIS_INVALID_PARAMETER ==
+            themis_secure_message_wrap(priv, priv_length, peer_pub, peer_pub_length - 1, plaintext,
+                                       plaintext_length, ciphertext, &ciphertext_length),
+        "themis_secure_message_wrap: invalid peer public key length");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_message_wrap(priv, priv_length, peer_pub,
+                                                         peer_pub_length, NULL, plaintext_length,
+                                                         ciphertext, &ciphertext_length),
+                          "themis_secure_message_wrap: invalid plaintext");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_message_wrap(priv, priv_length, peer_pub,
+                                                         peer_pub_length, plaintext, 0, ciphertext,
+                                                         &ciphertext_length),
+                          "themis_secure_message_wrap: invalid plaintext length");
+    testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL ==
+                              themis_secure_message_wrap(priv, priv_length, pub, pub_length,
+                                                         plaintext, plaintext_length, NULL,
+                                                         &ciphertext_length),
+                          "themis_secure_message_wrap: get output size (NULL out buffer)");
+    ciphertext_length--;
+    testsuite_fail_unless(
+        THEMIS_BUFFER_TOO_SMALL ==
+            themis_secure_message_wrap(priv, priv_length, peer_pub, peer_pub_length, plaintext,
+                                       plaintext_length, ciphertext, &ciphertext_length),
+        "themis_secure_message_wrap: get output size (small out buffer)");
 
-	res = themis_secure_message_wrap(priv, priv_length, peer_pub, peer_pub_length, plaintext, plaintext_length, ciphertext, &ciphertext_length);
-	if (THEMIS_SUCCESS != res)
-	{
-		testsuite_fail_if(true, "themis_secure_message_wrap fail");
-		return;
-	}
+    res = themis_secure_message_wrap(priv, priv_length, peer_pub, peer_pub_length, plaintext,
+                                     plaintext_length, ciphertext, &ciphertext_length);
+    if (THEMIS_SUCCESS != res) {
+        testsuite_fail_if(true, "themis_secure_message_wrap fail");
+        return;
+    }
 
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_unwrap(NULL, peer_priv_length, pub, pub_length, ciphertext, ciphertext_length, decryptext, &decryptext_length), "themis_secure_message_unwrap: invalid private key");
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_unwrap(peer_priv, peer_priv_length - 1, pub, pub_length, ciphertext, ciphertext_length, decryptext, &decryptext_length), "themis_secure_message_unwrap: invalid private key length");
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_unwrap(peer_priv, peer_priv_length, pub, pub_length - 1, ciphertext, ciphertext_length, decryptext, &decryptext_length), "themis_secure_message_unwrap: invalid peer public key length");
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_unwrap(peer_priv, peer_priv_length, pub, pub_length, NULL, ciphertext_length, decryptext, &decryptext_length), "themis_secure_message_unwrap: invalid ciphertext");
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_unwrap(peer_priv, peer_priv_length, pub, pub_length, ciphertext, 0, decryptext, &decryptext_length), "themis_secure_message_unwrap: invalid ciphertext length");
-	testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL == themis_secure_message_unwrap(peer_priv, peer_priv_length, pub, pub_length, ciphertext, ciphertext_length, NULL, &decryptext_length), "themis_secure_message_unwrap: get output size (NULL out buffer)");
-	decryptext_length--;
-	testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL == themis_secure_message_unwrap(peer_priv, peer_priv_length, pub, pub_length, ciphertext, ciphertext_length, decryptext, &decryptext_length), "themis_secure_message_unwrap: get output size (small out buffer)");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_message_unwrap(NULL, peer_priv_length, pub, pub_length,
+                                                           ciphertext, ciphertext_length,
+                                                           decryptext, &decryptext_length),
+                          "themis_secure_message_unwrap: invalid private key");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_unwrap(
+                                                          peer_priv, peer_priv_length - 1, pub,
+                                                          pub_length, ciphertext, ciphertext_length,
+                                                          decryptext, &decryptext_length),
+                          "themis_secure_message_unwrap: invalid private key length");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_message_unwrap(
+                                  peer_priv, peer_priv_length, pub, pub_length - 1, ciphertext,
+                                  ciphertext_length, decryptext, &decryptext_length),
+                          "themis_secure_message_unwrap: invalid peer public key length");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_message_unwrap(peer_priv, peer_priv_length, pub,
+                                                           pub_length, NULL, ciphertext_length,
+                                                           decryptext, &decryptext_length),
+                          "themis_secure_message_unwrap: invalid ciphertext");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_message_unwrap(peer_priv, peer_priv_length, pub,
+                                                           pub_length, ciphertext, 0, decryptext,
+                                                           &decryptext_length),
+                          "themis_secure_message_unwrap: invalid ciphertext length");
+    testsuite_fail_unless(
+        THEMIS_BUFFER_TOO_SMALL ==
+            themis_secure_message_unwrap(peer_priv, peer_priv_length, pub, pub_length, ciphertext,
+                                         ciphertext_length, NULL, &decryptext_length),
+        "themis_secure_message_unwrap: get output size (NULL out buffer)");
+    decryptext_length--;
+    testsuite_fail_unless(
+        THEMIS_BUFFER_TOO_SMALL ==
+            themis_secure_message_unwrap(peer_priv, peer_priv_length, pub, pub_length, ciphertext,
+                                         ciphertext_length, decryptext, &decryptext_length),
+        "themis_secure_message_unwrap: get output size (small out buffer)");
 
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_unwrap(peer_priv, peer_priv_length, NULL, pub_length, ciphertext, ciphertext_length, decryptext, &decryptext_length), "themis_secure_message_unwrap: treating encrypted message as signed (NULL peer public key)");
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_message_unwrap(peer_priv, peer_priv_length, pub, 0, ciphertext, ciphertext_length, decryptext, &decryptext_length), "themis_secure_message_unwrap: treating encrypted message as signed (zero peer public key length)");
+    testsuite_fail_unless(
+        THEMIS_INVALID_PARAMETER ==
+            themis_secure_message_unwrap(peer_priv, peer_priv_length, NULL, pub_length, ciphertext,
+                                         ciphertext_length, decryptext, &decryptext_length),
+        "themis_secure_message_unwrap: treating encrypted message as signed (NULL peer public "
+        "key)");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_message_unwrap(peer_priv, peer_priv_length, pub, 0,
+                                                           ciphertext, ciphertext_length,
+                                                           decryptext, &decryptext_length),
+                          "themis_secure_message_unwrap: treating encrypted message as signed "
+                          "(zero peer public key length)");
 
-	res = themis_secure_message_unwrap(peer_priv, peer_priv_length, pub, pub_length, ciphertext, ciphertext_length, decryptext, &decryptext_length);
-	if (THEMIS_SUCCESS != res)
-	{
-		testsuite_fail_if(true, "themis_secure_message_unwrap fail");
-		return;
-	}
+    res = themis_secure_message_unwrap(peer_priv, peer_priv_length, pub, pub_length, ciphertext,
+                                       ciphertext_length, decryptext, &decryptext_length);
+    if (THEMIS_SUCCESS != res) {
+        testsuite_fail_if(true, "themis_secure_message_unwrap fail");
+        return;
+    }
 
-	testsuite_fail_unless((decryptext_length == plaintext_length), "generic secure message: normal flow");
-	testsuite_fail_unless((!memcmp(plaintext, decryptext, plaintext_length)), "generic secure message: normal flow 2");
+    testsuite_fail_unless((decryptext_length == plaintext_length),
+                          "generic secure message: normal flow");
+    testsuite_fail_unless((!memcmp(plaintext, decryptext, plaintext_length)),
+                          "generic secure message: normal flow 2");
 }
 
-static void key_validation_test(void){
-  themis_status_t status=THEMIS_FAIL;
+static void key_validation_test(void)
+{
+    themis_status_t status = THEMIS_FAIL;
 
-  uint8_t ec_private_key[MAX_KEY_SIZE]={0};
-  uint8_t ec_public_key[MAX_KEY_SIZE]={0};
-  uint8_t rsa_private_key[MAX_KEY_SIZE]={0};
-  uint8_t rsa_public_key[MAX_KEY_SIZE]={0};
-  size_t ec_private_key_length = sizeof(ec_private_key);
-  size_t ec_public_key_length = sizeof(ec_public_key);
-  size_t rsa_private_key_length = sizeof(rsa_private_key);
-  size_t rsa_public_key_length = sizeof(rsa_public_key);
+    uint8_t ec_private_key[MAX_KEY_SIZE] = {0};
+    uint8_t ec_public_key[MAX_KEY_SIZE] = {0};
+    uint8_t rsa_private_key[MAX_KEY_SIZE] = {0};
+    uint8_t rsa_public_key[MAX_KEY_SIZE] = {0};
+    size_t ec_private_key_length = sizeof(ec_private_key);
+    size_t ec_public_key_length = sizeof(ec_public_key);
+    size_t rsa_private_key_length = sizeof(rsa_private_key);
+    size_t rsa_public_key_length = sizeof(rsa_public_key);
 
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_gen_ec_key_pair(NULL, NULL, NULL, NULL),
-                        "themis_gen_ec_key_pair: null pointers");
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_gen_rsa_key_pair(NULL, NULL, NULL, NULL),
-                        "themis_gen_rsa_key_pair: null pointers");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_gen_ec_key_pair(NULL, NULL, NULL, NULL),
+                          "themis_gen_ec_key_pair: null pointers");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_gen_rsa_key_pair(NULL, NULL, NULL, NULL),
+                          "themis_gen_rsa_key_pair: null pointers");
 
-  testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL == themis_gen_ec_key_pair(NULL, &ec_private_key_length, NULL, &ec_public_key_length),
-                        "themis_gen_ec_key_pair: check length");
-  testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL == themis_gen_rsa_key_pair(NULL, &rsa_private_key_length, NULL, &rsa_public_key_length),
-                    "   themis_gen_rsa_key_pair: check length");
+    testsuite_fail_unless(
+        THEMIS_BUFFER_TOO_SMALL ==
+            themis_gen_ec_key_pair(NULL, &ec_private_key_length, NULL, &ec_public_key_length),
+        "themis_gen_ec_key_pair: check length");
+    testsuite_fail_unless(
+        THEMIS_BUFFER_TOO_SMALL ==
+            themis_gen_rsa_key_pair(NULL, &rsa_private_key_length, NULL, &rsa_public_key_length),
+        "   themis_gen_rsa_key_pair: check length");
 
-  ec_private_key_length -= 1;
-  ec_public_key_length -= 1;
-  rsa_private_key_length -= 1;
-  rsa_public_key_length -= 1;
-  testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL == themis_gen_ec_key_pair(ec_private_key, &ec_private_key_length, ec_public_key, &ec_public_key_length),
-                        "themis_gen_ec_key_pair: small buffer");
-  testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL == themis_gen_rsa_key_pair(rsa_private_key, &rsa_private_key_length, rsa_public_key, &rsa_public_key_length),
-                        "themis_gen_rsa_key_pair: small buffer");
+    ec_private_key_length -= 1;
+    ec_public_key_length -= 1;
+    rsa_private_key_length -= 1;
+    rsa_public_key_length -= 1;
+    testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL ==
+                              themis_gen_ec_key_pair(ec_private_key, &ec_private_key_length,
+                                                     ec_public_key, &ec_public_key_length),
+                          "themis_gen_ec_key_pair: small buffer");
+    testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL ==
+                              themis_gen_rsa_key_pair(rsa_private_key, &rsa_private_key_length,
+                                                      rsa_public_key, &rsa_public_key_length),
+                          "themis_gen_rsa_key_pair: small buffer");
 
-  status=themis_gen_ec_key_pair(ec_private_key, &ec_private_key_length, ec_public_key, &ec_public_key_length);
-  if(status!=THEMIS_SUCCESS){
-    testsuite_fail_if(true, "themis_gen_ec_key_pair failed");
-    return;
-  }
+    status = themis_gen_ec_key_pair(ec_private_key, &ec_private_key_length, ec_public_key,
+                                    &ec_public_key_length);
+    if (status != THEMIS_SUCCESS) {
+        testsuite_fail_if(true, "themis_gen_ec_key_pair failed");
+        return;
+    }
 
-  status=themis_gen_rsa_key_pair(rsa_private_key, &rsa_private_key_length, rsa_public_key, &rsa_public_key_length);
-  if(status!=THEMIS_SUCCESS){
-    testsuite_fail_if(true, "themis_gen_rsa_key_pair failed");
-    return;
-  }
+    status = themis_gen_rsa_key_pair(rsa_private_key, &rsa_private_key_length, rsa_public_key,
+                                     &rsa_public_key_length);
+    if (status != THEMIS_SUCCESS) {
+        testsuite_fail_if(true, "themis_gen_rsa_key_pair failed");
+        return;
+    }
 
-  testsuite_fail_unless(THEMIS_KEY_EC_PRIVATE == themis_get_asym_key_kind(ec_private_key, ec_private_key_length),
-                        "themis_get_asym_key_kind: EC private");
-  testsuite_fail_unless(THEMIS_KEY_EC_PUBLIC == themis_get_asym_key_kind(ec_public_key, ec_public_key_length),
-                        "themis_get_asym_key_kind: EC public");
+    testsuite_fail_unless(THEMIS_KEY_EC_PRIVATE ==
+                              themis_get_asym_key_kind(ec_private_key, ec_private_key_length),
+                          "themis_get_asym_key_kind: EC private");
+    testsuite_fail_unless(THEMIS_KEY_EC_PUBLIC ==
+                              themis_get_asym_key_kind(ec_public_key, ec_public_key_length),
+                          "themis_get_asym_key_kind: EC public");
 
-  testsuite_fail_unless(THEMIS_KEY_RSA_PRIVATE == themis_get_asym_key_kind(rsa_private_key, rsa_private_key_length),
-                        "themis_get_asym_key_kind: RSA private");
-  testsuite_fail_unless(THEMIS_KEY_RSA_PUBLIC == themis_get_asym_key_kind(rsa_public_key, rsa_public_key_length),
-                        "themis_get_asym_key_kind: RSA public");
+    testsuite_fail_unless(THEMIS_KEY_RSA_PRIVATE ==
+                              themis_get_asym_key_kind(rsa_private_key, rsa_private_key_length),
+                          "themis_get_asym_key_kind: RSA private");
+    testsuite_fail_unless(THEMIS_KEY_RSA_PUBLIC ==
+                              themis_get_asym_key_kind(rsa_public_key, rsa_public_key_length),
+                          "themis_get_asym_key_kind: RSA public");
 
-  testsuite_fail_unless(THEMIS_SUCCESS == themis_is_valid_asym_key(ec_private_key, ec_private_key_length),
-                        "themis_is_valid_asym_key: EC private");
-  testsuite_fail_unless(THEMIS_SUCCESS == themis_is_valid_asym_key(ec_public_key, ec_public_key_length),
-                        "themis_is_valid_asym_key: EC public");
-  testsuite_fail_unless(THEMIS_SUCCESS == themis_is_valid_asym_key(rsa_private_key, rsa_private_key_length),
-                        "themis_is_valid_asym_key: RSA private");
-  testsuite_fail_unless(THEMIS_SUCCESS == themis_is_valid_asym_key(rsa_public_key, rsa_public_key_length),
-                        "themis_is_valid_asym_key: RSA public");
+    testsuite_fail_unless(THEMIS_SUCCESS ==
+                              themis_is_valid_asym_key(ec_private_key, ec_private_key_length),
+                          "themis_is_valid_asym_key: EC private");
+    testsuite_fail_unless(THEMIS_SUCCESS ==
+                              themis_is_valid_asym_key(ec_public_key, ec_public_key_length),
+                          "themis_is_valid_asym_key: EC public");
+    testsuite_fail_unless(THEMIS_SUCCESS ==
+                              themis_is_valid_asym_key(rsa_private_key, rsa_private_key_length),
+                          "themis_is_valid_asym_key: RSA private");
+    testsuite_fail_unless(THEMIS_SUCCESS ==
+                              themis_is_valid_asym_key(rsa_public_key, rsa_public_key_length),
+                          "themis_is_valid_asym_key: RSA public");
 
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_is_valid_asym_key(NULL, 0),
-                        "themis_is_valid_asym_key: invalid arguments");
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_is_valid_asym_key(ec_private_key, ec_private_key_length-1),
-                        "themis_is_valid_asym_key: truncated buffer");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_is_valid_asym_key(NULL, 0),
+                          "themis_is_valid_asym_key: invalid arguments");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_is_valid_asym_key(ec_private_key, ec_private_key_length - 1),
+                          "themis_is_valid_asym_key: truncated buffer");
 
-  testsuite_fail_unless(THEMIS_KEY_INVALID == themis_get_asym_key_kind(NULL, 0),
-                        "themis_get_asym_key_kind: invalid arguments");
-  testsuite_fail_unless(THEMIS_KEY_INVALID == themis_get_asym_key_kind(ec_private_key, 2),
-                        "themis_get_asym_key_kind: truncated buffer");
+    testsuite_fail_unless(THEMIS_KEY_INVALID == themis_get_asym_key_kind(NULL, 0),
+                          "themis_get_asym_key_kind: invalid arguments");
+    testsuite_fail_unless(THEMIS_KEY_INVALID == themis_get_asym_key_kind(ec_private_key, 2),
+                          "themis_get_asym_key_kind: truncated buffer");
 
-  const char* input = "definitely not a valid key";
-  testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_is_valid_asym_key((const uint8_t*)input, strlen(input)),
-                        "themis_is_valid_asym_key: garbage input");
-  testsuite_fail_unless(THEMIS_KEY_INVALID == themis_get_asym_key_kind((const uint8_t*)input, strlen(input)),
-                        "themis_get_asym_key_kind: garbage input");
+    const char* input = "definitely not a valid key";
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_is_valid_asym_key((const uint8_t*)input, strlen(input)),
+                          "themis_is_valid_asym_key: garbage input");
+    testsuite_fail_unless(THEMIS_KEY_INVALID ==
+                              themis_get_asym_key_kind((const uint8_t*)input, strlen(input)),
+                          "themis_get_asym_key_kind: garbage input");
 }
 
-void run_secure_message_test(){
-  testsuite_enter_suite("generic secure message");
-  testsuite_run_test(themis_secure_message_test);
+void run_secure_message_test()
+{
+    testsuite_enter_suite("generic secure message");
+    testsuite_run_test(themis_secure_message_test);
 
-  testsuite_enter_suite("generic secure message: api test");
-  testsuite_run_test(themis_secure_message_encrypt_decrypt_api_test);
-  testsuite_run_test(themis_secure_message_sign_verify_api_test);
-  testsuite_run_test(secure_message_old_api_test);
+    testsuite_enter_suite("generic secure message: api test");
+    testsuite_run_test(themis_secure_message_encrypt_decrypt_api_test);
+    testsuite_run_test(themis_secure_message_sign_verify_api_test);
+    testsuite_run_test(secure_message_old_api_test);
 
-  testsuite_enter_suite("key generation and validation");
-  testsuite_run_test(key_validation_test);
+    testsuite_enter_suite("key generation and validation");
+    testsuite_run_test(key_validation_test);
 }

--- a/tests/themis/themis_secure_cell.c
+++ b/tests/themis/themis_secure_cell.c
@@ -1,18 +1,18 @@
 /*
-* Copyright (c) 2015 Cossack Labs Limited
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2015 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "themis/themis_test.h"
 
@@ -25,347 +25,525 @@
 #define MAX_CONTEXT_SIZE 2048
 #define MAX_MESSAGE_SIZE 4096
 
-static char passwd[]="password";
-static char message[]="secure cell test message by Mnatsakanov Andrey from Cossack Labs";
-static char user_context[]="secure cell user context";
+static char passwd[] = "password";
+static char message[] = "secure cell test message by Mnatsakanov Andrey from Cossack Labs";
+static char user_context[] = "secure cell user context";
 
-static int secure_cell_seal(){
-  uint8_t* encrypted_message;
-  size_t encrypted_message_length=0;
-  if(themis_secure_cell_encrypt_seal((uint8_t*)passwd, sizeof(passwd), NULL,0,(uint8_t*)message, sizeof(message), NULL, &encrypted_message_length)!=THEMIS_BUFFER_TOO_SMALL || encrypted_message_length==0){
-    testsuite_fail_if(true, "themis_secure_cell_encrypt_seal (encrypted_message_length determination) fail");
-    return -1;
-  }
-  encrypted_message=malloc(encrypted_message_length);
-  if(encrypted_message==NULL){
-    testsuite_fail_if(true, "encrypted_message malloc fail");
-    return -2;
-  }
-  if(themis_secure_cell_encrypt_seal((uint8_t*)passwd, sizeof(passwd), NULL,0,(uint8_t*)message, sizeof(message), encrypted_message, &encrypted_message_length)!=THEMIS_SUCCESS){
-    testsuite_fail_if(true, "themis_secure_cell_encrypt_seal fail");
-    free(encrypted_message);
-    return -3;
-  }
-  
-  uint8_t* decrypted_message;
-  size_t decrypted_message_length=0;
+static int secure_cell_seal()
+{
+    uint8_t* encrypted_message;
+    size_t encrypted_message_length = 0;
+    if (themis_secure_cell_encrypt_seal((uint8_t*)passwd, sizeof(passwd), NULL, 0,
+                                        (uint8_t*)message, sizeof(message), NULL,
+                                        &encrypted_message_length) != THEMIS_BUFFER_TOO_SMALL ||
+        encrypted_message_length == 0) {
+        testsuite_fail_if(
+            true, "themis_secure_cell_encrypt_seal (encrypted_message_length determination) fail");
+        return -1;
+    }
+    encrypted_message = malloc(encrypted_message_length);
+    if (encrypted_message == NULL) {
+        testsuite_fail_if(true, "encrypted_message malloc fail");
+        return -2;
+    }
+    if (themis_secure_cell_encrypt_seal((uint8_t*)passwd, sizeof(passwd), NULL, 0,
+                                        (uint8_t*)message, sizeof(message), encrypted_message,
+                                        &encrypted_message_length) != THEMIS_SUCCESS) {
+        testsuite_fail_if(true, "themis_secure_cell_encrypt_seal fail");
+        free(encrypted_message);
+        return -3;
+    }
 
-  if(themis_secure_cell_decrypt_seal((uint8_t*)passwd, sizeof(passwd), NULL,0,encrypted_message, encrypted_message_length, NULL, &decrypted_message_length)!=THEMIS_BUFFER_TOO_SMALL || decrypted_message_length==0){
-    testsuite_fail_if(true, "themis_secure_cell_decrypt_seal (decrypted_message_length determination) fail");
-    free(encrypted_message);
-    return -4;
-  }
-  decrypted_message=malloc(decrypted_message_length);
-  if(decrypted_message==NULL){
-    testsuite_fail_if(true, "decrypted_message malloc fail");
-    free(encrypted_message);
-    return -5;
-  }
-  if(themis_secure_cell_decrypt_seal((uint8_t*)passwd, sizeof(passwd), NULL,0,encrypted_message, encrypted_message_length, decrypted_message, &decrypted_message_length)!=THEMIS_SUCCESS){
-    testsuite_fail_if(true, "themis_secure_cell_decrypt_seal fail");
+    uint8_t* decrypted_message;
+    size_t decrypted_message_length = 0;
+
+    if (themis_secure_cell_decrypt_seal((uint8_t*)passwd, sizeof(passwd), NULL, 0,
+                                        encrypted_message, encrypted_message_length, NULL,
+                                        &decrypted_message_length) != THEMIS_BUFFER_TOO_SMALL ||
+        decrypted_message_length == 0) {
+        testsuite_fail_if(
+            true, "themis_secure_cell_decrypt_seal (decrypted_message_length determination) fail");
+        free(encrypted_message);
+        return -4;
+    }
+    decrypted_message = malloc(decrypted_message_length);
+    if (decrypted_message == NULL) {
+        testsuite_fail_if(true, "decrypted_message malloc fail");
+        free(encrypted_message);
+        return -5;
+    }
+    if (themis_secure_cell_decrypt_seal(
+            (uint8_t*)passwd, sizeof(passwd), NULL, 0, encrypted_message, encrypted_message_length,
+            decrypted_message, &decrypted_message_length) != THEMIS_SUCCESS) {
+        testsuite_fail_if(true, "themis_secure_cell_decrypt_seal fail");
+        free(encrypted_message);
+        free(decrypted_message);
+        return -6;
+    }
+
+    if (sizeof(message) != decrypted_message_length ||
+        memcmp((uint8_t*)message, decrypted_message, decrypted_message_length) != 0) {
+        testsuite_fail_if(true, "message and decrypted_message not equal");
+        free(encrypted_message);
+        free(decrypted_message);
+        return -6;
+    }
     free(encrypted_message);
     free(decrypted_message);
-    return -6;
-  }
-
-  if(sizeof(message)!=decrypted_message_length || memcmp((uint8_t*)message, decrypted_message, decrypted_message_length)!=0){
-    testsuite_fail_if(true, "message and decrypted_message not equal");
-    free(encrypted_message);
-    free(decrypted_message);
-    return -6;
-  }
-  free(encrypted_message);
-  free(decrypted_message);
-  return 0;
+    return 0;
 }
 
-static int secure_cell_token_protect(){
-  uint8_t* encrypted_message;
-  size_t encrypted_message_length=0;
-  uint8_t* context;
-  size_t context_length=0;
-  
-  if(themis_secure_cell_encrypt_token_protect((uint8_t*)passwd, sizeof(passwd), NULL,0,(uint8_t*)message, sizeof(message), NULL, &context_length, NULL, &encrypted_message_length)!=THEMIS_BUFFER_TOO_SMALL || encrypted_message_length==0){
-    testsuite_fail_if(true, "themis_secure_cell_encrypt_token_protect (encrypted_message_length determination) fail");
-    return -1;
-  }
-  if(encrypted_message_length !=  sizeof(message)){
-      testsuite_fail_if(true, "themis_secure_cell_encrypt_token_protect (encrypted_message_length != message length) fail");
-      return -1;
-  }
-  encrypted_message=malloc(encrypted_message_length);
-  if(encrypted_message==NULL){
-    testsuite_fail_if(true, "encrypted_message malloc fail");
-    return -2;
-  }
-  context=malloc(context_length);
-  if(context==NULL){
-    testsuite_fail_if(true, "context malloc fail");
-    free(encrypted_message);
-    return -2;
-  }
-  
-  if(themis_secure_cell_encrypt_token_protect((uint8_t*)passwd, sizeof(passwd), NULL,0, (uint8_t*)message, sizeof(message), context, &context_length, encrypted_message, &encrypted_message_length)!=THEMIS_SUCCESS){
-    testsuite_fail_if(true, "themis_secure_cell_encrypt_token_protect fail");
-    free(encrypted_message);
-    free(context);
-    return -3;
-  }
-  if(encrypted_message_length !=  sizeof(message)){
-    testsuite_fail_if(true, "themis_secure_cell_encrypt_token_protect (encrypted_message_length != message length) fail");
-    free(encrypted_message);
-    free(context);
-    return -3;
-  }
-  uint8_t* decrypted_message;
-  size_t decrypted_message_length=0;
+static int secure_cell_token_protect()
+{
+    uint8_t* encrypted_message;
+    size_t encrypted_message_length = 0;
+    uint8_t* context;
+    size_t context_length = 0;
 
-  if(themis_secure_cell_decrypt_token_protect((uint8_t*)passwd, sizeof(passwd), NULL,0,encrypted_message, encrypted_message_length, context, context_length, NULL, &decrypted_message_length)!=THEMIS_BUFFER_TOO_SMALL || decrypted_message_length==0){
-    testsuite_fail_if(true, "themis_secure_cell_decrypt_token_protect (decrypted_message_length determination) fail");
-    free(encrypted_message);
-    free(context);
-    return -4;
-  }
-  decrypted_message=malloc(decrypted_message_length);
-  if(decrypted_message==NULL){
-    testsuite_fail_if(true, "decrypted_message malloc fail");
-    free(encrypted_message);
-    free(context);
-    return -5;
-  }
-  if(themis_secure_cell_decrypt_token_protect((uint8_t*)passwd, sizeof(passwd), NULL,0,encrypted_message, encrypted_message_length, context, context_length, decrypted_message, &decrypted_message_length)!=THEMIS_SUCCESS){
-    testsuite_fail_if(true, "themis_secure_cell_decrypt_token_protect fail");
+    if (themis_secure_cell_encrypt_token_protect(
+            (uint8_t*)passwd, sizeof(passwd), NULL, 0, (uint8_t*)message, sizeof(message), NULL,
+            &context_length, NULL, &encrypted_message_length) != THEMIS_BUFFER_TOO_SMALL ||
+        encrypted_message_length == 0) {
+        testsuite_fail_if(true, "themis_secure_cell_encrypt_token_protect "
+                                "(encrypted_message_length determination) fail");
+        return -1;
+    }
+    if (encrypted_message_length != sizeof(message)) {
+        testsuite_fail_if(true, "themis_secure_cell_encrypt_token_protect "
+                                "(encrypted_message_length != message length) fail");
+        return -1;
+    }
+    encrypted_message = malloc(encrypted_message_length);
+    if (encrypted_message == NULL) {
+        testsuite_fail_if(true, "encrypted_message malloc fail");
+        return -2;
+    }
+    context = malloc(context_length);
+    if (context == NULL) {
+        testsuite_fail_if(true, "context malloc fail");
+        free(encrypted_message);
+        return -2;
+    }
+
+    if (themis_secure_cell_encrypt_token_protect(
+            (uint8_t*)passwd, sizeof(passwd), NULL, 0, (uint8_t*)message, sizeof(message), context,
+            &context_length, encrypted_message, &encrypted_message_length) != THEMIS_SUCCESS) {
+        testsuite_fail_if(true, "themis_secure_cell_encrypt_token_protect fail");
+        free(encrypted_message);
+        free(context);
+        return -3;
+    }
+    if (encrypted_message_length != sizeof(message)) {
+        testsuite_fail_if(true, "themis_secure_cell_encrypt_token_protect "
+                                "(encrypted_message_length != message length) fail");
+        free(encrypted_message);
+        free(context);
+        return -3;
+    }
+    uint8_t* decrypted_message;
+    size_t decrypted_message_length = 0;
+
+    if (themis_secure_cell_decrypt_token_protect(
+            (uint8_t*)passwd, sizeof(passwd), NULL, 0, encrypted_message, encrypted_message_length,
+            context, context_length, NULL, &decrypted_message_length) != THEMIS_BUFFER_TOO_SMALL ||
+        decrypted_message_length == 0) {
+        testsuite_fail_if(true, "themis_secure_cell_decrypt_token_protect "
+                                "(decrypted_message_length determination) fail");
+        free(encrypted_message);
+        free(context);
+        return -4;
+    }
+    decrypted_message = malloc(decrypted_message_length);
+    if (decrypted_message == NULL) {
+        testsuite_fail_if(true, "decrypted_message malloc fail");
+        free(encrypted_message);
+        free(context);
+        return -5;
+    }
+    if (themis_secure_cell_decrypt_token_protect((uint8_t*)passwd, sizeof(passwd), NULL, 0,
+                                                 encrypted_message, encrypted_message_length,
+                                                 context, context_length, decrypted_message,
+                                                 &decrypted_message_length) != THEMIS_SUCCESS) {
+        testsuite_fail_if(true, "themis_secure_cell_decrypt_token_protect fail");
+        free(encrypted_message);
+        free(decrypted_message);
+        free(context);
+        return -6;
+    }
+
+    if (sizeof(message) != decrypted_message_length ||
+        memcmp((uint8_t*)message, decrypted_message, decrypted_message_length) != 0) {
+        testsuite_fail_if(true, "message and decrypted_message not equal");
+        free(encrypted_message);
+        free(decrypted_message);
+        free(context);
+        return -7;
+    }
     free(encrypted_message);
     free(decrypted_message);
     free(context);
-    return -6;
-  }
-
-  if(sizeof(message)!=decrypted_message_length || memcmp((uint8_t*)message, decrypted_message, decrypted_message_length)!=0){
-    testsuite_fail_if(true, "message and decrypted_message not equal");
-    free(encrypted_message);
-    free(decrypted_message);
-    free(context);
-    return -7;
-  }
-  free(encrypted_message);
-  free(decrypted_message);
-  free(context);  
-  return 0;
+    return 0;
 }
 
-static int secure_cell_context_imprint(){
-  uint8_t* encrypted_message;
-  size_t encrypted_message_length=0;
-  
-  if(themis_secure_cell_encrypt_context_imprint((uint8_t*)passwd, sizeof(passwd), (uint8_t*)message, sizeof(message), (uint8_t*)user_context, strlen(user_context), NULL, &encrypted_message_length)!=THEMIS_BUFFER_TOO_SMALL || encrypted_message_length==0){
-    testsuite_fail_if(true, "themis_secure_cell_encrypt_context_imprint (encrypted_message_length determination) fail");
-    return -1;
-  }
-  encrypted_message=malloc(encrypted_message_length);
-  if(encrypted_message==NULL){
-    testsuite_fail_if(true, "encrypted_message malloc fail");
-    return -2;
-  }
-  
-  if(themis_secure_cell_encrypt_context_imprint((uint8_t*)passwd, sizeof(passwd), (uint8_t*)message, sizeof(message), (uint8_t*)user_context, strlen(user_context), encrypted_message, &encrypted_message_length)!=THEMIS_SUCCESS){
-    testsuite_fail_if(true, "themis_secure_cell_encrypt_context_imprint fail");
-    free(encrypted_message);
-    return -3;
-  }
+static int secure_cell_context_imprint()
+{
+    uint8_t* encrypted_message;
+    size_t encrypted_message_length = 0;
 
-  uint8_t* decrypted_message;
-  size_t decrypted_message_length=0;
+    if (themis_secure_cell_encrypt_context_imprint(
+            (uint8_t*)passwd, sizeof(passwd), (uint8_t*)message, sizeof(message),
+            (uint8_t*)user_context, strlen(user_context), NULL,
+            &encrypted_message_length) != THEMIS_BUFFER_TOO_SMALL ||
+        encrypted_message_length == 0) {
+        testsuite_fail_if(true, "themis_secure_cell_encrypt_context_imprint "
+                                "(encrypted_message_length determination) fail");
+        return -1;
+    }
+    encrypted_message = malloc(encrypted_message_length);
+    if (encrypted_message == NULL) {
+        testsuite_fail_if(true, "encrypted_message malloc fail");
+        return -2;
+    }
 
-  if(themis_secure_cell_decrypt_context_imprint((uint8_t*)passwd, sizeof(passwd), encrypted_message, encrypted_message_length, (uint8_t*)user_context, strlen(user_context), NULL, &decrypted_message_length)!=THEMIS_BUFFER_TOO_SMALL || decrypted_message_length==0){
-    testsuite_fail_if(true, "themis_secure_cell_decrypt_context_imprint (decrypted_message_length determination) fail");
-    free(encrypted_message);
-    return -4;
-  }
-  decrypted_message=malloc(decrypted_message_length);
-  if(decrypted_message==NULL){
-    testsuite_fail_if(true, "decrypted_message malloc fail");
-    free(encrypted_message);
-    return -5;
-  }
-    if(themis_secure_cell_encrypt_context_imprint((uint8_t*)passwd, sizeof(passwd), encrypted_message, encrypted_message_length, (uint8_t*)user_context, strlen(user_context), decrypted_message, &decrypted_message_length)!=THEMIS_SUCCESS){
-    testsuite_fail_if(true, "themis_secure_cell_decrypt_context_imprint fail");
+    if (themis_secure_cell_encrypt_context_imprint(
+            (uint8_t*)passwd, sizeof(passwd), (uint8_t*)message, sizeof(message),
+            (uint8_t*)user_context, strlen(user_context), encrypted_message,
+            &encrypted_message_length) != THEMIS_SUCCESS) {
+        testsuite_fail_if(true, "themis_secure_cell_encrypt_context_imprint fail");
+        free(encrypted_message);
+        return -3;
+    }
+
+    uint8_t* decrypted_message;
+    size_t decrypted_message_length = 0;
+
+    if (themis_secure_cell_decrypt_context_imprint(
+            (uint8_t*)passwd, sizeof(passwd), encrypted_message, encrypted_message_length,
+            (uint8_t*)user_context, strlen(user_context), NULL,
+            &decrypted_message_length) != THEMIS_BUFFER_TOO_SMALL ||
+        decrypted_message_length == 0) {
+        testsuite_fail_if(true, "themis_secure_cell_decrypt_context_imprint "
+                                "(decrypted_message_length determination) fail");
+        free(encrypted_message);
+        return -4;
+    }
+    decrypted_message = malloc(decrypted_message_length);
+    if (decrypted_message == NULL) {
+        testsuite_fail_if(true, "decrypted_message malloc fail");
+        free(encrypted_message);
+        return -5;
+    }
+    if (themis_secure_cell_encrypt_context_imprint(
+            (uint8_t*)passwd, sizeof(passwd), encrypted_message, encrypted_message_length,
+            (uint8_t*)user_context, strlen(user_context), decrypted_message,
+            &decrypted_message_length) != THEMIS_SUCCESS) {
+        testsuite_fail_if(true, "themis_secure_cell_decrypt_context_imprint fail");
+        free(encrypted_message);
+        free(decrypted_message);
+        return -6;
+    }
+
+    if (sizeof(message) != decrypted_message_length ||
+        memcmp((uint8_t*)message, decrypted_message, decrypted_message_length) != 0) {
+        testsuite_fail_if(true, "message and decrypted_message not equal");
+        free(encrypted_message);
+        free(decrypted_message);
+        return -7;
+    }
     free(encrypted_message);
     free(decrypted_message);
-    return -6;
-  }
-
-  if(sizeof(message)!=decrypted_message_length || memcmp((uint8_t*)message, decrypted_message, decrypted_message_length)!=0){
-    testsuite_fail_if(true, "message and decrypted_message not equal");
-    free(encrypted_message);
-    free(decrypted_message);
-    return -7;
-  }
-  free(encrypted_message);
-  free(decrypted_message);
-  return 0;
+    return 0;
 }
 
-
-static void secure_cell_test(){
-  testsuite_fail_if(secure_cell_seal(),"secure cell seal mode");
-  testsuite_fail_if(secure_cell_token_protect(),"secure cell token protect mode");
-  testsuite_fail_if(secure_cell_context_imprint(),"secure cell context imprint mode");
+static void secure_cell_test()
+{
+    testsuite_fail_if(secure_cell_seal(), "secure cell seal mode");
+    testsuite_fail_if(secure_cell_token_protect(), "secure cell token protect mode");
+    testsuite_fail_if(secure_cell_context_imprint(), "secure cell context imprint mode");
 }
 
 static void secure_cell_api_test_seal(void)
 {
-	uint8_t key[MAX_KEY_SIZE];
-	uint8_t message[MAX_MESSAGE_SIZE];
+    uint8_t key[MAX_KEY_SIZE];
+    uint8_t message[MAX_MESSAGE_SIZE];
 
-	size_t key_length = rand_int(MAX_KEY_SIZE);
-	size_t message_length = rand_int(MAX_MESSAGE_SIZE);
+    size_t key_length = rand_int(MAX_KEY_SIZE);
+    size_t message_length = rand_int(MAX_MESSAGE_SIZE);
 
-	uint8_t *encrypted = NULL;
-	size_t encrypted_length;
+    uint8_t* encrypted = NULL;
+    size_t encrypted_length;
 
-	uint8_t *decrypted = NULL;
-	size_t decrypted_length;
+    uint8_t* decrypted = NULL;
+    size_t decrypted_length;
 
-	if (THEMIS_SUCCESS != soter_rand(key, key_length))
-	{
-		testsuite_fail_if(true, "soter_rand fail");
-		return;
-	}
+    if (THEMIS_SUCCESS != soter_rand(key, key_length)) {
+        testsuite_fail_if(true, "soter_rand fail");
+        return;
+    }
 
-	if (THEMIS_SUCCESS != soter_rand(message, message_length))
-	{
-		testsuite_fail_if(true, "soter_rand fail");
-		return;
-	}
+    if (THEMIS_SUCCESS != soter_rand(message, message_length)) {
+        testsuite_fail_if(true, "soter_rand fail");
+        return;
+    }
 
-	testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL == themis_secure_cell_encrypt_seal(key, key_length, NULL,0,message, message_length, NULL, &encrypted_length), "themis_secure_cell_encrypt_seal: get output size (NULL out buffer)");
-	encrypted = malloc(encrypted_length);
-	if (!encrypted)
-	{
-		testsuite_fail_if(true, "malloc fail");
-		return;
-	}
+    testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL == themis_secure_cell_encrypt_seal(
+                                                         key, key_length, NULL, 0, message,
+                                                         message_length, NULL, &encrypted_length),
+                          "themis_secure_cell_encrypt_seal: get output size (NULL out buffer)");
+    encrypted = malloc(encrypted_length);
+    if (!encrypted) {
+        testsuite_fail_if(true, "malloc fail");
+        return;
+    }
 
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_cell_encrypt_seal(NULL, key_length, NULL,0,message, message_length, encrypted, &encrypted_length), "themis_secure_cell_encrypt_seal: invalid key");
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_cell_encrypt_seal(key, 0, NULL,0,message, message_length, encrypted, &encrypted_length), "themis_secure_cell_encrypt_seal: invalid key length");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_cell_encrypt_seal(NULL, key_length, NULL, 0, message,
+                                                              message_length, encrypted,
+                                                              &encrypted_length),
+                          "themis_secure_cell_encrypt_seal: invalid key");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_cell_encrypt_seal(
+                                                          key, 0, NULL, 0, message, message_length,
+                                                          encrypted, &encrypted_length),
+                          "themis_secure_cell_encrypt_seal: invalid key length");
 
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_cell_encrypt_seal(key, key_length, NULL,0,NULL, message_length, encrypted, &encrypted_length), "themis_secure_cell_encrypt_seal: invalid message");
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_cell_encrypt_seal(key, key_length, NULL,0,message, 0, encrypted, &encrypted_length), "themis_secure_cell_encrypt_seal: invalid message length");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_cell_encrypt_seal(key, key_length, NULL, 0, NULL,
+                                                              message_length, encrypted,
+                                                              &encrypted_length),
+                          "themis_secure_cell_encrypt_seal: invalid message");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_cell_encrypt_seal(key, key_length, NULL, 0, message, 0,
+                                                              encrypted, &encrypted_length),
+                          "themis_secure_cell_encrypt_seal: invalid message length");
 
-	encrypted_length--;
-	testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL == themis_secure_cell_encrypt_seal(key, key_length, NULL,0,message, message_length, encrypted, &encrypted_length), "themis_secure_cell_encrypt_seal: get output size (small out buffer)");
+    encrypted_length--;
+    testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL ==
+                              themis_secure_cell_encrypt_seal(key, key_length, NULL, 0, message,
+                                                              message_length, encrypted,
+                                                              &encrypted_length),
+                          "themis_secure_cell_encrypt_seal: get output size (small out buffer)");
 
-	testsuite_fail_unless(THEMIS_SUCCESS == themis_secure_cell_encrypt_seal(key, key_length, NULL,0,message, message_length, encrypted, &encrypted_length), "themis_secure_cell_encrypt_seal: normal flow");
+    testsuite_fail_unless(THEMIS_SUCCESS == themis_secure_cell_encrypt_seal(
+                                                key, key_length, NULL, 0, message, message_length,
+                                                encrypted, &encrypted_length),
+                          "themis_secure_cell_encrypt_seal: normal flow");
 
-	testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL == themis_secure_cell_decrypt_seal(key, key_length, NULL,0,encrypted, encrypted_length, NULL, &decrypted_length), "themis_secure_cell_decrypt_seal: get output size (NULL out buffer)");
+    testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL == themis_secure_cell_decrypt_seal(
+                                                         key, key_length, NULL, 0, encrypted,
+                                                         encrypted_length, NULL, &decrypted_length),
+                          "themis_secure_cell_decrypt_seal: get output size (NULL out buffer)");
 
-	decrypted = malloc(decrypted_length);
-	if (!decrypted)
-	{
-		testsuite_fail_if(true, "malloc fail");
-		free(encrypted);
-		return;
-	}
+    decrypted = malloc(decrypted_length);
+    if (!decrypted) {
+        testsuite_fail_if(true, "malloc fail");
+        free(encrypted);
+        return;
+    }
 
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_cell_decrypt_seal(NULL, key_length, NULL,0,encrypted, encrypted_length, decrypted, &decrypted_length), "themis_secure_cell_decrypt_seal: invalid key");
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_cell_decrypt_seal(key, 0, NULL,0,encrypted, encrypted_length, decrypted, &decrypted_length), "themis_secure_cell_decrypt_seal: invalid key length");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_cell_decrypt_seal(NULL, key_length, NULL, 0, encrypted,
+                                                              encrypted_length, decrypted,
+                                                              &decrypted_length),
+                          "themis_secure_cell_decrypt_seal: invalid key");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_cell_decrypt_seal(key, 0, NULL, 0, encrypted,
+                                                              encrypted_length, decrypted,
+                                                              &decrypted_length),
+                          "themis_secure_cell_decrypt_seal: invalid key length");
 
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_cell_decrypt_seal(key, key_length, NULL,0,NULL, encrypted_length, decrypted, &decrypted_length), "themis_secure_cell_decrypt_seal: invalid message");
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_cell_decrypt_seal(key, key_length, NULL,0,encrypted, 0, decrypted, &decrypted_length), "themis_secure_cell_decrypt_seal: invalid message length");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_cell_decrypt_seal(key, key_length, NULL, 0, NULL,
+                                                              encrypted_length, decrypted,
+                                                              &decrypted_length),
+                          "themis_secure_cell_decrypt_seal: invalid message");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              themis_secure_cell_decrypt_seal(key, key_length, NULL, 0, encrypted,
+                                                              0, decrypted, &decrypted_length),
+                          "themis_secure_cell_decrypt_seal: invalid message length");
 
-	decrypted_length--;
-	testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL == themis_secure_cell_decrypt_seal(key, key_length, NULL,0,encrypted, encrypted_length, decrypted, &decrypted_length), "themis_secure_cell_decrypt_seal: get output size (small out buffer)");
+    decrypted_length--;
+    testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL ==
+                              themis_secure_cell_decrypt_seal(key, key_length, NULL, 0, encrypted,
+                                                              encrypted_length, decrypted,
+                                                              &decrypted_length),
+                          "themis_secure_cell_decrypt_seal: get output size (small out buffer)");
 
-	encrypted[0]++;
-	testsuite_fail_unless(THEMIS_FAIL == themis_secure_cell_decrypt_seal(key, key_length, NULL,0,encrypted, encrypted_length, decrypted, &decrypted_length), "themis_secure_cell_decrypt_seal: header corrupt");
-	encrypted[0]--;
+    encrypted[0]++;
+    testsuite_fail_unless(THEMIS_FAIL == themis_secure_cell_decrypt_seal(
+                                             key, key_length, NULL, 0, encrypted, encrypted_length,
+                                             decrypted, &decrypted_length),
+                          "themis_secure_cell_decrypt_seal: header corrupt");
+    encrypted[0]--;
 
-	encrypted[encrypted_length / 2]++;
-	testsuite_fail_unless(THEMIS_FAIL == themis_secure_cell_decrypt_seal(key, key_length, NULL,0,encrypted, encrypted_length, decrypted, &decrypted_length), "themis_secure_cell_decrypt_seal: message corrupt");
-	encrypted[encrypted_length / 2]--;
+    encrypted[encrypted_length / 2]++;
+    testsuite_fail_unless(THEMIS_FAIL == themis_secure_cell_decrypt_seal(
+                                             key, key_length, NULL, 0, encrypted, encrypted_length,
+                                             decrypted, &decrypted_length),
+                          "themis_secure_cell_decrypt_seal: message corrupt");
+    encrypted[encrypted_length / 2]--;
 
-	encrypted[encrypted_length - 1]++;
-	testsuite_fail_unless(THEMIS_FAIL == themis_secure_cell_decrypt_seal(key, key_length, NULL,0,encrypted, encrypted_length, decrypted, &decrypted_length), "themis_secure_cell_decrypt_seal: tag corrupt");
-	encrypted[encrypted_length - 1]--;
+    encrypted[encrypted_length - 1]++;
+    testsuite_fail_unless(THEMIS_FAIL == themis_secure_cell_decrypt_seal(
+                                             key, key_length, NULL, 0, encrypted, encrypted_length,
+                                             decrypted, &decrypted_length),
+                          "themis_secure_cell_decrypt_seal: tag corrupt");
+    encrypted[encrypted_length - 1]--;
 
-	testsuite_fail_unless(THEMIS_SUCCESS == themis_secure_cell_decrypt_seal(key, key_length, NULL,0,encrypted, encrypted_length, decrypted, &decrypted_length) && (message_length == decrypted_length) && !memcmp(message, decrypted, message_length), "themis_secure_cell_decrypt_seal: normal flow");
+    testsuite_fail_unless(
+        THEMIS_SUCCESS == themis_secure_cell_decrypt_seal(key, key_length, NULL, 0, encrypted,
+                                                          encrypted_length, decrypted,
+                                                          &decrypted_length) &&
+            (message_length == decrypted_length) && !memcmp(message, decrypted, message_length),
+        "themis_secure_cell_decrypt_seal: normal flow");
 
-	free(decrypted);
-	free(encrypted);
+    free(decrypted);
+    free(encrypted);
 }
 
 static void secure_cell_api_test_context_imprint(void)
 {
-	uint8_t key[MAX_KEY_SIZE];
-	uint8_t context[MAX_CONTEXT_SIZE];
-	uint8_t message[MAX_MESSAGE_SIZE];
+    uint8_t key[MAX_KEY_SIZE];
+    uint8_t context[MAX_CONTEXT_SIZE];
+    uint8_t message[MAX_MESSAGE_SIZE];
 
-	size_t key_length = rand_int(MAX_KEY_SIZE);
-	size_t context_length = rand_int(MAX_CONTEXT_SIZE);
-	size_t message_length = rand_int(MAX_MESSAGE_SIZE);
+    size_t key_length = rand_int(MAX_KEY_SIZE);
+    size_t context_length = rand_int(MAX_CONTEXT_SIZE);
+    size_t message_length = rand_int(MAX_MESSAGE_SIZE);
 
-	uint8_t encrypted[MAX_MESSAGE_SIZE];
-	size_t encrypted_length = message_length;
+    uint8_t encrypted[MAX_MESSAGE_SIZE];
+    size_t encrypted_length = message_length;
 
-	uint8_t decrypted[MAX_MESSAGE_SIZE];
-	size_t decrypted_length = message_length;
+    uint8_t decrypted[MAX_MESSAGE_SIZE];
+    size_t decrypted_length = message_length;
 
-	if (THEMIS_SUCCESS != soter_rand(key, key_length))
-	{
-		testsuite_fail_if(true, "soter_rand fail");
-		return;
-	}
+    if (THEMIS_SUCCESS != soter_rand(key, key_length)) {
+        testsuite_fail_if(true, "soter_rand fail");
+        return;
+    }
 
-	if (THEMIS_SUCCESS != soter_rand(context, context_length))
-	{
-		testsuite_fail_if(true, "soter_rand fail");
-		return;
-	}
+    if (THEMIS_SUCCESS != soter_rand(context, context_length)) {
+        testsuite_fail_if(true, "soter_rand fail");
+        return;
+    }
 
-	if (THEMIS_SUCCESS != soter_rand(message, message_length))
-	{
-		testsuite_fail_if(true, "soter_rand fail");
-		return;
-	}
+    if (THEMIS_SUCCESS != soter_rand(message, message_length)) {
+        testsuite_fail_if(true, "soter_rand fail");
+        return;
+    }
 
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_cell_encrypt_context_imprint(NULL, key_length, message, message_length, context, context_length, encrypted, &encrypted_length), "themis_secure_cell_encrypt_context_imprint: invalid key");
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_cell_encrypt_context_imprint(key, 0, message, message_length, context, context_length, encrypted, &encrypted_length), "themis_secure_cell_encrypt_context_imprint: invalid key length");
-	
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_cell_encrypt_context_imprint(key, key_length, NULL, message_length, context, context_length, encrypted, &encrypted_length), "themis_secure_cell_encrypt_context_imprint: invalid message");
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_cell_encrypt_context_imprint(key, key_length, message, 0, context, context_length, encrypted, &encrypted_length), "themis_secure_cell_encrypt_context_imprint: invalid message length");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_cell_encrypt_context_imprint(
+                                                          NULL, key_length, message, message_length,
+                                                          context, context_length, encrypted,
+                                                          &encrypted_length),
+                          "themis_secure_cell_encrypt_context_imprint: invalid key");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_cell_encrypt_context_imprint(
+                                                          key, 0, message, message_length, context,
+                                                          context_length, encrypted,
+                                                          &encrypted_length),
+                          "themis_secure_cell_encrypt_context_imprint: invalid key length");
 
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_cell_encrypt_context_imprint(key, key_length, message, message_length, NULL, context_length, encrypted, &encrypted_length), "themis_secure_cell_encrypt_context_imprint: invalid context");
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_cell_encrypt_context_imprint(key, key_length, message, message_length, context, 0, encrypted, &encrypted_length), "themis_secure_cell_encrypt_context_imprint: invalid context length");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_cell_encrypt_context_imprint(
+                                                          key, key_length, NULL, message_length,
+                                                          context, context_length, encrypted,
+                                                          &encrypted_length),
+                          "themis_secure_cell_encrypt_context_imprint: invalid message");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_cell_encrypt_context_imprint(
+                                                          key, key_length, message, 0, context,
+                                                          context_length, encrypted,
+                                                          &encrypted_length),
+                          "themis_secure_cell_encrypt_context_imprint: invalid message length");
 
-	testsuite_fail_unless((THEMIS_BUFFER_TOO_SMALL == themis_secure_cell_encrypt_context_imprint(key, key_length, message, message_length, context, context_length, NULL, &encrypted_length)) && (encrypted_length == message_length), "themis_secure_cell_encrypt_context_imprint: get output size (NULL out buffer)");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_cell_encrypt_context_imprint(
+                                                          key, key_length, message, message_length,
+                                                          NULL, context_length, encrypted,
+                                                          &encrypted_length),
+                          "themis_secure_cell_encrypt_context_imprint: invalid context");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_cell_encrypt_context_imprint(
+                                                          key, key_length, message, message_length,
+                                                          context, 0, encrypted, &encrypted_length),
+                          "themis_secure_cell_encrypt_context_imprint: invalid context length");
 
-	 encrypted_length--;
-	testsuite_fail_unless((THEMIS_BUFFER_TOO_SMALL == themis_secure_cell_encrypt_context_imprint(key, key_length, message, message_length, context, context_length, encrypted, &encrypted_length)) && (encrypted_length == message_length) , "themis_secure_cell_encrypt_context_imprint: get output size (small out buffer)");
+    testsuite_fail_unless(
+        (THEMIS_BUFFER_TOO_SMALL == themis_secure_cell_encrypt_context_imprint(
+                                        key, key_length, message, message_length, context,
+                                        context_length, NULL, &encrypted_length)) &&
+            (encrypted_length == message_length),
+        "themis_secure_cell_encrypt_context_imprint: get output size (NULL out buffer)");
 
-	testsuite_fail_unless((THEMIS_SUCCESS == themis_secure_cell_encrypt_context_imprint(key, key_length, message, message_length, context, context_length, encrypted, &encrypted_length)) && (encrypted_length == message_length), "themis_secure_cell_encrypt_context_imprint: normal flow");
+    encrypted_length--;
+    testsuite_fail_unless(
+        (THEMIS_BUFFER_TOO_SMALL == themis_secure_cell_encrypt_context_imprint(
+                                        key, key_length, message, message_length, context,
+                                        context_length, encrypted, &encrypted_length)) &&
+            (encrypted_length == message_length),
+        "themis_secure_cell_encrypt_context_imprint: get output size (small out buffer)");
 
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_cell_decrypt_context_imprint(NULL, key_length, encrypted, encrypted_length, context, context_length, decrypted, &decrypted_length), "themis_secure_cell_decrypt_context_imprint: invalid key");
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_cell_decrypt_context_imprint(key, 0, encrypted, encrypted_length, context, context_length, decrypted, &decrypted_length), "themis_secure_cell_decrypt_context_imprint: invalid key length");
+    testsuite_fail_unless((THEMIS_SUCCESS == themis_secure_cell_encrypt_context_imprint(
+                                                 key, key_length, message, message_length, context,
+                                                 context_length, encrypted, &encrypted_length)) &&
+                              (encrypted_length == message_length),
+                          "themis_secure_cell_encrypt_context_imprint: normal flow");
 
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_cell_decrypt_context_imprint(key, key_length, NULL, encrypted_length, context, context_length, decrypted, &decrypted_length), "themis_secure_cell_decrypt_context_imprint: invalid message");
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_cell_decrypt_context_imprint(key, key_length, encrypted, 0, context, context_length, decrypted, &decrypted_length), "themis_secure_cell_decrypt_context_imprint: invalid message length");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_cell_decrypt_context_imprint(
+                                                          NULL, key_length, encrypted,
+                                                          encrypted_length, context, context_length,
+                                                          decrypted, &decrypted_length),
+                          "themis_secure_cell_decrypt_context_imprint: invalid key");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_cell_decrypt_context_imprint(
+                                                          key, 0, encrypted, encrypted_length,
+                                                          context, context_length, decrypted,
+                                                          &decrypted_length),
+                          "themis_secure_cell_decrypt_context_imprint: invalid key length");
 
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_cell_decrypt_context_imprint(key, key_length, encrypted, encrypted_length, NULL, context_length, decrypted, &decrypted_length), "themis_secure_cell_decrypt_context_imprint: invalid context");
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_cell_decrypt_context_imprint(key, key_length, encrypted, encrypted_length, context, 0, decrypted, &decrypted_length), "themis_secure_cell_decrypt_context_imprint: invalid context length");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_cell_decrypt_context_imprint(
+                                                          key, key_length, NULL, encrypted_length,
+                                                          context, context_length, decrypted,
+                                                          &decrypted_length),
+                          "themis_secure_cell_decrypt_context_imprint: invalid message");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_cell_decrypt_context_imprint(
+                                                          key, key_length, encrypted, 0, context,
+                                                          context_length, decrypted,
+                                                          &decrypted_length),
+                          "themis_secure_cell_decrypt_context_imprint: invalid message length");
 
-	testsuite_fail_unless((THEMIS_BUFFER_TOO_SMALL == themis_secure_cell_decrypt_context_imprint(key, key_length, encrypted, encrypted_length, context, context_length, NULL, &decrypted_length)) && (decrypted_length == encrypted_length), "themis_secure_cell_decrypt_context_imprint: get output size (NULL out buffer)");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_secure_cell_decrypt_context_imprint(
+                                                          key, key_length, encrypted,
+                                                          encrypted_length, NULL, context_length,
+                                                          decrypted, &decrypted_length),
+                          "themis_secure_cell_decrypt_context_imprint: invalid context");
+    testsuite_fail_unless(
+        THEMIS_INVALID_PARAMETER ==
+            themis_secure_cell_decrypt_context_imprint(key, key_length, encrypted, encrypted_length,
+                                                       context, 0, decrypted, &decrypted_length),
+        "themis_secure_cell_decrypt_context_imprint: invalid context length");
 
-	decrypted_length--;
-	testsuite_fail_unless((THEMIS_BUFFER_TOO_SMALL == themis_secure_cell_decrypt_context_imprint(key, key_length, encrypted, encrypted_length, context, context_length, decrypted, &decrypted_length)) && (decrypted_length == encrypted_length), "themis_secure_cell_decrypt_context_imprint: get output size (small out buffer)");
+    testsuite_fail_unless(
+        (THEMIS_BUFFER_TOO_SMALL == themis_secure_cell_decrypt_context_imprint(
+                                        key, key_length, encrypted, encrypted_length, context,
+                                        context_length, NULL, &decrypted_length)) &&
+            (decrypted_length == encrypted_length),
+        "themis_secure_cell_decrypt_context_imprint: get output size (NULL out buffer)");
 
-	testsuite_fail_unless(THEMIS_SUCCESS == themis_secure_cell_decrypt_context_imprint(key, key_length, encrypted, encrypted_length, context, context_length, decrypted, &decrypted_length) && (message_length == decrypted_length) && (!memcmp(message, decrypted, message_length)), "themis_secure_cell_decrypt_context_imprint: normal flow");
+    decrypted_length--;
+    testsuite_fail_unless(
+        (THEMIS_BUFFER_TOO_SMALL == themis_secure_cell_decrypt_context_imprint(
+                                        key, key_length, encrypted, encrypted_length, context,
+                                        context_length, decrypted, &decrypted_length)) &&
+            (decrypted_length == encrypted_length),
+        "themis_secure_cell_decrypt_context_imprint: get output size (small out buffer)");
+
+    testsuite_fail_unless(
+        THEMIS_SUCCESS == themis_secure_cell_decrypt_context_imprint(
+                              key, key_length, encrypted, encrypted_length, context, context_length,
+                              decrypted, &decrypted_length) &&
+            (message_length == decrypted_length) && (!memcmp(message, decrypted, message_length)),
+        "themis_secure_cell_decrypt_context_imprint: normal flow");
 }
 
 static void secure_cell_api_test(void)
 {
-	secure_cell_api_test_seal();
-	secure_cell_api_test_context_imprint();
+    secure_cell_api_test_seal();
+    secure_cell_api_test_context_imprint();
 }
 
 /*
@@ -374,273 +552,337 @@ static void secure_cell_api_test(void)
 
 static inline uint32_t get_context_iv_length(const uint8_t* context)
 {
-	return ((const uint32_t*)context)[1];
+    return ((const uint32_t*)context)[1];
 }
 
 static inline void set_context_iv_length(uint8_t* context, uint32_t value)
 {
-	((uint32_t*)context)[1] = value;
+    ((uint32_t*)context)[1] = value;
 }
 
 static inline uint32_t get_context_auth_tag_length(const uint8_t* context)
 {
-	return ((const uint32_t*)context)[2];
+    return ((const uint32_t*)context)[2];
 }
 
 static inline void set_context_auth_tag_length(uint8_t* context, uint32_t value)
 {
-	((uint32_t*)context)[2] = value;
+    ((uint32_t*)context)[2] = value;
 }
 
 static inline uint32_t get_context_message_length(const uint8_t* context)
 {
-	return ((const uint32_t*)context)[3];
+    return ((const uint32_t*)context)[3];
 }
 
 static inline void set_context_message_length(uint8_t* context, uint32_t value)
 {
-	((uint32_t*)context)[3] = value;
+    ((uint32_t*)context)[3] = value;
 }
 
 static themis_status_t encrypt_seal(uint8_t** encrypted_message, size_t* encrypted_message_length)
 {
-	themis_status_t res = THEMIS_SUCCESS;
+    themis_status_t res = THEMIS_SUCCESS;
 
-	res = themis_secure_cell_encrypt_seal((uint8_t*)passwd, sizeof(passwd), NULL, 0, (uint8_t*)message, sizeof(message), NULL, encrypted_message_length);
-	if(res!=THEMIS_BUFFER_TOO_SMALL){
-		testsuite_fail_if(true, "themis_secure_cell_encrypt_seal: failed to determine encrypted message length");
-		return res;
-	}
+    res = themis_secure_cell_encrypt_seal((uint8_t*)passwd, sizeof(passwd), NULL, 0,
+                                          (uint8_t*)message, sizeof(message), NULL,
+                                          encrypted_message_length);
+    if (res != THEMIS_BUFFER_TOO_SMALL) {
+        testsuite_fail_if(
+            true, "themis_secure_cell_encrypt_seal: failed to determine encrypted message length");
+        return res;
+    }
 
-	*encrypted_message = malloc(*encrypted_message_length);
-	if(*encrypted_message==NULL){
-		testsuite_fail_if(true, "themis_secure_cell_encrypt_seal: failed to allocate memory for encrypted message");
-		return THEMIS_NO_MEMORY;
-	}
+    *encrypted_message = malloc(*encrypted_message_length);
+    if (*encrypted_message == NULL) {
+        testsuite_fail_if(
+            true,
+            "themis_secure_cell_encrypt_seal: failed to allocate memory for encrypted message");
+        return THEMIS_NO_MEMORY;
+    }
 
-	res = themis_secure_cell_encrypt_seal((uint8_t*)passwd, sizeof(passwd), NULL, 0, (uint8_t*)message, sizeof(message), *encrypted_message, encrypted_message_length);
-	if(res!=THEMIS_SUCCESS){
-		testsuite_fail_if(true, "themis_secure_cell_encrypt_seal: failed to encrypt message");
-		free(encrypted_message);
-		return res;
-	}
+    res = themis_secure_cell_encrypt_seal((uint8_t*)passwd, sizeof(passwd), NULL, 0,
+                                          (uint8_t*)message, sizeof(message), *encrypted_message,
+                                          encrypted_message_length);
+    if (res != THEMIS_SUCCESS) {
+        testsuite_fail_if(true, "themis_secure_cell_encrypt_seal: failed to encrypt message");
+        free(encrypted_message);
+        return res;
+    }
 
-	return THEMIS_SUCCESS;
+    return THEMIS_SUCCESS;
 }
 
-static themis_status_t prepare_decrypt_seal(uint8_t* encrypted_message, size_t encrypted_message_length, uint8_t** decrypted_message, size_t* decrypted_message_length)
+static themis_status_t prepare_decrypt_seal(uint8_t* encrypted_message,
+                                            size_t encrypted_message_length,
+                                            uint8_t** decrypted_message,
+                                            size_t* decrypted_message_length)
 {
-	themis_status_t res = THEMIS_SUCCESS;
+    themis_status_t res = THEMIS_SUCCESS;
 
-	res = themis_secure_cell_decrypt_seal((uint8_t*)passwd, sizeof(passwd), NULL, 0, encrypted_message, encrypted_message_length, NULL, decrypted_message_length);
-	if(res!=THEMIS_BUFFER_TOO_SMALL){
-		testsuite_fail_if(true, "themis_secure_cell_decrypt_seal: failed to determine decrypted message length");
-		return res;
-	}
+    res = themis_secure_cell_decrypt_seal((uint8_t*)passwd, sizeof(passwd), NULL, 0,
+                                          encrypted_message, encrypted_message_length, NULL,
+                                          decrypted_message_length);
+    if (res != THEMIS_BUFFER_TOO_SMALL) {
+        testsuite_fail_if(
+            true, "themis_secure_cell_decrypt_seal: failed to determine decrypted message length");
+        return res;
+    }
 
-	*decrypted_message = malloc(*decrypted_message_length);
-	if(*decrypted_message==NULL){
-		testsuite_fail_if(true, "themis_secure_cell_decrypt_seal: failed to allocate memory for decrypted message");
-		return THEMIS_NO_MEMORY;
-	}
+    *decrypted_message = malloc(*decrypted_message_length);
+    if (*decrypted_message == NULL) {
+        testsuite_fail_if(
+            true,
+            "themis_secure_cell_decrypt_seal: failed to allocate memory for decrypted message");
+        return THEMIS_NO_MEMORY;
+    }
 
-	return THEMIS_SUCCESS;
+    return THEMIS_SUCCESS;
 }
 
 static void secure_cell_context_corruption_seal(void)
 {
-	themis_status_t res = THEMIS_SUCCESS;
+    themis_status_t res = THEMIS_SUCCESS;
 
-	uint8_t* encrypted_message = NULL;
-	size_t encrypted_message_length = 0;
+    uint8_t* encrypted_message = NULL;
+    size_t encrypted_message_length = 0;
 
-	res = encrypt_seal(&encrypted_message, &encrypted_message_length);
-	if(res!=THEMIS_SUCCESS){
-		goto out;
-	}
+    res = encrypt_seal(&encrypted_message, &encrypted_message_length);
+    if (res != THEMIS_SUCCESS) {
+        goto out;
+    }
 
-	uint32_t old_value = 0;
+    uint32_t old_value = 0;
 
-	uint8_t* decrypted_message = NULL;
-	size_t decrypted_message_length = 0;
+    uint8_t* decrypted_message = NULL;
+    size_t decrypted_message_length = 0;
 
-	old_value = get_context_iv_length(encrypted_message);
-	set_context_iv_length(encrypted_message, 0xDEADBEEF);
-	{
-		res = prepare_decrypt_seal(encrypted_message, encrypted_message_length, &decrypted_message, &decrypted_message_length);
-		if(res!=THEMIS_SUCCESS){
-			goto out;
-		}
+    old_value = get_context_iv_length(encrypted_message);
+    set_context_iv_length(encrypted_message, 0xDEADBEEF);
+    {
+        res = prepare_decrypt_seal(encrypted_message, encrypted_message_length, &decrypted_message,
+                                   &decrypted_message_length);
+        if (res != THEMIS_SUCCESS) {
+            goto out;
+        }
 
-		res = themis_secure_cell_decrypt_seal((uint8_t*)passwd, sizeof(passwd), NULL, 0, encrypted_message, encrypted_message_length, decrypted_message, &decrypted_message_length);
-		testsuite_fail_if(res==THEMIS_SUCCESS, "themis_secure_cell_decrypt_seal detects corrupted IV length");
+        res = themis_secure_cell_decrypt_seal((uint8_t*)passwd, sizeof(passwd), NULL, 0,
+                                              encrypted_message, encrypted_message_length,
+                                              decrypted_message, &decrypted_message_length);
+        testsuite_fail_if(res == THEMIS_SUCCESS,
+                          "themis_secure_cell_decrypt_seal detects corrupted IV length");
 
-		free(decrypted_message);
-	}
-	set_context_iv_length(encrypted_message, old_value);
+        free(decrypted_message);
+    }
+    set_context_iv_length(encrypted_message, old_value);
 
-	old_value = get_context_auth_tag_length(encrypted_message);
-	set_context_auth_tag_length(encrypted_message, 0xDEADBEEF);
-	{
-		res = prepare_decrypt_seal(encrypted_message, encrypted_message_length, &decrypted_message, &decrypted_message_length);
-		if(res!=THEMIS_SUCCESS){
-			goto out;
-		}
+    old_value = get_context_auth_tag_length(encrypted_message);
+    set_context_auth_tag_length(encrypted_message, 0xDEADBEEF);
+    {
+        res = prepare_decrypt_seal(encrypted_message, encrypted_message_length, &decrypted_message,
+                                   &decrypted_message_length);
+        if (res != THEMIS_SUCCESS) {
+            goto out;
+        }
 
-		res = themis_secure_cell_decrypt_seal((uint8_t*)passwd, sizeof(passwd), NULL, 0, encrypted_message, encrypted_message_length, decrypted_message, &decrypted_message_length);
-		testsuite_fail_if(res==THEMIS_SUCCESS, "themis_secure_cell_decrypt_seal detects corrupted auth tag length");
+        res = themis_secure_cell_decrypt_seal((uint8_t*)passwd, sizeof(passwd), NULL, 0,
+                                              encrypted_message, encrypted_message_length,
+                                              decrypted_message, &decrypted_message_length);
+        testsuite_fail_if(res == THEMIS_SUCCESS,
+                          "themis_secure_cell_decrypt_seal detects corrupted auth tag length");
 
-		free(decrypted_message);
-	}
-	set_context_auth_tag_length(encrypted_message, old_value);
+        free(decrypted_message);
+    }
+    set_context_auth_tag_length(encrypted_message, old_value);
 
-	old_value = get_context_message_length(encrypted_message);
-	set_context_message_length(encrypted_message, 0xDEADBEEF);
-	{
-		res = themis_secure_cell_decrypt_seal((uint8_t*)passwd, sizeof(passwd), NULL, 0, encrypted_message, encrypted_message_length, NULL, &decrypted_message_length);
-		testsuite_fail_if(res==THEMIS_BUFFER_TOO_SMALL, "themis_secure_cell_decrypt_seal detects corrupted message length");
-	}
-	set_context_message_length(encrypted_message, old_value);
+    old_value = get_context_message_length(encrypted_message);
+    set_context_message_length(encrypted_message, 0xDEADBEEF);
+    {
+        res = themis_secure_cell_decrypt_seal((uint8_t*)passwd, sizeof(passwd), NULL, 0,
+                                              encrypted_message, encrypted_message_length, NULL,
+                                              &decrypted_message_length);
+        testsuite_fail_if(res == THEMIS_BUFFER_TOO_SMALL,
+                          "themis_secure_cell_decrypt_seal detects corrupted message length");
+    }
+    set_context_message_length(encrypted_message, old_value);
 
 out:
-	free(encrypted_message);
+    free(encrypted_message);
 }
 
-static themis_status_t encrypt_token_protect(uint8_t** encrypted_message, size_t* encrypted_message_length, uint8_t** context, size_t* context_length)
+static themis_status_t encrypt_token_protect(uint8_t** encrypted_message,
+                                             size_t* encrypted_message_length, uint8_t** context,
+                                             size_t* context_length)
 {
-	themis_status_t res = THEMIS_SUCCESS;
+    themis_status_t res = THEMIS_SUCCESS;
 
-	res = themis_secure_cell_encrypt_token_protect((uint8_t*)passwd, sizeof(passwd), NULL, 0, (uint8_t*)message, sizeof(message), NULL, context_length, NULL, encrypted_message_length);
-	if(res!=THEMIS_BUFFER_TOO_SMALL || context_length==0 || encrypted_message_length==0){
-		testsuite_fail_if(true, "themis_secure_cell_encrypt_token_protect: failed to determine encrypted message length");
-		return res;
-	}
+    res = themis_secure_cell_encrypt_token_protect((uint8_t*)passwd, sizeof(passwd), NULL, 0,
+                                                   (uint8_t*)message, sizeof(message), NULL,
+                                                   context_length, NULL, encrypted_message_length);
+    if (res != THEMIS_BUFFER_TOO_SMALL || context_length == 0 || encrypted_message_length == 0) {
+        testsuite_fail_if(true, "themis_secure_cell_encrypt_token_protect: failed to determine "
+                                "encrypted message length");
+        return res;
+    }
 
-	*encrypted_message = malloc(*encrypted_message_length);
-	if(*encrypted_message==NULL){
-		testsuite_fail_if(true, "themis_secure_cell_encrypt_token_protect: failed to allocate memory for encrypted message");
-		return res;
-	}
+    *encrypted_message = malloc(*encrypted_message_length);
+    if (*encrypted_message == NULL) {
+        testsuite_fail_if(true, "themis_secure_cell_encrypt_token_protect: failed to allocate "
+                                "memory for encrypted message");
+        return res;
+    }
 
-	*context = malloc(*context_length);
-	if(*context==NULL){
-		testsuite_fail_if(true, "themis_secure_cell_encrypt_token_protect: failed to allocate memory for auth context");
-		free(*encrypted_message);
-		return res;
-	}
+    *context = malloc(*context_length);
+    if (*context == NULL) {
+        testsuite_fail_if(
+            true,
+            "themis_secure_cell_encrypt_token_protect: failed to allocate memory for auth context");
+        free(*encrypted_message);
+        return res;
+    }
 
-	res = themis_secure_cell_encrypt_token_protect((uint8_t*)passwd, sizeof(passwd), NULL, 0, (uint8_t*)message, sizeof(message), *context, context_length, *encrypted_message, encrypted_message_length);
-	if(res!=THEMIS_SUCCESS){
-		testsuite_fail_if(true, "themis_secure_cell_encrypt_token_protect: failed to encrypt message");
-		free(*encrypted_message);
-		free(*context);
-		return res;
-	}
+    res = themis_secure_cell_encrypt_token_protect(
+        (uint8_t*)passwd, sizeof(passwd), NULL, 0, (uint8_t*)message, sizeof(message), *context,
+        context_length, *encrypted_message, encrypted_message_length);
+    if (res != THEMIS_SUCCESS) {
+        testsuite_fail_if(true,
+                          "themis_secure_cell_encrypt_token_protect: failed to encrypt message");
+        free(*encrypted_message);
+        free(*context);
+        return res;
+    }
 
-	return THEMIS_SUCCESS;
+    return THEMIS_SUCCESS;
 }
 
-static themis_status_t prepare_decrypt_token_protect(uint8_t* encrypted_message, size_t encrypted_message_length, uint8_t* context, size_t context_length, uint8_t** decrypted_message, size_t* decrypted_message_length)
+static themis_status_t prepare_decrypt_token_protect(uint8_t* encrypted_message,
+                                                     size_t encrypted_message_length,
+                                                     uint8_t* context, size_t context_length,
+                                                     uint8_t** decrypted_message,
+                                                     size_t* decrypted_message_length)
 {
-	themis_status_t res = THEMIS_SUCCESS;
+    themis_status_t res = THEMIS_SUCCESS;
 
-	res = themis_secure_cell_decrypt_token_protect((uint8_t*)passwd, sizeof(passwd), NULL, 0, encrypted_message, encrypted_message_length, context, context_length, NULL, decrypted_message_length);
-	if(res!=THEMIS_BUFFER_TOO_SMALL || decrypted_message_length==0){
-		testsuite_fail_if(true, "themis_secure_cell_decrypt_token_protect: failed to determine decrypted message length");
-		return res;
-	}
+    res = themis_secure_cell_decrypt_token_protect(
+        (uint8_t*)passwd, sizeof(passwd), NULL, 0, encrypted_message, encrypted_message_length,
+        context, context_length, NULL, decrypted_message_length);
+    if (res != THEMIS_BUFFER_TOO_SMALL || decrypted_message_length == 0) {
+        testsuite_fail_if(true, "themis_secure_cell_decrypt_token_protect: failed to determine "
+                                "decrypted message length");
+        return res;
+    }
 
-	*decrypted_message = malloc(*decrypted_message_length);
-	if(*decrypted_message==NULL){
-		testsuite_fail_if(true, "themis_secure_cell_decrypt_token_protect: failed to allocate memory for decrypted message");
-		return THEMIS_NO_MEMORY;
-	}
+    *decrypted_message = malloc(*decrypted_message_length);
+    if (*decrypted_message == NULL) {
+        testsuite_fail_if(true, "themis_secure_cell_decrypt_token_protect: failed to allocate "
+                                "memory for decrypted message");
+        return THEMIS_NO_MEMORY;
+    }
 
-	return THEMIS_SUCCESS;
+    return THEMIS_SUCCESS;
 }
 
 static void secure_cell_context_corruption_token_protect(void)
 {
-	themis_status_t res = THEMIS_SUCCESS;
+    themis_status_t res = THEMIS_SUCCESS;
 
-	uint8_t* encrypted_message = NULL;
-	size_t encrypted_message_length = 0;
-	uint8_t* context = NULL;
-	size_t context_length = 0;
+    uint8_t* encrypted_message = NULL;
+    size_t encrypted_message_length = 0;
+    uint8_t* context = NULL;
+    size_t context_length = 0;
 
-	res = encrypt_token_protect(&encrypted_message, &encrypted_message_length, &context, &context_length);
-	if(res!=THEMIS_SUCCESS){
-		goto out;
-	}
+    res = encrypt_token_protect(&encrypted_message, &encrypted_message_length, &context,
+                                &context_length);
+    if (res != THEMIS_SUCCESS) {
+        goto out;
+    }
 
-	uint32_t old_value = 0;
+    uint32_t old_value = 0;
 
-	uint8_t* decrypted_message = NULL;
-	size_t decrypted_message_length = 0;
+    uint8_t* decrypted_message = NULL;
+    size_t decrypted_message_length = 0;
 
-	old_value = get_context_iv_length(context);
-	set_context_iv_length(context, 0xDEADBEEF);
-	{
-		res = prepare_decrypt_token_protect(encrypted_message, encrypted_message_length, context, context_length, &decrypted_message, &decrypted_message_length);
-		if(res!=THEMIS_SUCCESS){
-			goto out;
-		}
+    old_value = get_context_iv_length(context);
+    set_context_iv_length(context, 0xDEADBEEF);
+    {
+        res = prepare_decrypt_token_protect(encrypted_message, encrypted_message_length, context,
+                                            context_length, &decrypted_message,
+                                            &decrypted_message_length);
+        if (res != THEMIS_SUCCESS) {
+            goto out;
+        }
 
-		res = themis_secure_cell_decrypt_token_protect((uint8_t*)passwd, sizeof(passwd), NULL, 0, encrypted_message, encrypted_message_length, context, context_length, decrypted_message, &decrypted_message_length);
-		testsuite_fail_if(res==THEMIS_SUCCESS, "themis_secure_cell_decrypt_token_protect detects corrupted IV length");
+        res = themis_secure_cell_decrypt_token_protect(
+            (uint8_t*)passwd, sizeof(passwd), NULL, 0, encrypted_message, encrypted_message_length,
+            context, context_length, decrypted_message, &decrypted_message_length);
+        testsuite_fail_if(res == THEMIS_SUCCESS,
+                          "themis_secure_cell_decrypt_token_protect detects corrupted IV length");
 
-		free(decrypted_message);
-	}
-	set_context_iv_length(context, old_value);
+        free(decrypted_message);
+    }
+    set_context_iv_length(context, old_value);
 
-	old_value = get_context_auth_tag_length(context);
-	set_context_auth_tag_length(context, 0xDEADBEEF);
-	{
-		res = prepare_decrypt_token_protect(encrypted_message, encrypted_message_length, context, context_length, &decrypted_message, &decrypted_message_length);
-		if(res!=THEMIS_SUCCESS){
-			goto out;
-		}
+    old_value = get_context_auth_tag_length(context);
+    set_context_auth_tag_length(context, 0xDEADBEEF);
+    {
+        res = prepare_decrypt_token_protect(encrypted_message, encrypted_message_length, context,
+                                            context_length, &decrypted_message,
+                                            &decrypted_message_length);
+        if (res != THEMIS_SUCCESS) {
+            goto out;
+        }
 
-		res = themis_secure_cell_decrypt_token_protect((uint8_t*)passwd, sizeof(passwd), NULL, 0, encrypted_message, encrypted_message_length, context, context_length, decrypted_message, &decrypted_message_length);
-		testsuite_fail_if(res==THEMIS_SUCCESS, "themis_secure_cell_decrypt_token_protect detects corrupted auth tag length");
+        res = themis_secure_cell_decrypt_token_protect(
+            (uint8_t*)passwd, sizeof(passwd), NULL, 0, encrypted_message, encrypted_message_length,
+            context, context_length, decrypted_message, &decrypted_message_length);
+        testsuite_fail_if(
+            res == THEMIS_SUCCESS,
+            "themis_secure_cell_decrypt_token_protect detects corrupted auth tag length");
 
-		free(decrypted_message);
-	}
-	set_context_auth_tag_length(context, old_value);
+        free(decrypted_message);
+    }
+    set_context_auth_tag_length(context, old_value);
 
-	old_value = get_context_message_length(context);
-	set_context_message_length(context, 0xDEADBEEF);
-	{
-		res = prepare_decrypt_token_protect(encrypted_message, encrypted_message_length, context, context_length, &decrypted_message, &decrypted_message_length);
-		if(res!=THEMIS_SUCCESS){
-			goto out;
-		}
+    old_value = get_context_message_length(context);
+    set_context_message_length(context, 0xDEADBEEF);
+    {
+        res = prepare_decrypt_token_protect(encrypted_message, encrypted_message_length, context,
+                                            context_length, &decrypted_message,
+                                            &decrypted_message_length);
+        if (res != THEMIS_SUCCESS) {
+            goto out;
+        }
 
-		res = themis_secure_cell_decrypt_token_protect((uint8_t*)passwd, sizeof(passwd), NULL, 0, encrypted_message, encrypted_message_length, context, context_length, decrypted_message, &decrypted_message_length);
-		testsuite_fail_if(res==THEMIS_SUCCESS, "themis_secure_cell_decrypt_token_protect detects corrupted message length");
+        res = themis_secure_cell_decrypt_token_protect(
+            (uint8_t*)passwd, sizeof(passwd), NULL, 0, encrypted_message, encrypted_message_length,
+            context, context_length, decrypted_message, &decrypted_message_length);
+        testsuite_fail_if(
+            res == THEMIS_SUCCESS,
+            "themis_secure_cell_decrypt_token_protect detects corrupted message length");
 
-		free(decrypted_message);
-	}
-	set_context_message_length(context, old_value);
+        free(decrypted_message);
+    }
+    set_context_message_length(context, old_value);
 
 out:
-	free(encrypted_message);
-	free(context);
+    free(encrypted_message);
+    free(context);
 }
 
 static void secure_cell_context_corruption(void)
 {
-	secure_cell_context_corruption_seal();
-	secure_cell_context_corruption_token_protect();
+    secure_cell_context_corruption_seal();
+    secure_cell_context_corruption_token_protect();
 }
 
-void run_secure_cell_test(){
-  testsuite_enter_suite("secure cell: basic flow");
-  testsuite_run_test(secure_cell_test);
+void run_secure_cell_test()
+{
+    testsuite_enter_suite("secure cell: basic flow");
+    testsuite_run_test(secure_cell_test);
 
-  testsuite_enter_suite("secure cell: api test");
-  testsuite_run_test(secure_cell_api_test);
+    testsuite_enter_suite("secure cell: api test");
+    testsuite_run_test(secure_cell_api_test);
 
-  testsuite_enter_suite("secure cell: context corruption");
-  testsuite_run_test(secure_cell_context_corruption);
+    testsuite_enter_suite("secure cell: context corruption");
+    testsuite_run_test(secure_cell_context_corruption);
 }

--- a/tests/themis/themis_secure_comparator.c
+++ b/tests/themis/themis_secure_comparator.c
@@ -1,18 +1,18 @@
 /*
-* Copyright (c) 2015 Cossack Labs Limited
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2015 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "themis/themis_test.h"
 
@@ -33,8 +33,8 @@ void secure_comparator_security_test(void);
 static uint8_t secret[MAX_SECRET_SIZE];
 static size_t secret_length = sizeof(secret);
 
-static secure_comparator_t *alice = NULL;
-static secure_comparator_t *bob = NULL;
+static secure_comparator_t* alice = NULL;
+static secure_comparator_t* bob = NULL;
 
 /* Peers will communicate using shared memory */
 static uint8_t shared_mem[512];
@@ -42,205 +42,212 @@ static size_t current_length = 0;
 
 static int alice_function(void)
 {
-	size_t input_length = current_length;
-	themis_status_t themis_status;
+    size_t input_length = current_length;
+    themis_status_t themis_status;
 
-	current_length = sizeof(shared_mem);
+    current_length = sizeof(shared_mem);
 
-	themis_status = secure_comparator_proceed_compare(alice, shared_mem, input_length, shared_mem, &current_length);
+    themis_status = secure_comparator_proceed_compare(alice, shared_mem, input_length, shared_mem,
+                                                      &current_length);
 
-	switch (themis_status)
-	{
-	case THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER:
-		if (0 == current_length)
-		{
-			testsuite_fail_if(true, "secure_comparator_proceed_compare: invalid output length");
-			return TEST_STOP_ERROR;
-		}
-		return TEST_CONTINUE;
-	case THEMIS_SUCCESS:
-		if (current_length > 0)
-		{
-			testsuite_fail_if(true, "secure_comparator_proceed_compare: invalid output length");
-			return TEST_STOP_ERROR;
-		}
-		return TEST_STOP_SUCCESS;
-	default:
-		return TEST_STOP_ERROR;
-	}
+    switch (themis_status) {
+    case THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER:
+        if (0 == current_length) {
+            testsuite_fail_if(true, "secure_comparator_proceed_compare: invalid output length");
+            return TEST_STOP_ERROR;
+        }
+        return TEST_CONTINUE;
+    case THEMIS_SUCCESS:
+        if (current_length > 0) {
+            testsuite_fail_if(true, "secure_comparator_proceed_compare: invalid output length");
+            return TEST_STOP_ERROR;
+        }
+        return TEST_STOP_SUCCESS;
+    default:
+        return TEST_STOP_ERROR;
+    }
 }
 
 static int bob_function(void)
 {
-	size_t input_length = current_length;
-	themis_status_t themis_status;
+    size_t input_length = current_length;
+    themis_status_t themis_status;
 
-	current_length = sizeof(shared_mem);
+    current_length = sizeof(shared_mem);
 
-	themis_status = secure_comparator_proceed_compare(bob, shared_mem, input_length, shared_mem, &current_length);
+    themis_status = secure_comparator_proceed_compare(bob, shared_mem, input_length, shared_mem,
+                                                      &current_length);
 
-	switch (themis_status)
-	{
-	case THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER:
-		if (0 == current_length)
-		{
-			testsuite_fail_if(true, "secure_comparator_proceed_compare: invalid output length");
-			return TEST_STOP_ERROR;
-		}
-		return TEST_CONTINUE;
-	/* bob (as a responder) should not return THEMIS_SUCCESS */
-	default:
-		return TEST_STOP_ERROR;
-	}
+    switch (themis_status) {
+    case THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER:
+        if (0 == current_length) {
+            testsuite_fail_if(true, "secure_comparator_proceed_compare: invalid output length");
+            return TEST_STOP_ERROR;
+        }
+        return TEST_CONTINUE;
+    /* bob (as a responder) should not return THEMIS_SUCCESS */
+    default:
+        return TEST_STOP_ERROR;
+    }
 }
 
 static void schedule(void)
 {
-	int (*peer_run)(void) = bob_function;
-	int res = TEST_CONTINUE;
-	themis_status_t themis_status;
+    int (*peer_run)(void) = bob_function;
+    int res = TEST_CONTINUE;
+    themis_status_t themis_status;
 
-	/* alice starts */
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == secure_comparator_begin_compare(NULL, shared_mem, &current_length), "secure_comparator_begin_compare: invalid context");
-	testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL == secure_comparator_begin_compare(alice, NULL, &current_length), "secure_comparator_begin_compare: get output size (NULL out buffer)");
-	current_length--;
-	testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL == secure_comparator_begin_compare(alice, shared_mem, &current_length), "secure_comparator_begin_compare: get output size (small out buffer)");
+    /* alice starts */
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              secure_comparator_begin_compare(NULL, shared_mem, &current_length),
+                          "secure_comparator_begin_compare: invalid context");
+    testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL ==
+                              secure_comparator_begin_compare(alice, NULL, &current_length),
+                          "secure_comparator_begin_compare: get output size (NULL out buffer)");
+    current_length--;
+    testsuite_fail_unless(THEMIS_BUFFER_TOO_SMALL ==
+                              secure_comparator_begin_compare(alice, shared_mem, &current_length),
+                          "secure_comparator_begin_compare: get output size (small out buffer)");
 
-	themis_status = secure_comparator_begin_compare(alice, shared_mem, &current_length);
-	if (THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER != themis_status)
-	{
-		testsuite_fail_if(true, "secure_comparator_begin_compare: failed");
-		return;
-	}
+    themis_status = secure_comparator_begin_compare(alice, shared_mem, &current_length);
+    if (THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER != themis_status) {
+        testsuite_fail_if(true, "secure_comparator_begin_compare: failed");
+        return;
+    }
 
-	while (TEST_CONTINUE == res)
-	{
-		res = peer_run();
-		peer_run = (peer_run == alice_function) ? bob_function : alice_function;
-	}
+    while (TEST_CONTINUE == res) {
+        res = peer_run();
+        peer_run = (peer_run == alice_function) ? bob_function : alice_function;
+    }
 
-	testsuite_fail_if(res, "secure comparator: protocol exchange");
+    testsuite_fail_if(res, "secure comparator: protocol exchange");
 }
 
 static void secure_comparator_api_test(void)
 {
-	/* setup */
-	themis_status_t themis_status;
-	secret_length = rand_int(MAX_SECRET_SIZE);
-	if (SOTER_SUCCESS != soter_rand(secret, secret_length))
-	{
-		testsuite_fail_if(true, "soter_rand failed");
-		return;
-	}
+    /* setup */
+    themis_status_t themis_status;
+    secret_length = rand_int(MAX_SECRET_SIZE);
+    if (SOTER_SUCCESS != soter_rand(secret, secret_length)) {
+        testsuite_fail_if(true, "soter_rand failed");
+        return;
+    }
 
-	/* match */
-	alice = secure_comparator_create();
-	if (!alice)
-	{
-		testsuite_fail_if(true, "secure_comparator_create failed");
-		return;
-	}
+    /* match */
+    alice = secure_comparator_create();
+    if (!alice) {
+        testsuite_fail_if(true, "secure_comparator_create failed");
+        return;
+    }
 
-	bob = secure_comparator_create();
-	if (!bob)
-	{
-		testsuite_fail_if(true, "secure_comparator_create failed");
-		secure_comparator_destroy(alice);
-		alice = NULL;
-		return;
-	}
+    bob = secure_comparator_create();
+    if (!bob) {
+        testsuite_fail_if(true, "secure_comparator_create failed");
+        secure_comparator_destroy(alice);
+        alice = NULL;
+        return;
+    }
 
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == secure_comparator_append_secret(NULL, secret, secret_length), "secure_comparator_append_secret: invalid context");
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == secure_comparator_append_secret(alice, NULL, secret_length), "secure_comparator_append_secret: invalid input buffer");
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == secure_comparator_append_secret(alice, secret, 0), "secure_comparator_append_secret: invalid input length");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              secure_comparator_append_secret(NULL, secret, secret_length),
+                          "secure_comparator_append_secret: invalid context");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              secure_comparator_append_secret(alice, NULL, secret_length),
+                          "secure_comparator_append_secret: invalid input buffer");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER ==
+                              secure_comparator_append_secret(alice, secret, 0),
+                          "secure_comparator_append_secret: invalid input length");
 
-	themis_status = secure_comparator_append_secret(alice, secret, secret_length);
-	if (THEMIS_SUCCESS != themis_status)
-	{
-		testsuite_fail_if(true, "secure_comparator_append_secret failed");
-		secure_comparator_destroy(bob);
-		bob = NULL;
-		secure_comparator_destroy(alice);
-		alice = NULL;
-		return;
-	}
+    themis_status = secure_comparator_append_secret(alice, secret, secret_length);
+    if (THEMIS_SUCCESS != themis_status) {
+        testsuite_fail_if(true, "secure_comparator_append_secret failed");
+        secure_comparator_destroy(bob);
+        bob = NULL;
+        secure_comparator_destroy(alice);
+        alice = NULL;
+        return;
+    }
 
-	themis_status = secure_comparator_append_secret(bob, secret, secret_length);
-	if (THEMIS_SUCCESS != themis_status)
-	{
-		testsuite_fail_if(true, "secure_comparator_append_secret failed");
-		secure_comparator_destroy(bob);
-		bob = NULL;
-		secure_comparator_destroy(alice);
-		alice = NULL;
-		return;
-	}
+    themis_status = secure_comparator_append_secret(bob, secret, secret_length);
+    if (THEMIS_SUCCESS != themis_status) {
+        testsuite_fail_if(true, "secure_comparator_append_secret failed");
+        secure_comparator_destroy(bob);
+        bob = NULL;
+        secure_comparator_destroy(alice);
+        alice = NULL;
+        return;
+    }
 
-	schedule();
+    schedule();
 
-	testsuite_fail_unless((THEMIS_SCOMPARE_MATCH == secure_comparator_get_result(alice)) && (THEMIS_SCOMPARE_MATCH == secure_comparator_get_result(bob)), "compare result match");
+    testsuite_fail_unless((THEMIS_SCOMPARE_MATCH == secure_comparator_get_result(alice)) &&
+                              (THEMIS_SCOMPARE_MATCH == secure_comparator_get_result(bob)),
+                          "compare result match");
 
-	testsuite_fail_unless(THEMIS_INVALID_PARAMETER == secure_comparator_destroy(NULL), "secure_comparator_destroy: invalid context");
-	testsuite_fail_unless(THEMIS_SUCCESS == secure_comparator_destroy(bob), "secure_comparator_destroy: destroy bob");
-	testsuite_fail_unless(THEMIS_SUCCESS == secure_comparator_destroy(alice), "secure_comparator_destroy: destroy alice");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER == secure_comparator_destroy(NULL),
+                          "secure_comparator_destroy: invalid context");
+    testsuite_fail_unless(THEMIS_SUCCESS == secure_comparator_destroy(bob),
+                          "secure_comparator_destroy: destroy bob");
+    testsuite_fail_unless(THEMIS_SUCCESS == secure_comparator_destroy(alice),
+                          "secure_comparator_destroy: destroy alice");
 
-	bob = NULL;
-	alice = NULL;
+    bob = NULL;
+    alice = NULL;
 
-	alice = secure_comparator_create();
-	if (!alice)
-	{
-		testsuite_fail_if(true, "secure_comparator_create failed");
-		return;
-	}
+    alice = secure_comparator_create();
+    if (!alice) {
+        testsuite_fail_if(true, "secure_comparator_create failed");
+        return;
+    }
 
-	bob = secure_comparator_create();
-	if (!bob)
-	{
-		testsuite_fail_if(true, "secure_comparator_create failed");
-		secure_comparator_destroy(alice);
-		alice = NULL;
-		return;
-	}
+    bob = secure_comparator_create();
+    if (!bob) {
+        testsuite_fail_if(true, "secure_comparator_create failed");
+        secure_comparator_destroy(alice);
+        alice = NULL;
+        return;
+    }
 
-	themis_status = secure_comparator_append_secret(alice, secret, secret_length);
-	if (THEMIS_SUCCESS != themis_status)
-	{
-		testsuite_fail_if(true, "secure_comparator_append_secret failed");
-		secure_comparator_destroy(bob);
-		bob = NULL;
-		secure_comparator_destroy(alice);
-		alice = NULL;
-		return;
-	}
+    themis_status = secure_comparator_append_secret(alice, secret, secret_length);
+    if (THEMIS_SUCCESS != themis_status) {
+        testsuite_fail_if(true, "secure_comparator_append_secret failed");
+        secure_comparator_destroy(bob);
+        bob = NULL;
+        secure_comparator_destroy(alice);
+        alice = NULL;
+        return;
+    }
 
-	themis_status = secure_comparator_append_secret(bob, secret, secret_length - 1);
-	if (THEMIS_SUCCESS != themis_status)
-	{
-		testsuite_fail_if(true, "secure_comparator_append_secret failed");
-		secure_comparator_destroy(bob);
-		bob = NULL;
-		secure_comparator_destroy(alice);
-		alice = NULL;
-		return;
-	}
+    themis_status = secure_comparator_append_secret(bob, secret, secret_length - 1);
+    if (THEMIS_SUCCESS != themis_status) {
+        testsuite_fail_if(true, "secure_comparator_append_secret failed");
+        secure_comparator_destroy(bob);
+        bob = NULL;
+        secure_comparator_destroy(alice);
+        alice = NULL;
+        return;
+    }
 
-	schedule();
+    schedule();
 
-	testsuite_fail_unless((THEMIS_SCOMPARE_NO_MATCH == secure_comparator_get_result(alice)) && (THEMIS_SCOMPARE_NO_MATCH == secure_comparator_get_result(bob)), "compare result no match");
+    testsuite_fail_unless((THEMIS_SCOMPARE_NO_MATCH == secure_comparator_get_result(alice)) &&
+                              (THEMIS_SCOMPARE_NO_MATCH == secure_comparator_get_result(bob)),
+                          "compare result no match");
 
-	testsuite_fail_unless(THEMIS_SUCCESS == secure_comparator_destroy(bob), "secure_comparator_destroy: destroy bob");
-	testsuite_fail_unless(THEMIS_SUCCESS == secure_comparator_destroy(alice), "secure_comparator_destroy: destroy alice");
+    testsuite_fail_unless(THEMIS_SUCCESS == secure_comparator_destroy(bob),
+                          "secure_comparator_destroy: destroy bob");
+    testsuite_fail_unless(THEMIS_SUCCESS == secure_comparator_destroy(alice),
+                          "secure_comparator_destroy: destroy alice");
 
-	bob = NULL;
-	alice = NULL;
+    bob = NULL;
+    alice = NULL;
 }
 
 void run_secure_comparator_test(void)
 {
-	testsuite_enter_suite("secure comparator: api test");
-	testsuite_run_test(secure_comparator_api_test);
+    testsuite_enter_suite("secure comparator: api test");
+    testsuite_run_test(secure_comparator_api_test);
 
-	testsuite_enter_suite("secure comparator: security test");
-	testsuite_run_test(secure_comparator_security_test);
+    testsuite_enter_suite("secure comparator: security test");
+    testsuite_run_test(secure_comparator_security_test);
 }

--- a/tests/themis/themis_secure_comparator_security.c
+++ b/tests/themis/themis_secure_comparator_security.c
@@ -18,319 +18,310 @@ static size_t current_length = 0;
 
 /* below functions are copied from secure_comparator.c */
 /* Having duplicate code in tests is better than making them public in real code */
-static bool ge_is_zero(const ge_p3 *ge)
+static bool ge_is_zero(const ge_p3* ge)
 {
-	uint8_t y[ED25519_GE_LENGTH];
-	uint8_t z[ED25519_GE_LENGTH];
+    uint8_t y[ED25519_GE_LENGTH];
+    uint8_t z[ED25519_GE_LENGTH];
 
-	fe_tobytes(y, ge->Y);
-	fe_tobytes(z, ge->Z);
+    fe_tobytes(y, ge->Y);
+    fe_tobytes(z, ge->Z);
 
-	return (!fe_isnonzero(ge->X)) && (!crypto_verify_32(y, z));
+    return (!fe_isnonzero(ge->X)) && (!crypto_verify_32(y, z));
 }
 
-static themis_status_t ed_sign(uint8_t pos, const uint8_t *scalar, uint8_t *signature)
+static themis_status_t ed_sign(uint8_t pos, const uint8_t* scalar, uint8_t* signature)
 {
-	uint8_t r[ED25519_GE_LENGTH];
-	ge_p3 R;
-	uint8_t k[64];
-	size_t hash_length = 64;
-	themis_status_t res;
+    uint8_t r[ED25519_GE_LENGTH];
+    ge_p3 R;
+    uint8_t k[64];
+    size_t hash_length = 64;
+    themis_status_t res;
 
-	generate_random_32(r);
-	ge_scalarmult_base(&R, r);
-	ge_p3_tobytes(k, &R);
+    generate_random_32(r);
+    ge_scalarmult_base(&R, r);
+    ge_p3_tobytes(k, &R);
 
-	soter_hash_ctx_t* hash_ctx = soter_hash_create(SOTER_HASH_SHA512);
-	if (!hash_ctx)
-	{
-		return THEMIS_FAIL;
-	}
+    soter_hash_ctx_t* hash_ctx = soter_hash_create(SOTER_HASH_SHA512);
+    if (!hash_ctx) {
+        return THEMIS_FAIL;
+    }
 
-	res = soter_hash_update(hash_ctx, k, ED25519_GE_LENGTH);
-	if (THEMIS_SUCCESS != res)
-	{
-		soter_hash_destroy(hash_ctx);
-		return res;
-	}
+    res = soter_hash_update(hash_ctx, k, ED25519_GE_LENGTH);
+    if (THEMIS_SUCCESS != res) {
+        soter_hash_destroy(hash_ctx);
+        return res;
+    }
 
-	res = soter_hash_update(hash_ctx, &pos, sizeof(pos));
-	if (THEMIS_SUCCESS != res)
-	{
-		soter_hash_destroy(hash_ctx);
-		return res;
-	}
+    res = soter_hash_update(hash_ctx, &pos, sizeof(pos));
+    if (THEMIS_SUCCESS != res) {
+        soter_hash_destroy(hash_ctx);
+        return res;
+    }
 
-	res = soter_hash_final(hash_ctx, k, &hash_length);
-	soter_hash_destroy(hash_ctx);
-	if (THEMIS_SUCCESS == res)
-	{
-		sc_reduce(k);
+    res = soter_hash_final(hash_ctx, k, &hash_length);
+    soter_hash_destroy(hash_ctx);
+    if (THEMIS_SUCCESS == res) {
+        sc_reduce(k);
 
-		memcpy(signature, k, ED25519_GE_LENGTH);
-		sc_muladd(signature + ED25519_GE_LENGTH, k, scalar, r);
-	}
+        memcpy(signature, k, ED25519_GE_LENGTH);
+        sc_muladd(signature + ED25519_GE_LENGTH, k, scalar, r);
+    }
 
-	return res;
+    return res;
 }
 
-static themis_status_t ed_dbl_base_sign(uint8_t pos, const uint8_t *scalar1, const uint8_t *scalar2, const ge_p3 *base1, const ge_p3 *base2, uint8_t *signature)
+static themis_status_t ed_dbl_base_sign(uint8_t pos, const uint8_t* scalar1, const uint8_t* scalar2,
+                                        const ge_p3* base1, const ge_p3* base2, uint8_t* signature)
 {
-	uint8_t r1[ED25519_GE_LENGTH];
-	uint8_t r2[ED25519_GE_LENGTH];
-	ge_p3 R1;
-	ge_p2 R2;
-	uint8_t k[64];
+    uint8_t r1[ED25519_GE_LENGTH];
+    uint8_t r2[ED25519_GE_LENGTH];
+    ge_p3 R1;
+    ge_p2 R2;
+    uint8_t k[64];
 
-	size_t hash_length = 64;
+    size_t hash_length = 64;
 
-	themis_status_t res;
+    themis_status_t res;
 
-	generate_random_32(r1);
-	generate_random_32(r2);
-	ge_scalarmult_blinded(&R1, r1, base2);
-	ge_double_scalarmult_vartime(&R2, r2, base1, r1);
+    generate_random_32(r1);
+    generate_random_32(r2);
+    ge_scalarmult_blinded(&R1, r1, base2);
+    ge_double_scalarmult_vartime(&R2, r2, base1, r1);
 
-	soter_hash_ctx_t* hash_ctx = soter_hash_create(SOTER_HASH_SHA512);
-	if (!hash_ctx)
-	{
-		return THEMIS_FAIL;
-	}
+    soter_hash_ctx_t* hash_ctx = soter_hash_create(SOTER_HASH_SHA512);
+    if (!hash_ctx) {
+        return THEMIS_FAIL;
+    }
 
-	ge_p3_tobytes(k, &R1);
-	res = soter_hash_update(hash_ctx, k, ED25519_GE_LENGTH);
-	if (THEMIS_SUCCESS != res)
-	{
-		soter_hash_destroy(hash_ctx);
-		return res;
-	}
+    ge_p3_tobytes(k, &R1);
+    res = soter_hash_update(hash_ctx, k, ED25519_GE_LENGTH);
+    if (THEMIS_SUCCESS != res) {
+        soter_hash_destroy(hash_ctx);
+        return res;
+    }
 
-	ge_tobytes(k, &R2);
-	res = soter_hash_update(hash_ctx, k, ED25519_GE_LENGTH);
-	if (THEMIS_SUCCESS != res)
-	{
-		soter_hash_destroy(hash_ctx);
-		return res;
-	}
+    ge_tobytes(k, &R2);
+    res = soter_hash_update(hash_ctx, k, ED25519_GE_LENGTH);
+    if (THEMIS_SUCCESS != res) {
+        soter_hash_destroy(hash_ctx);
+        return res;
+    }
 
-	res = soter_hash_update(hash_ctx, &pos, sizeof(pos));
-	if (THEMIS_SUCCESS != res)
-	{
-		soter_hash_destroy(hash_ctx);
-		return res;
-	}
+    res = soter_hash_update(hash_ctx, &pos, sizeof(pos));
+    if (THEMIS_SUCCESS != res) {
+        soter_hash_destroy(hash_ctx);
+        return res;
+    }
 
-	res = soter_hash_final(hash_ctx, k, &hash_length);
-	soter_hash_destroy(hash_ctx);
+    res = soter_hash_final(hash_ctx, k, &hash_length);
+    soter_hash_destroy(hash_ctx);
 
-	if (THEMIS_SUCCESS == res)
-	{
-		sc_reduce(k);
-		memcpy(signature, k, ED25519_GE_LENGTH);
-		sc_muladd(signature + ED25519_GE_LENGTH, k, scalar1, r1);
-		sc_muladd(signature + (2 * ED25519_GE_LENGTH), k, scalar2, r2);
-	}
+    if (THEMIS_SUCCESS == res) {
+        sc_reduce(k);
+        memcpy(signature, k, ED25519_GE_LENGTH);
+        sc_muladd(signature + ED25519_GE_LENGTH, k, scalar1, r1);
+        sc_muladd(signature + (2 * ED25519_GE_LENGTH), k, scalar2, r2);
+    }
 
-	return res;
+    return res;
 }
 
-static themis_status_t ed_point_sign(uint8_t pos, const uint8_t *scalar, const ge_p3 *point, uint8_t *signature)
+static themis_status_t ed_point_sign(uint8_t pos, const uint8_t* scalar, const ge_p3* point,
+                                     uint8_t* signature)
 {
-	uint8_t r[ED25519_GE_LENGTH];
-	ge_p3 R;
-	uint8_t k[64];
+    uint8_t r[ED25519_GE_LENGTH];
+    ge_p3 R;
+    uint8_t k[64];
 
-	size_t hash_length = 64;
+    size_t hash_length = 64;
 
-	themis_status_t res;
+    themis_status_t res;
 
-	generate_random_32(r);
-	ge_scalarmult_base(&R, r);
-	ge_p3_tobytes(k, &R);
+    generate_random_32(r);
+    ge_scalarmult_base(&R, r);
+    ge_p3_tobytes(k, &R);
 
-	soter_hash_ctx_t* hash_ctx = soter_hash_create(SOTER_HASH_SHA512);
-	if (!hash_ctx)
-	{
-		return THEMIS_FAIL;
-	}
+    soter_hash_ctx_t* hash_ctx = soter_hash_create(SOTER_HASH_SHA512);
+    if (!hash_ctx) {
+        return THEMIS_FAIL;
+    }
 
-	res = soter_hash_update(hash_ctx, k, ED25519_GE_LENGTH);
-	if (THEMIS_SUCCESS != res)
-	{
-		soter_hash_destroy(hash_ctx);
-		return res;
-	}
+    res = soter_hash_update(hash_ctx, k, ED25519_GE_LENGTH);
+    if (THEMIS_SUCCESS != res) {
+        soter_hash_destroy(hash_ctx);
+        return res;
+    }
 
-	ge_scalarmult_blinded(&R, r, point);
-	ge_p3_tobytes(k, &R);
+    ge_scalarmult_blinded(&R, r, point);
+    ge_p3_tobytes(k, &R);
 
-	res = soter_hash_update(hash_ctx, k, ED25519_GE_LENGTH);
-	if (THEMIS_SUCCESS != res)
-	{
-		soter_hash_destroy(hash_ctx);
-		return res;
-	}
+    res = soter_hash_update(hash_ctx, k, ED25519_GE_LENGTH);
+    if (THEMIS_SUCCESS != res) {
+        soter_hash_destroy(hash_ctx);
+        return res;
+    }
 
-	res = soter_hash_update(hash_ctx, &pos, sizeof(pos));
-	if (THEMIS_SUCCESS != res)
-	{
-		soter_hash_destroy(hash_ctx);
-		return res;
-	}
+    res = soter_hash_update(hash_ctx, &pos, sizeof(pos));
+    if (THEMIS_SUCCESS != res) {
+        soter_hash_destroy(hash_ctx);
+        return res;
+    }
 
-	res = soter_hash_final(hash_ctx, k, &hash_length);
-	soter_hash_destroy(hash_ctx);
-	if (THEMIS_SUCCESS != res)
-	{
-		return res;
-	}
+    res = soter_hash_final(hash_ctx, k, &hash_length);
+    soter_hash_destroy(hash_ctx);
+    if (THEMIS_SUCCESS != res) {
+        return res;
+    }
 
-	if (THEMIS_SUCCESS == res)
-	{
-		sc_reduce(k);
-		memcpy(signature, k, ED25519_GE_LENGTH);
-		sc_muladd(signature + ED25519_GE_LENGTH, k, scalar, r);
-	}
+    if (THEMIS_SUCCESS == res) {
+        sc_reduce(k);
+        memcpy(signature, k, ED25519_GE_LENGTH);
+        sc_muladd(signature + ED25519_GE_LENGTH, k, scalar, r);
+    }
 
-	return res;
+    return res;
 }
 
-static void corrupt_alice_step1(secure_comparator_t *alice, void *output)
+static void corrupt_alice_step1(secure_comparator_t* alice, void* output)
 {
-	/* Let's assume alice is malicious and uses zeroes instead of random numbers */
+    /* Let's assume alice is malicious and uses zeroes instead of random numbers */
 
-	ge_p3 g2a;
-	ge_p3 g3a;
+    ge_p3 g2a;
+    ge_p3 g3a;
 
-	memset(alice->rand2, 0, sizeof(alice->rand2));
-	memset(alice->rand3, 0, sizeof(alice->rand3));
+    memset(alice->rand2, 0, sizeof(alice->rand2));
+    memset(alice->rand3, 0, sizeof(alice->rand3));
 
-	ge_scalarmult_base(&g2a, alice->rand2);
-	ge_scalarmult_base(&g3a, alice->rand3);
+    ge_scalarmult_base(&g2a, alice->rand2);
+    ge_scalarmult_base(&g3a, alice->rand3);
 
-	ge_p3_tobytes((unsigned char *)output, &g2a);
-	ed_sign(1, alice->rand2, ((unsigned char *)output) + ED25519_GE_LENGTH);
+    ge_p3_tobytes((unsigned char*)output, &g2a);
+    ed_sign(1, alice->rand2, ((unsigned char*)output) + ED25519_GE_LENGTH);
 
-	ge_p3_tobytes(((unsigned char *)output) + (3 * ED25519_GE_LENGTH), &g3a);
-	ed_sign(2, alice->rand3, ((unsigned char *)output) + (4 * ED25519_GE_LENGTH));
+    ge_p3_tobytes(((unsigned char*)output) + (3 * ED25519_GE_LENGTH), &g3a);
+    ed_sign(2, alice->rand3, ((unsigned char*)output) + (4 * ED25519_GE_LENGTH));
 }
 
-static void corrupt_bob_step2(secure_comparator_t *bob, const void *input, size_t input_length, void *output, size_t *output_length)
+static void corrupt_bob_step2(secure_comparator_t* bob, const void* input, size_t input_length,
+                              void* output, size_t* output_length)
 {
-	/* Let's assume bob is malicious and uses zeroes instead of random numbers */
+    /* Let's assume bob is malicious and uses zeroes instead of random numbers */
 
-	ge_p3 g2a;
-	ge_p3 g3a;
+    ge_p3 g2a;
+    ge_p3 g3a;
 
-	ge_p3 g2b;
-	ge_p3 g3b;
+    ge_p3 g2b;
+    ge_p3 g3b;
 
-	ge_frombytes_vartime(&g2a, (const unsigned char *)input);
-	ge_frombytes_vartime(&g3a, ((const unsigned char *)input) + (3 * ED25519_GE_LENGTH));
+    ge_frombytes_vartime(&g2a, (const unsigned char*)input);
+    ge_frombytes_vartime(&g3a, ((const unsigned char*)input) + (3 * ED25519_GE_LENGTH));
 
-	if (THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER != secure_comparator_proceed_compare(bob, input, input_length, output, output_length))
-	{
-		testsuite_fail_if(true, "secure_comparator_proceed_compare failed");
-		return;
-	}
+    if (THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER !=
+        secure_comparator_proceed_compare(bob, input, input_length, output, output_length)) {
+        testsuite_fail_if(true, "secure_comparator_proceed_compare failed");
+        return;
+    }
 
-	memset(bob->rand2, 0, sizeof(bob->rand2));
-	memset(bob->rand3, 0, sizeof(bob->rand3));
+    memset(bob->rand2, 0, sizeof(bob->rand2));
+    memset(bob->rand3, 0, sizeof(bob->rand3));
 
-	ge_scalarmult_base(&g2b, bob->rand2);
-	ge_scalarmult_base(&g3b, bob->rand3);
+    ge_scalarmult_base(&g2b, bob->rand2);
+    ge_scalarmult_base(&g3b, bob->rand3);
 
-	ge_scalarmult_blinded(&(bob->g2), bob->rand2, &g2a);
-	ge_scalarmult_blinded(&(bob->g3), bob->rand3, &g3a);
+    ge_scalarmult_blinded(&(bob->g2), bob->rand2, &g2a);
+    ge_scalarmult_blinded(&(bob->g3), bob->rand3, &g3a);
 
-	memset(bob->rand, 0, sizeof(bob->rand));
+    memset(bob->rand, 0, sizeof(bob->rand));
 
-	ge_scalarmult_blinded(&(bob->P), bob->rand, &(bob->g3));
-	ge_double_scalarmult_vartime((ge_p2 *)&(bob->Q), bob->secret, &(bob->g2), bob->rand);
-	ge_p2_to_p3(&(bob->Q), (const ge_p2 *)&(bob->Q));
+    ge_scalarmult_blinded(&(bob->P), bob->rand, &(bob->g3));
+    ge_double_scalarmult_vartime((ge_p2*)&(bob->Q), bob->secret, &(bob->g2), bob->rand);
+    ge_p2_to_p3(&(bob->Q), (const ge_p2*)&(bob->Q));
 
-	ge_p3_tobytes((unsigned char *)output, &g2b);
-	ed_sign(3, bob->rand2, ((unsigned char *)output) + ED25519_GE_LENGTH);
+    ge_p3_tobytes((unsigned char*)output, &g2b);
+    ed_sign(3, bob->rand2, ((unsigned char*)output) + ED25519_GE_LENGTH);
 
-	ge_p3_tobytes(((unsigned char *)output) + (3 * ED25519_GE_LENGTH), &g3b);
-	ed_sign(4, bob->rand3, ((unsigned char *)output) + (4 * ED25519_GE_LENGTH));
+    ge_p3_tobytes(((unsigned char*)output) + (3 * ED25519_GE_LENGTH), &g3b);
+    ed_sign(4, bob->rand3, ((unsigned char*)output) + (4 * ED25519_GE_LENGTH));
 
-	ge_p3_tobytes(((unsigned char *)output) + (6 * ED25519_GE_LENGTH), &(bob->P));
-	ge_p3_tobytes(((unsigned char *)output) + (7 * ED25519_GE_LENGTH), &(bob->Q));
-	ed_dbl_base_sign(5, bob->rand, bob->secret, &(bob->g2), &(bob->g3), ((unsigned char *)output) + (8 * ED25519_GE_LENGTH));
+    ge_p3_tobytes(((unsigned char*)output) + (6 * ED25519_GE_LENGTH), &(bob->P));
+    ge_p3_tobytes(((unsigned char*)output) + (7 * ED25519_GE_LENGTH), &(bob->Q));
+    ed_dbl_base_sign(5, bob->rand, bob->secret, &(bob->g2), &(bob->g3),
+                     ((unsigned char*)output) + (8 * ED25519_GE_LENGTH));
 }
 
 void secure_comparator_security_test(void)
 {
-	const char alice_secret[] = "alice secret";
-	const char bob_secret[] = "bob secret";
+    const char alice_secret[] = "alice secret";
+    const char bob_secret[] = "bob secret";
 
-	size_t output_length = sizeof(shared_mem);
+    size_t output_length = sizeof(shared_mem);
 
-	secure_comparator_t* alice = secure_comparator_create();
-    if(!alice){
+    secure_comparator_t* alice = secure_comparator_create();
+    if (!alice) {
         testsuite_fail_if(true, "secure_comparator_create failed");
         return;
     }
     secure_comparator_t* bob = secure_comparator_create();
-    if(!bob){
+    if (!bob) {
         testsuite_fail_if(true, "secure_comparator_create failed");
         return;
     }
 
+    if (THEMIS_SUCCESS !=
+        secure_comparator_append_secret(alice, alice_secret, sizeof(alice_secret))) {
+        testsuite_fail_if(true, "secure_comparator_append_secret failed");
+        return;
+    }
 
-	if (THEMIS_SUCCESS != secure_comparator_append_secret(alice, alice_secret, sizeof(alice_secret)))
-	{
-		testsuite_fail_if(true, "secure_comparator_append_secret failed");
-		return;
-	}
+    if (THEMIS_SUCCESS != secure_comparator_append_secret(bob, bob_secret, sizeof(bob_secret))) {
+        testsuite_fail_if(true, "secure_comparator_append_secret failed");
+        return;
+    }
 
-	if (THEMIS_SUCCESS != secure_comparator_append_secret(bob, bob_secret, sizeof(bob_secret)))
-	{
-		testsuite_fail_if(true, "secure_comparator_append_secret failed");
-		return;
-	}
+    current_length = sizeof(shared_mem);
 
-	current_length = sizeof(shared_mem);
+    if (THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER !=
+        secure_comparator_begin_compare(alice, shared_mem, &current_length)) {
+        testsuite_fail_if(true, "secure_comparator_begin_compare failed");
+        return;
+    }
 
-	if (THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER != secure_comparator_begin_compare(alice, shared_mem, &current_length))
-	{
-		testsuite_fail_if(true, "secure_comparator_begin_compare failed");
-		return;
-	}
+    corrupt_alice_step1(alice, shared_mem);
 
-	corrupt_alice_step1(alice, shared_mem);
+    corrupt_bob_step2(bob, shared_mem, current_length, shared_mem, &output_length);
 
-	corrupt_bob_step2(bob, shared_mem, current_length, shared_mem, &output_length);
+    current_length = output_length;
+    output_length = sizeof(shared_mem);
 
-	current_length = output_length;
-	output_length = sizeof(shared_mem);
+    if (THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER !=
+        secure_comparator_proceed_compare(alice, shared_mem, current_length, shared_mem,
+                                          &output_length)) {
+        testsuite_fail_if(true, "secure_comparator_proceed_compare failed");
+        return;
+    }
 
-	if (THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER != secure_comparator_proceed_compare(alice, shared_mem, current_length, shared_mem, &output_length))
-	{
-		testsuite_fail_if(true, "secure_comparator_proceed_compare failed");
-		return;
-	}
+    current_length = output_length;
+    output_length = sizeof(shared_mem);
 
-	current_length = output_length;
-	output_length = sizeof(shared_mem);
+    if (THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER !=
+        secure_comparator_proceed_compare(bob, shared_mem, current_length, shared_mem,
+                                          &output_length)) {
+        testsuite_fail_if(true, "secure_comparator_proceed_compare failed");
+        return;
+    }
 
-	if (THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER != secure_comparator_proceed_compare(bob, shared_mem, current_length, shared_mem, &output_length))
-	{
-		testsuite_fail_if(true, "secure_comparator_proceed_compare failed");
-		return;
-	}
+    current_length = output_length;
+    output_length = sizeof(shared_mem);
 
-	current_length = output_length;
-	output_length = sizeof(shared_mem);
+    if (THEMIS_SUCCESS != secure_comparator_proceed_compare(alice, shared_mem, current_length,
+                                                            shared_mem, &output_length)) {
+        testsuite_fail_if(true, "secure_comparator_proceed_compare failed");
+        return;
+    }
 
-	if (THEMIS_SUCCESS != secure_comparator_proceed_compare(alice, shared_mem, current_length, shared_mem, &output_length))
-	{
-		testsuite_fail_if(true, "secure_comparator_proceed_compare failed");
-		return;
-	}
-
-	testsuite_fail_unless((THEMIS_SCOMPARE_NO_MATCH == secure_comparator_get_result(alice)) && (THEMIS_SCOMPARE_NO_MATCH == secure_comparator_get_result(bob)), "compare result no match");
-	secure_comparator_destroy(alice);
-	secure_comparator_destroy(bob);
+    testsuite_fail_unless((THEMIS_SCOMPARE_NO_MATCH == secure_comparator_get_result(alice)) &&
+                              (THEMIS_SCOMPARE_NO_MATCH == secure_comparator_get_result(bob)),
+                          "compare result no match");
+    secure_comparator_destroy(alice);
+    secure_comparator_destroy(bob);
 }

--- a/tests/themis/themis_secure_session.c
+++ b/tests/themis/themis_secure_session.c
@@ -1,18 +1,18 @@
 /*
-* Copyright (c) 2015 Cossack Labs Limited
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2015 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "themis/themis_test.h"
 
@@ -28,619 +28,588 @@
 #define TEST_STOP_SUCCESS 0
 #define TEST_STOP_ERROR (-1)
 
-static uint8_t client_priv[] = {0x52, 0x45, 0x43, 0x32, 0x00, 0x00, 0x00, 0x2d, 0x51, 0xf4, 0xaa, 0x72, 0x00, 0x9f, 0x0f, 0x09, 0xce, 0xbe, 0x09, 0x33, 0xc2, 0x5e, 0x9a, 0x05, 0x99, 0x53, 0x9d, 0xb2, 0x32, 0xa2, 0x34, 0x64, 0x7a, 0xde, 0xde, 0x83, 0x8f, 0x65, 0xa9, 0x2a, 0x14, 0x6d, 0xaa, 0x90, 0x01};
-static uint8_t client_pub[] = {0x55, 0x45, 0x43, 0x32, 0x00, 0x00, 0x00, 0x2d, 0x13, 0x8b, 0xdf, 0x0c, 0x02, 0x1f, 0x09, 0x88, 0x39, 0xd9, 0x73, 0x3a, 0x84, 0x8f, 0xa8, 0x50, 0xd9, 0x2b, 0xed, 0x3d, 0x38, 0xcf, 0x1d, 0xd0, 0xce, 0xf4, 0xae, 0xdb, 0xcf, 0xaf, 0xcb, 0x6b, 0xa5, 0x4a, 0x08, 0x11, 0x21};
+static uint8_t client_priv[] = {
+    0x52, 0x45, 0x43, 0x32, 0x00, 0x00, 0x00, 0x2d, 0x51, 0xf4, 0xaa, 0x72, 0x00, 0x9f, 0x0f,
+    0x09, 0xce, 0xbe, 0x09, 0x33, 0xc2, 0x5e, 0x9a, 0x05, 0x99, 0x53, 0x9d, 0xb2, 0x32, 0xa2,
+    0x34, 0x64, 0x7a, 0xde, 0xde, 0x83, 0x8f, 0x65, 0xa9, 0x2a, 0x14, 0x6d, 0xaa, 0x90, 0x01,
+};
+static uint8_t client_pub[] = {
+    0x55, 0x45, 0x43, 0x32, 0x00, 0x00, 0x00, 0x2d, 0x13, 0x8b, 0xdf, 0x0c, 0x02, 0x1f, 0x09,
+    0x88, 0x39, 0xd9, 0x73, 0x3a, 0x84, 0x8f, 0xa8, 0x50, 0xd9, 0x2b, 0xed, 0x3d, 0x38, 0xcf,
+    0x1d, 0xd0, 0xce, 0xf4, 0xae, 0xdb, 0xcf, 0xaf, 0xcb, 0x6b, 0xa5, 0x4a, 0x08, 0x11, 0x21,
+};
 
-static uint8_t server_priv[] = {0x52, 0x45, 0x43, 0x32, 0x00, 0x00, 0x00, 0x2d, 0x49, 0x87, 0x04, 0x6b, 0x00, 0xf2, 0x06, 0x07, 0x7d, 0xc7, 0x1c, 0x59, 0xa1, 0x8f, 0x39, 0xfc, 0x94, 0x81, 0x3f, 0x9e, 0xc5, 0xba, 0x70, 0x6f, 0x93, 0x08, 0x8d, 0xe3, 0x85, 0x82, 0x5b, 0xf8, 0x3f, 0xc6, 0x9f, 0x0b, 0xdf};
-static uint8_t server_pub[] = {0x55, 0x45, 0x43, 0x32, 0x00, 0x00, 0x00, 0x2d, 0x75, 0x58, 0x33, 0xd4, 0x02, 0x12, 0xdf, 0x1f, 0xe9, 0xea, 0x48, 0x11, 0xe1, 0xf9, 0x71, 0x8e, 0x24, 0x11, 0xcb, 0xfd, 0xc0, 0xa3, 0x6e, 0xd6, 0xac, 0x88, 0xb6, 0x44, 0xc2, 0x9a, 0x24, 0x84, 0xee, 0x50, 0x4c, 0x3e, 0xa0};
+static uint8_t server_priv[] = {
+    0x52, 0x45, 0x43, 0x32, 0x00, 0x00, 0x00, 0x2d, 0x49, 0x87, 0x04, 0x6b, 0x00, 0xf2, 0x06,
+    0x07, 0x7d, 0xc7, 0x1c, 0x59, 0xa1, 0x8f, 0x39, 0xfc, 0x94, 0x81, 0x3f, 0x9e, 0xc5, 0xba,
+    0x70, 0x6f, 0x93, 0x08, 0x8d, 0xe3, 0x85, 0x82, 0x5b, 0xf8, 0x3f, 0xc6, 0x9f, 0x0b, 0xdf,
+};
+static uint8_t server_pub[] = {
+    0x55, 0x45, 0x43, 0x32, 0x00, 0x00, 0x00, 0x2d, 0x75, 0x58, 0x33, 0xd4, 0x02, 0x12, 0xdf,
+    0x1f, 0xe9, 0xea, 0x48, 0x11, 0xe1, 0xf9, 0x71, 0x8e, 0x24, 0x11, 0xcb, 0xfd, 0xc0, 0xa3,
+    0x6e, 0xd6, 0xac, 0x88, 0xb6, 0x44, 0xc2, 0x9a, 0x24, 0x84, 0xee, 0x50, 0x4c, 0x3e, 0xa0,
+};
 
 typedef struct client_info_type client_info_t;
 
-struct client_info_type
-{
-	const char *id;
+struct client_info_type {
+    const char* id;
 
-	const uint8_t *priv;
-	size_t priv_length;
+    const uint8_t* priv;
+    size_t priv_length;
 
-	const uint8_t *pub;
-	size_t pub_length;
+    const uint8_t* pub;
+    size_t pub_length;
 
-	secure_session_t* session;
-	secure_session_user_callbacks_t transport;
+    secure_session_t* session;
+    secure_session_user_callbacks_t transport;
 };
 
-static client_info_t client = {"client", client_priv, sizeof(client_priv), client_pub, sizeof(client_pub), NULL, {0}};
-static client_info_t server = {"server", server_priv, sizeof(server_priv), server_pub, sizeof(server_pub), NULL, {0}};
+static client_info_t client = {
+    "client", client_priv, sizeof(client_priv), client_pub, sizeof(client_pub), NULL, {0},
+};
+static client_info_t server = {
+    "server", server_priv, sizeof(server_priv), server_pub, sizeof(server_pub), NULL, {0},
+};
 
 /* Peers will communicate using shared memory */
 static uint8_t shared_mem[4096];
 static size_t current_length = 0;
 
-static int on_get_public_key(const void *id, size_t id_length, void *key_buffer, size_t key_buffer_length, void *user_data)
+static int on_get_public_key(const void* id, size_t id_length, void* key_buffer,
+                             size_t key_buffer_length, void* user_data)
 {
-	client_info_t *info = user_data;
-	client_info_t *peer;
+    client_info_t* info = user_data;
+    client_info_t* peer;
 
-	if (info == &client)
-	{
-		/* The client should request server's public key */
-		peer = &server;
-	}
-	else if (info == &server)
-	{
-		/* The server should request client's public key */
-		peer = &client;
-	}
-	else
-	{
-		return -1;
-	}
+    if (info == &client) {
+        /* The client should request server's public key */
+        peer = &server;
+    } else if (info == &server) {
+        /* The server should request client's public key */
+        peer = &client;
+    } else {
+        return -1;
+    }
 
-	if (memcmp(peer->id, id, id_length))
-	{
-		return -1;
-	}
+    if (memcmp(peer->id, id, id_length)) {
+        return -1;
+    }
 
-	if (peer->pub_length > key_buffer_length)
-	{
-		return -1;
-	}
+    if (peer->pub_length > key_buffer_length) {
+        return -1;
+    }
 
-	memcpy(key_buffer, peer->pub, peer->pub_length);
-	return 0;
+    memcpy(key_buffer, peer->pub, peer->pub_length);
+    return 0;
 }
 
-static ssize_t on_send_data(const uint8_t *data, size_t data_length, void *user_data)
+static ssize_t on_send_data(const uint8_t* data, size_t data_length, void* user_data)
 {
-	memcpy(shared_mem, data, data_length);
-	current_length = data_length;
-	return (ssize_t)data_length;
+    memcpy(shared_mem, data, data_length);
+    current_length = data_length;
+    return (ssize_t)data_length;
 }
 
-static ssize_t on_receive_data(uint8_t *data, size_t data_length, void *user_data)
+static ssize_t on_receive_data(uint8_t* data, size_t data_length, void* user_data)
 {
-	if (data_length < current_length)
-	{
-		return -1;
-	}
+    if (data_length < current_length) {
+        return -1;
+    }
 
-	memcpy(data, shared_mem, current_length);
+    memcpy(data, shared_mem, current_length);
 
-	return current_length;
+    return current_length;
 }
 
-static void on_state_changed(int event, void *user_data)
+static void on_state_changed(int event, void* user_data)
 {
-	/* TODO: implement */
+    /* TODO: implement */
 }
 
-static secure_session_user_callbacks_t transport =
-{
-	on_send_data,
-	on_receive_data,
-	on_state_changed,
-	on_get_public_key,
-	NULL
-};
+static secure_session_user_callbacks_t transport = {on_send_data, on_receive_data, on_state_changed,
+                                                    on_get_public_key, NULL};
 
 static int client_function(void)
 {
-	static bool connected = false;
-	themis_status_t res;
-	uint8_t recv_buf[2048];
-	ssize_t bytes_received;
-	ssize_t bytes_sent;
+    static bool connected = false;
+    themis_status_t res;
+    uint8_t recv_buf[2048];
+    ssize_t bytes_received;
+    ssize_t bytes_sent;
 
-	/* Client is not connected yet. Initiate key agreement */
-	if (!connected)
-	{
-		res = secure_session_connect((client.session));
-		if (THEMIS_SUCCESS == res)
-		{
-			connected = true;
-			return TEST_CONTINUE;
-		}
-		else
-		{
-			testsuite_fail_if(res, "secure_session_connect failed");
-			return TEST_STOP_ERROR;
-		}
-	}
-	if (secure_session_is_established(client.session))
-	{
-		size_t remote_id_length=0;
-		if(THEMIS_BUFFER_TOO_SMALL!=secure_session_get_remote_id(client.session, NULL, &remote_id_length)){
-			testsuite_fail_if(true, "remote id getting failed (length_determination)");
-			return TEST_STOP_ERROR;
-		}
-		uint8_t *remote_id=malloc(remote_id_length);
-		assert(remote_id);
-		if(THEMIS_SUCCESS!=secure_session_get_remote_id(client.session, remote_id, &remote_id_length)){
-			testsuite_fail_if(true, "remote id getting failed");
-			free(remote_id);
-			return TEST_STOP_ERROR;
-		}
-		testsuite_fail_unless(remote_id_length==strlen(server.id) && 0==memcmp(remote_id, server.id, strlen(server.id)), "secure_session remote id getting");
-		free(remote_id);
+    /* Client is not connected yet. Initiate key agreement */
+    if (!connected) {
+        res = secure_session_connect((client.session));
+        if (THEMIS_SUCCESS == res) {
+            connected = true;
+            return TEST_CONTINUE;
+        }
 
-		static int messages_to_send = MESSAGES_TO_SEND;
+        testsuite_fail_if(res, "secure_session_connect failed");
+        return TEST_STOP_ERROR;
+    }
+    if (secure_session_is_established(client.session)) {
+        size_t remote_id_length = 0;
+        if (THEMIS_BUFFER_TOO_SMALL !=
+            secure_session_get_remote_id(client.session, NULL, &remote_id_length)) {
+            testsuite_fail_if(true, "remote id getting failed (length_determination)");
+            return TEST_STOP_ERROR;
+        }
+        uint8_t* remote_id = malloc(remote_id_length);
+        assert(remote_id);
+        if (THEMIS_SUCCESS !=
+            secure_session_get_remote_id(client.session, remote_id, &remote_id_length)) {
+            testsuite_fail_if(true, "remote id getting failed");
+            free(remote_id);
+            return TEST_STOP_ERROR;
+        }
+        testsuite_fail_unless(remote_id_length == strlen(server.id) &&
+                                  0 == memcmp(remote_id, server.id, strlen(server.id)),
+                              "secure_session remote id getting");
+        free(remote_id);
 
-		/* Connection is already established. */
-		static uint8_t data_to_send[MAX_MESSAGE_SIZE];
-		static size_t length_to_send;
+        static int messages_to_send = MESSAGES_TO_SEND;
 
-		/* If there is anything to receive, receive it */
-		if (current_length)
-		{
-			bytes_received = secure_session_receive(client.session, recv_buf, sizeof(recv_buf));
-			if (bytes_received > 0)
-			{
-				/* The server should echo our previously sent data */
-				testsuite_fail_unless((length_to_send == (size_t)bytes_received) && (!memcmp(recv_buf, data_to_send, bytes_received)), "secure_session message send/receive");
-				messages_to_send--;
+        /* Connection is already established. */
+        static uint8_t data_to_send[MAX_MESSAGE_SIZE];
+        static size_t length_to_send;
 
-				if (!messages_to_send)
-				{
-					return TEST_STOP_SUCCESS;
-				}
-			}
-			else
-			{
-				/* We shoud receive something. */
-				testsuite_fail_if(bytes_received, "secure_session_receive failed");
-				return TEST_STOP_ERROR;
-			}
-		}
+        /* If there is anything to receive, receive it */
+        if (current_length) {
+            bytes_received = secure_session_receive(client.session, recv_buf, sizeof(recv_buf));
+            if (bytes_received > 0) {
+                /* The server should echo our previously sent data */
+                testsuite_fail_unless((length_to_send == (size_t)bytes_received) &&
+                                          (!memcmp(recv_buf, data_to_send, bytes_received)),
+                                      "secure_session message send/receive");
+                messages_to_send--;
 
-		length_to_send = rand_int(MAX_MESSAGE_SIZE);
+                if (!messages_to_send) {
+                    return TEST_STOP_SUCCESS;
+                }
+            } else {
+                /* We shoud receive something. */
+                testsuite_fail_if(bytes_received, "secure_session_receive failed");
+                return TEST_STOP_ERROR;
+            }
+        }
 
-		if (THEMIS_SUCCESS != soter_rand(data_to_send, length_to_send))
-		{
-			testsuite_fail_if(true, "soter_rand failed");
-			return TEST_STOP_ERROR;
-		}
+        length_to_send = rand_int(MAX_MESSAGE_SIZE);
 
-		bytes_sent = secure_session_send((client.session), data_to_send, length_to_send);
-		if (bytes_sent > 0)
-		{
-			/* Check whether data was indeed encrypted (it should not be the same as in data_to_send) */
-			testsuite_fail_if((length_to_send == current_length) || (!memcmp(data_to_send, shared_mem, length_to_send)), "secure_session client message wrap");
-			return TEST_CONTINUE;
-		}
-		else
-		{
-			testsuite_fail_if(true, "secure_session_send failed");
-			return TEST_STOP_ERROR;
-		}
-	}
-	else
-	{
-		/* Connection is not established. We should receive some key agreement data. */
+        if (THEMIS_SUCCESS != soter_rand(data_to_send, length_to_send)) {
+            testsuite_fail_if(true, "soter_rand failed");
+            return TEST_STOP_ERROR;
+        }
 
-		bytes_received = secure_session_receive((client.session), recv_buf, sizeof(recv_buf));
-		/* When key agreement data is received and processed client gets 0 in return value (no data for client is received) */
-		if (bytes_received)
-		{
-			testsuite_fail_if(bytes_received, "secure_session_receive failed");
-			return TEST_STOP_ERROR;
-		}
-		else
-		{
-			if (secure_session_is_established((client.session)))
-			{
-				/* Negotiation completed. Clear the shared memory. */
-				current_length = 0;
-			}
+        bytes_sent = secure_session_send((client.session), data_to_send, length_to_send);
+        if (bytes_sent > 0) {
+            /* Check whether data was indeed encrypted (it should not be the same as in
+             * data_to_send) */
+            testsuite_fail_if((length_to_send == current_length) ||
+                                  (!memcmp(data_to_send, shared_mem, length_to_send)),
+                              "secure_session client message wrap");
+            return TEST_CONTINUE;
+        }
 
-			return TEST_CONTINUE;
-		}
-	}
+        testsuite_fail_if(true, "secure_session_send failed");
+        return TEST_STOP_ERROR;
+    }
+    /* Connection is not established. We should receive some key agreement data. */
+
+    bytes_received = secure_session_receive((client.session), recv_buf, sizeof(recv_buf));
+    /* When key agreement data is received and processed client gets 0 in return value (no data
+     * for client is received) */
+    if (bytes_received) {
+        testsuite_fail_if(bytes_received, "secure_session_receive failed");
+        return TEST_STOP_ERROR;
+    }
+
+    if (secure_session_is_established((client.session))) {
+        /* Negotiation completed. Clear the shared memory. */
+        current_length = 0;
+    }
+
+    return TEST_CONTINUE;
 }
 
 static int client_function_no_transport(void)
 {
-	static bool connected = false;
-	themis_status_t res;
-	uint8_t recv_buf[2048];
+    static bool connected = false;
+    themis_status_t res;
+    uint8_t recv_buf[2048];
     ssize_t bytes_received = 0;
     uint8_t processing_buf[2048];
     size_t processing_buf_size = 0;
-	ssize_t bytes_sent;
+    ssize_t bytes_sent;
 
-	/* Client is not connected yet. Initiate key agreement */
-	if (!connected)
-	{
-		res = secure_session_generate_connect_request((client.session), processing_buf, (size_t*)(&processing_buf_size));
-		if (THEMIS_BUFFER_TOO_SMALL != res)
-		{
-			testsuite_fail_if(res, "secure_session_generate_connect_request failed");
-			return TEST_STOP_ERROR;
-		}
+    /* Client is not connected yet. Initiate key agreement */
+    if (!connected) {
+        res = secure_session_generate_connect_request((client.session), processing_buf,
+                                                      (size_t*)(&processing_buf_size));
+        if (THEMIS_BUFFER_TOO_SMALL != res) {
+            testsuite_fail_if(res, "secure_session_generate_connect_request failed");
+            return TEST_STOP_ERROR;
+        }
 
-		res = secure_session_generate_connect_request((client.session), processing_buf, (size_t*)(&processing_buf_size));
-		if (THEMIS_SUCCESS == res)
-		{
-			/* This test-send function never fails, so we do not check for error here */
-			on_send_data(processing_buf, processing_buf_size, NULL);
-			connected = true;
-			return TEST_CONTINUE;
-		}
-		else
-		{
-			testsuite_fail_if(res, "secure_session_generate_connect_request failed");
-			return TEST_STOP_ERROR;
-		}
-	}
+        res = secure_session_generate_connect_request((client.session), processing_buf,
+                                                      (size_t*)(&processing_buf_size));
+        if (THEMIS_SUCCESS == res) {
+            /* This test-send function never fails, so we do not check for error here */
+            on_send_data(processing_buf, processing_buf_size, NULL);
+            connected = true;
+            return TEST_CONTINUE;
+        }
 
-	if (secure_session_is_established((client.session)))
-	{
-		size_t remote_id_length=0;
-		if(THEMIS_BUFFER_TOO_SMALL!=secure_session_get_remote_id(client.session, NULL, &remote_id_length)){
-			testsuite_fail_if(true, "remote id getting failed (length_determination)");
-			return TEST_STOP_ERROR;
-		}
-		uint8_t *remote_id=malloc(remote_id_length);
-		assert(remote_id);
-		if(THEMIS_SUCCESS!=secure_session_get_remote_id(client.session, remote_id, &remote_id_length)){
-			testsuite_fail_if(true, "remote id getting failed");
-			free(remote_id);
-			return TEST_STOP_ERROR;
-		}
-		testsuite_fail_unless(remote_id_length==strlen(server.id) && 0==memcmp(remote_id, server.id, strlen(server.id)), "secure_session remote id getting");
-		free(remote_id);
+        testsuite_fail_if(res, "secure_session_generate_connect_request failed");
+        return TEST_STOP_ERROR;
+    }
 
-		static int messages_to_send = MESSAGES_TO_SEND;
+    if (secure_session_is_established((client.session))) {
+        size_t remote_id_length = 0;
+        if (THEMIS_BUFFER_TOO_SMALL !=
+            secure_session_get_remote_id(client.session, NULL, &remote_id_length)) {
+            testsuite_fail_if(true, "remote id getting failed (length_determination)");
+            return TEST_STOP_ERROR;
+        }
+        uint8_t* remote_id = malloc(remote_id_length);
+        assert(remote_id);
+        if (THEMIS_SUCCESS !=
+            secure_session_get_remote_id(client.session, remote_id, &remote_id_length)) {
+            testsuite_fail_if(true, "remote id getting failed");
+            free(remote_id);
+            return TEST_STOP_ERROR;
+        }
+        testsuite_fail_unless(remote_id_length == strlen(server.id) &&
+                                  0 == memcmp(remote_id, server.id, strlen(server.id)),
+                              "secure_session remote id getting");
+        free(remote_id);
 
-		/* Connection is already established. */
-		static uint8_t data_to_send[MAX_MESSAGE_SIZE];
-		static size_t length_to_send;
+        static int messages_to_send = MESSAGES_TO_SEND;
+
+        /* Connection is already established. */
+        static uint8_t data_to_send[MAX_MESSAGE_SIZE];
+        static size_t length_to_send;
         processing_buf_size = sizeof(processing_buf);
 
-		/* If there is anything to receive, receive it */
-		if (current_length)
-		{
-			bytes_received = on_receive_data(recv_buf, sizeof(recv_buf), NULL);
-			if (bytes_received > 0)
-			{
-				res = secure_session_unwrap((client.session), recv_buf, (size_t)bytes_received, processing_buf, (size_t*)(&processing_buf_size));
-				if (THEMIS_SUCCESS != res)
-				{
-					testsuite_fail_if(res, "secure_session_unwrap failed");
-					return TEST_STOP_ERROR;
-				}
+        /* If there is anything to receive, receive it */
+        if (current_length) {
+            bytes_received = on_receive_data(recv_buf, sizeof(recv_buf), NULL);
+            if (bytes_received > 0) {
+                res = secure_session_unwrap((client.session), recv_buf, (size_t)bytes_received,
+                                            processing_buf, (size_t*)(&processing_buf_size));
+                if (THEMIS_SUCCESS != res) {
+                    testsuite_fail_if(res, "secure_session_unwrap failed");
+                    return TEST_STOP_ERROR;
+                }
 
-				/* The server should echo our previously sent data */
-				testsuite_fail_if(current_length == (size_t)processing_buf_size, "secure_session message send/receive");
-				messages_to_send--;
+                /* The server should echo our previously sent data */
+                testsuite_fail_if(current_length == (size_t)processing_buf_size,
+                                  "secure_session message send/receive");
+                messages_to_send--;
 
-				if (!messages_to_send)
-				{
-					return TEST_STOP_SUCCESS;
-				}
-			}
-			else
-			{
-				/* We shoud receive something. */
-				testsuite_fail_if(bytes_received, "secure_session_receive failed");
-				return TEST_STOP_ERROR;
-			}
-		}
+                if (!messages_to_send) {
+                    return TEST_STOP_SUCCESS;
+                }
+            } else {
+                /* We shoud receive something. */
+                testsuite_fail_if(bytes_received, "secure_session_receive failed");
+                return TEST_STOP_ERROR;
+            }
+        }
 
-		length_to_send = rand_int(MAX_MESSAGE_SIZE - 64);
+        length_to_send = rand_int(MAX_MESSAGE_SIZE - 64);
 
-		if (THEMIS_SUCCESS != soter_rand(data_to_send, length_to_send))
-		{
-			testsuite_fail_if(true, "soter_rand failed");
-			return TEST_STOP_ERROR;
-		}
+        if (THEMIS_SUCCESS != soter_rand(data_to_send, length_to_send)) {
+            testsuite_fail_if(true, "soter_rand failed");
+            return TEST_STOP_ERROR;
+        }
 
         processing_buf_size = sizeof(processing_buf);
-		res = secure_session_wrap((client.session), data_to_send, length_to_send, processing_buf, (size_t*)(&processing_buf_size));
-		if (THEMIS_SUCCESS != res)
-		{
-			testsuite_fail_if(res, "secure_session_wrap failed");
-			return TEST_STOP_ERROR;
-		}
+        res = secure_session_wrap((client.session), data_to_send, length_to_send, processing_buf,
+                                  (size_t*)(&processing_buf_size));
+        if (THEMIS_SUCCESS != res) {
+            testsuite_fail_if(res, "secure_session_wrap failed");
+            return TEST_STOP_ERROR;
+        }
 
-		/* This test-send function never fails, so we do not check for error here */
-		on_send_data(processing_buf, processing_buf_size, NULL);
-	    testsuite_fail_if(length_to_send == current_length, "secure_session client message wrap");
-	    return TEST_CONTINUE;
-	}
-	else
-	{
-		/* Connection is not established. We should receive some key agreement data. */
+        /* This test-send function never fails, so we do not check for error here */
+        on_send_data(processing_buf, processing_buf_size, NULL);
+        testsuite_fail_if(length_to_send == current_length, "secure_session client message wrap");
+        return TEST_CONTINUE;
+    }
 
-		bytes_received = on_receive_data(recv_buf, sizeof(recv_buf), NULL);
-		if (bytes_received <= 0)
-		{
-			testsuite_fail_if(bytes_received, "secure_session_receive failed");
-			return TEST_STOP_ERROR;
-		}
+    /* Connection is not established. We should receive some key agreement data. */
 
-		res = secure_session_unwrap((client.session), recv_buf, bytes_received, processing_buf, (size_t*)(&processing_buf_size));
-		if (THEMIS_SUCCESS == res)
-		{
-			if (secure_session_is_established((client.session)))
-			{
-				/* Negotiation completed. Clear the shared memory. */
-				current_length = 0;
-				return TEST_CONTINUE;
-			}
-			else
-			{
-				testsuite_fail_if(true, "secure_session_unwrap failed");
-				return TEST_STOP_ERROR;
-			}
-		}
-		else if (THEMIS_BUFFER_TOO_SMALL != res)
-		{
-			testsuite_fail_if(true, "secure_session_unwrap failed");
-			return TEST_STOP_ERROR;
-		}
+    bytes_received = on_receive_data(recv_buf, sizeof(recv_buf), NULL);
+    if (bytes_received <= 0) {
+        testsuite_fail_if(bytes_received, "secure_session_receive failed");
+        return TEST_STOP_ERROR;
+    }
 
-		res = secure_session_unwrap((client.session), recv_buf, bytes_received, processing_buf, (size_t*)(&processing_buf_size));
-		if ((THEMIS_SSESSION_SEND_OUTPUT_TO_PEER == res) && (processing_buf_size > 0))
-		{
-			/* This test-send function never fails, so we do not check for error here */
-			on_send_data(processing_buf, processing_buf_size, NULL);
-			return TEST_CONTINUE;
-		}
-		else
-		{
-			testsuite_fail_if(true, "secure_session_unwrap failed");
-			return TEST_STOP_ERROR;
-		}
-	}
+    res = secure_session_unwrap((client.session), recv_buf, bytes_received, processing_buf,
+                                (size_t*)(&processing_buf_size));
+    if (THEMIS_SUCCESS == res) {
+        if (secure_session_is_established((client.session))) {
+            /* Negotiation completed. Clear the shared memory. */
+            current_length = 0;
+            return TEST_CONTINUE;
+        }
+
+        testsuite_fail_if(true, "secure_session_unwrap failed");
+        return TEST_STOP_ERROR;
+    }
+    if (THEMIS_BUFFER_TOO_SMALL != res) {
+        testsuite_fail_if(true, "secure_session_unwrap failed");
+        return TEST_STOP_ERROR;
+    }
+
+    res = secure_session_unwrap((client.session), recv_buf, bytes_received, processing_buf,
+                                (size_t*)(&processing_buf_size));
+    if ((THEMIS_SSESSION_SEND_OUTPUT_TO_PEER == res) && (processing_buf_size > 0)) {
+        /* This test-send function never fails, so we do not check for error here */
+        on_send_data(processing_buf, processing_buf_size, NULL);
+        return TEST_CONTINUE;
+    }
+
+    testsuite_fail_if(true, "secure_session_unwrap failed");
+    return TEST_STOP_ERROR;
 }
 
 static void server_function(void)
 {
-	uint8_t recv_buf[2048];
-	ssize_t bytes_received;
+    uint8_t recv_buf[2048];
+    ssize_t bytes_received;
 
-	if (current_length > 0)
-	{
-		bytes_received = secure_session_receive((server.session), recv_buf, sizeof(recv_buf));
-	}
-	else
-	{
-		/* Nothing to receive. Do nothing */
-		return;
-	}
-
-	if (bytes_received < 0)
-	{
-		testsuite_fail_if(bytes_received, "secure_session_receive failed");
-		return;
-	}
-
-	size_t remote_id_length=0;
-	if(THEMIS_BUFFER_TOO_SMALL!=secure_session_get_remote_id(server.session, NULL, &remote_id_length)){
-		testsuite_fail_if(true, "remote id getting failed (length_determination)");
-		return;
-	}
-	uint8_t *remote_id=malloc(remote_id_length);
-	assert(remote_id);
-	if(THEMIS_SUCCESS!=secure_session_get_remote_id(server.session, remote_id, &remote_id_length)){
-		testsuite_fail_if(true, "remote id getting failed");
-		free(remote_id);
-		return;
-	}
-	testsuite_fail_unless(remote_id_length==strlen(client.id) && 0==memcmp(remote_id, client.id, strlen(client.id)), "secure_session remote id getting");
-	free(remote_id);
-
-
-	if (0 == bytes_received)
-	{
-		/* This was a key agreement packet. Nothing to do */
-		return;
-	}
-
-	if (bytes_received > 0)
-	{
-		/* We received some data. Echo it back to the client. */
-		ssize_t bytes_sent = secure_session_send((server.session), recv_buf, (size_t)bytes_received);
-
-		if (bytes_sent == bytes_received)
-		{
-			/* Check whether data was indeed encrypted (it should not be the same as in data_to_send) */
-			testsuite_fail_if((bytes_sent == current_length) || (!memcmp(recv_buf, shared_mem, bytes_sent)), "secure_session server message wrap");
-		}
-		else
-		{
-			testsuite_fail_if(true, "secure_session_send failed");
-		}
-	}
-}
-
-static void server_function_no_transport(void)
-{
-	uint8_t recv_buf[2048];
-	ssize_t bytes_received;
-    uint8_t processing_buf[2048];
-	ssize_t processing_buf_size = sizeof(processing_buf);
-	themis_status_t res;
-	if (current_length > 0)
-    {
-        bytes_received = on_receive_data(recv_buf, sizeof(recv_buf), NULL);
-        res = secure_session_unwrap((server.session), recv_buf, bytes_received, processing_buf, (size_t*)(&processing_buf_size));
-    }
-	else
-	{
+    if (current_length > 0) {
+        bytes_received = secure_session_receive((server.session), recv_buf, sizeof(recv_buf));
+    } else {
         /* Nothing to receive. Do nothing */
         return;
     }
 
-	size_t remote_id_length=0;
-	if(THEMIS_BUFFER_TOO_SMALL!=secure_session_get_remote_id(server.session, NULL, &remote_id_length)){
-		testsuite_fail_if(true, "remote id getting failed (length_determination)");
-		return;
-	}
-	uint8_t *remote_id=malloc(remote_id_length);
-	assert(remote_id);
-	if(THEMIS_SUCCESS!=secure_session_get_remote_id(server.session, remote_id, &remote_id_length)){
-		testsuite_fail_if(true, "remote id getting failed");
-		free(remote_id);
-		return;
-	}
-	testsuite_fail_unless(remote_id_length==strlen(client.id) && 0==memcmp(remote_id, client.id, strlen(client.id)), "secure_session remote id getting");
-	free(remote_id);
+    if (bytes_received < 0) {
+        testsuite_fail_if(bytes_received, "secure_session_receive failed");
+        return;
+    }
 
-	if ((THEMIS_SSESSION_SEND_OUTPUT_TO_PEER == res) && (processing_buf_size > 0))
-	{
-		/* This is key agreement data. Return response to the client. */
-		on_send_data(processing_buf, processing_buf_size, NULL);
-		return;
-	}
-	else if ((THEMIS_SUCCESS == res) && (processing_buf_size > 0))
-	{
-		ssize_t bytes_sent = 0;
+    size_t remote_id_length = 0;
+    if (THEMIS_BUFFER_TOO_SMALL !=
+        secure_session_get_remote_id(server.session, NULL, &remote_id_length)) {
+        testsuite_fail_if(true, "remote id getting failed (length_determination)");
+        return;
+    }
+    uint8_t* remote_id = malloc(remote_id_length);
+    assert(remote_id);
+    if (THEMIS_SUCCESS !=
+        secure_session_get_remote_id(server.session, remote_id, &remote_id_length)) {
+        testsuite_fail_if(true, "remote id getting failed");
+        free(remote_id);
+        return;
+    }
+    testsuite_fail_unless(remote_id_length == strlen(client.id) &&
+                              0 == memcmp(remote_id, client.id, strlen(client.id)),
+                          "secure_session remote id getting");
+    free(remote_id);
 
-		/* This is actual data. Echo it to the client. */
-		if (!secure_session_is_established((server.session)))
-		{
-			/* Should not happen */
-			testsuite_fail_if(true, "secure_session_unwrap failed");
-			return;
-		}
-		memcpy(recv_buf, processing_buf, (size_t)processing_buf_size);
-		res = secure_session_wrap((server.session), recv_buf, processing_buf_size, processing_buf, (size_t*)(&bytes_sent));
-		if (THEMIS_BUFFER_TOO_SMALL != res)
-		{
-			testsuite_fail_if(true, "secure_session_wrap failed");
-			return;
-		}
+    if (0 == bytes_received) {
+        /* This was a key agreement packet. Nothing to do */
+        return;
+    }
 
-		res = secure_session_wrap((server.session), recv_buf, processing_buf_size, processing_buf, (size_t*)(&bytes_sent));
-		if (THEMIS_SUCCESS != res)
-		{
-			testsuite_fail_if(true, "secure_session_wrap failed");
-			return;
-		}
+    if (bytes_received > 0) {
+        /* We received some data. Echo it back to the client. */
+        ssize_t bytes_sent =
+            secure_session_send((server.session), recv_buf, (size_t)bytes_received);
 
-		testsuite_fail_if(processing_buf_size == bytes_sent, "secure_session server message wrap");
-		on_send_data(processing_buf, bytes_sent, NULL);
-		return;
-	}
-	else
-	{
-		testsuite_fail_if(true, "secure_session_unwrap failed");
-	}
+        if (bytes_sent == bytes_received) {
+            /* Check whether data was indeed encrypted (it should not be the same as in
+             * data_to_send) */
+            testsuite_fail_if((bytes_sent == current_length) ||
+                                  (!memcmp(recv_buf, shared_mem, bytes_sent)),
+                              "secure_session server message wrap");
+        } else {
+            testsuite_fail_if(true, "secure_session_send failed");
+        }
+    }
+}
+
+static void server_function_no_transport(void)
+{
+    uint8_t recv_buf[2048];
+    ssize_t bytes_received;
+    uint8_t processing_buf[2048];
+    ssize_t processing_buf_size = sizeof(processing_buf);
+    themis_status_t res;
+    if (current_length > 0) {
+        bytes_received = on_receive_data(recv_buf, sizeof(recv_buf), NULL);
+        res = secure_session_unwrap((server.session), recv_buf, bytes_received, processing_buf,
+                                    (size_t*)(&processing_buf_size));
+    } else {
+        /* Nothing to receive. Do nothing */
+        return;
+    }
+
+    size_t remote_id_length = 0;
+    if (THEMIS_BUFFER_TOO_SMALL !=
+        secure_session_get_remote_id(server.session, NULL, &remote_id_length)) {
+        testsuite_fail_if(true, "remote id getting failed (length_determination)");
+        return;
+    }
+    uint8_t* remote_id = malloc(remote_id_length);
+    assert(remote_id);
+    if (THEMIS_SUCCESS !=
+        secure_session_get_remote_id(server.session, remote_id, &remote_id_length)) {
+        testsuite_fail_if(true, "remote id getting failed");
+        free(remote_id);
+        return;
+    }
+    testsuite_fail_unless(remote_id_length == strlen(client.id) &&
+                              0 == memcmp(remote_id, client.id, strlen(client.id)),
+                          "secure_session remote id getting");
+    free(remote_id);
+
+    if ((THEMIS_SSESSION_SEND_OUTPUT_TO_PEER == res) && (processing_buf_size > 0)) {
+        /* This is key agreement data. Return response to the client. */
+        on_send_data(processing_buf, processing_buf_size, NULL);
+        return;
+    }
+    if ((THEMIS_SUCCESS == res) && (processing_buf_size > 0)) {
+        ssize_t bytes_sent = 0;
+
+        /* This is actual data. Echo it to the client. */
+        if (!secure_session_is_established((server.session))) {
+            /* Should not happen */
+            testsuite_fail_if(true, "secure_session_unwrap failed");
+            return;
+        }
+        memcpy(recv_buf, processing_buf, (size_t)processing_buf_size);
+        res = secure_session_wrap((server.session), recv_buf, processing_buf_size, processing_buf,
+                                  (size_t*)(&bytes_sent));
+        if (THEMIS_BUFFER_TOO_SMALL != res) {
+            testsuite_fail_if(true, "secure_session_wrap failed");
+            return;
+        }
+
+        res = secure_session_wrap((server.session), recv_buf, processing_buf_size, processing_buf,
+                                  (size_t*)(&bytes_sent));
+        if (THEMIS_SUCCESS != res) {
+            testsuite_fail_if(true, "secure_session_wrap failed");
+            return;
+        }
+
+        testsuite_fail_if(processing_buf_size == bytes_sent, "secure_session server message wrap");
+        on_send_data(processing_buf, bytes_sent, NULL);
+        return;
+    }
+    testsuite_fail_if(true, "secure_session_unwrap failed");
 }
 
 static void schedule(void)
 {
-	int res = client_function();
+    int res = client_function();
 
-	while (TEST_CONTINUE == res)
-	{
-		server_function();
-		res = client_function();
-	}
+    while (TEST_CONTINUE == res) {
+        server_function();
+        res = client_function();
+    }
 
-	testsuite_fail_if(res, "secure session: basic flow");
+    testsuite_fail_if(res, "secure session: basic flow");
 }
 
 static void schedule_no_transport(void)
 {
-	int res = client_function_no_transport();
+    int res = client_function_no_transport();
 
-	while (TEST_CONTINUE == res)
-	{
-		server_function_no_transport();
-		res = client_function_no_transport();
-	}
+    while (TEST_CONTINUE == res) {
+        server_function_no_transport();
+        res = client_function_no_transport();
+    }
 
-	testsuite_fail_if(res, "secure session: basic flow (no transport)");
+    testsuite_fail_if(res, "secure session: basic flow (no transport)");
 }
 
 static void test_basic_flow(void)
 {
-	themis_status_t res;
+    themis_status_t res;
 
-	memcpy(&(client.transport), &transport, sizeof(secure_session_user_callbacks_t));
-	client.transport.user_data = &client;
+    memcpy(&(client.transport), &transport, sizeof(secure_session_user_callbacks_t));
+    client.transport.user_data = &client;
 
-	memcpy(&(server.transport), &transport, sizeof(secure_session_user_callbacks_t));
-	server.transport.user_data = &server;
+    memcpy(&(server.transport), &transport, sizeof(secure_session_user_callbacks_t));
+    server.transport.user_data = &server;
 
-	client.session = secure_session_create(client.id, strlen(client.id), client.priv, client.priv_length, &(client.transport));
-	if (client.session==NULL)
-	{
-		testsuite_fail_if(res, "secure_session_init failed");
-		return;
-	}
+    client.session = secure_session_create(client.id, strlen(client.id), client.priv,
+                                           client.priv_length, &(client.transport));
+    if (client.session == NULL) {
+        testsuite_fail_if(res, "secure_session_init failed");
+        return;
+    }
 
-	server.session = secure_session_create(server.id, strlen(server.id), server.priv, server.priv_length, &(server.transport));
-	if (server.session==NULL)
-	{
-		testsuite_fail_if(res, "secure_session_init failed");
-		secure_session_destroy((client.session));
-		return;
-	}
+    server.session = secure_session_create(server.id, strlen(server.id), server.priv,
+                                           server.priv_length, &(server.transport));
+    if (server.session == NULL) {
+        testsuite_fail_if(res, "secure_session_init failed");
+        secure_session_destroy((client.session));
+        return;
+    }
 
-	schedule();
+    schedule();
 
-	res = secure_session_destroy((server.session));
-	if (res)
-	{
-		testsuite_fail_if(res, "secure_session_destroy failed");
-	}
+    res = secure_session_destroy((server.session));
+    if (res) {
+        testsuite_fail_if(res, "secure_session_destroy failed");
+    }
 
-	res = secure_session_destroy((client.session));
-	if (res)
-	{
-		testsuite_fail_if(res, "secure_session_destroy failed");
-	}
+    res = secure_session_destroy((client.session));
+    if (res) {
+        testsuite_fail_if(res, "secure_session_destroy failed");
+    }
 }
 
 static void test_basic_flow_no_transport(void)
 {
-	themis_status_t res;
+    themis_status_t res;
 
-	memcpy(&(client.transport), &transport, sizeof(secure_session_user_callbacks_t));
-	client.transport.user_data = &client;
+    memcpy(&(client.transport), &transport, sizeof(secure_session_user_callbacks_t));
+    client.transport.user_data = &client;
 
-	memcpy(&(server.transport), &transport, sizeof(secure_session_user_callbacks_t));
-	server.transport.user_data = &server;
+    memcpy(&(server.transport), &transport, sizeof(secure_session_user_callbacks_t));
+    server.transport.user_data = &server;
 
-	client.session = secure_session_create(client.id, strlen(client.id), client.priv, client.priv_length, &(client.transport));
-	if (client.session==NULL)
-	{
-		testsuite_fail_if(res, "secure_session_init failed");
-		return;
-	}
+    client.session = secure_session_create(client.id, strlen(client.id), client.priv,
+                                           client.priv_length, &(client.transport));
+    if (client.session == NULL) {
+        testsuite_fail_if(res, "secure_session_init failed");
+        return;
+    }
 
-	server.session = secure_session_create(server.id, strlen(server.id), server.priv, server.priv_length, &(server.transport));
-	if (server.session==NULL)
-	{
-		testsuite_fail_if(res, "secure_session_init failed");
-		secure_session_destroy((client.session));
-		return;
-	}
+    server.session = secure_session_create(server.id, strlen(server.id), server.priv,
+                                           server.priv_length, &(server.transport));
+    if (server.session == NULL) {
+        testsuite_fail_if(res, "secure_session_init failed");
+        secure_session_destroy((client.session));
+        return;
+    }
 
-	schedule_no_transport();
+    schedule_no_transport();
 
-	res = secure_session_destroy((server.session));
-	if (res)
-	{
-		testsuite_fail_if(res, "secure_session_destroy failed");
-	}
+    res = secure_session_destroy((server.session));
+    if (res) {
+        testsuite_fail_if(res, "secure_session_destroy failed");
+    }
 
-	res = secure_session_destroy((client.session));
-	if (res)
-	{
-		testsuite_fail_if(res, "secure_session_destroy failed");
-	}
+    res = secure_session_destroy((client.session));
+    if (res) {
+        testsuite_fail_if(res, "secure_session_destroy failed");
+    }
 }
 
 void run_secure_session_test(void)
 {
-	testsuite_enter_suite("secure session: basic flow");
-	testsuite_run_test(test_basic_flow);
+    testsuite_enter_suite("secure session: basic flow");
+    testsuite_run_test(test_basic_flow);
 
-	testsuite_enter_suite("secure session: basic flow (no transport)");
-	testsuite_run_test(test_basic_flow_no_transport);
+    testsuite_enter_suite("secure session: basic flow (no transport)");
+    testsuite_run_test(test_basic_flow_no_transport);
 }

--- a/tests/themis/themis_test.c
+++ b/tests/themis/themis_test.c
@@ -1,18 +1,18 @@
 /*
-* Copyright (c) 2015 Cossack Labs Limited
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2015 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include <stdio.h>
 #include <string.h>
@@ -21,15 +21,15 @@
 
 int main(int argc, char* argv[])
 {
-  UNUSED(argc);
-  UNUSED(argv);
-  testsuite_start_testing();
+    UNUSED(argc);
+    UNUSED(argv);
+    testsuite_start_testing();
 
-  run_secure_message_test();
-  run_secure_session_test();
-  run_secure_cell_test();
-  run_secure_comparator_test();
+    run_secure_message_test();
+    run_secure_session_test();
+    run_secure_cell_test();
+    run_secure_comparator_test();
 
-  testsuite_finish_testing();
-  return testsuite_get_return_value();
+    testsuite_finish_testing();
+    return testsuite_get_return_value();
 }

--- a/tests/themis/themis_test.h
+++ b/tests/themis/themis_test.h
@@ -1,18 +1,18 @@
 /*
-* Copyright (c) 2015 Cossack Labs Limited
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2015 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #ifndef THEMIS_TEST_H
 #define THEMIS_TEST_H


### PR DESCRIPTION
Reformat the tests in accordance with the code style.

The code looks unreadable in some places, but meh... We use way too many long_and_detailed_multi_word_identifiers as well as test macros which effectively require to write code in a single line.

I'd suggest us to just deal with it (⌐■ _■) Let's leave this code as is now. For new code we can make an effort to keep it readable with the new formatting rules. Older code can be refactored to be more readable when we actually change it.