### PR TITLE
Update iOS wrapper header structure to compile Swift framework

### DIFF
--- a/docs/examples/swift/Podfile
+++ b/docs/examples/swift/Podfile
@@ -15,6 +15,7 @@
 #
 
 source 'https://github.com/CocoaPods/Specs.git'
+source 'https://github.com/cossacklabs/Podspecs.git'
 
 platform :ios, '8.0'
 project 'ThemisSwift/ThemisSwift.xcodeproj'
@@ -23,7 +24,7 @@ use_frameworks!
 
 target :"ThemisSwift" do
 
-  pod 'themis', :podspec => "https://gist.githubusercontent.com/vixentael/ddd4b19dfd354b24ad7fcf022ffaff4b/raw/7a3fd60f3367640917c6aaec82e58318ac39d16d/themis.podspec"
+  pod 'themis', '0.10.4'
 
 end
 

--- a/docs/examples/swift/Podfile
+++ b/docs/examples/swift/Podfile
@@ -23,7 +23,7 @@ use_frameworks!
 
 target :"ThemisSwift" do
 
-  pod 'themis', '0.10.3'
+  pod 'themis', :podspec => "https://gist.githubusercontent.com/vixentael/ddd4b19dfd354b24ad7fcf022ffaff4b/raw/7a3fd60f3367640917c6aaec82e58318ac39d16d/themis.podspec"
 
 end
 

--- a/docs/examples/swift/Podfile.lock
+++ b/docs/examples/swift/Podfile.lock
@@ -1,29 +1,37 @@
 PODS:
   - GRKOpenSSLFramework (1.0.2.16)
-  - themis (0.10.3):
-    - themis/themis-openssl (= 0.10.3)
-  - themis/themis-openssl (0.10.3):
+  - themis (0.10.5):
+    - themis/themis-openssl (= 0.10.5)
+  - themis/themis-openssl (0.10.5):
     - GRKOpenSSLFramework (~> 1.0.1)
-    - themis/themis-openssl/core (= 0.10.3)
-    - themis/themis-openssl/objcwrapper (= 0.10.3)
-  - themis/themis-openssl/core (0.10.3):
+    - themis/themis-openssl/core (= 0.10.5)
+    - themis/themis-openssl/objcwrapper (= 0.10.5)
+  - themis/themis-openssl/core (0.10.5):
     - GRKOpenSSLFramework (~> 1.0.1)
-  - themis/themis-openssl/objcwrapper (0.10.3):
+  - themis/themis-openssl/objcwrapper (0.10.5):
     - GRKOpenSSLFramework (~> 1.0.1)
     - themis/themis-openssl/core
 
 DEPENDENCIES:
-  - themis (= 0.10.3)
+  - themis (from `https://gist.githubusercontent.com/vixentael/ddd4b19dfd354b24ad7fcf022ffaff4b/raw/7a3fd60f3367640917c6aaec82e58318ac39d16d/themis.podspec`)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - GRKOpenSSLFramework
-    - themis
+
+EXTERNAL SOURCES:
+  themis:
+    :podspec: https://gist.githubusercontent.com/vixentael/ddd4b19dfd354b24ad7fcf022ffaff4b/raw/7a3fd60f3367640917c6aaec82e58318ac39d16d/themis.podspec
+
+CHECKOUT OPTIONS:
+  themis:
+    :commit: d91d2f58f6765067f77747dddf2817b863503b55
+    :git: https://github.com/cossacklabs/themis.git
 
 SPEC CHECKSUMS:
   GRKOpenSSLFramework: 35944e317e6336b2944ad70b059d84db6b2d8532
-  themis: bdbb1d0baeee19ff213dc7355e9e2b48debea359
+  themis: 47e2e513d090407b3c3c3b89253fef38a0209cb7
 
-PODFILE CHECKSUM: f5f6e45353fa284e162f817a401303a38430bc12
+PODFILE CHECKSUM: d63205eaf0fb10330df50e675d3e09b5611710f4
 
 COCOAPODS: 1.5.3

--- a/docs/examples/swift/Podfile.lock
+++ b/docs/examples/swift/Podfile.lock
@@ -1,37 +1,30 @@
 PODS:
   - GRKOpenSSLFramework (1.0.2.16)
-  - themis (0.10.5):
-    - themis/themis-openssl (= 0.10.5)
-  - themis/themis-openssl (0.10.5):
+  - themis (0.10.4):
+    - themis/themis-openssl (= 0.10.4)
+  - themis/themis-openssl (0.10.4):
     - GRKOpenSSLFramework (~> 1.0.1)
-    - themis/themis-openssl/core (= 0.10.5)
-    - themis/themis-openssl/objcwrapper (= 0.10.5)
-  - themis/themis-openssl/core (0.10.5):
+    - themis/themis-openssl/core (= 0.10.4)
+    - themis/themis-openssl/objcwrapper (= 0.10.4)
+  - themis/themis-openssl/core (0.10.4):
     - GRKOpenSSLFramework (~> 1.0.1)
-  - themis/themis-openssl/objcwrapper (0.10.5):
+  - themis/themis-openssl/objcwrapper (0.10.4):
     - GRKOpenSSLFramework (~> 1.0.1)
     - themis/themis-openssl/core
 
 DEPENDENCIES:
-  - themis (from `https://gist.githubusercontent.com/vixentael/ddd4b19dfd354b24ad7fcf022ffaff4b/raw/7a3fd60f3367640917c6aaec82e58318ac39d16d/themis.podspec`)
+  - themis (= 0.10.4)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - GRKOpenSSLFramework
-
-EXTERNAL SOURCES:
-  themis:
-    :podspec: https://gist.githubusercontent.com/vixentael/ddd4b19dfd354b24ad7fcf022ffaff4b/raw/7a3fd60f3367640917c6aaec82e58318ac39d16d/themis.podspec
-
-CHECKOUT OPTIONS:
-  themis:
-    :commit: d91d2f58f6765067f77747dddf2817b863503b55
-    :git: https://github.com/cossacklabs/themis.git
+  https://github.com/cossacklabs/Podspecs.git:
+    - themis
 
 SPEC CHECKSUMS:
   GRKOpenSSLFramework: 35944e317e6336b2944ad70b059d84db6b2d8532
-  themis: 47e2e513d090407b3c3c3b89253fef38a0209cb7
+  themis: 7e0ee3b12ba243c11ac95f25f552df6481740ce0
 
-PODFILE CHECKSUM: d63205eaf0fb10330df50e675d3e09b5611710f4
+PODFILE CHECKSUM: 2ce293e8232afcf7e23e5943358ba0e39583e2a0
 
 COCOAPODS: 1.5.3

--- a/docs/examples/swift/ThemisSwift/ThemisSwift.xcodeproj/project.pbxproj
+++ b/docs/examples/swift/ThemisSwift/ThemisSwift.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		2938DCFAD1C67BFE6924A22B /* Pods_ThemisSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 88148889734D441701947791 /* Pods_ThemisSwift.framework */; };
+		41F501C19293A5218A2CACC3 /* Pods_ThemisSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B291DA89A51E7B7AAE3842C /* Pods_ThemisSwift.framework */; };
 		7399813E1CC449010095138F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7399812E1CC449010095138F /* AppDelegate.swift */; };
 		7399813F1CC449010095138F /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7399812F1CC449010095138F /* ViewController.swift */; };
 		739981401CC449010095138F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 739981311CC449010095138F /* Assets.xcassets */; };
@@ -32,9 +32,9 @@
 		7399813A1CC449010095138F /* server.pub */ = {isa = PBXFileReference; lastKnownFileType = file; path = server.pub; sourceTree = "<group>"; };
 		739981491CC44ABA0095138F /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7399814A1CC44ABA0095138F /* ThemisSwift-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ThemisSwift-Bridging-Header.h"; sourceTree = "<group>"; };
-		73E9145F7D78F736CC48F062 /* Pods-ThemisSwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ThemisSwift.release.xcconfig"; path = "../Pods/Target Support Files/Pods-ThemisSwift/Pods-ThemisSwift.release.xcconfig"; sourceTree = "<group>"; };
-		88148889734D441701947791 /* Pods_ThemisSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ThemisSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		AAE4A2C93BCFD8FDA3341749 /* Pods-ThemisSwift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ThemisSwift.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-ThemisSwift/Pods-ThemisSwift.debug.xcconfig"; sourceTree = "<group>"; };
+		8788D92E22F2833AB53570F4 /* Pods-ThemisSwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ThemisSwift.release.xcconfig"; path = "../Pods/Target Support Files/Pods-ThemisSwift/Pods-ThemisSwift.release.xcconfig"; sourceTree = "<group>"; };
+		8B291DA89A51E7B7AAE3842C /* Pods_ThemisSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ThemisSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A491A87A0EF08ACAC0FF89D8 /* Pods-ThemisSwift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ThemisSwift.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-ThemisSwift/Pods-ThemisSwift.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -42,19 +42,28 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2938DCFAD1C67BFE6924A22B /* Pods_ThemisSwift.framework in Frameworks */,
+				41F501C19293A5218A2CACC3 /* Pods_ThemisSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		3E141E9E6F0169F78886765C /* Frameworks */ = {
+		0DA459D5C948C35F4334C335 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				88148889734D441701947791 /* Pods_ThemisSwift.framework */,
+				8B291DA89A51E7B7AAE3842C /* Pods_ThemisSwift.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		6B51EDA757BE91C0E85571E3 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				A491A87A0EF08ACAC0FF89D8 /* Pods-ThemisSwift.debug.xcconfig */,
+				8788D92E22F2833AB53570F4 /* Pods-ThemisSwift.release.xcconfig */,
+			);
+			name = Pods;
 			sourceTree = "<group>";
 		};
 		7399810E1CC42C880095138F = {
@@ -62,8 +71,8 @@
 			children = (
 				739981191CC42C880095138F /* ThemisSwift */,
 				739981181CC42C880095138F /* Products */,
-				FD3118EA117CE641A653C37A /* Pods */,
-				3E141E9E6F0169F78886765C /* Frameworks */,
+				6B51EDA757BE91C0E85571E3 /* Pods */,
+				0DA459D5C948C35F4334C335 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -125,15 +134,6 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
-		FD3118EA117CE641A653C37A /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				AAE4A2C93BCFD8FDA3341749 /* Pods-ThemisSwift.debug.xcconfig */,
-				73E9145F7D78F736CC48F062 /* Pods-ThemisSwift.release.xcconfig */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -141,12 +141,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 739981291CC42C880095138F /* Build configuration list for PBXNativeTarget "ThemisSwift" */;
 			buildPhases = (
-				A72D54FE0037DAE82BE40EAE /* [CP] Check Pods Manifest.lock */,
+				C4843E32EE3360C6B7E35650 /* [CP] Check Pods Manifest.lock */,
 				739981131CC42C880095138F /* Sources */,
 				739981141CC42C880095138F /* Frameworks */,
 				739981151CC42C880095138F /* Resources */,
 				73688AFE1CC4504F00D3C430 /* ShellScript */,
-				9CD725710B91A3A184B8E2E5 /* [CP] Embed Pods Frameworks */,
+				3F7435D4E70C63CC9E5AFF52 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -211,20 +211,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		73688AFE1CC4504F00D3C430 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n# uncomment for autocorrection\n# swiftlint autocorrect\n    swiftlint lint --quiet\nelse\n    echo \"SwiftLint does not exist, download from https://github.com/realm/SwiftLint\"\nfi";
-		};
-		9CD725710B91A3A184B8E2E5 /* [CP] Embed Pods Frameworks */ = {
+		3F7435D4E70C63CC9E5AFF52 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -248,7 +235,20 @@
 			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-ThemisSwift/Pods-ThemisSwift-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		A72D54FE0037DAE82BE40EAE /* [CP] Check Pods Manifest.lock */ = {
+		73688AFE1CC4504F00D3C430 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n# uncomment for autocorrection\n# swiftlint autocorrect\n    swiftlint lint --quiet\nelse\n    echo \"SwiftLint does not exist, download from https://github.com/realm/SwiftLint\"\nfi";
+		};
+		C4843E32EE3360C6B7E35650 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -406,7 +406,7 @@
 		};
 		7399812A1CC42C880095138F /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AAE4A2C93BCFD8FDA3341749 /* Pods-ThemisSwift.debug.xcconfig */;
+			baseConfigurationReference = A491A87A0EF08ACAC0FF89D8 /* Pods-ThemisSwift.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -428,7 +428,7 @@
 		};
 		7399812B1CC42C880095138F /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 73E9145F7D78F736CC48F062 /* Pods-ThemisSwift.release.xcconfig */;
+			baseConfigurationReference = 8788D92E22F2833AB53570F4 /* Pods-ThemisSwift.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";

--- a/docs/examples/swift/ThemisSwift/ThemisSwift.xcodeproj/project.pbxproj
+++ b/docs/examples/swift/ThemisSwift/ThemisSwift.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		2B98B674D47479213A83A406 /* Pods_ThemisSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C6670E03033C41A0938AC23 /* Pods_ThemisSwift.framework */; };
+		2938DCFAD1C67BFE6924A22B /* Pods_ThemisSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 88148889734D441701947791 /* Pods_ThemisSwift.framework */; };
 		7399813E1CC449010095138F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7399812E1CC449010095138F /* AppDelegate.swift */; };
 		7399813F1CC449010095138F /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7399812F1CC449010095138F /* ViewController.swift */; };
 		739981401CC449010095138F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 739981311CC449010095138F /* Assets.xcassets */; };
@@ -20,8 +20,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		249F8D1DB897120A883BB860 /* Pods-ThemisSwift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ThemisSwift.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-ThemisSwift/Pods-ThemisSwift.debug.xcconfig"; sourceTree = "<group>"; };
-		3C6670E03033C41A0938AC23 /* Pods_ThemisSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ThemisSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		739981171CC42C880095138F /* ThemisSwift.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ThemisSwift.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7399812E1CC449010095138F /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7399812F1CC449010095138F /* ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -34,7 +32,9 @@
 		7399813A1CC449010095138F /* server.pub */ = {isa = PBXFileReference; lastKnownFileType = file; path = server.pub; sourceTree = "<group>"; };
 		739981491CC44ABA0095138F /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7399814A1CC44ABA0095138F /* ThemisSwift-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ThemisSwift-Bridging-Header.h"; sourceTree = "<group>"; };
-		A1BA1DAC1040AFCE77C7D55B /* Pods-ThemisSwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ThemisSwift.release.xcconfig"; path = "../Pods/Target Support Files/Pods-ThemisSwift/Pods-ThemisSwift.release.xcconfig"; sourceTree = "<group>"; };
+		73E9145F7D78F736CC48F062 /* Pods-ThemisSwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ThemisSwift.release.xcconfig"; path = "../Pods/Target Support Files/Pods-ThemisSwift/Pods-ThemisSwift.release.xcconfig"; sourceTree = "<group>"; };
+		88148889734D441701947791 /* Pods_ThemisSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ThemisSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		AAE4A2C93BCFD8FDA3341749 /* Pods-ThemisSwift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ThemisSwift.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-ThemisSwift/Pods-ThemisSwift.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -42,20 +42,28 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2B98B674D47479213A83A406 /* Pods_ThemisSwift.framework in Frameworks */,
+				2938DCFAD1C67BFE6924A22B /* Pods_ThemisSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3E141E9E6F0169F78886765C /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				88148889734D441701947791 /* Pods_ThemisSwift.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		7399810E1CC42C880095138F = {
 			isa = PBXGroup;
 			children = (
 				739981191CC42C880095138F /* ThemisSwift */,
 				739981181CC42C880095138F /* Products */,
-				DF643A7268BE1985F1F32BA6 /* Pods */,
-				74CE1841A757C1D673A397C2 /* Frameworks */,
+				FD3118EA117CE641A653C37A /* Pods */,
+				3E141E9E6F0169F78886765C /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -117,19 +125,11 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
-		74CE1841A757C1D673A397C2 /* Frameworks */ = {
+		FD3118EA117CE641A653C37A /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				3C6670E03033C41A0938AC23 /* Pods_ThemisSwift.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		DF643A7268BE1985F1F32BA6 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				249F8D1DB897120A883BB860 /* Pods-ThemisSwift.debug.xcconfig */,
-				A1BA1DAC1040AFCE77C7D55B /* Pods-ThemisSwift.release.xcconfig */,
+				AAE4A2C93BCFD8FDA3341749 /* Pods-ThemisSwift.debug.xcconfig */,
+				73E9145F7D78F736CC48F062 /* Pods-ThemisSwift.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -141,12 +141,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 739981291CC42C880095138F /* Build configuration list for PBXNativeTarget "ThemisSwift" */;
 			buildPhases = (
-				D3D33A5514B8D3BF6E9B871F /* [CP] Check Pods Manifest.lock */,
+				A72D54FE0037DAE82BE40EAE /* [CP] Check Pods Manifest.lock */,
 				739981131CC42C880095138F /* Sources */,
 				739981141CC42C880095138F /* Frameworks */,
 				739981151CC42C880095138F /* Resources */,
 				73688AFE1CC4504F00D3C430 /* ShellScript */,
-				BF36FB0676CC14527D294FFC /* [CP] Embed Pods Frameworks */,
+				9CD725710B91A3A184B8E2E5 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -224,7 +224,7 @@
 			shellPath = /bin/sh;
 			shellScript = "if which swiftlint >/dev/null; then\n# uncomment for autocorrection\n# swiftlint autocorrect\n    swiftlint lint --quiet\nelse\n    echo \"SwiftLint does not exist, download from https://github.com/realm/SwiftLint\"\nfi";
 		};
-		BF36FB0676CC14527D294FFC /* [CP] Embed Pods Frameworks */ = {
+		9CD725710B91A3A184B8E2E5 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -248,7 +248,7 @@
 			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-ThemisSwift/Pods-ThemisSwift-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		D3D33A5514B8D3BF6E9B871F /* [CP] Check Pods Manifest.lock */ = {
+		A72D54FE0037DAE82BE40EAE /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -406,7 +406,7 @@
 		};
 		7399812A1CC42C880095138F /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 249F8D1DB897120A883BB860 /* Pods-ThemisSwift.debug.xcconfig */;
+			baseConfigurationReference = AAE4A2C93BCFD8FDA3341749 /* Pods-ThemisSwift.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -428,7 +428,7 @@
 		};
 		7399812B1CC42C880095138F /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A1BA1DAC1040AFCE77C7D55B /* Pods-ThemisSwift.release.xcconfig */;
+			baseConfigurationReference = 73E9145F7D78F736CC48F062 /* Pods-ThemisSwift.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";

--- a/docs/examples/swift/ThemisSwift/ThemisSwift/Classes/AppDelegate.swift
+++ b/docs/examples/swift/ThemisSwift/ThemisSwift/Classes/AppDelegate.swift
@@ -14,7 +14,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions
         launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         

--- a/docs/examples/swift/ThemisSwift/ThemisSwift/Classes/AppDelegate.swift
+++ b/docs/examples/swift/ThemisSwift/ThemisSwift/Classes/AppDelegate.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import themis
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {

--- a/src/wrappers/themis/Obj-C/objcthemis/objcthemis.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/objcthemis.h
@@ -1,14 +1,6 @@
 #ifndef _OBJCTHEMIS_
     #define _OBJCTHEMIS_
 
-	#import <objcthemis/scell_seal.h>
-	#import <objcthemis/scell_token.h>
-	#import <objcthemis/scell_context_imprint.h>
-	#import <objcthemis/skeygen.h>
-	#import <objcthemis/smessage.h>
-	#import <objcthemis/scomparator.h>
-	#import <objcthemis/ssession.h>
-	#import <objcthemis/serror.h>
 
 #endif /* _OBJCTHEMIS_ */
 

--- a/src/wrappers/themis/Obj-C/objcthemis/objcthemis.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/objcthemis.h
@@ -1,6 +1,14 @@
 #ifndef _OBJCTHEMIS_
     #define _OBJCTHEMIS_
 
+    #import <objcthemis/scell_seal.h>
+    #import <objcthemis/scell_token.h>
+    #import <objcthemis/scell_context_imprint.h>
+    #import <objcthemis/skeygen.h>
+    #import <objcthemis/smessage.h>
+    #import <objcthemis/scomparator.h>
+    #import <objcthemis/ssession.h>
+    #import <objcthemis/serror.h>
 
 #endif /* _OBJCTHEMIS_ */
 

--- a/src/wrappers/themis/Obj-C/objcthemis/objcthemis.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/objcthemis.h
@@ -1,14 +1,14 @@
 #ifndef _OBJCTHEMIS_
     #define _OBJCTHEMIS_
 
-    #import <objcthemis/scell_seal.h>
-    #import <objcthemis/scell_token.h>
-    #import <objcthemis/scell_context_imprint.h>
-    #import <objcthemis/skeygen.h>
-    #import <objcthemis/smessage.h>
-    #import <objcthemis/scomparator.h>
-    #import <objcthemis/ssession.h>
-    #import <objcthemis/serror.h>
+    #import "scell_seal.h"
+    #import "scell_token.h"
+    #import "scell_context_imprint.h"
+    #import "skeygen.h"
+    #import "smessage.h"
+    #import "scomparator.h"
+    #import "ssession.h"
+    #import "serror.h"
 
 #endif /* _OBJCTHEMIS_ */
 

--- a/src/wrappers/themis/Obj-C/objcthemis/scell_context_imprint.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_context_imprint.h
@@ -20,7 +20,7 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <objcthemis/scell.h>
+#import "scell.h"
 
 /**
  * @addtogroup WRAPPERS

--- a/src/wrappers/themis/Obj-C/objcthemis/scell_context_imprint.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_context_imprint.h
@@ -20,7 +20,6 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <themis/themis.h>
 #import <objcthemis/scell.h>
 
 /**

--- a/src/wrappers/themis/Obj-C/objcthemis/scell_context_imprint.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_context_imprint.m
@@ -16,7 +16,7 @@
 
 #import <objcthemis/scell_context_imprint.h>
 #import <objcthemis/serror.h>
-
+#import <themis/themis.h>
 
 @implementation TSCellContextImprint
 

--- a/src/wrappers/themis/Obj-C/objcthemis/scell_seal.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_seal.h
@@ -20,7 +20,7 @@
 */
 
 #import <Foundation/Foundation.h>
-#import <objcthemis/scell.h>
+#import "scell.h"
 
 /**
 * @addtogroup WRAPPERS

--- a/src/wrappers/themis/Obj-C/objcthemis/scell_seal.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_seal.h
@@ -20,7 +20,6 @@
 */
 
 #import <Foundation/Foundation.h>
-#import <themis/themis.h>
 #import <objcthemis/scell.h>
 
 /**

--- a/src/wrappers/themis/Obj-C/objcthemis/scell_seal.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_seal.m
@@ -16,7 +16,7 @@
 
 #import <objcthemis/scell_seal.h>
 #import <objcthemis/serror.h>
-
+#import <themis/themis.h>
 
 @implementation TSCellSeal
 

--- a/src/wrappers/themis/Obj-C/objcthemis/scell_token.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_token.h
@@ -20,7 +20,7 @@
 */
 
 #import <Foundation/Foundation.h>
-#import <objcthemis/scell.h>
+#import "scell.h"
 
 /**
 * @addtogroup WRAPPERS

--- a/src/wrappers/themis/Obj-C/objcthemis/scell_token.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_token.h
@@ -20,7 +20,6 @@
 */
 
 #import <Foundation/Foundation.h>
-#import <themis/themis.h>
 #import <objcthemis/scell.h>
 
 /**

--- a/src/wrappers/themis/Obj-C/objcthemis/scell_token.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_token.m
@@ -16,7 +16,7 @@
 
 #import <objcthemis/scell_token.h>
 #import <objcthemis/serror.h>
-
+#import <themis/themis.h>
 
 @implementation TSCellTokenEncryptedData
 

--- a/src/wrappers/themis/Obj-C/objcthemis/scomparator.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/scomparator.h
@@ -19,6 +19,7 @@
 * @brief secure comparator interface
 */
 
+#import <Foundation/Foundation.h>
 
 /**
 * @addtogroup WRAPPERS

--- a/src/wrappers/themis/Obj-C/objcthemis/scomparator.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/scomparator.h
@@ -19,7 +19,6 @@
 * @brief secure comparator interface
 */
 
-#import <themis/themis.h>
 
 /**
 * @addtogroup WRAPPERS

--- a/src/wrappers/themis/Obj-C/objcthemis/scomparator.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/scomparator.m
@@ -16,7 +16,7 @@
 
 #import <objcthemis/scomparator.h>
 #import <objcthemis/serror.h>
-
+#import <themis/themis.h>
 
 @interface TSComparator ()
 

--- a/src/wrappers/themis/Obj-C/objcthemis/skeygen.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/skeygen.h
@@ -20,7 +20,6 @@
 */
 
 #import <Foundation/Foundation.h>
-#import <themis/themis.h>
 
 /**
 * @addtogroup WRAPPERS

--- a/src/wrappers/themis/Obj-C/objcthemis/skeygen.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/skeygen.m
@@ -16,7 +16,7 @@
 
 #import <objcthemis/skeygen.h>
 #import <objcthemis/serror.h>
-
+#import <themis/themis.h>
 
 @interface TSKeyGen ()
 

--- a/src/wrappers/themis/Obj-C/objcthemis/smessage.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/smessage.h
@@ -20,7 +20,6 @@
 */
 
 #import <Foundation/Foundation.h>
-#import <themis/themis.h>
 
 /**
 * @addtogroup WRAPPERS

--- a/src/wrappers/themis/Obj-C/objcthemis/smessage.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/smessage.m
@@ -16,7 +16,7 @@
 
 #import <objcthemis/smessage.h>
 #import <objcthemis/serror.h>
-
+#import <themis/themis.h>
 
 @interface TSMessage ()
 

--- a/src/wrappers/themis/Obj-C/objcthemis/ssession.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/ssession.h
@@ -20,7 +20,6 @@
 */
 
 #import <objcthemis/ssession_transport_interface.h>
-#import <themis/themis.h>
 
 /**
 * @addtogroup WRAPPERS

--- a/src/wrappers/themis/Obj-C/objcthemis/ssession.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/ssession.h
@@ -19,7 +19,7 @@
 * @brief secure session interface
 */
 
-#import <objcthemis/ssession_transport_interface.h>
+#import "ssession_transport_interface.h"
 
 /**
 * @addtogroup WRAPPERS

--- a/src/wrappers/themis/Obj-C/objcthemis/ssession.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/ssession.m
@@ -16,7 +16,7 @@
 
 #import <objcthemis/ssession.h>
 #import <objcthemis/serror.h>
-
+#import <themis/themis.h>
 
 @interface TSSession ()
 

--- a/src/wrappers/themis/Obj-C/objcthemis/ssession_transport_interface.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/ssession_transport_interface.h
@@ -19,7 +19,7 @@
 * @brief secure session trancport callbacs interface
 */
 #import <Foundation/Foundation.h>
-#import <themis/themis.h>
+#include <themis/secure_session.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/src/wrappers/themis/Obj-C/objcthemis/ssession_transport_interface.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/ssession_transport_interface.h
@@ -19,15 +19,13 @@
 * @brief secure session trancport callbacs interface
 */
 #import <Foundation/Foundation.h>
-#include <themis/secure_session.h>
+
+typedef struct secure_session_user_callbacks_type secure_session_user_callbacks_t;
 
 NS_ASSUME_NONNULL_BEGIN
 
 /** @brief Secure session transport callbacks interface */
-@interface TSSessionTransportInterface : NSObject {
-    secure_session_user_callbacks_t _callbacks;
-}
-
+@interface TSSessionTransportInterface : NSObject
 
 /** @brief Send binary data to peer
 * @param [in] data binary data

--- a/src/wrappers/themis/Obj-C/objcthemis/ssession_transport_interface.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/ssession_transport_interface.m
@@ -18,6 +18,11 @@
 #import <objcthemis/serror.h>
 #import <themis/themis.h>
 
+@interface TSSessionTransportInterface () {
+    secure_session_user_callbacks_t _callbacks;
+}
+@end
+
 ssize_t on_send_callback(const uint8_t *data, size_t data_length, void *user_data) {
     return TSErrorTypeFail;
 }

--- a/src/wrappers/themis/Obj-C/objcthemis/ssession_transport_interface.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/ssession_transport_interface.m
@@ -16,7 +16,7 @@
 
 #import <objcthemis/ssession_transport_interface.h>
 #import <objcthemis/serror.h>
-
+#import <themis/themis.h>
 
 ssize_t on_send_callback(const uint8_t *data, size_t data_length, void *user_data) {
     return TSErrorTypeFail;


### PR DESCRIPTION
Compiling Swift framework (f.e. adding Themis as dependency into some Swift framework) requires using modular framework.

This change aims to solve https://github.com/cossacklabs/themis/issues/411, there you can find more details about modular frameworks.

Modular frameworks don't expose non-modular headers as public. It's quite a tricky issue, because of non-trivial themis-soter source code structure and how it's exposed to the objc wrapper files. Previously we lived happily, because most users linked Themis from Bridging Header :)

**What was changed:**

- remove extra headers in objc wrapper code, especially remove large headers like `#import <themis/themis.h>`
- move many headers from `.h` files to `.m` files
- use local `#import "scell_seal.h"` imports instead of `#import <objcthemis/scell_seal.h>`
- (workaround) to remove themis secure session callback headers, I re-defined one structure `typedef struct secure_session_user_callbacks_type secure_session_user_callbacks_t;` [here](https://github.com/cossacklabs/themis/compare/vxtl/ios-header?expand=1#diff-0f5817ba440dd5f041cf92ceba600bf3R23) (not sure if this is a best thing to do, but I couldn't imagine any other quick way to remove themis import from header). 

**How to test:**

- if you have access to [Cossack Labs' private CocoaPods repo](https://github.com/cossacklabs/Podspecs), then you can run modified Swift example project that uses `0.10.4` podspec. 

Example project linked Themis as `import themis` from Swift code, which triggers Xcode to build Swift (modular) framework, and here we are.

**Updated podspec:**

- Podspec was updated to hide as much as possible headers, see next PR.

**Next steps:**

Upon testing and merging, podspec will be updated to link to the master branch (next PR), all example projects will be updated, podspec will be pushed.

P.S. I have tested on real device. Works fine 💁