### PR TITLE
Run Rust tests in a single thread

### DIFF
--- a/tests/rust/run_tests.sh
+++ b/tests/rust/run_tests.sh
@@ -23,7 +23,10 @@ LIBTHEMIS_STATIC=1  cargo build
 echo
 echo "Running tests..."
 echo
-cargo test --all
+# Rust tests are multithreaded by default. Themis may be using an old OpenSSL
+# which requires global initialization for correct operation. This is hard to
+# do in Rust for tests so simply don't use multithreading to avoid failures.
+cargo test --all -- --test-threads 1
 
 echo
 echo "Checking documentation..."


### PR DESCRIPTION
Occasionally I see [Rust tests fail on CI][2] when calling keygen functions like `themis_gen_ec_key_pair()`. This is only possible when the crypto backend fails for unexplainable reasons.

I suspect these failures to be caused by OpenSSL insanity: older versions of this ${expletive} library — and we do use OpenSSL 1.0.2f on CircleCI currently — require global initialization of [locking callbacks][1] in order for OpenSSL to operate correctly.

Unfortunately, Rust testing framework does not support any form of global setup-teardown so we cannot run any custom code in main() before the tests. I also do not want to use custom macros for tests or insert function calls in each and every one of them. We also cannot initialize OpenSSL in Themis because that's not its job.

Therefore, I give up and simply run all the tests in single-threaded mode. This should fix those occasional failures, I hope🤞

[1]: https://www.openssl.org/blog/blog/2017/02/21/threads/
[2]: https://circleci.com/gh/cossacklabs/themis/2815