### PR TITLE
Use new Secure Message API in GoThemis

### DIFF
--- a/gothemis/keys/keypair.go
+++ b/gothemis/keys/keypair.go
@@ -7,7 +7,7 @@ package keys
 #include <stdint.h>
 #include <stdbool.h>
 #include <themis/themis_error.h>
-#include <themis/secure_message.h>
+#include <themis/secure_keygen.h>
 
 #define KEYTYPE_EC 0
 #define KEYTYPE_RSA 1

--- a/gothemis/message/message.go
+++ b/gothemis/message/message.go
@@ -9,33 +9,50 @@ package message
 #include <themis/themis_error.h>
 #include <themis/secure_message.h>
 
-static bool get_message_size(const void *priv, size_t priv_len, const void *public, size_t pub_len, const void *message, size_t message_len, bool is_wrap, size_t *out_len)
-{
-	themis_status_t res;
+#define SECURE_MESSAGE_ENCRYPT 0
+#define SECURE_MESSAGE_DECRYPT 1
+#define SECURE_MESSAGE_SIGN    2
+#define SECURE_MESSAGE_VERIFY  3
 
-	if (is_wrap)
-	{
-		res = themis_secure_message_wrap(priv, priv_len, public, pub_len, message, message_len, NULL, out_len);
-	}
-	else
-	{
-		res = themis_secure_message_unwrap(priv, priv_len, public, pub_len, message, message_len, NULL, out_len);
+static bool get_message_size(const void *priv, size_t priv_len, const void *public, size_t pub_len, const void *message, size_t message_len, int mode, size_t *out_len)
+{
+	themis_status_t res = THEMIS_NOT_SUPPORTED;
+
+	switch (mode) {
+	case SECURE_MESSAGE_ENCRYPT:
+		res = themis_secure_message_encrypt(priv, priv_len, public, pub_len, message, message_len, NULL, out_len);
+		break;
+	case SECURE_MESSAGE_DECRYPT:
+		res = themis_secure_message_decrypt(priv, priv_len, public, pub_len, message, message_len, NULL, out_len);
+		break;
+	case SECURE_MESSAGE_SIGN:
+		res = themis_secure_message_sign(priv, priv_len, message, message_len, NULL, out_len);
+		break;
+	case SECURE_MESSAGE_VERIFY:
+		res = themis_secure_message_verify(public, pub_len, message, message_len, NULL, out_len);
+		break;
 	}
 
 	return THEMIS_BUFFER_TOO_SMALL == res;
 }
 
-static bool process(const void *priv, size_t priv_len, const void *public, size_t pub_len, const void *message, size_t message_len, bool is_wrap, void *out, size_t out_len)
+static bool process(const void *priv, size_t priv_len, const void *public, size_t pub_len, const void *message, size_t message_len, int mode, void *out, size_t out_len)
 {
-	themis_status_t res;
+	themis_status_t res = THEMIS_NOT_SUPPORTED;
 
-	if (is_wrap)
-	{
-		res = themis_secure_message_wrap(priv, priv_len, public, pub_len, message, message_len, out, &out_len);
-	}
-	else
-	{
-		res = themis_secure_message_unwrap(priv, priv_len, public, pub_len, message, message_len, out, &out_len);
+	switch (mode) {
+	case SECURE_MESSAGE_ENCRYPT:
+		res = themis_secure_message_encrypt(priv, priv_len, public, pub_len, message, message_len, out, &out_len);
+		break;
+	case SECURE_MESSAGE_DECRYPT:
+		res = themis_secure_message_decrypt(priv, priv_len, public, pub_len, message, message_len, out, &out_len);
+		break;
+	case SECURE_MESSAGE_SIGN:
+		res = themis_secure_message_sign(priv, priv_len, message, message_len, out, &out_len);
+		break;
+	case SECURE_MESSAGE_VERIFY:
+		res = themis_secure_message_verify(public, pub_len, message, message_len, out, &out_len);
+		break;
 	}
 
 	return THEMIS_SUCCESS == res;
@@ -49,6 +66,13 @@ import (
 	"unsafe"
 )
 
+const (
+	SECURE_MESSAGE_ENCRYPT = 0
+	SECURE_MESSAGE_DECRYPT = 1
+	SECURE_MESSAGE_SIGN    = 2
+	SECURE_MESSAGE_VERIFY  = 3
+)
+
 type SecureMessage struct {
 	private    *keys.PrivateKey
 	peerPublic *keys.PublicKey
@@ -58,7 +82,7 @@ func New(private *keys.PrivateKey, peerPublic *keys.PublicKey) *SecureMessage {
 	return &SecureMessage{private, peerPublic}
 }
 
-func messageProcess(private *keys.PrivateKey, peerPublic *keys.PublicKey, message []byte, is_wrap bool) ([]byte, error) {
+func messageProcess(private *keys.PrivateKey, peerPublic *keys.PublicKey, message []byte, mode int) ([]byte, error) {
 	if nil == message || 0 == len(message) {
 		return nil, errors.New("No message was provided")
 	}
@@ -87,7 +111,7 @@ func messageProcess(private *keys.PrivateKey, peerPublic *keys.PublicKey, messag
 		pubLen,
 		unsafe.Pointer(&message[0]),
 		C.size_t(len(message)),
-		C.bool(is_wrap),
+		C.int(mode),
 		&output_length)) {
 		return nil, errors.New("Failed to get output size")
 	}
@@ -99,15 +123,21 @@ func messageProcess(private *keys.PrivateKey, peerPublic *keys.PublicKey, messag
 		pubLen,
 		unsafe.Pointer(&message[0]),
 		C.size_t(len(message)),
-		C.bool(is_wrap),
+		C.int(mode),
 		unsafe.Pointer(&output[0]),
 		output_length)) {
-		if is_wrap {
-			return nil, errors.New("Failed to wrap message")
-		} else {
-			return nil, errors.New("Failed to unwrap message")
+		switch mode {
+		case SECURE_MESSAGE_ENCRYPT:
+			return nil, errors.New("Failed to encrypt message")
+		case SECURE_MESSAGE_DECRYPT:
+			return nil, errors.New("Failed to decrypt message")
+		case SECURE_MESSAGE_SIGN:
+			return nil, errors.New("Failed to sign message")
+		case SECURE_MESSAGE_VERIFY:
+			return nil, errors.New("Failed to verify message")
+		default:
+			return nil, errors.New("Failed to process message")
 		}
-
 	}
 
 	return output, nil
@@ -121,7 +151,7 @@ func (sm *SecureMessage) Wrap(message []byte) ([]byte, error) {
 	if nil == sm.peerPublic || 0 == len(sm.peerPublic.Value) {
 		return nil, errors.New("Peer public key was not provided")
 	}
-	return messageProcess(sm.private, sm.peerPublic, message, true)
+	return messageProcess(sm.private, sm.peerPublic, message, SECURE_MESSAGE_ENCRYPT)
 }
 
 func (sm *SecureMessage) Unwrap(message []byte) ([]byte, error) {
@@ -132,7 +162,7 @@ func (sm *SecureMessage) Unwrap(message []byte) ([]byte, error) {
 	if nil == sm.peerPublic || 0 == len(sm.peerPublic.Value) {
 		return nil, errors.New("Peer public key was not provided")
 	}
-	return messageProcess(sm.private, sm.peerPublic, message, false)
+	return messageProcess(sm.private, sm.peerPublic, message, SECURE_MESSAGE_DECRYPT)
 }
 
 func (sm *SecureMessage) Sign(message []byte) ([]byte, error) {
@@ -140,7 +170,7 @@ func (sm *SecureMessage) Sign(message []byte) ([]byte, error) {
 		return nil, errors.New("Private key was not provided")
 	}
 
-	return messageProcess(sm.private, nil, message, true)
+	return messageProcess(sm.private, nil, message, SECURE_MESSAGE_SIGN)
 }
 
 func (sm *SecureMessage) Verify(message []byte) ([]byte, error) {
@@ -148,5 +178,5 @@ func (sm *SecureMessage) Verify(message []byte) ([]byte, error) {
 		return nil, errors.New("Peer public key was not provided")
 	}
 
-	return messageProcess(nil, sm.peerPublic, message, false)
+	return messageProcess(nil, sm.peerPublic, message, SECURE_MESSAGE_VERIFY)
 }


### PR DESCRIPTION
Exactly what it says on the tin. Get rid of the deprecation warnings and use the new API from #389 instead. It's hard to use proper enums in Go-to-C interop so just use integer constants, that's good enough.

Keep the old API naming for now. We'll update it later.

Also, include correct header for keygen. Key generation functions are now exported by `<themis/secure_keygen.h>`, not `<themis/secure_message.h>`. Include the correct header if we do not want to use `<themis/themis.h>`.