### PR TITLE
 Use new Secure Message API in RubyThemis

### DIFF
--- a/src/wrappers/themis/ruby/lib/rubythemis.rb
+++ b/src/wrappers/themis/ruby/lib/rubythemis.rb
@@ -414,7 +414,7 @@ module Themis
       raise ThemisError, "Secure Message: invalid private key"
     end
     if not private_key(private_key)
-      raise ThemisError, "Secure Message: not a private key"
+      raise ThemisError, "Secure Message: public key used instead of private"
     end
 
     private_key_, private_key_length_ = string_to_pointer_size(private_key)
@@ -450,7 +450,7 @@ module Themis
       raise ThemisError, "Secure Message: invalid public key"
     end
     if not public_key(peer_public_key)
-      raise ThemisError, "Secure Message: not a public key"
+      raise ThemisError, "Secure Message: private key used instead of public"
     end
 
     public_key_, public_key_length_ = string_to_pointer_size(peer_public_key)

--- a/tests/rubythemis/smessage_test.rb
+++ b/tests/rubythemis/smessage_test.rb
@@ -52,7 +52,6 @@ class TestMessage < Test::Unit::TestCase
     ].each do |k1, k2|
       assert_raise(Themis::ThemisError) do
         smessage = Themis::Smessage.new(k1, k2)
-        encrypted_message = smessage.wrap(@message)
       end
     end
 
@@ -74,11 +73,23 @@ class TestMessage < Test::Unit::TestCase
 
   def test_sign_verify
     assert_raise(Themis::ThemisError) do
+      signed_message = Themis.s_sign('', @message)
+    end
+    assert_raise(Themis::ThemisError) do
       signed_message = Themis.s_sign(@ec256_pub, @message)
     end
     assert_raise(Themis::ThemisError) do
       signed_message = Themis.s_sign(@ec256_priv, '')
     end
+
+    signed_message = Themis.s_sign(@ec256_priv, @message)
+    assert_raise(Themis::ThemisError) do
+      verified_message = Themis.s_verify('', signed_message)
+    end
+    assert_raise(Themis::ThemisError) do
+      verified_message = Themis.s_verify(@ec256_priv, signed_message)
+    end
+
     @keys.each do |k|
       signed_message = Themis.s_sign(k[0], @message)
       verifyed_message = Themis.s_verify(k[1], signed_message)


### PR DESCRIPTION
It's easy to use the new API even if I don't know Ruby, just "attach" the new functions instead of the old ones and use them.

Just like with other language wrappers, improve key validation in Secure Message: perform early checks of private and public key and signal the user if there's anything wrong with them.