### PR TITLE
 Use new Secure Message API in PyThemis

### DIFF
--- a/src/wrappers/themis/python/pythemis/smessage.py
+++ b/src/wrappers/themis/python/pythemis/smessage.py
@@ -78,6 +78,12 @@ class SMessage(object):
 
 
 def ssign(private_key, message):
+    if not private_key:
+        raise ThemisError(THEMIS_CODES.FAIL,
+                          "Secure Message: missing private key")
+    if not _private_key(private_key):
+        raise ThemisError(THEMIS_CODES.FAIL,
+                          "Secure Message: invalid private key")
     encrypted_message_length = c_int(0)
     res = themis.themis_secure_message_sign(
         private_key, len(private_key), message, len(message),
@@ -94,6 +100,12 @@ def ssign(private_key, message):
 
 
 def sverify(public_key, message):
+    if not public_key:
+        raise ThemisError(THEMIS_CODES.FAIL,
+                          "Secure Message: missing public key")
+    if not _public_key(public_key):
+        raise ThemisError(THEMIS_CODES.FAIL,
+                          "Secure Message: invalid public key")
     plain_message_length = c_int(0)
     res = themis.themis_secure_message_verify(
         public_key, len(public_key), message, len(message),

--- a/src/wrappers/themis/python/pythemis/smessage.py
+++ b/src/wrappers/themis/python/pythemis/smessage.py
@@ -32,14 +32,14 @@ class SMessage(object):
 
     def wrap(self, message):
         encrypted_message_length = c_int(0)
-        res = themis.themis_secure_message_wrap(
+        res = themis.themis_secure_message_encrypt(
             self.private_key, len(self.private_key),
             self.peer_public_key, len(self.peer_public_key),
             message, len(message), None, byref(encrypted_message_length))
         if res != THEMIS_CODES.BUFFER_TOO_SMALL:
             raise ThemisError(res, "Secure Message failed encrypting")
         encrypted_message = create_string_buffer(encrypted_message_length.value)
-        res = themis.themis_secure_message_wrap(
+        res = themis.themis_secure_message_encrypt(
             self.private_key, len(self.private_key),
             self.peer_public_key, len(self.peer_public_key),
             message, len(message), encrypted_message,
@@ -51,14 +51,14 @@ class SMessage(object):
 
     def unwrap(self, message):
         plain_message_length = c_int(0)
-        res = themis.themis_secure_message_unwrap(
+        res = themis.themis_secure_message_decrypt(
             self.private_key, len(self.private_key),
             self.peer_public_key, len(self.peer_public_key),
             message, len(message), None, byref(plain_message_length))
         if res != THEMIS_CODES.BUFFER_TOO_SMALL:
             raise ThemisError(res, "Secure Message failed decrypting")
         plain_message = create_string_buffer(plain_message_length.value)
-        res = themis.themis_secure_message_unwrap(
+        res = themis.themis_secure_message_decrypt(
             self.private_key, len(self.private_key),
             self.peer_public_key, len(self.peer_public_key),
             message, len(message), plain_message, byref(plain_message_length))
@@ -69,14 +69,14 @@ class SMessage(object):
 
 def ssign(private_key, message):
     encrypted_message_length = c_int(0)
-    res = themis.themis_secure_message_wrap(
-        private_key, len(private_key), None, 0, message, len(message),
+    res = themis.themis_secure_message_sign(
+        private_key, len(private_key), message, len(message),
         None, byref(encrypted_message_length))
     if res != THEMIS_CODES.BUFFER_TOO_SMALL:
         raise ThemisError(res, "Secure Message failed singing")
     encrypted_message = create_string_buffer(encrypted_message_length.value)
-    res = themis.themis_secure_message_wrap(
-        private_key, len(private_key), None, 0, message, len(message),
+    res = themis.themis_secure_message_sign(
+        private_key, len(private_key), message, len(message),
         encrypted_message, byref(encrypted_message_length))
     if res != THEMIS_CODES.SUCCESS:
         raise ThemisError(res, "Secure Message failed singing")
@@ -85,14 +85,14 @@ def ssign(private_key, message):
 
 def sverify(public_key, message):
     plain_message_length = c_int(0)
-    res = themis.themis_secure_message_unwrap(
-        None, 0, public_key, len(public_key), message, len(message),
+    res = themis.themis_secure_message_verify(
+        public_key, len(public_key), message, len(message),
         None, byref(plain_message_length))
     if res != THEMIS_CODES.BUFFER_TOO_SMALL:
         raise ThemisError(res, "Secure Message failed verifying")
     plain_message = create_string_buffer(plain_message_length.value)
-    res = themis.themis_secure_message_unwrap(
-        None, 0, public_key, len(public_key), message, len(message),
+    res = themis.themis_secure_message_verify(
+        public_key, len(public_key), message, len(message),
         plain_message, byref(plain_message_length))
     if res != THEMIS_CODES.SUCCESS:
         raise ThemisError(res, "Secure Message failed verifying")

--- a/src/wrappers/themis/python/pythemis/smessage.py
+++ b/src/wrappers/themis/python/pythemis/smessage.py
@@ -16,6 +16,7 @@
 import warnings
 from ctypes import cdll, create_string_buffer, c_int, string_at, byref
 from ctypes.util import find_library
+from enum import IntEnum
 
 from .exception import ThemisError, THEMIS_CODES
 
@@ -24,9 +25,18 @@ themis = cdll.LoadLibrary(find_library('themis'))
 
 class SMessage(object):
     def __init__(self, private_key, peer_public_key):
-        if not (private_key and peer_public_key):
+        if not private_key:
             raise ThemisError(THEMIS_CODES.FAIL,
-                              "Secure Message failed creating")
+                              "Secure Message: missing private key")
+        if not peer_public_key:
+            raise ThemisError(THEMIS_CODES.FAIL,
+                              "Secure Message: missing public key")
+        if not _private_key(private_key):
+            raise ThemisError(THEMIS_CODES.FAIL,
+                              "Secure Message: invalid private key")
+        if not _public_key(peer_public_key):
+            raise ThemisError(THEMIS_CODES.FAIL,
+                              "Secure Message: invalid public key")
         self.private_key = private_key
         self.peer_public_key = peer_public_key
 
@@ -37,7 +47,7 @@ class SMessage(object):
             self.peer_public_key, len(self.peer_public_key),
             message, len(message), None, byref(encrypted_message_length))
         if res != THEMIS_CODES.BUFFER_TOO_SMALL:
-            raise ThemisError(res, "Secure Message failed encrypting")
+            raise ThemisError(res, "Secure Message failed to encrypt")
         encrypted_message = create_string_buffer(encrypted_message_length.value)
         res = themis.themis_secure_message_encrypt(
             self.private_key, len(self.private_key),
@@ -45,7 +55,7 @@ class SMessage(object):
             message, len(message), encrypted_message,
             byref(encrypted_message_length))
         if res != THEMIS_CODES.SUCCESS:
-            raise ThemisError(res, "Secure Message failed encrypting")
+            raise ThemisError(res, "Secure Message failed to encrypt")
 
         return string_at(encrypted_message, encrypted_message_length.value)
 
@@ -56,14 +66,14 @@ class SMessage(object):
             self.peer_public_key, len(self.peer_public_key),
             message, len(message), None, byref(plain_message_length))
         if res != THEMIS_CODES.BUFFER_TOO_SMALL:
-            raise ThemisError(res, "Secure Message failed decrypting")
+            raise ThemisError(res, "Secure Message failed to decrypt")
         plain_message = create_string_buffer(plain_message_length.value)
         res = themis.themis_secure_message_decrypt(
             self.private_key, len(self.private_key),
             self.peer_public_key, len(self.peer_public_key),
             message, len(message), plain_message, byref(plain_message_length))
         if res != THEMIS_CODES.SUCCESS:
-            raise ThemisError(res, "Secure Message failed decrypting")
+            raise ThemisError(res, "Secure Message failed to decrypt")
         return string_at(plain_message, plain_message_length.value)
 
 
@@ -73,13 +83,13 @@ def ssign(private_key, message):
         private_key, len(private_key), message, len(message),
         None, byref(encrypted_message_length))
     if res != THEMIS_CODES.BUFFER_TOO_SMALL:
-        raise ThemisError(res, "Secure Message failed singing")
+        raise ThemisError(res, "Secure Message failed to sign")
     encrypted_message = create_string_buffer(encrypted_message_length.value)
     res = themis.themis_secure_message_sign(
         private_key, len(private_key), message, len(message),
         encrypted_message, byref(encrypted_message_length))
     if res != THEMIS_CODES.SUCCESS:
-        raise ThemisError(res, "Secure Message failed singing")
+        raise ThemisError(res, "Secure Message failed to sign")
     return string_at(encrypted_message, encrypted_message_length.value)
 
 
@@ -89,15 +99,39 @@ def sverify(public_key, message):
         public_key, len(public_key), message, len(message),
         None, byref(plain_message_length))
     if res != THEMIS_CODES.BUFFER_TOO_SMALL:
-        raise ThemisError(res, "Secure Message failed verifying")
+        raise ThemisError(res, "Secure Message failed to verify")
     plain_message = create_string_buffer(plain_message_length.value)
     res = themis.themis_secure_message_verify(
         public_key, len(public_key), message, len(message),
         plain_message, byref(plain_message_length))
     if res != THEMIS_CODES.SUCCESS:
-        raise ThemisError(res, "Secure Message failed verifying")
+        raise ThemisError(res, "Secure Message failed to verify")
 
     return string_at(plain_message, plain_message_length.value)
+
+
+class THEMIS_KEY(IntEnum):
+    INVALID = 0
+    RSA_PRIVATE = 1
+    RSA_PUBLIC = 2
+    EC_PRIVATE = 3
+    EC_PUBLIC = 4
+
+
+def _public_key(key):
+    res = themis.themis_is_valid_asym_key(key, len(key))
+    if res != THEMIS_CODES.SUCCESS:
+        return False
+    kind = themis.themis_get_asym_key_kind(key, len(key))
+    return kind in [THEMIS_KEY.RSA_PUBLIC, THEMIS_KEY.EC_PUBLIC]
+
+
+def _private_key(key):
+    res = themis.themis_is_valid_asym_key(key, len(key))
+    if res != THEMIS_CODES.SUCCESS:
+        return False
+    kind = themis.themis_get_asym_key_kind(key, len(key))
+    return kind in [THEMIS_KEY.RSA_PRIVATE, THEMIS_KEY.EC_PRIVATE]
 
 
 class smessage(SMessage):

--- a/tests/pythemis/test_smessage.py
+++ b/tests/pythemis/test_smessage.py
@@ -60,7 +60,7 @@ class TestSMessage(unittest.TestCase):
         with self.assertRaises(ThemisError):
             smessage.ssign("", "")
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ThemisError):
             smessage.ssign(None, self.message)
 
         with self.assertRaises(ThemisError):

--- a/tests/pythemis/test_smessage.py
+++ b/tests/pythemis/test_smessage.py
@@ -42,6 +42,9 @@ class TestSMessage(unittest.TestCase):
         with self.assertRaises(ThemisError):
             smessage.SMessage(private, "")
 
+        with self.assertRaises(ThemisError):
+            smessage.SMessage(public, private)
+
         encryptor = smessage.SMessage(private, public)
         with self.assertRaises(ThemisError):
             encryptor.wrap("")
@@ -63,9 +66,15 @@ class TestSMessage(unittest.TestCase):
         with self.assertRaises(ThemisError):
             smessage.ssign(private, "")
 
+        with self.assertRaises(ThemisError):
+            smessage.ssign(public, "message")
+
         encrypted_message = smessage.ssign(private, self.message)
         with self.assertRaises(ThemisError):
             smessage.sverify(public, "")
+
+        with self.assertRaises(ThemisError):
+            smessage.sverify(private, encrypted_message)
 
         with self.assertRaises(ThemisError):
             smessage.sverify(public, b"".join([b"11", encrypted_message]))


### PR DESCRIPTION
Straightforward changes to use new C API of Secure Message. We just need to call different functions and that's it.

Keep Python method naming the same, we'll update it later separately.

Previous implementation allowed to (ab)use SecureMessage class in sign/verify mode by not specifying one of the keys. It is not possible now since we're using the new C API. Now we require both public and private key to be specified at Secure Message construction.

Update the tests to verify the new requirement and add more error checking to constructor to ensure that both keys are provided and that they have correct kinds.