### PR TITLE
Enforce C++ formatting for ThemisPP

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
 ---
-Checks: 'readability-*'
+Checks: 'readability-*,-readability-implicit-bool-conversion'
 FormatStyle: none
 ...

--- a/Makefile
+++ b/Makefile
@@ -318,6 +318,17 @@ $(OBJ_PATH)/%.fmt_check: $(SRC_PATH)/%
 	@echo -n "check $< "
 	@$(BUILD_CMD_)
 
+THEMISPP_HEADERS = $(wildcard $(SRC_PATH)/wrappers/themis/themispp/*.hpp)
+
+FMT_FIXUP += $(patsubst $(SRC_PATH)/%,$(OBJ_PATH)/%.fmt_fixup,$(THEMISPP_HEADERS))
+FMT_CHECK += $(patsubst $(SRC_PATH)/%,$(OBJ_PATH)/%.fmt_check,$(THEMISPP_HEADERS))
+
+$(OBJ_PATH)/%.hpp.fmt_fixup: \
+    CMD = $(CLANG_TIDY) -fix $< -- $(CFLAGS) 2>/dev/null && $(CLANG_FORMAT) -i $< && touch $@
+
+$(OBJ_PATH)/%.hpp.fmt_check: \
+    CMD = $(CLANG_FORMAT) $< | diff -u $< - && $(CLANG_TIDY) $< -- $(CFLAGS) 2>/dev/null && touch $@
+
 #$(AUD_PATH)/%: CMD = $(CC) $(CFLAGS) -E -dI -dD $< -o $@
 $(AUD_PATH)/%: CMD = ./scripts/pp.sh  $< $@
 

--- a/src/wrappers/themis/themispp/.clang-format
+++ b/src/wrappers/themis/themispp/.clang-format
@@ -1,0 +1,19 @@
+﻿---
+BasedOnStyle: LLVM
+AccessModifierOffset: -4
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakTemplateDeclarations: true
+BreakBeforeBraces: Linux
+BreakConstructorInitializersBeforeComma: true
+ColumnLimit: 120
+IndentWidth: 4
+ObjCSpaceAfterProperty: true
+PointerAlignment: Left
+TabWidth: 8
+UseTab: Never
+...

--- a/src/wrappers/themis/themispp/exception.hpp
+++ b/src/wrappers/themis/themispp/exception.hpp
@@ -1,46 +1,53 @@
 /*
-* Copyright (c) 2015 Cossack Labs Limited
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2015 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #ifndef THEMISPP_EXCEPTION_HPP_
 #define THEMISPP_EXCEPTION_HPP_
 
 #include <stdexcept>
+
 #include <themis/themis.h>
 
-namespace themispp{
-  class exception_t: public std::runtime_error
-  {
-  public:
+namespace themispp
+{
+
+class exception_t : public std::runtime_error
+{
+public:
     explicit exception_t(const char* what)
-      : std::runtime_error(what)
-      , status_(THEMIS_INVALID_PARAMETER)
-    {}
-
-    exception_t(const char* what, ::themis_status_t status)
-      : std::runtime_error(what)
-      , status_(status)
-    {}
-
-    ::themis_status_t status() const {
-      return status_;
+        : std::runtime_error(what)
+        , status_(THEMIS_INVALID_PARAMETER)
+    {
     }
 
-  private:
+    exception_t(const char* what, ::themis_status_t status)
+        : std::runtime_error(what)
+        , status_(status)
+    {
+    }
+
+    ::themis_status_t status() const
+    {
+        return status_;
+    }
+
+private:
     ::themis_status_t status_;
-  };
-}//themispp ns
+};
+
+} // namespace themispp
 
 #endif

--- a/src/wrappers/themis/themispp/secure_cell.hpp
+++ b/src/wrappers/themis/themispp/secure_cell.hpp
@@ -1,275 +1,356 @@
 /*
-* Copyright (c) 2015 Cossack Labs Limited
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2015 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #ifndef THEMISPP_SECURE_CELL_
 #define THEMISPP_SECURE_CELL_
 
 #include <vector>
+
 #include <themis/themis.h>
+
 #include "exception.hpp"
 
-namespace themispp{
+namespace themispp
+{
 
-  class secure_cell_t{
-  public:
+class secure_cell_t
+{
+public:
     typedef std::vector<uint8_t> data_t;
-    
-    secure_cell_t(data_t::const_iterator password_begin, data_t::const_iterator password_end):
-      _password(password_begin, password_end),
-      _res(0)
+
+    secure_cell_t(data_t::const_iterator password_begin, data_t::const_iterator password_end)
+        : _password(password_begin, password_end)
+        , _res(0)
     {
-      if(_password.empty()){
-        throw themispp::exception_t("Secure Cell must have non-empty password");
-      }
+        if (_password.empty()) {
+            throw themispp::exception_t("Secure Cell must have non-empty password");
+        }
     }
 
-    secure_cell_t(const data_t& password):
-      _password(password.begin(), password.end()),
-      _res(0)
+    secure_cell_t(const data_t& password)
+        : _password(password.begin(), password.end())
+        , _res(0)
     {
-      if(_password.empty()){
-        throw themispp::exception_t("Secure Cell must have non-empty password");
-      }
+        if (_password.empty()) {
+            throw themispp::exception_t("Secure Cell must have non-empty password");
+        }
     }
 
-    virtual const data_t& encrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end,  data_t::const_iterator context_begin, data_t::const_iterator context_end)=0;
-    virtual const data_t& decrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end,  data_t::const_iterator context_begin, data_t::const_iterator context_end)=0;
+    virtual const data_t& encrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end,
+                                  data_t::const_iterator context_begin, data_t::const_iterator context_end) = 0;
+    virtual const data_t& decrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end,
+                                  data_t::const_iterator context_begin, data_t::const_iterator context_end) = 0;
 
-    const data_t& encrypt(const data_t& data, const data_t& context){
-      return encrypt(data.begin(), data.end(), context.begin(), context.end());
+    const data_t& encrypt(const data_t& data, const data_t& context)
+    {
+        return encrypt(data.begin(), data.end(), context.begin(), context.end());
     }
 
-    const data_t& encrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end, const data_t& context){
-      return encrypt(data_begin, data_end, context.begin(), context.end());
+    const data_t& encrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end, const data_t& context)
+    {
+        return encrypt(data_begin, data_end, context.begin(), context.end());
     }
 
-    const data_t& encrypt(const data_t& data, data_t::const_iterator context_begin, data_t::const_iterator context_end){
-      return encrypt(data.begin(), data.end(), context_begin, context_end);
+    const data_t& encrypt(const data_t& data, data_t::const_iterator context_begin, data_t::const_iterator context_end)
+    {
+        return encrypt(data.begin(), data.end(), context_begin, context_end);
     }
 
-    const data_t& decrypt(const data_t& data, const data_t& context){
-      return decrypt(data.begin(), data.end(), context.begin(), context.end());
+    const data_t& decrypt(const data_t& data, const data_t& context)
+    {
+        return decrypt(data.begin(), data.end(), context.begin(), context.end());
     }
 
-    const data_t& decrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end, const data_t& context){
-      return decrypt(data_begin, data_end, context.begin(), context.end());
-    }
-    
-    const data_t& decrypt(const data_t& data, data_t::const_iterator context_begin, data_t::const_iterator context_end){
-      return decrypt(data.begin(), data.end(), context_begin, context_end);
+    const data_t& decrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end, const data_t& context)
+    {
+        return decrypt(data_begin, data_end, context.begin(), context.end());
     }
 
-  protected:
+    const data_t& decrypt(const data_t& data, data_t::const_iterator context_begin, data_t::const_iterator context_end)
+    {
+        return decrypt(data.begin(), data.end(), context_begin, context_end);
+    }
+
+protected:
     data_t _password;
     data_t _res;
-  };
-    
-  class secure_cell_optional_context_t: public secure_cell_t{
-  public:
-    secure_cell_optional_context_t(data_t::const_iterator password_begin, data_t::const_iterator password_end):
-      secure_cell_t(password_begin, password_end){}
-      
-    secure_cell_optional_context_t(const data_t& password):
-      secure_cell_t(password){}
-    
-    virtual const data_t& encrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end){
-      data_t context(0);
-      return secure_cell_t::encrypt(data_begin, data_end, context);
+};
+
+class secure_cell_optional_context_t : public secure_cell_t
+{
+public:
+    secure_cell_optional_context_t(data_t::const_iterator password_begin, data_t::const_iterator password_end)
+        : secure_cell_t(password_begin, password_end)
+    {
     }
 
-    virtual const data_t& encrypt(const data_t& data){
-      return encrypt(data.begin(), data.end());
+    secure_cell_optional_context_t(const data_t& password)
+        : secure_cell_t(password)
+    {
+    }
+
+    virtual const data_t& encrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end)
+    {
+        data_t context(0);
+        return secure_cell_t::encrypt(data_begin, data_end, context);
+    }
+
+    virtual const data_t& encrypt(const data_t& data)
+    {
+        return encrypt(data.begin(), data.end());
     }
     using secure_cell_t::encrypt;
 
-    const data_t& decrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end){
-      data_t context(0);
-      return secure_cell_t::decrypt(data_begin, data_end, context);
+    const data_t& decrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end)
+    {
+        data_t context(0);
+        return secure_cell_t::decrypt(data_begin, data_end, context);
     }
 
-    const data_t& decrypt(const data_t data){
-      return decrypt(data.begin(), data.end());
+    const data_t& decrypt(const data_t data)
+    {
+        return decrypt(data.begin(), data.end());
     }
     using secure_cell_t::decrypt;
-  };
-    
-  class secure_cell_seal_t: public secure_cell_optional_context_t{
-  public:
-    secure_cell_seal_t(data_t::const_iterator password_begin, data_t::const_iterator password_end):
-      secure_cell_optional_context_t(password_begin, password_end){}
+};
 
-    secure_cell_seal_t(const data_t& password):
-      secure_cell_optional_context_t(password){}
-
-    const data_t& encrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end,  data_t::const_iterator context_begin, data_t::const_iterator context_end){
-      if(data_end<=data_begin){
-        throw themispp::exception_t("Secure Cell (Seal) failed to encrypt message: data must be non-empty");
-      }
-      themis_status_t status=THEMIS_FAIL;
-      const uint8_t* context_ptr=(context_end>context_begin) ? &(*context_begin) : NULL;
-      const size_t context_len=(context_end>context_begin) ? (context_end-context_begin) : 0;
-      size_t encrypted_length=0;
-      status=themis_secure_cell_encrypt_seal(&_password[0], _password.size(), context_ptr, context_len, &(*data_begin), data_end-data_begin, NULL, &encrypted_length);
-      if(status!=THEMIS_BUFFER_TOO_SMALL){
-        throw themispp::exception_t("Secure Cell (Seal) failed to encrypt message", status);
-      }
-      _res.resize(encrypted_length);
-      status=themis_secure_cell_encrypt_seal(&_password[0], _password.size(), context_ptr, context_len, &(*data_begin), data_end-data_begin, &_res[0], &encrypted_length);
-      if(status!=THEMIS_SUCCESS){
-        throw themispp::exception_t("Secure Cell (Seal) failed to encrypt message", status);
-      }
-      return _res;
+class secure_cell_seal_t : public secure_cell_optional_context_t
+{
+public:
+    secure_cell_seal_t(data_t::const_iterator password_begin, data_t::const_iterator password_end)
+        : secure_cell_optional_context_t(password_begin, password_end)
+    {
     }
-    using secure_cell_optional_context_t::encrypt;
-    
-    const data_t& decrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end,  data_t::const_iterator context_begin, data_t::const_iterator context_end){
-      if(data_end<=data_begin){
-        throw themispp::exception_t("Secure Cell (Seal) failed to decrypt message: data must be non-empty");
-      }
-      themis_status_t status=THEMIS_FAIL;
-      const uint8_t* context_ptr=(context_end>context_begin) ? &(*context_begin) : NULL;
-      const size_t context_len=(context_end>context_begin) ? (context_end-context_begin) : 0;
-      size_t decrypted_length=0;
-      status=themis_secure_cell_decrypt_seal(&_password[0], _password.size(), context_ptr, context_len, &(*data_begin), data_end-data_begin, NULL, &decrypted_length);
-      if(status!=THEMIS_BUFFER_TOO_SMALL){
-        throw themispp::exception_t("Secure Cell (Seal) failed to decrypt message", status);
-      }
-      _res.resize(decrypted_length);
-      status=themis_secure_cell_decrypt_seal(&_password[0], _password.size(), context_ptr, context_len, &(*data_begin), data_end-data_begin, &_res[0], &decrypted_length);
-      if(status!=THEMIS_SUCCESS){
-        throw themispp::exception_t("Secure Cell (Seal) failed to decrypt message", status);
-      }
-      return _res;
+
+    secure_cell_seal_t(const data_t& password)
+        : secure_cell_optional_context_t(password)
+    {
     }
-    using secure_cell_optional_context_t::decrypt;
-  };
 
-  class secure_cell_token_protect_t: public secure_cell_optional_context_t{
-  public:
-    secure_cell_token_protect_t(data_t::const_iterator password_begin, data_t::const_iterator password_end):
-      secure_cell_optional_context_t(password_begin, password_end),
-      _token(0){}
-
-    secure_cell_token_protect_t(const data_t& password):
-      secure_cell_optional_context_t(password),
-      _token(0){}
-
-    const data_t& encrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end, data_t::const_iterator context_begin, data_t::const_iterator context_end){
-      if(data_end<=data_begin){
-        throw themispp::exception_t("Secure Cell (Token Protect) failed to encrypt message: data must be non-empty");
-      }
-      themis_status_t status=THEMIS_FAIL;
-      const uint8_t* context_ptr=(context_end>context_begin) ? &(*context_begin) : NULL;
-      const size_t context_len=(context_end>context_begin) ? (context_end-context_begin) : 0;
-      size_t encrypted_length=0;
-      size_t token_length=0;
-      status=themis_secure_cell_encrypt_token_protect(&_password[0], _password.size(), context_ptr, context_len, &(*data_begin), data_end-data_begin, NULL, &token_length, NULL, &encrypted_length);
-      if(status!=THEMIS_BUFFER_TOO_SMALL){
-        throw themispp::exception_t("Secure Cell (Token Protect) failed to encrypt message", status);
-      }
-      _res.resize(encrypted_length);
-      _token.resize(token_length);
-      status=themis_secure_cell_encrypt_token_protect(&_password[0], _password.size(), context_ptr, context_len, &(*data_begin), data_end-data_begin, &_token[0], &token_length, &_res[0], &encrypted_length);
-      if(status!=THEMIS_SUCCESS){
-        throw themispp::exception_t("Secure Cell (Token Protect) failed to encrypt message", status);
-      }
-      return _res;
+    const data_t& encrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end,
+                          data_t::const_iterator context_begin, data_t::const_iterator context_end)
+    {
+        if (data_end <= data_begin) {
+            throw themispp::exception_t("Secure Cell (Seal) failed to encrypt message: data must be non-empty");
+        }
+        themis_status_t status = THEMIS_FAIL;
+        const uint8_t* context_ptr = (context_end > context_begin) ? &(*context_begin) : NULL;
+        const size_t context_len = (context_end > context_begin) ? (context_end - context_begin) : 0;
+        size_t encrypted_length = 0;
+        status = themis_secure_cell_encrypt_seal(&_password[0], _password.size(), context_ptr, context_len,
+                                                 &(*data_begin), data_end - data_begin, NULL, &encrypted_length);
+        if (status != THEMIS_BUFFER_TOO_SMALL) {
+            throw themispp::exception_t("Secure Cell (Seal) failed to encrypt message", status);
+        }
+        _res.resize(encrypted_length);
+        status = themis_secure_cell_encrypt_seal(&_password[0], _password.size(), context_ptr, context_len,
+                                                 &(*data_begin), data_end - data_begin, &_res[0], &encrypted_length);
+        if (status != THEMIS_SUCCESS) {
+            throw themispp::exception_t("Secure Cell (Seal) failed to encrypt message", status);
+        }
+        return _res;
     }
     using secure_cell_optional_context_t::encrypt;
 
-    const data_t& decrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end, data_t::const_iterator context_begin, data_t::const_iterator context_end){
-      if(data_end<=data_begin){
-        throw themispp::exception_t("Secure Cell (Token Protect) failed to decrypt message: data must be non-empty");
-      }
-      if(_token.empty()){
-        throw themispp::exception_t("Secure Cell (Token Protect) failed to decrypt message: token must be non-empty (set with set_token())");
-      }
-      themis_status_t status=THEMIS_FAIL;
-      const uint8_t* context_ptr=(context_end>context_begin) ? &(*context_begin) : NULL;
-      const size_t context_len=(context_end>context_begin) ? (context_end-context_begin) : 0;
-      size_t decrypted_length=0;
-      status=themis_secure_cell_decrypt_token_protect(&_password[0], _password.size(), context_ptr, context_len, &(*data_begin), data_end-data_begin, &_token[0], _token.size(), NULL, &decrypted_length);
-      if(status!=THEMIS_BUFFER_TOO_SMALL){
-        throw themispp::exception_t("Secure Cell (Token Protect) failed to decrypt message", status);
-      }
-      _res.resize(decrypted_length);
-      status=themis_secure_cell_decrypt_token_protect(&_password[0], _password.size(), context_ptr, context_len, &(*data_begin), data_end-data_begin, &_token[0], _token.size(), &_res[0], &decrypted_length);
-      if(status!=THEMIS_SUCCESS){
-        throw themispp::exception_t("Secure Cell (Token Protect) failed to decrypt message", status);
-      }
-      return _res;
+    const data_t& decrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end,
+                          data_t::const_iterator context_begin, data_t::const_iterator context_end)
+    {
+        if (data_end <= data_begin) {
+            throw themispp::exception_t("Secure Cell (Seal) failed to decrypt message: data must be non-empty");
+        }
+        themis_status_t status = THEMIS_FAIL;
+        const uint8_t* context_ptr = (context_end > context_begin) ? &(*context_begin) : NULL;
+        const size_t context_len = (context_end > context_begin) ? (context_end - context_begin) : 0;
+        size_t decrypted_length = 0;
+        status = themis_secure_cell_decrypt_seal(&_password[0], _password.size(), context_ptr, context_len,
+                                                 &(*data_begin), data_end - data_begin, NULL, &decrypted_length);
+        if (status != THEMIS_BUFFER_TOO_SMALL) {
+            throw themispp::exception_t("Secure Cell (Seal) failed to decrypt message", status);
+        }
+        _res.resize(decrypted_length);
+        status = themis_secure_cell_decrypt_seal(&_password[0], _password.size(), context_ptr, context_len,
+                                                 &(*data_begin), data_end - data_begin, &_res[0], &decrypted_length);
+        if (status != THEMIS_SUCCESS) {
+            throw themispp::exception_t("Secure Cell (Seal) failed to decrypt message", status);
+        }
+        return _res;
+    }
+    using secure_cell_optional_context_t::decrypt;
+};
+
+class secure_cell_token_protect_t : public secure_cell_optional_context_t
+{
+public:
+    secure_cell_token_protect_t(data_t::const_iterator password_begin, data_t::const_iterator password_end)
+        : secure_cell_optional_context_t(password_begin, password_end)
+        , _token(0)
+    {
+    }
+
+    secure_cell_token_protect_t(const data_t& password)
+        : secure_cell_optional_context_t(password)
+        , _token(0)
+    {
+    }
+
+    const data_t& encrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end,
+                          data_t::const_iterator context_begin, data_t::const_iterator context_end)
+    {
+        if (data_end <= data_begin) {
+            throw themispp::exception_t(
+                "Secure Cell (Token Protect) failed to encrypt message: data must be non-empty");
+        }
+        themis_status_t status = THEMIS_FAIL;
+        const uint8_t* context_ptr = (context_end > context_begin) ? &(*context_begin) : NULL;
+        const size_t context_len = (context_end > context_begin) ? (context_end - context_begin) : 0;
+        size_t encrypted_length = 0;
+        size_t token_length = 0;
+        status = themis_secure_cell_encrypt_token_protect(&_password[0], _password.size(), context_ptr, context_len,
+                                                          &(*data_begin), data_end - data_begin, NULL, &token_length,
+                                                          NULL, &encrypted_length);
+        if (status != THEMIS_BUFFER_TOO_SMALL) {
+            throw themispp::exception_t("Secure Cell (Token Protect) failed to encrypt message", status);
+        }
+        _res.resize(encrypted_length);
+        _token.resize(token_length);
+        status = themis_secure_cell_encrypt_token_protect(&_password[0], _password.size(), context_ptr, context_len,
+                                                          &(*data_begin), data_end - data_begin, &_token[0],
+                                                          &token_length, &_res[0], &encrypted_length);
+        if (status != THEMIS_SUCCESS) {
+            throw themispp::exception_t("Secure Cell (Token Protect) failed to encrypt message", status);
+        }
+        return _res;
+    }
+    using secure_cell_optional_context_t::encrypt;
+
+    const data_t& decrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end,
+                          data_t::const_iterator context_begin, data_t::const_iterator context_end)
+    {
+        if (data_end <= data_begin) {
+            throw themispp::exception_t(
+                "Secure Cell (Token Protect) failed to decrypt message: data must be non-empty");
+        }
+        if (_token.empty()) {
+            throw themispp::exception_t("Secure Cell (Token Protect) failed to decrypt message: "
+                                        "token must be non-empty (set with set_token())");
+        }
+        themis_status_t status = THEMIS_FAIL;
+        const uint8_t* context_ptr = (context_end > context_begin) ? &(*context_begin) : NULL;
+        const size_t context_len = (context_end > context_begin) ? (context_end - context_begin) : 0;
+        size_t decrypted_length = 0;
+        status = themis_secure_cell_decrypt_token_protect(&_password[0], _password.size(), context_ptr, context_len,
+                                                          &(*data_begin), data_end - data_begin, &_token[0],
+                                                          _token.size(), NULL, &decrypted_length);
+        if (status != THEMIS_BUFFER_TOO_SMALL) {
+            throw themispp::exception_t("Secure Cell (Token Protect) failed to decrypt message", status);
+        }
+        _res.resize(decrypted_length);
+        status = themis_secure_cell_decrypt_token_protect(&_password[0], _password.size(), context_ptr, context_len,
+                                                          &(*data_begin), data_end - data_begin, &_token[0],
+                                                          _token.size(), &_res[0], &decrypted_length);
+        if (status != THEMIS_SUCCESS) {
+            throw themispp::exception_t("Secure Cell (Token Protect) failed to decrypt message", status);
+        }
+        return _res;
     }
 
     using secure_cell_optional_context_t::decrypt;
 
-    const data_t& get_token(){return _token;}
-    void set_token(const data_t& token){_token=token;}
-  protected:
+    const data_t& get_token()
+    {
+        return _token;
+    }
+    void set_token(const data_t& token)
+    {
+        _token = token;
+    }
+
+protected:
     data_t _token;
-  };
+};
 
-  class secure_cell_context_imprint_t: public secure_cell_t{
-  public:
-    secure_cell_context_imprint_t(const data_t& password):
-      secure_cell_t(password){}
+class secure_cell_context_imprint_t : public secure_cell_t
+{
+public:
+    secure_cell_context_imprint_t(const data_t& password)
+        : secure_cell_t(password)
+    {
+    }
 
-    const data_t& encrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end, data_t::const_iterator context_begin, data_t::const_iterator context_end){
-      if(data_end<=data_begin){
-        throw themispp::exception_t("Secure Cell (Context Imprint) failed to encrypt message: data must be non-empty");
-      }
-      if(context_end<=context_begin){
-        throw themispp::exception_t("Secure Cell (Context Imprint) failed to encrypt message: context must be non-empty");
-      }
-      themis_status_t status=THEMIS_FAIL;
-      size_t encrypted_length=0;
-      status=themis_secure_cell_encrypt_context_imprint(&_password[0], _password.size(), &(*context_begin), context_end-context_begin, &(*data_begin), data_end-data_begin, NULL, &encrypted_length);
-      if(status!=THEMIS_BUFFER_TOO_SMALL){
-        throw themispp::exception_t("Secure Cell (Context Imprint) failed to encrypt message", status);
-      }
-      _res.resize(encrypted_length);
-      status=themis_secure_cell_encrypt_context_imprint(&_password[0], _password.size(), &(*context_begin), context_end-context_begin, &(*data_begin), data_end-data_begin, &_res[0], &encrypted_length);
-      if(status!=THEMIS_SUCCESS){
-        throw themispp::exception_t("Secure Cell (Context Imprint) failed to encrypt message", status);
-      }
-      return _res;
+    const data_t& encrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end,
+                          data_t::const_iterator context_begin, data_t::const_iterator context_end)
+    {
+        if (data_end <= data_begin) {
+            throw themispp::exception_t(
+                "Secure Cell (Context Imprint) failed to encrypt message: data must be non-empty");
+        }
+        if (context_end <= context_begin) {
+            throw themispp::exception_t("Secure Cell (Context Imprint) failed to encrypt message: "
+                                        "context must be non-empty");
+        }
+        themis_status_t status = THEMIS_FAIL;
+        size_t encrypted_length = 0;
+        status = themis_secure_cell_encrypt_context_imprint(&_password[0], _password.size(), &(*context_begin),
+                                                            context_end - context_begin, &(*data_begin),
+                                                            data_end - data_begin, NULL, &encrypted_length);
+        if (status != THEMIS_BUFFER_TOO_SMALL) {
+            throw themispp::exception_t("Secure Cell (Context Imprint) failed to encrypt message", status);
+        }
+        _res.resize(encrypted_length);
+        status = themis_secure_cell_encrypt_context_imprint(&_password[0], _password.size(), &(*context_begin),
+                                                            context_end - context_begin, &(*data_begin),
+                                                            data_end - data_begin, &_res[0], &encrypted_length);
+        if (status != THEMIS_SUCCESS) {
+            throw themispp::exception_t("Secure Cell (Context Imprint) failed to encrypt message", status);
+        }
+        return _res;
     }
     using secure_cell_t::encrypt;
 
-    const data_t& decrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end, data_t::const_iterator context_begin, data_t::const_iterator context_end){
-      if(data_end<=data_begin){
-        throw themispp::exception_t("Secure Cell (Context Imprint) failed to decrypt message: data must be non-empty");
-      }
-      if(context_end<=context_begin){
-        throw themispp::exception_t("Secure Cell (Context Imprint) failed to decrypt message: context must be non-empty");
-      }
-      themis_status_t status=THEMIS_FAIL;
-      size_t decrypted_length=0;
-      status=themis_secure_cell_decrypt_context_imprint(&_password[0], _password.size(), &(*context_begin), context_end-context_begin, &(*data_begin), data_end-data_begin, NULL, &decrypted_length);
-      if(status!=THEMIS_BUFFER_TOO_SMALL){
-        throw themispp::exception_t("Secure Cell (Context Imprint) failed to decrypt message", status);
-      }
-      _res.resize(decrypted_length);
-      status=themis_secure_cell_decrypt_context_imprint(&_password[0], _password.size(), &(*context_begin), context_end-context_begin, &(*data_begin), data_end-data_begin, &_res[0], &decrypted_length);
-      if(status!=THEMIS_SUCCESS){
-        throw themispp::exception_t("Secure Cell (Context Imprint) failed to decrypt message", status);
-      }
-      return _res;
+    const data_t& decrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end,
+                          data_t::const_iterator context_begin, data_t::const_iterator context_end)
+    {
+        if (data_end <= data_begin) {
+            throw themispp::exception_t(
+                "Secure Cell (Context Imprint) failed to decrypt message: data must be non-empty");
+        }
+        if (context_end <= context_begin) {
+            throw themispp::exception_t("Secure Cell (Context Imprint) failed to decrypt message: "
+                                        "context must be non-empty");
+        }
+        themis_status_t status = THEMIS_FAIL;
+        size_t decrypted_length = 0;
+        status = themis_secure_cell_decrypt_context_imprint(&_password[0], _password.size(), &(*context_begin),
+                                                            context_end - context_begin, &(*data_begin),
+                                                            data_end - data_begin, NULL, &decrypted_length);
+        if (status != THEMIS_BUFFER_TOO_SMALL) {
+            throw themispp::exception_t("Secure Cell (Context Imprint) failed to decrypt message", status);
+        }
+        _res.resize(decrypted_length);
+        status = themis_secure_cell_decrypt_context_imprint(&_password[0], _password.size(), &(*context_begin),
+                                                            context_end - context_begin, &(*data_begin),
+                                                            data_end - data_begin, &_res[0], &decrypted_length);
+        if (status != THEMIS_SUCCESS) {
+            throw themispp::exception_t("Secure Cell (Context Imprint) failed to decrypt message", status);
+        }
+        return _res;
     }
     using secure_cell_t::decrypt;
-  };
-}//themispp ns
+};
+
+} // namespace themispp
 
 #endif

--- a/src/wrappers/themis/themispp/secure_comparator.hpp
+++ b/src/wrappers/themis/themispp/secure_comparator.hpp
@@ -1,94 +1,105 @@
 /*
-* Copyright (c) 2015 Cossack Labs Limited
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2015 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #ifndef THEMISPP_SECURE_COMPARATOR_HPP_
 #define THEMISPP_SECURE_COMPARATOR_HPP_
 
 #include <cstring>
 #include <vector>
+
 #include <themis/themis.h>
+
 #include "exception.hpp"
 
 #define THEMISPP_SECURE_SESSION_MAX_MESSAGE_SIZE 2048
-namespace themispp{
+namespace themispp
+{
 
-  class secure_comparator_t{
-  public:
-    typedef std::vector<uint8_t> data_t; 
-    
-    secure_comparator_t(const data_t& shared_secret):
-      comparator_(NULL){
-      if(shared_secret.empty()){
-        throw themispp::exception_t("Secure Comparator must have non-empty shared secret");
-      }
-      res_.reserve(512);
-      comparator_=secure_comparator_create();
-      if(!comparator_){
-        throw themispp::exception_t("Secure Comparator construction failed");
-      }
-      themis_status_t status=secure_comparator_append_secret(comparator_, &shared_secret[0], shared_secret.size());
-      if(THEMIS_SUCCESS!=status){
-        throw themispp::exception_t("Secure Comparator failed to append secret", status);
-      }
-    }
+class secure_comparator_t
+{
+public:
+    typedef std::vector<uint8_t> data_t;
 
-    virtual ~secure_comparator_t(){
-      secure_comparator_destroy(comparator_);
-    }
-
-    const data_t& init(){
-      themis_status_t status=THEMIS_FAIL;
-      size_t data_length=0;
-      status=secure_comparator_begin_compare(comparator_, NULL, &data_length);
-      if(THEMIS_BUFFER_TOO_SMALL!=status){
-        throw themispp::exception_t("Secure Comparator failed to initialize comparison", status);
-      }
-      res_.resize(data_length);
-      status=secure_comparator_begin_compare(comparator_, &res_[0], &data_length);
-      if(THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER!=status){
-        throw themispp::exception_t("Secure Comparator failed to initialize comparison", status);
-      }
-      return res_;
+    secure_comparator_t(const data_t& shared_secret)
+        : comparator_(NULL)
+    {
+        if (shared_secret.empty()) {
+            throw themispp::exception_t("Secure Comparator must have non-empty shared secret");
+        }
+        res_.reserve(512);
+        comparator_ = secure_comparator_create();
+        if (!comparator_) {
+            throw themispp::exception_t("Secure Comparator construction failed");
+        }
+        themis_status_t status = secure_comparator_append_secret(comparator_, &shared_secret[0], shared_secret.size());
+        if (THEMIS_SUCCESS != status) {
+            throw themispp::exception_t("Secure Comparator failed to append secret", status);
+        }
     }
 
-    const data_t& proceed(const std::vector<uint8_t>& data){
-      if(data.empty()){
-        throw themispp::exception_t("Secure Comparator failed to proceed comparison: data must be non-empty");
-      }
-      themis_status_t status=THEMIS_FAIL;
-      size_t res_data_length=0;
-      status=secure_comparator_proceed_compare(comparator_, &data[0], data.size(), NULL, &res_data_length);
-      if(THEMIS_BUFFER_TOO_SMALL!=status){
-        throw themispp::exception_t("Secure Comparator failed to proceed comparison", status);
-      }
-      res_.resize(res_data_length);
-      status=secure_comparator_proceed_compare(comparator_, &data[0], data.size(), &res_[0], &res_data_length);
-      if(THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER!=status && THEMIS_SUCCESS!=status){
-        throw themispp::exception_t("Secure Comparator failed to proceed comparison", status);
-      }
-      return res_;
+    virtual ~secure_comparator_t()
+    {
+        secure_comparator_destroy(comparator_);
     }
-    
-    const bool get(){
-      return (THEMIS_SCOMPARE_MATCH == secure_comparator_get_result(comparator_))?true:false;
+
+    const data_t& init()
+    {
+        themis_status_t status = THEMIS_FAIL;
+        size_t data_length = 0;
+        status = secure_comparator_begin_compare(comparator_, NULL, &data_length);
+        if (THEMIS_BUFFER_TOO_SMALL != status) {
+            throw themispp::exception_t("Secure Comparator failed to initialize comparison", status);
+        }
+        res_.resize(data_length);
+        status = secure_comparator_begin_compare(comparator_, &res_[0], &data_length);
+        if (THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER != status) {
+            throw themispp::exception_t("Secure Comparator failed to initialize comparison", status);
+        }
+        return res_;
     }
-  private:
+
+    const data_t& proceed(const std::vector<uint8_t>& data)
+    {
+        if (data.empty()) {
+            throw themispp::exception_t("Secure Comparator failed to proceed comparison: data must be non-empty");
+        }
+        themis_status_t status = THEMIS_FAIL;
+        size_t res_data_length = 0;
+        status = secure_comparator_proceed_compare(comparator_, &data[0], data.size(), NULL, &res_data_length);
+        if (THEMIS_BUFFER_TOO_SMALL != status) {
+            throw themispp::exception_t("Secure Comparator failed to proceed comparison", status);
+        }
+        res_.resize(res_data_length);
+        status = secure_comparator_proceed_compare(comparator_, &data[0], data.size(), &res_[0], &res_data_length);
+        if (THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER != status && THEMIS_SUCCESS != status) {
+            throw themispp::exception_t("Secure Comparator failed to proceed comparison", status);
+        }
+        return res_;
+    }
+
+    const bool get()
+    {
+        return THEMIS_SCOMPARE_MATCH == secure_comparator_get_result(comparator_);
+    }
+
+private:
     ::secure_comparator_t* comparator_;
     std::vector<uint8_t> res_;
-  };
-}// ns themis
+};
+
+} // namespace themispp
 
 #endif

--- a/src/wrappers/themis/themispp/secure_keygen.hpp
+++ b/src/wrappers/themis/themispp/secure_keygen.hpp
@@ -1,114 +1,129 @@
 /*
-* Copyright (c) 2015 Cossack Labs Limited
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2015 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #ifndef THEMISPP_SECURE_KEYGEN_HPP_
 #define THEMISPP_SECURE_KEYGEN_HPP_
 
 #include <cstring>
 #include <vector>
-#include "themis/themis.h"
+
+#include <themis/themis.h>
+
 #include "exception.hpp"
 
-#define MAX_KEY_LENGTH 10*1024
+#define MAX_KEY_LENGTH 10 * 1024
 
-namespace themispp{
+namespace themispp
+{
 
-  enum asym_algs {EC, RSA};
+enum asym_algs { EC, RSA };
 
-
-  template <asym_algs alg_t_p, size_t max_key_length_t_p = MAX_KEY_LENGTH>
-  class secure_key_pair_generator_t{
-  public:
-    secure_key_pair_generator_t():
-      private_key(max_key_length_t_p),
-      public_key(max_key_length_t_p){
-      gen();
+template <asym_algs alg_t_p, size_t max_key_length_t_p = MAX_KEY_LENGTH>
+class secure_key_pair_generator_t
+{
+public:
+    secure_key_pair_generator_t()
+        : private_key(max_key_length_t_p)
+        , public_key(max_key_length_t_p)
+    {
+        gen();
     }
-    
-    void gen(){
-      themis_status_t status=THEMIS_FAIL;
-      size_t private_key_length=max_key_length_t_p;
-      size_t public_key_length=max_key_length_t_p;
-      switch(alg_t_p){
-      case EC:
-        status=themis_gen_ec_key_pair(&private_key[0], &private_key_length, &public_key[0], &public_key_length);
-        if(status!=THEMIS_SUCCESS){
-          throw themispp::exception_t("Themis failed to generate EC key pair", status);
-        }
-        break;
-      case RSA:
-        status=themis_gen_rsa_key_pair(&private_key[0], &private_key_length, &public_key[0], &public_key_length);
-        if(status!=THEMIS_SUCCESS){
-          throw themispp::exception_t("Themis failed to generate RSA key pair", status);
-        }
-        break;
-      default:
-        throw themispp::exception_t("Themis failed generate key pair: unsupported algorithm");
-      }
-      private_key.resize(private_key_length);
-      public_key.resize(public_key_length);
-    }
-      
-    const std::vector<uint8_t>& get_priv(){return private_key;}
-    const std::vector<uint8_t>& get_pub(){return public_key;}
 
-  private:
+    void gen()
+    {
+        themis_status_t status = THEMIS_FAIL;
+        size_t private_key_length = max_key_length_t_p;
+        size_t public_key_length = max_key_length_t_p;
+        switch (alg_t_p) {
+        case EC:
+            status = themis_gen_ec_key_pair(&private_key[0], &private_key_length, &public_key[0], &public_key_length);
+            if (status != THEMIS_SUCCESS) {
+                throw themispp::exception_t("Themis failed to generate EC key pair", status);
+            }
+            break;
+        case RSA:
+            status = themis_gen_rsa_key_pair(&private_key[0], &private_key_length, &public_key[0], &public_key_length);
+            if (status != THEMIS_SUCCESS) {
+                throw themispp::exception_t("Themis failed to generate RSA key pair", status);
+            }
+            break;
+        default:
+            throw themispp::exception_t("Themis failed generate key pair: unsupported algorithm");
+        }
+        private_key.resize(private_key_length);
+        public_key.resize(public_key_length);
+    }
+
+    const std::vector<uint8_t>& get_priv()
+    {
+        return private_key;
+    }
+    const std::vector<uint8_t>& get_pub()
+    {
+        return public_key;
+    }
+
+private:
     std::vector<uint8_t> private_key;
     std::vector<uint8_t> public_key;
-  };
+};
 
-  inline themis_status_t validate_key(const std::vector<uint8_t>& key){
-    if(key.empty()){
-      return THEMIS_INVALID_PARAMETER;
+inline themis_status_t validate_key(const std::vector<uint8_t>& key)
+{
+    if (key.empty()) {
+        return THEMIS_INVALID_PARAMETER;
     }
     return themis_is_valid_asym_key(&key[0], key.size());
-  }
+}
 
-  inline bool is_valid_key(const std::vector<uint8_t>& key){
-    return validate_key(key)==THEMIS_SUCCESS;
-  }
+inline bool is_valid_key(const std::vector<uint8_t>& key)
+{
+    return validate_key(key) == THEMIS_SUCCESS;
+}
 
-  inline bool is_private_key(const std::vector<uint8_t>& key){
-    if(!key.empty()){
-      themis_key_kind_t kind=themis_get_asym_key_kind(&key[0], key.size());
-      switch(kind){
-      case THEMIS_KEY_EC_PRIVATE:
-      case THEMIS_KEY_RSA_PRIVATE:
-        return true;
-      default:
-        break;
-      }
+inline bool is_private_key(const std::vector<uint8_t>& key)
+{
+    if (!key.empty()) {
+        themis_key_kind_t kind = themis_get_asym_key_kind(&key[0], key.size());
+        switch (kind) {
+        case THEMIS_KEY_EC_PRIVATE:
+        case THEMIS_KEY_RSA_PRIVATE:
+            return true;
+        default:
+            break;
+        }
     }
     return false;
-  }
+}
 
-  inline bool is_public_key(const std::vector<uint8_t>& key){
-    if(!key.empty()){
-      themis_key_kind_t kind=themis_get_asym_key_kind(&key[0], key.size());
-      switch(kind){
-      case THEMIS_KEY_EC_PUBLIC:
-      case THEMIS_KEY_RSA_PUBLIC:
-        return true;
-      default:
-        break;
-      }
+inline bool is_public_key(const std::vector<uint8_t>& key)
+{
+    if (!key.empty()) {
+        themis_key_kind_t kind = themis_get_asym_key_kind(&key[0], key.size());
+        switch (kind) {
+        case THEMIS_KEY_EC_PUBLIC:
+        case THEMIS_KEY_RSA_PUBLIC:
+            return true;
+        default:
+            break;
+        }
     }
     return false;
-  }
+}
 
-}// ns themis
+} // namespace themispp
 
 #endif

--- a/src/wrappers/themis/themispp/secure_message.hpp
+++ b/src/wrappers/themis/themispp/secure_message.hpp
@@ -17,181 +17,212 @@
 #ifndef THEMISPP_SECURE_MESSAGE_HPP_
 #define THEMISPP_SECURE_MESSAGE_HPP_
 
-#include "exception.hpp"
-#include "secure_keygen.hpp"
-#include <themis/themis.h>
 #include <vector>
 
-namespace themispp {
+#include <themis/themis.h>
 
-  class secure_message_t
-  {
-  public:
+#include "exception.hpp"
+#include "secure_keygen.hpp"
+
+namespace themispp
+{
+
+class secure_message_t
+{
+public:
     typedef std::vector<uint8_t> data_t;
-    
-    secure_message_t(data_t::const_iterator private_key_begin, data_t::const_iterator private_key_end, data_t::const_iterator peer_public_key_begin, data_t::const_iterator peer_public_key_end):
-      private_key_(private_key_begin, private_key_end),
-      peer_public_key_(peer_public_key_begin, peer_public_key_end)
+
+    secure_message_t(data_t::const_iterator private_key_begin, data_t::const_iterator private_key_end,
+                     data_t::const_iterator peer_public_key_begin, data_t::const_iterator peer_public_key_end)
+        : private_key_(private_key_begin, private_key_end)
+        , peer_public_key_(peer_public_key_begin, peer_public_key_end)
     {
-      validate_keys();
+        validate_keys();
     }
 
-    secure_message_t(const data_t& private_key, data_t::const_iterator peer_public_key_begin, data_t::const_iterator peer_public_key_end):
-      private_key_(private_key.begin(), private_key.end()),
-      peer_public_key_(peer_public_key_begin, peer_public_key_end)
+    secure_message_t(const data_t& private_key, data_t::const_iterator peer_public_key_begin,
+                     data_t::const_iterator peer_public_key_end)
+        : private_key_(private_key.begin(), private_key.end())
+        , peer_public_key_(peer_public_key_begin, peer_public_key_end)
     {
-      validate_keys();
+        validate_keys();
     }
 
-    secure_message_t(data_t::const_iterator private_key_begin, data_t::const_iterator private_key_end, const data_t& peer_public_key):
-      private_key_(private_key_begin, private_key_end),
-      peer_public_key_(peer_public_key.begin(), peer_public_key.end())
+    secure_message_t(data_t::const_iterator private_key_begin, data_t::const_iterator private_key_end,
+                     const data_t& peer_public_key)
+        : private_key_(private_key_begin, private_key_end)
+        , peer_public_key_(peer_public_key.begin(), peer_public_key.end())
     {
-      validate_keys();
+        validate_keys();
     }
 
-    secure_message_t(const data_t& private_key, const data_t& peer_public_key):
-      private_key_(private_key.begin(), private_key.end()),
-      peer_public_key_(peer_public_key.begin(), peer_public_key.end())
+    secure_message_t(const data_t& private_key, const data_t& peer_public_key)
+        : private_key_(private_key.begin(), private_key.end())
+        , peer_public_key_(peer_public_key.begin(), peer_public_key.end())
     {
-      validate_keys();
+        validate_keys();
     }
 
-    virtual ~secure_message_t(){}
-
-    const data_t& encrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end){
-      if(private_key_.empty()){
-        throw themispp::exception_t("Secure Message failed to encrypt message: private key not set");
-      }
-      if(peer_public_key_.empty()){
-        throw themispp::exception_t("Secure Message failed to encrypt message: public key not set");
-      }
-      if(data_end<=data_begin){
-        throw themispp::exception_t("Secure Message failed to encrypt message: data must be non-empty");
-      }
-      themis_status_t status=THEMIS_FAIL;
-      size_t encrypted_data_length=0;
-      status=themis_secure_message_encrypt(&private_key_[0], private_key_.size(), &peer_public_key_[0], peer_public_key_.size(), &(*data_begin), data_end-data_begin, NULL, &encrypted_data_length);
-      if(status!=THEMIS_BUFFER_TOO_SMALL){
-        throw themispp::exception_t("Secure Message failed to encrypt message", status);
-      }
-      res_.resize(encrypted_data_length);
-      status=themis_secure_message_encrypt(&private_key_[0], private_key_.size(), &peer_public_key_[0], peer_public_key_.size(), &(*data_begin), data_end-data_begin, &res_[0], &encrypted_data_length);
-      if(status!=THEMIS_SUCCESS){
-        throw themispp::exception_t("Secure Message failed to encrypt message", status);
-      }
-      return res_;
+    virtual ~secure_message_t()
+    {
     }
 
-    const data_t& encrypt(const data_t& data){
-      return encrypt(data.begin(), data.end());
+    const data_t& encrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end)
+    {
+        if (private_key_.empty()) {
+            throw themispp::exception_t("Secure Message failed to encrypt message: private key not set");
+        }
+        if (peer_public_key_.empty()) {
+            throw themispp::exception_t("Secure Message failed to encrypt message: public key not set");
+        }
+        if (data_end <= data_begin) {
+            throw themispp::exception_t("Secure Message failed to encrypt message: data must be non-empty");
+        }
+        themis_status_t status = THEMIS_FAIL;
+        size_t encrypted_data_length = 0;
+        status = themis_secure_message_encrypt(&private_key_[0], private_key_.size(), &peer_public_key_[0],
+                                               peer_public_key_.size(), &(*data_begin), data_end - data_begin, NULL,
+                                               &encrypted_data_length);
+        if (status != THEMIS_BUFFER_TOO_SMALL) {
+            throw themispp::exception_t("Secure Message failed to encrypt message", status);
+        }
+        res_.resize(encrypted_data_length);
+        status = themis_secure_message_encrypt(&private_key_[0], private_key_.size(), &peer_public_key_[0],
+                                               peer_public_key_.size(), &(*data_begin), data_end - data_begin, &res_[0],
+                                               &encrypted_data_length);
+        if (status != THEMIS_SUCCESS) {
+            throw themispp::exception_t("Secure Message failed to encrypt message", status);
+        }
+        return res_;
     }
 
-    const data_t& decrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end){
-      if(private_key_.empty()){
-        throw themispp::exception_t("Secure Message failed to decrypt message: private key not set");
-      }
-      if(peer_public_key_.empty()){
-        throw themispp::exception_t("Secure Message failed to decrypt message: public key not set");
-      }
-      if(data_end<=data_begin){
-        throw themispp::exception_t("Secure Message failed to decrypt message: data must be non-empty");
-      }
-      themis_status_t status=THEMIS_FAIL;
-      size_t decrypted_data_length=0;
-      status=themis_secure_message_decrypt(&private_key_[0], private_key_.size(), &peer_public_key_[0], peer_public_key_.size(), &(*data_begin), data_end-data_begin, NULL, &decrypted_data_length);
-      if(status!=THEMIS_BUFFER_TOO_SMALL){
-        throw themispp::exception_t("Secure Message failed to decrypt message", status);
-      }
-      res_.resize(decrypted_data_length);
-      status=themis_secure_message_decrypt(&private_key_[0], private_key_.size(), &peer_public_key_[0], peer_public_key_.size(), &(*data_begin), data_end-data_begin, &res_[0], &decrypted_data_length);
-      if(status!=THEMIS_SUCCESS){
-        throw themispp::exception_t("Secure Message failed to decrypt message", status);
-      }
-      return res_;
+    const data_t& encrypt(const data_t& data)
+    {
+        return encrypt(data.begin(), data.end());
     }
 
-    const data_t& decrypt(const data_t& data){
-      return decrypt(data.begin(), data.end());
+    const data_t& decrypt(data_t::const_iterator data_begin, data_t::const_iterator data_end)
+    {
+        if (private_key_.empty()) {
+            throw themispp::exception_t("Secure Message failed to decrypt message: private key not set");
+        }
+        if (peer_public_key_.empty()) {
+            throw themispp::exception_t("Secure Message failed to decrypt message: public key not set");
+        }
+        if (data_end <= data_begin) {
+            throw themispp::exception_t("Secure Message failed to decrypt message: data must be non-empty");
+        }
+        themis_status_t status = THEMIS_FAIL;
+        size_t decrypted_data_length = 0;
+        status = themis_secure_message_decrypt(&private_key_[0], private_key_.size(), &peer_public_key_[0],
+                                               peer_public_key_.size(), &(*data_begin), data_end - data_begin, NULL,
+                                               &decrypted_data_length);
+        if (status != THEMIS_BUFFER_TOO_SMALL) {
+            throw themispp::exception_t("Secure Message failed to decrypt message", status);
+        }
+        res_.resize(decrypted_data_length);
+        status = themis_secure_message_decrypt(&private_key_[0], private_key_.size(), &peer_public_key_[0],
+                                               peer_public_key_.size(), &(*data_begin), data_end - data_begin, &res_[0],
+                                               &decrypted_data_length);
+        if (status != THEMIS_SUCCESS) {
+            throw themispp::exception_t("Secure Message failed to decrypt message", status);
+        }
+        return res_;
     }
 
-    const data_t& sign(data_t::const_iterator data_begin, data_t::const_iterator data_end){
-      if(private_key_.empty()){
-        throw themispp::exception_t("Secure Message failed to sign message: private key not set");
-      }
-      if(data_end<=data_begin){
-        throw themispp::exception_t("Secure Message failed to sign message: data must be non-empty");
-      }
-      themis_status_t status=THEMIS_FAIL;
-      size_t encrypted_data_length=0;
-      status=themis_secure_message_sign(&private_key_[0], private_key_.size(), &(*data_begin), data_end-data_begin, NULL, &encrypted_data_length);
-      if(status!=THEMIS_BUFFER_TOO_SMALL){
-        throw themispp::exception_t("Secure Message failed to sign message", status);
-      }
-      res_.resize(encrypted_data_length);
-      status=themis_secure_message_sign(&private_key_[0], private_key_.size(), &(*data_begin), data_end-data_begin, &res_[0], &encrypted_data_length);
-      if(status!=THEMIS_SUCCESS){
-        throw themispp::exception_t("Secure Message failed to sign message", status);
-      }
-      return res_;
+    const data_t& decrypt(const data_t& data)
+    {
+        return decrypt(data.begin(), data.end());
     }
 
-    const data_t& sign(const data_t& data){
-      return sign(data.begin(), data.end());
+    const data_t& sign(data_t::const_iterator data_begin, data_t::const_iterator data_end)
+    {
+        if (private_key_.empty()) {
+            throw themispp::exception_t("Secure Message failed to sign message: private key not set");
+        }
+        if (data_end <= data_begin) {
+            throw themispp::exception_t("Secure Message failed to sign message: data must be non-empty");
+        }
+        themis_status_t status = THEMIS_FAIL;
+        size_t encrypted_data_length = 0;
+        status = themis_secure_message_sign(&private_key_[0], private_key_.size(), &(*data_begin),
+                                            data_end - data_begin, NULL, &encrypted_data_length);
+        if (status != THEMIS_BUFFER_TOO_SMALL) {
+            throw themispp::exception_t("Secure Message failed to sign message", status);
+        }
+        res_.resize(encrypted_data_length);
+        status = themis_secure_message_sign(&private_key_[0], private_key_.size(), &(*data_begin),
+                                            data_end - data_begin, &res_[0], &encrypted_data_length);
+        if (status != THEMIS_SUCCESS) {
+            throw themispp::exception_t("Secure Message failed to sign message", status);
+        }
+        return res_;
     }
 
-    const data_t& verify(data_t::const_iterator data_begin, data_t::const_iterator data_end){
-      if(peer_public_key_.empty()){
-        throw themispp::exception_t("Secure Message failed to verify signature: public key not set");
-      }
-      if(data_end<=data_begin){
-        throw themispp::exception_t("Secure Message failed to verify signature: data must be non-empty");
-      }
-      themis_status_t status=THEMIS_FAIL;
-      size_t decrypted_data_length=0;
-      status=themis_secure_message_verify(&peer_public_key_[0], peer_public_key_.size(), &(*data_begin), data_end-data_begin, NULL, &decrypted_data_length);
-      if(status!=THEMIS_BUFFER_TOO_SMALL){
-        throw themispp::exception_t("Secure Message failed to verify signature", status);
-      }
-      res_.resize(decrypted_data_length);
-      status=themis_secure_message_verify(&peer_public_key_[0], peer_public_key_.size(), &(*data_begin), data_end-data_begin, &res_[0], &decrypted_data_length);
-      if(status!=THEMIS_SUCCESS){
-        throw themispp::exception_t("Secure Message failed to verify signature", status);
-      }
-      return res_;
+    const data_t& sign(const data_t& data)
+    {
+        return sign(data.begin(), data.end());
     }
 
-    const data_t& verify(const data_t& data){
-      return verify(data.begin(), data.end());
+    const data_t& verify(data_t::const_iterator data_begin, data_t::const_iterator data_end)
+    {
+        if (peer_public_key_.empty()) {
+            throw themispp::exception_t("Secure Message failed to verify signature: public key not set");
+        }
+        if (data_end <= data_begin) {
+            throw themispp::exception_t("Secure Message failed to verify signature: data must be non-empty");
+        }
+        themis_status_t status = THEMIS_FAIL;
+        size_t decrypted_data_length = 0;
+        status = themis_secure_message_verify(&peer_public_key_[0], peer_public_key_.size(), &(*data_begin),
+                                              data_end - data_begin, NULL, &decrypted_data_length);
+        if (status != THEMIS_BUFFER_TOO_SMALL) {
+            throw themispp::exception_t("Secure Message failed to verify signature", status);
+        }
+        res_.resize(decrypted_data_length);
+        status = themis_secure_message_verify(&peer_public_key_[0], peer_public_key_.size(), &(*data_begin),
+                                              data_end - data_begin, &res_[0], &decrypted_data_length);
+        if (status != THEMIS_SUCCESS) {
+            throw themispp::exception_t("Secure Message failed to verify signature", status);
+        }
+        return res_;
     }
 
-  private:
+    const data_t& verify(const data_t& data)
+    {
+        return verify(data.begin(), data.end());
+    }
+
+private:
     data_t private_key_;
     data_t peer_public_key_;
     data_t res_;
-  private:
+
+private:
     secure_message_t(const secure_message_t&);
     secure_message_t& operator=(const secure_message_t&);
 
-    void validate_keys(){
-      if(!private_key_.empty()){
-        if(!is_valid_key(private_key_)){
-          throw themispp::exception_t("Secure Message: invalid private key");
+    void validate_keys()
+    {
+        if (!private_key_.empty()) {
+            if (!is_valid_key(private_key_)) {
+                throw themispp::exception_t("Secure Message: invalid private key");
+            }
+            if (!is_private_key(private_key_)) {
+                throw themispp::exception_t("Secure Message: using public key instead of private key");
+            }
         }
-        if(!is_private_key(private_key_)){
-          throw themispp::exception_t("Secure Message: using public key instead of private key");
+        if (!peer_public_key_.empty()) {
+            if (!is_valid_key(peer_public_key_)) {
+                throw themispp::exception_t("Secure Message: invalid public key");
+            }
+            if (!is_public_key(peer_public_key_)) {
+                throw themispp::exception_t("Secure Message: using private key instead of public key");
+            }
         }
-      }
-      if(!peer_public_key_.empty()){
-        if(!is_valid_key(peer_public_key_)){
-          throw themispp::exception_t("Secure Message: invalid public key");
-        }
-        if(!is_public_key(peer_public_key_)){
-          throw themispp::exception_t("Secure Message: using private key instead of public key");
-        }
-      }
     }
-  };
-} //end themispp
+};
+
+} // namespace themispp
 
 #endif /* THEMISPP_SECURE_MESSAGE_HPP_ */

--- a/src/wrappers/themis/themispp/secure_rand.hpp
+++ b/src/wrappers/themis/themispp/secure_rand.hpp
@@ -1,41 +1,50 @@
 /*
-* Copyright (c) 2015 Cossack Labs Limited
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2015 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #ifndef THEMISPP_SECURE_RAND_HPP_
 #define THEMISPP_SECURE_RAND_HPP_
 
 #include <vector>
+
 #include <themis/themis.h>
+
 #include "exception.hpp"
 
-namespace themispp{
+namespace themispp
+{
 
-    template <size_t block_length_t_p>
-    class secure_rand_t{
-	public:
-	    secure_rand_t():
-		n_(block_length_t_p, 0){}
+template <size_t block_length_t_p>
+class secure_rand_t
+{
+public:
+    secure_rand_t()
+        : n_(block_length_t_p, 0)
+    {
+    }
 
-	    std::vector<uint8_t>& get(){
-		soter_rand(&n_[0], block_length_t_p);
-		return n_;
-	    }
-	private:
-	    std::vector<uint8_t> n_;
-    };
-}//themis
+    std::vector<uint8_t>& get()
+    {
+        soter_rand(&n_[0], block_length_t_p);
+        return n_;
+    }
+
+private:
+    std::vector<uint8_t> n_;
+};
+
+} // namespace themispp
 
 #endif

--- a/src/wrappers/themis/themispp/secure_session.hpp
+++ b/src/wrappers/themis/themispp/secure_session.hpp
@@ -1,285 +1,325 @@
 /*
-* Copyright (c) 2015 Cossack Labs Limited
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2015 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #ifndef THEMISPP_SECURE_SESSION_HPP_
 #define THEMISPP_SECURE_SESSION_HPP_
 
 #include <cstring>
+#include <vector>
+
 #if __cplusplus >= 201103L
 #include <memory>
 #endif
-#include <vector>
+
 #include <themis/themis.h>
+
 #include "exception.hpp"
 
 #define THEMISPP_SECURE_SESSION_MAX_MESSAGE_SIZE 2048
-namespace themispp{
 
-  class secure_session_callback_interface_t{
-  public:
+namespace themispp
+{
+
+class secure_session_callback_interface_t
+{
+public:
     typedef std::vector<uint8_t> data_t;
-    virtual const data_t get_pub_key_by_id(const data_t& id)=0;
-    virtual void send(const data_t& data){throw themispp::exception_t("Secure Session failed sending, send callback not set");}
-    virtual const data_t& receive(){throw themispp::exception_t("Secure Session failed receiving, receive callback not set");}
-  };
-
-  inline ssize_t send_callback(const uint8_t* data, size_t data_length, void *user_data){
-    try{
-      ((secure_session_callback_interface_t*)user_data)->send(std::vector<uint8_t>((uint8_t*)data, (uint8_t*)data+data_length));
-    }catch(...){return -1;}
-    return ssize_t(data_length);
-  }
-
-  inline ssize_t receive_callback(uint8_t* data, size_t data_length, void *user_data){
-    try{
-      std::vector<uint8_t> received_data=((secure_session_callback_interface_t*)user_data)->receive();
-      if(received_data.empty() || received_data.size()>data_length){
-        return -1;
-      }
-      memcpy(data, &received_data[0], received_data.size());
-      return ssize_t(received_data.size());
-    }catch(...){}
-    return -1;
-  }
-
-  inline int get_public_key_for_id_callback(const void *id, size_t id_length, void *key_buffer, size_t key_buffer_length, void *user_data){
-    std::vector<uint8_t> pubk=((secure_session_callback_interface_t*)user_data)->get_pub_key_by_id(std::vector<uint8_t>(static_cast<const uint8_t*>(id), static_cast<const uint8_t*>(id)+id_length));
-    if(pubk.empty()){
-      return THEMIS_FAIL;
+    virtual const data_t get_pub_key_by_id(const data_t& id) = 0;
+    virtual void send(const data_t& data)
+    {
+        throw themispp::exception_t("Secure Session failed sending, send callback not set");
     }
-    if(pubk.size()>key_buffer_length){
-      return THEMIS_BUFFER_TOO_SMALL;
+    virtual const data_t& receive()
+    {
+        throw themispp::exception_t("Secure Session failed receiving, receive callback not set");
+    }
+};
+
+inline ssize_t send_callback(const uint8_t* data, size_t data_length, void* user_data)
+{
+    try {
+        ((secure_session_callback_interface_t*)user_data)
+            ->send(std::vector<uint8_t>((uint8_t*)data, (uint8_t*)data + data_length));
+    } catch (...) {
+        return -1;
+    }
+    return ssize_t(data_length);
+}
+
+inline ssize_t receive_callback(uint8_t* data, size_t data_length, void* user_data)
+{
+    try {
+        std::vector<uint8_t> received_data = ((secure_session_callback_interface_t*)user_data)->receive();
+        if (received_data.empty() || received_data.size() > data_length) {
+            return -1;
+        }
+        memcpy(data, &received_data[0], received_data.size());
+        return ssize_t(received_data.size());
+    } catch (...) {
+    }
+    return -1;
+}
+
+inline int get_public_key_for_id_callback(const void* id, size_t id_length, void* key_buffer, size_t key_buffer_length,
+                                          void* user_data)
+{
+    std::vector<uint8_t> pubk = ((secure_session_callback_interface_t*)user_data)
+                                    ->get_pub_key_by_id(std::vector<uint8_t>(
+                                        static_cast<const uint8_t*>(id), static_cast<const uint8_t*>(id) + id_length));
+    if (pubk.empty()) {
+        return THEMIS_FAIL;
+    }
+    if (pubk.size() > key_buffer_length) {
+        return THEMIS_BUFFER_TOO_SMALL;
     }
     std::memcpy(key_buffer, &pubk[0], pubk.size());
     return THEMIS_SUCCESS;
-  }
+}
 
-  class secure_session_t{
-  public:
-    typedef std::vector<uint8_t> data_t; 
+class secure_session_t
+{
+public:
+    typedef std::vector<uint8_t> data_t;
 
-    secure_session_t():
-      _session(NULL),
-      _callback(NULL){
+    secure_session_t()
+        : _session(NULL)
+        , _callback(NULL)
+    {
     }
 
 #if __cplusplus >= 201103L
     DEPRECATED("please use std::shared_ptr<secure_session_callback_interface_t> constructor instead")
 #endif
-    secure_session_t(const data_t& id, const data_t& priv_key, secure_session_callback_interface_t* callbacks):
-      _session(NULL),
-      _callback(NULL),
-      _res(0){
-      initialize_session(id, priv_key, callbacks);
+    secure_session_t(const data_t& id, const data_t& priv_key, secure_session_callback_interface_t* callbacks)
+        : _session(NULL)
+        , _callback(NULL)
+        , _res(0)
+    {
+        initialize_session(id, priv_key, callbacks);
     }
 
-    virtual ~secure_session_t(){
-      if(_session){
-        secure_session_destroy(_session);
-        _session=NULL;
-      }
-      delete _callback;
-      _callback=NULL;
+    virtual ~secure_session_t()
+    {
+        if (_session) {
+            secure_session_destroy(_session);
+            _session = NULL;
+        }
+        delete _callback;
+        _callback = NULL;
     }
 
 #if __cplusplus >= 201103L
-    secure_session_t(const data_t& id, const data_t& priv_key, std::shared_ptr<secure_session_callback_interface_t> &&callbacks):
-      _session(nullptr),
-      _callback(nullptr),
-      _res(0),
-      _interface(std::move(callbacks)){
-      initialize_session(id, priv_key, _interface.get());
+    secure_session_t(const data_t& id, const data_t& priv_key,
+                     std::shared_ptr<secure_session_callback_interface_t>&& callbacks)
+        : _session(nullptr)
+        , _callback(nullptr)
+        , _res(0)
+        , _interface(std::move(callbacks))
+    {
+        initialize_session(id, priv_key, _interface.get());
     }
 
     secure_session_t(const secure_session_t&) = delete;
     secure_session_t& operator=(const secure_session_t&) = delete;
 
-    secure_session_t(secure_session_t&& other){
-      _session=other._session;
-      _callback=other._callback;
-      _res=std::move(other._res);
-      _interface=std::move(other._interface);
-      other._session=nullptr;
-      other._callback=nullptr;
+    secure_session_t(secure_session_t&& other)
+    {
+        _session = other._session;
+        _callback = other._callback;
+        _res = std::move(other._res);
+        _interface = std::move(other._interface);
+        other._session = nullptr;
+        other._callback = nullptr;
     }
 
-    secure_session_t& operator=(secure_session_t&& other){
-      if(this!=&other){
-        if(_session){
-          secure_session_destroy(_session);
+    secure_session_t& operator=(secure_session_t&& other)
+    {
+        if (this != &other) {
+            if (_session) {
+                secure_session_destroy(_session);
+            }
+            delete _callback;
+            _session = other._session;
+            _callback = other._callback;
+            _res = std::move(other._res);
+            _interface = std::move(other._interface);
+            other._session = nullptr;
+            other._callback = nullptr;
         }
-        delete _callback;
-        _session=other._session;
-        _callback=other._callback;
-        _res=std::move(other._res);
-        _interface=std::move(other._interface);
-        other._session=nullptr;
-        other._callback=nullptr;
-      }
-      return *this;
+        return *this;
     }
 #else
-  private:
+private:
     secure_session_t(const secure_session_t&);
     secure_session_t& operator=(const secure_session_t&);
-  public:
+
+public:
 #endif
 
-    const data_t& unwrap(const std::vector<uint8_t>& data){
-      if(!_session){
-        throw themispp::exception_t("uninitialized Secure Session");
-      }
-      if(data.empty()){
-        throw themispp::exception_t("Secure Session failed to unwrap message: data must be non-empty");
-      }
-      themis_status_t status=THEMIS_FAIL;
-      size_t unwrapped_data_length=0;
-      status=secure_session_unwrap(_session, &data[0],data.size(), NULL, &unwrapped_data_length);
-      if(status==THEMIS_SUCCESS){
-        _res.resize(0);
+    const data_t& unwrap(const std::vector<uint8_t>& data)
+    {
+        if (!_session) {
+            throw themispp::exception_t("uninitialized Secure Session");
+        }
+        if (data.empty()) {
+            throw themispp::exception_t("Secure Session failed to unwrap message: data must be non-empty");
+        }
+        themis_status_t status = THEMIS_FAIL;
+        size_t unwrapped_data_length = 0;
+        status = secure_session_unwrap(_session, &data[0], data.size(), NULL, &unwrapped_data_length);
+        if (status == THEMIS_SUCCESS) {
+            _res.resize(0);
+            return _res;
+        }
+        if (status != THEMIS_BUFFER_TOO_SMALL) {
+            throw themispp::exception_t("Secure Session failed to unwrap message", status);
+        }
+        _res.resize(unwrapped_data_length);
+        status = secure_session_unwrap(_session, &data[0], data.size(), &_res[0], &unwrapped_data_length);
+        if (status == THEMIS_SSESSION_SEND_OUTPUT_TO_PEER) {
+            return _res;
+        }
+        if (status != THEMIS_SUCCESS) {
+            throw themispp::exception_t("Secure Session failed to unwrap message", status);
+        }
         return _res;
-      }
-      if(status!=THEMIS_BUFFER_TOO_SMALL){
-        throw themispp::exception_t("Secure Session failed to unwrap message", status);
-      }
-      _res.resize(unwrapped_data_length);
-      status=secure_session_unwrap(_session, &data[0],data.size(), &_res[0], &unwrapped_data_length);
-      if(status==THEMIS_SSESSION_SEND_OUTPUT_TO_PEER){
+    }
+
+    const data_t& wrap(const std::vector<uint8_t>& data)
+    {
+        if (!_session) {
+            throw themispp::exception_t("uninitialized Secure Session");
+        }
+        if (data.empty()) {
+            throw themispp::exception_t("Secure Session failed to wrap message: data must be non-empty");
+        }
+        themis_status_t status = THEMIS_FAIL;
+        size_t wrapped_message_length = 0;
+        status = secure_session_wrap(_session, &data[0], data.size(), NULL, &wrapped_message_length);
+        if (status != THEMIS_BUFFER_TOO_SMALL) {
+            throw themispp::exception_t("Secure Session failed to wrap message", status);
+        }
+        _res.resize(wrapped_message_length);
+        status = secure_session_wrap(_session, &data[0], data.size(), &_res[0], &wrapped_message_length);
+        if (status != THEMIS_SUCCESS) {
+            throw themispp::exception_t("Secure Session failed to wrap message", status);
+        }
         return _res;
-      }
-      if(status!=THEMIS_SUCCESS){
-        throw themispp::exception_t("Secure Session failed to unwrap message", status);
-      }
-      return _res;
     }
 
-    const data_t& wrap(const std::vector<uint8_t>& data){
-      if(!_session){
-        throw themispp::exception_t("uninitialized Secure Session");
-      }
-      if(data.empty()){
-        throw themispp::exception_t("Secure Session failed to wrap message: data must be non-empty");
-      }
-      themis_status_t status=THEMIS_FAIL;
-      size_t wrapped_message_length=0;
-      status=secure_session_wrap(_session, &data[0], data.size(), NULL, &wrapped_message_length);
-      if(status!=THEMIS_BUFFER_TOO_SMALL){
-        throw themispp::exception_t("Secure Session failed to wrap message", status);
-      }
-      _res.resize(wrapped_message_length);
-      status=secure_session_wrap(_session, &data[0], data.size(), &_res[0], &wrapped_message_length);
-      if(status!=THEMIS_SUCCESS){
-        throw themispp::exception_t("Secure Session failed to wrap message", status);
-      }
-      return _res;
-    }
-    
-    const data_t& init(){
-      if(!_session){
-        throw themispp::exception_t("uninitialized Secure Session");
-      }
-      themis_status_t status=THEMIS_FAIL;
-      size_t init_data_length=0;
-      status=secure_session_generate_connect_request(_session, NULL, &init_data_length);
-      if(status!=THEMIS_BUFFER_TOO_SMALL){
-        throw themispp::exception_t("Secure Session failed to initialize", status);
-      }
-      _res.resize(init_data_length);
-      status=secure_session_generate_connect_request(_session, &_res.front(), &init_data_length);
-      if(status!=THEMIS_SUCCESS){
-        throw themispp::exception_t("Secure Session failed to initialize", status);
-      }
-      return _res;
-    }
-    
-    const bool is_established(){
-      if(!_session){
-        throw themispp::exception_t("uninitialized Secure Session");
-      }
-      return secure_session_is_established(_session);
+    const data_t& init()
+    {
+        if (!_session) {
+            throw themispp::exception_t("uninitialized Secure Session");
+        }
+        themis_status_t status = THEMIS_FAIL;
+        size_t init_data_length = 0;
+        status = secure_session_generate_connect_request(_session, NULL, &init_data_length);
+        if (status != THEMIS_BUFFER_TOO_SMALL) {
+            throw themispp::exception_t("Secure Session failed to initialize", status);
+        }
+        _res.resize(init_data_length);
+        status = secure_session_generate_connect_request(_session, &_res.front(), &init_data_length);
+        if (status != THEMIS_SUCCESS) {
+            throw themispp::exception_t("Secure Session failed to initialize", status);
+        }
+        return _res;
     }
 
-    void connect(){
-      if(!_session){
-        throw themispp::exception_t("uninitialized Secure Session");
-      }
-      themis_status_t status=secure_session_connect(_session);
-      if(status!=THEMIS_SUCCESS){
-        throw themispp::exception_t("Secure Session failed to connect", status);
-      }
+    const bool is_established()
+    {
+        if (!_session) {
+            throw themispp::exception_t("uninitialized Secure Session");
+        }
+        return secure_session_is_established(_session);
     }
 
-    const data_t& receive(){
-      if(!_session){
-        throw themispp::exception_t("uninitialized Secure Session");
-      }
-      _res.resize(THEMISPP_SECURE_SESSION_MAX_MESSAGE_SIZE);
-      ssize_t recv_size=secure_session_receive(_session, &_res[0], _res.size());
-      if(recv_size<=0){
-        throw themispp::exception_t("Secure Session failed to receive message", THEMIS_SSESSION_TRANSPORT_ERROR);
-      }
-      _res.resize(recv_size);
-      return _res;
+    void connect()
+    {
+        if (!_session) {
+            throw themispp::exception_t("uninitialized Secure Session");
+        }
+        themis_status_t status = secure_session_connect(_session);
+        if (status != THEMIS_SUCCESS) {
+            throw themispp::exception_t("Secure Session failed to connect", status);
+        }
     }
 
-    void send(const data_t& data){
-      if(!_session){
-        throw themispp::exception_t("uninitialized Secure Session");
-      }
-      if(data.empty()){
-        throw themispp::exception_t("Secure Session failed to send message: data must be non-empty");
-      }
-      ssize_t send_size=secure_session_send(_session, &data[0], data.size());
-      if(send_size<=0){
-        throw themispp::exception_t("Secure Session failed to send message", THEMIS_SSESSION_TRANSPORT_ERROR);
-      }
+    const data_t& receive()
+    {
+        if (!_session) {
+            throw themispp::exception_t("uninitialized Secure Session");
+        }
+        _res.resize(THEMISPP_SECURE_SESSION_MAX_MESSAGE_SIZE);
+        ssize_t recv_size = secure_session_receive(_session, &_res[0], _res.size());
+        if (recv_size <= 0) {
+            throw themispp::exception_t("Secure Session failed to receive message", THEMIS_SSESSION_TRANSPORT_ERROR);
+        }
+        _res.resize(recv_size);
+        return _res;
     }
 
-  private:
-    void initialize_session(const data_t& id, const data_t& priv_key, secure_session_callback_interface_t* callbacks){
-      if(id.empty()){
-        throw themispp::exception_t("Secure Session construction failed: client ID must be non-empty");
-      }
-      if(priv_key.empty()){
-        throw themispp::exception_t("Secure Session construction failed: private key must be non-empty");
-      }
-      if(!callbacks){
-        throw themispp::exception_t("Secure Session construction failed: callbacks must be non-NULL");
-      }
-      _callback=new secure_session_user_callbacks_t();
-      _callback->get_public_key_for_id=themispp::get_public_key_for_id_callback;
-      _callback->send_data=themispp::send_callback;
-      _callback->receive_data=themispp::receive_callback;
-      _callback->state_changed=NULL;
-      _callback->user_data=callbacks;
-      _session=secure_session_create(&id[0], id.size(), &priv_key[0], priv_key.size(), _callback);
-      if(!_session){
-        delete _callback;
-        throw themispp::exception_t("Secure Session construction failed");
-      }
+    void send(const data_t& data)
+    {
+        if (!_session) {
+            throw themispp::exception_t("uninitialized Secure Session");
+        }
+        if (data.empty()) {
+            throw themispp::exception_t("Secure Session failed to send message: data must be non-empty");
+        }
+        ssize_t send_size = secure_session_send(_session, &data[0], data.size());
+        if (send_size <= 0) {
+            throw themispp::exception_t("Secure Session failed to send message", THEMIS_SSESSION_TRANSPORT_ERROR);
+        }
     }
 
-  private:
+private:
+    void initialize_session(const data_t& id, const data_t& priv_key, secure_session_callback_interface_t* callbacks)
+    {
+        if (id.empty()) {
+            throw themispp::exception_t("Secure Session construction failed: client ID must be non-empty");
+        }
+        if (priv_key.empty()) {
+            throw themispp::exception_t("Secure Session construction failed: private key must be non-empty");
+        }
+        if (!callbacks) {
+            throw themispp::exception_t("Secure Session construction failed: callbacks must be non-NULL");
+        }
+        _callback = new secure_session_user_callbacks_t();
+        _callback->get_public_key_for_id = themispp::get_public_key_for_id_callback;
+        _callback->send_data = themispp::send_callback;
+        _callback->receive_data = themispp::receive_callback;
+        _callback->state_changed = NULL;
+        _callback->user_data = callbacks;
+        _session = secure_session_create(&id[0], id.size(), &priv_key[0], priv_key.size(), _callback);
+        if (!_session) {
+            delete _callback;
+            throw themispp::exception_t("Secure Session construction failed");
+        }
+    }
+
+private:
     ::secure_session_t* _session;
-    ::secure_session_user_callbacks_t *_callback;
+    ::secure_session_user_callbacks_t* _callback;
     std::vector<uint8_t> _res;
 #if __cplusplus >= 201103L
     std::shared_ptr<secure_session_callback_interface_t> _interface;
 #endif
-  };
-}// ns themis
+};
+
+} // namespace themispp
 
 #endif


### PR DESCRIPTION
Add ThemisPP headers to formatting. ThemisPP is header-only so we don't need to compile it for real.

We use a custom style for C++ with a bit longer line lengths than for C code elsewhere. Unfortunately, clang-format does not seem to support format file inheritance so we cannot reuse the top-level format file.

Use the new format for ThemisPP and apply some manual fixes in include order and add some empty lines.