### PR TITLE
Remove "cargo deadlinks" check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,6 @@ jobs:
       - run: curl https://sh.rustup.rs -sSf | sh -s -- -y && cat ~/.cargo/env >> $BASH_ENV && source ~/.cargo/env && cargo --version && rustc --version
       - run: rustup component add clippy
       - run: rustup component add rustfmt
-      - run: cargo deadlinks --version || cargo install cargo-deadlinks
 
       # download last valgrind because current version of valgrind on ubuntu (3.11.0) gives false positive errors
       # link from http://valgrind.org/downloads/current.html

--- a/tests/rust/run_tests.sh
+++ b/tests/rust/run_tests.sh
@@ -30,7 +30,6 @@ echo "Checking documentation..."
 echo
 cargo clean --doc && cargo doc --no-deps
 cargo clean --doc && cargo doc --no-deps --features "vendored"
-cargo deadlinks
 
 echo
 echo "Rust tests OK!"


### PR DESCRIPTION
I have found this tool not *that* useful in preventing mistakes in API documentation, but it adds quite a considerable chunk to the build time of a development environment. I don't really want developers to wait 5-15 minutes to download and build all the dependencies just to have a check which passes 99.9999% of time.

We may reconsider this decision later if we actually run into issues with dead links in API docs.