### PR TITLE
Formatting: JNI module for Java/Android wrappers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ jobs:
       CLANG_FORMAT: clang-format-7
       CLANG_TIDY: clang-tidy-7
     steps:
+      - run: sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get -y install default-jdk
       - checkout
       - run: git submodule update --init
       - run: make fmt_check ENGINE=boringssl

--- a/jni/themis_cell.c
+++ b/jni/themis_cell.c
@@ -1,377 +1,422 @@
 /*
-* Copyright (c) 2015 Cossack Labs Limited
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2015 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include <jni.h>
-#include <themis/themis_error.h>
 #include <themis/secure_cell.h>
+#include <themis/themis_error.h>
 
 /* These definitions should correspond to the ones in SecureCell.java */
 #define MODE_SEAL 0
 #define MODE_TOKEN_PROTECT 1
 #define MODE_CONTEXT_IMPRINT 2
 
-JNIEXPORT jobjectArray JNICALL Java_com_cossacklabs_themis_SecureCell_encrypt(JNIEnv *env, jobject thiz, jbyteArray key, jbyteArray context, jbyteArray data, jint mode)
+JNIEXPORT jobjectArray JNICALL Java_com_cossacklabs_themis_SecureCell_encrypt(
+    JNIEnv* env, jobject thiz, jbyteArray key, jbyteArray context, jbyteArray data, jint mode)
 {
-	size_t key_length = (*env)->GetArrayLength(env, key);
-	size_t data_length = (*env)->GetArrayLength(env, data);
-	size_t context_length = 0;
+    size_t key_length = (*env)->GetArrayLength(env, key);
+    size_t data_length = (*env)->GetArrayLength(env, data);
+    size_t context_length = 0;
 
-	size_t encrypted_data_length = 0;
-	size_t additional_data_length = 0;
+    size_t encrypted_data_length = 0;
+    size_t additional_data_length = 0;
 
-	jbyte *key_buf = NULL;
-	jbyte *data_buf = NULL;
-	jbyte *context_buf = NULL;
+    jbyte* key_buf = NULL;
+    jbyte* data_buf = NULL;
+    jbyte* context_buf = NULL;
 
-	jobjectArray protected_data = NULL;
-	jbyteArray encrypted_data = NULL;
-	jbyteArray additional_data = NULL;
+    jobjectArray protected_data = NULL;
+    jbyteArray encrypted_data = NULL;
+    jbyteArray additional_data = NULL;
 
-	jbyte *encrypted_data_buf = NULL;
-	jbyte *additional_data_buf = NULL;
+    jbyte* encrypted_data_buf = NULL;
+    jbyte* additional_data_buf = NULL;
 
-	themis_status_t res;
+    themis_status_t res;
 
-	if (context)
-	{
-		context_length = (*env)->GetArrayLength(env, context);
-	}
+    if (context) {
+        context_length = (*env)->GetArrayLength(env, context);
+    }
 
-	key_buf = (*env)->GetByteArrayElements(env, key, NULL);
-	if (!key_buf)
-	{
-		return NULL;
-	}
+    key_buf = (*env)->GetByteArrayElements(env, key, NULL);
+    if (!key_buf) {
+        return NULL;
+    }
 
-	data_buf = (*env)->GetByteArrayElements(env, data, NULL);
-	if (!data_buf)
-	{
-		goto err;
-	}
+    data_buf = (*env)->GetByteArrayElements(env, data, NULL);
+    if (!data_buf) {
+        goto err;
+    }
 
-	if (context)
-	{
-		context_buf = (*env)->GetByteArrayElements(env, context, NULL);
-		if (!context_buf)
-		{
-			goto err;
-		}
-	}
+    if (context) {
+        context_buf = (*env)->GetByteArrayElements(env, context, NULL);
+        if (!context_buf) {
+            goto err;
+        }
+    }
 
-	switch (mode)
-	{
-	case MODE_SEAL:
-		res = themis_secure_cell_encrypt_seal((uint8_t *)key_buf, key_length, (uint8_t *)context_buf, context_length, (uint8_t *)data_buf, data_length, NULL, &encrypted_data_length);
-		break;
-	case MODE_TOKEN_PROTECT:
-		res = themis_secure_cell_encrypt_token_protect((uint8_t *)key_buf, key_length, (uint8_t *)context_buf, context_length, (uint8_t *)data_buf, data_length, NULL, &additional_data_length, NULL, &encrypted_data_length);
-		break;
-	case MODE_CONTEXT_IMPRINT:
-		if (!context)
-		{
-			/* Context is mandatory for this mode */
-			goto err;
-		}
+    switch (mode) {
+    case MODE_SEAL:
+        res = themis_secure_cell_encrypt_seal((uint8_t*)key_buf,
+                                              key_length,
+                                              (uint8_t*)context_buf,
+                                              context_length,
+                                              (uint8_t*)data_buf,
+                                              data_length,
+                                              NULL,
+                                              &encrypted_data_length);
+        break;
+    case MODE_TOKEN_PROTECT:
+        res = themis_secure_cell_encrypt_token_protect((uint8_t*)key_buf,
+                                                       key_length,
+                                                       (uint8_t*)context_buf,
+                                                       context_length,
+                                                       (uint8_t*)data_buf,
+                                                       data_length,
+                                                       NULL,
+                                                       &additional_data_length,
+                                                       NULL,
+                                                       &encrypted_data_length);
+        break;
+    case MODE_CONTEXT_IMPRINT:
+        if (!context) {
+            /* Context is mandatory for this mode */
+            goto err;
+        }
 
-		res = themis_secure_cell_encrypt_context_imprint((uint8_t *)key_buf, key_length, (uint8_t *)data_buf, data_length, (uint8_t *)context_buf, context_length, NULL, &encrypted_data_length);
-		break;
-	default:
-		goto err;
-	}
+        res = themis_secure_cell_encrypt_context_imprint((uint8_t*)key_buf,
+                                                         key_length,
+                                                         (uint8_t*)data_buf,
+                                                         data_length,
+                                                         (uint8_t*)context_buf,
+                                                         context_length,
+                                                         NULL,
+                                                         &encrypted_data_length);
+        break;
+    default:
+        goto err;
+    }
 
-	if (THEMIS_BUFFER_TOO_SMALL != res)
-	{
-		goto err;
-	}
+    if (THEMIS_BUFFER_TOO_SMALL != res) {
+        goto err;
+    }
 
-	encrypted_data = (*env)->NewByteArray(env, encrypted_data_length);
-	if (!encrypted_data)
-	{
-		goto err;
-	}
+    encrypted_data = (*env)->NewByteArray(env, encrypted_data_length);
+    if (!encrypted_data) {
+        goto err;
+    }
 
-	if (additional_data_length)
-	{
-		additional_data = (*env)->NewByteArray(env, additional_data_length);
-		if (!additional_data)
-		{
-			goto err;
-		}
-	}
+    if (additional_data_length) {
+        additional_data = (*env)->NewByteArray(env, additional_data_length);
+        if (!additional_data) {
+            goto err;
+        }
+    }
 
-	encrypted_data_buf = (*env)->GetByteArrayElements(env, encrypted_data, NULL);
-	if (!encrypted_data_buf)
-	{
-		goto err;
-	}
+    encrypted_data_buf = (*env)->GetByteArrayElements(env, encrypted_data, NULL);
+    if (!encrypted_data_buf) {
+        goto err;
+    }
 
-	if (additional_data_length)
-	{
-		additional_data_buf = (*env)->GetByteArrayElements(env, additional_data, NULL);
-		if (!additional_data_buf) 
-		{
-			goto err;
-		}
-	}
+    if (additional_data_length) {
+        additional_data_buf = (*env)->GetByteArrayElements(env, additional_data, NULL);
+        if (!additional_data_buf) {
+            goto err;
+        }
+    }
 
-	switch (mode)
-	{
-	case MODE_SEAL:
-		res = themis_secure_cell_encrypt_seal((uint8_t *)key_buf, key_length, (uint8_t *)context_buf, context_length, (uint8_t *)data_buf, data_length, (uint8_t *)encrypted_data_buf, &encrypted_data_length);
-		break;
-	case MODE_TOKEN_PROTECT:
-		res = themis_secure_cell_encrypt_token_protect((uint8_t *)key_buf, key_length, (uint8_t *)context_buf, context_length, (uint8_t *)data_buf, data_length, (uint8_t *)additional_data_buf, &additional_data_length, (uint8_t *)encrypted_data_buf, &encrypted_data_length);
-		break;
-	case MODE_CONTEXT_IMPRINT:
-		if (!context)
-		{
-			/* Context is mandatory for this mode */
-			goto err;
-		}
+    switch (mode) {
+    case MODE_SEAL:
+        res = themis_secure_cell_encrypt_seal((uint8_t*)key_buf,
+                                              key_length,
+                                              (uint8_t*)context_buf,
+                                              context_length,
+                                              (uint8_t*)data_buf,
+                                              data_length,
+                                              (uint8_t*)encrypted_data_buf,
+                                              &encrypted_data_length);
+        break;
+    case MODE_TOKEN_PROTECT:
+        res = themis_secure_cell_encrypt_token_protect((uint8_t*)key_buf,
+                                                       key_length,
+                                                       (uint8_t*)context_buf,
+                                                       context_length,
+                                                       (uint8_t*)data_buf,
+                                                       data_length,
+                                                       (uint8_t*)additional_data_buf,
+                                                       &additional_data_length,
+                                                       (uint8_t*)encrypted_data_buf,
+                                                       &encrypted_data_length);
+        break;
+    case MODE_CONTEXT_IMPRINT:
+        if (!context) {
+            /* Context is mandatory for this mode */
+            goto err;
+        }
 
-		res = themis_secure_cell_encrypt_context_imprint((uint8_t *)key_buf, key_length, (uint8_t *)data_buf, data_length, (uint8_t *)context_buf, context_length, (uint8_t *)encrypted_data_buf, &encrypted_data_length);
-		break;
-	default:
-		goto err;
-	}
+        res = themis_secure_cell_encrypt_context_imprint((uint8_t*)key_buf,
+                                                         key_length,
+                                                         (uint8_t*)data_buf,
+                                                         data_length,
+                                                         (uint8_t*)context_buf,
+                                                         context_length,
+                                                         (uint8_t*)encrypted_data_buf,
+                                                         &encrypted_data_length);
+        break;
+    default:
+        goto err;
+    }
 
-	if (THEMIS_SUCCESS != res)
-	{
-		goto err;
-	}
+    if (THEMIS_SUCCESS != res) {
+        goto err;
+    }
 
-	protected_data = (*env)->NewObjectArray(env, 2, (*env)->GetObjectClass(env, data), NULL);
-	if (!protected_data)
-	{
-		goto err;
-	}
+    protected_data = (*env)->NewObjectArray(env, 2, (*env)->GetObjectClass(env, data), NULL);
+    if (!protected_data) {
+        goto err;
+    }
 
-	(*env)->SetObjectArrayElement(env, protected_data, 0, encrypted_data);
+    (*env)->SetObjectArrayElement(env, protected_data, 0, encrypted_data);
 
-	if (additional_data_length)
-	{
-		(*env)->SetObjectArrayElement(env, protected_data, 1, additional_data);
-	}
+    if (additional_data_length) {
+        (*env)->SetObjectArrayElement(env, protected_data, 1, additional_data);
+    }
 
 err:
 
-	if (additional_data_buf)
-	{
-		(*env)->ReleaseByteArrayElements(env, additional_data, additional_data_buf, 0);
-	}
+    if (additional_data_buf) {
+        (*env)->ReleaseByteArrayElements(env, additional_data, additional_data_buf, 0);
+    }
 
-	if (encrypted_data_buf)
-	{
-		(*env)->ReleaseByteArrayElements(env, encrypted_data, encrypted_data_buf, 0);
-	}
+    if (encrypted_data_buf) {
+        (*env)->ReleaseByteArrayElements(env, encrypted_data, encrypted_data_buf, 0);
+    }
 
-	if (context_buf)
-	{
-		(*env)->ReleaseByteArrayElements(env, context, context_buf, 0);
-	}
+    if (context_buf) {
+        (*env)->ReleaseByteArrayElements(env, context, context_buf, 0);
+    }
 
-	if (data_buf)
-	{
-		(*env)->ReleaseByteArrayElements(env, data, data_buf, 0);
-	}
+    if (data_buf) {
+        (*env)->ReleaseByteArrayElements(env, data, data_buf, 0);
+    }
 
-	if (key_buf)
-	{
-		(*env)->ReleaseByteArrayElements(env, key, key_buf, 0);
-	}
+    if (key_buf) {
+        (*env)->ReleaseByteArrayElements(env, key, key_buf, 0);
+    }
 
-	return protected_data;
+    return protected_data;
 }
 
-JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureCell_decrypt(JNIEnv *env, jobject thiz, jbyteArray key, jbyteArray context, jobjectArray protected_data, jint mode)
+JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureCell_decrypt(
+    JNIEnv* env, jobject thiz, jbyteArray key, jbyteArray context, jobjectArray protected_data, jint mode)
 {
-	size_t key_length = (*env)->GetArrayLength(env, key);
-	size_t data_length = 0;
-	size_t context_length = 0;
+    size_t key_length = (*env)->GetArrayLength(env, key);
+    size_t data_length = 0;
+    size_t context_length = 0;
 
-	size_t encrypted_data_length = 0;
-	size_t additional_data_length = 0;
+    size_t encrypted_data_length = 0;
+    size_t additional_data_length = 0;
 
-	jbyte *key_buf = NULL;
-	jbyte *data_buf = NULL;
-	jbyte *context_buf = NULL;
+    jbyte* key_buf = NULL;
+    jbyte* data_buf = NULL;
+    jbyte* context_buf = NULL;
 
-	jbyteArray encrypted_data = NULL;
-	jbyteArray additional_data = NULL;
-	jbyteArray data = NULL;
-	jbyteArray output = NULL;
+    jbyteArray encrypted_data = NULL;
+    jbyteArray additional_data = NULL;
+    jbyteArray data = NULL;
+    jbyteArray output = NULL;
 
-	jbyte *encrypted_data_buf = NULL;
-	jbyte *additional_data_buf = NULL;
+    jbyte* encrypted_data_buf = NULL;
+    jbyte* additional_data_buf = NULL;
 
-	themis_status_t res;
+    themis_status_t res;
 
-	if (context)
-	{
-		context_length = (*env)->GetArrayLength(env, context);
-	}
+    if (context) {
+        context_length = (*env)->GetArrayLength(env, context);
+    }
 
-	encrypted_data = (*env)->GetObjectArrayElement(env, protected_data, 0);
-	additional_data = (*env)->GetObjectArrayElement(env, protected_data, 1);
-	if (!encrypted_data)
-	{
-		return NULL;
-	}
+    encrypted_data = (*env)->GetObjectArrayElement(env, protected_data, 0);
+    additional_data = (*env)->GetObjectArrayElement(env, protected_data, 1);
+    if (!encrypted_data) {
+        return NULL;
+    }
 
-	encrypted_data_length = (*env)->GetArrayLength(env, encrypted_data);
-	if (additional_data)
-	{
-		additional_data_length = (*env)->GetArrayLength(env, additional_data);
-	}
+    encrypted_data_length = (*env)->GetArrayLength(env, encrypted_data);
+    if (additional_data) {
+        additional_data_length = (*env)->GetArrayLength(env, additional_data);
+    }
 
-	key_buf = (*env)->GetByteArrayElements(env, key, NULL);
-	if (!key_buf)
-	{
-		return NULL;
-	}
+    key_buf = (*env)->GetByteArrayElements(env, key, NULL);
+    if (!key_buf) {
+        return NULL;
+    }
 
-	encrypted_data_buf = (*env)->GetByteArrayElements(env, encrypted_data, NULL);
-	if (!encrypted_data_buf)
-	{
-		goto err;
-	}
+    encrypted_data_buf = (*env)->GetByteArrayElements(env, encrypted_data, NULL);
+    if (!encrypted_data_buf) {
+        goto err;
+    }
 
-	if (context)
-	{
-		context_buf = (*env)->GetByteArrayElements(env, context, NULL);
-		if (!context_buf)
-		{
-			goto err;
-		}
-	}
+    if (context) {
+        context_buf = (*env)->GetByteArrayElements(env, context, NULL);
+        if (!context_buf) {
+            goto err;
+        }
+    }
 
-	if (additional_data)
-	{
-		additional_data_buf = (*env)->GetByteArrayElements(env, additional_data, NULL);
-		if (!additional_data_buf)
-		{
-			goto err;
-		}
-	}
+    if (additional_data) {
+        additional_data_buf = (*env)->GetByteArrayElements(env, additional_data, NULL);
+        if (!additional_data_buf) {
+            goto err;
+        }
+    }
 
-	switch (mode)
-	{
-	case MODE_SEAL:
-		res = themis_secure_cell_decrypt_seal((uint8_t *)key_buf, key_length, (uint8_t *)context_buf, context_length, (uint8_t *)encrypted_data_buf, encrypted_data_length, NULL, &data_length);
-		break;
-	case MODE_TOKEN_PROTECT:
-		if (!additional_data_buf)
-		{
-			/* Additional data is mandatory for this mode */
-			goto err;
-		}
+    switch (mode) {
+    case MODE_SEAL:
+        res = themis_secure_cell_decrypt_seal((uint8_t*)key_buf,
+                                              key_length,
+                                              (uint8_t*)context_buf,
+                                              context_length,
+                                              (uint8_t*)encrypted_data_buf,
+                                              encrypted_data_length,
+                                              NULL,
+                                              &data_length);
+        break;
+    case MODE_TOKEN_PROTECT:
+        if (!additional_data_buf) {
+            /* Additional data is mandatory for this mode */
+            goto err;
+        }
 
-		res = themis_secure_cell_decrypt_token_protect((uint8_t *)key_buf, key_length, (uint8_t *)context_buf, context_length, (uint8_t *)encrypted_data_buf, encrypted_data_length, (uint8_t *)additional_data_buf, additional_data_length, NULL, &data_length);
-		break;
-	case MODE_CONTEXT_IMPRINT:
-		if (!context)
-		{
-			/* Context is mandatory for this mode */
-			goto err;
-		}
+        res = themis_secure_cell_decrypt_token_protect((uint8_t*)key_buf,
+                                                       key_length,
+                                                       (uint8_t*)context_buf,
+                                                       context_length,
+                                                       (uint8_t*)encrypted_data_buf,
+                                                       encrypted_data_length,
+                                                       (uint8_t*)additional_data_buf,
+                                                       additional_data_length,
+                                                       NULL,
+                                                       &data_length);
+        break;
+    case MODE_CONTEXT_IMPRINT:
+        if (!context) {
+            /* Context is mandatory for this mode */
+            goto err;
+        }
 
-		res = themis_secure_cell_encrypt_context_imprint((uint8_t *)key_buf, key_length, (uint8_t *)encrypted_data_buf, encrypted_data_length, (uint8_t *)context_buf, context_length, NULL, &data_length);
-		break;
-	default:
-		goto err;
-	}
+        res = themis_secure_cell_encrypt_context_imprint((uint8_t*)key_buf,
+                                                         key_length,
+                                                         (uint8_t*)encrypted_data_buf,
+                                                         encrypted_data_length,
+                                                         (uint8_t*)context_buf,
+                                                         context_length,
+                                                         NULL,
+                                                         &data_length);
+        break;
+    default:
+        goto err;
+    }
 
-	if (THEMIS_BUFFER_TOO_SMALL != res)
-	{
-		goto err;
-	}
+    if (THEMIS_BUFFER_TOO_SMALL != res) {
+        goto err;
+    }
 
-	data = (*env)->NewByteArray(env, data_length);
-	if (!data)
-	{
-		goto err;
-	}
+    data = (*env)->NewByteArray(env, data_length);
+    if (!data) {
+        goto err;
+    }
 
-	data_buf = (*env)->GetByteArrayElements(env, data, NULL);
-	if (!data_buf)
-	{
-		goto err;
-	}
+    data_buf = (*env)->GetByteArrayElements(env, data, NULL);
+    if (!data_buf) {
+        goto err;
+    }
 
-	switch (mode)
-	{
-	case MODE_SEAL:
-		res = themis_secure_cell_decrypt_seal((uint8_t *)key_buf, key_length, (uint8_t *)context_buf, context_length, (uint8_t *)encrypted_data_buf, encrypted_data_length, (uint8_t *)data_buf, &data_length);
-		break;
-	case MODE_TOKEN_PROTECT:
-		if (!additional_data_buf)
-		{
-			/* Additional data is mandatory for this mode */
-			goto err;
-		}
+    switch (mode) {
+    case MODE_SEAL:
+        res = themis_secure_cell_decrypt_seal((uint8_t*)key_buf,
+                                              key_length,
+                                              (uint8_t*)context_buf,
+                                              context_length,
+                                              (uint8_t*)encrypted_data_buf,
+                                              encrypted_data_length,
+                                              (uint8_t*)data_buf,
+                                              &data_length);
+        break;
+    case MODE_TOKEN_PROTECT:
+        if (!additional_data_buf) {
+            /* Additional data is mandatory for this mode */
+            goto err;
+        }
 
-		res = themis_secure_cell_decrypt_token_protect((uint8_t *)key_buf, key_length, (uint8_t *)context_buf, context_length, (uint8_t *)encrypted_data_buf, encrypted_data_length, (uint8_t *)additional_data_buf, additional_data_length, (uint8_t *)data_buf, &data_length);
-		break;
-	case MODE_CONTEXT_IMPRINT:
-		if (!context)
-		{
-			/* Context is mandatory for this mode */
-			goto err;
-		}
+        res = themis_secure_cell_decrypt_token_protect((uint8_t*)key_buf,
+                                                       key_length,
+                                                       (uint8_t*)context_buf,
+                                                       context_length,
+                                                       (uint8_t*)encrypted_data_buf,
+                                                       encrypted_data_length,
+                                                       (uint8_t*)additional_data_buf,
+                                                       additional_data_length,
+                                                       (uint8_t*)data_buf,
+                                                       &data_length);
+        break;
+    case MODE_CONTEXT_IMPRINT:
+        if (!context) {
+            /* Context is mandatory for this mode */
+            goto err;
+        }
 
-		res = themis_secure_cell_encrypt_context_imprint((uint8_t *)key_buf, key_length, (uint8_t *)encrypted_data_buf, encrypted_data_length, (uint8_t *)context_buf, context_length, (uint8_t *)data_buf, &data_length);
-		break;
-	default:
-		goto err;
-	}
+        res = themis_secure_cell_encrypt_context_imprint((uint8_t*)key_buf,
+                                                         key_length,
+                                                         (uint8_t*)encrypted_data_buf,
+                                                         encrypted_data_length,
+                                                         (uint8_t*)context_buf,
+                                                         context_length,
+                                                         (uint8_t*)data_buf,
+                                                         &data_length);
+        break;
+    default:
+        goto err;
+    }
 
-	if (THEMIS_SUCCESS != res)
-	{
-		goto err;
-	}
+    if (THEMIS_SUCCESS != res) {
+        goto err;
+    }
 
-	output = data;
+    output = data;
 
 err:
 
-	if (additional_data_buf)
-	{
-		(*env)->ReleaseByteArrayElements(env, additional_data, additional_data_buf, 0);
-	}
+    if (additional_data_buf) {
+        (*env)->ReleaseByteArrayElements(env, additional_data, additional_data_buf, 0);
+    }
 
-	if (encrypted_data_buf)
-	{
-		(*env)->ReleaseByteArrayElements(env, encrypted_data, encrypted_data_buf, 0);
-	}
+    if (encrypted_data_buf) {
+        (*env)->ReleaseByteArrayElements(env, encrypted_data, encrypted_data_buf, 0);
+    }
 
-	if (context_buf)
-	{
-		(*env)->ReleaseByteArrayElements(env, context, context_buf, 0);
-	}
+    if (context_buf) {
+        (*env)->ReleaseByteArrayElements(env, context, context_buf, 0);
+    }
 
-	if (data_buf)
-	{
-		(*env)->ReleaseByteArrayElements(env, data, data_buf, 0);
-	}
+    if (data_buf) {
+        (*env)->ReleaseByteArrayElements(env, data, data_buf, 0);
+    }
 
-	if (key_buf)
-	{
-		(*env)->ReleaseByteArrayElements(env, key, key_buf, 0);
-	}
+    if (key_buf) {
+        (*env)->ReleaseByteArrayElements(env, key, key_buf, 0);
+    }
 
-	return output;
+    return output;
 }
-

--- a/jni/themis_compare.c
+++ b/jni/themis_compare.c
@@ -1,233 +1,226 @@
 /*
-* Copyright (c) 2015 Cossack Labs Limited
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2015 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include <jni.h>
-#include <themis/themis_error.h>
 #include <themis/secure_comparator.h>
+#include <themis/themis_error.h>
 
 #define COMPARE_CTX_FIELD_NAME "nativeCtx"
 #define COMPARE_CTX_FIELD_SIG "J"
 
-static secure_comparator_t *get_native_ctx(JNIEnv *env, jobject compare_obj)
+static secure_comparator_t* get_native_ctx(JNIEnv* env, jobject compare_obj)
 {
-	jfieldID compare_ctx_field_id = (*env)->GetFieldID(env, (*env)->GetObjectClass(env, compare_obj), COMPARE_CTX_FIELD_NAME, COMPARE_CTX_FIELD_SIG);
-	intptr_t compare_ctx_ptr;
+    jfieldID compare_ctx_field_id = (*env)->GetFieldID(env,
+                                                       (*env)->GetObjectClass(env, compare_obj),
+                                                       COMPARE_CTX_FIELD_NAME,
+                                                       COMPARE_CTX_FIELD_SIG);
+    intptr_t compare_ctx_ptr;
 
-	if (!compare_ctx_field_id)
-	{
-		return NULL;
-	}
+    if (!compare_ctx_field_id) {
+        return NULL;
+    }
 
-	compare_ctx_ptr = (intptr_t)((*env)->GetLongField(env, compare_obj, compare_ctx_field_id));
+    compare_ctx_ptr = (intptr_t)((*env)->GetLongField(env, compare_obj, compare_ctx_field_id));
 
-	return (secure_comparator_t *)compare_ctx_ptr;
+    return (secure_comparator_t*)compare_ctx_ptr;
 }
 
-JNIEXPORT jint JNICALL Java_com_cossacklabs_themis_SecureCompare_jniAppend(JNIEnv *env, jobject thiz, jbyteArray secret)
+JNIEXPORT jint JNICALL Java_com_cossacklabs_themis_SecureCompare_jniAppend(JNIEnv* env,
+                                                                           jobject thiz,
+                                                                           jbyteArray secret)
 {
-	secure_comparator_t *ctx = get_native_ctx(env, thiz);
-	size_t secret_length = (*env)->GetArrayLength(env, secret);
-	jbyte *secret_buf;
+    secure_comparator_t* ctx = get_native_ctx(env, thiz);
+    size_t secret_length = (*env)->GetArrayLength(env, secret);
+    jbyte* secret_buf;
 
-	themis_status_t res;
+    themis_status_t res;
 
-	if (NULL == ctx)
-	{
-		return THEMIS_FAIL;
-	}
+    if (NULL == ctx) {
+        return THEMIS_FAIL;
+    }
 
-	secret_buf = (*env)->GetByteArrayElements(env, secret, NULL);
-	if (!secret_buf)
-	{
-		return THEMIS_FAIL;
-	}
+    secret_buf = (*env)->GetByteArrayElements(env, secret, NULL);
+    if (!secret_buf) {
+        return THEMIS_FAIL;
+    }
 
-	res = secure_comparator_append_secret(ctx, secret_buf, secret_length);
+    res = secure_comparator_append_secret(ctx, secret_buf, secret_length);
 
-	(*env)->ReleaseByteArrayElements(env, secret, secret_buf, 0);
+    (*env)->ReleaseByteArrayElements(env, secret, secret_buf, 0);
 
-	return (jint)res;
+    return (jint)res;
 }
 
-JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureCompare_jniBegin(JNIEnv *env, jobject thiz)
+JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureCompare_jniBegin(JNIEnv* env, jobject thiz)
 {
-	secure_comparator_t *ctx = get_native_ctx(env, thiz);
-	size_t compare_data_length = 0;
+    secure_comparator_t* ctx = get_native_ctx(env, thiz);
+    size_t compare_data_length = 0;
 
-	jbyteArray compare_data;
-	jbyte *compare_data_buf;
+    jbyteArray compare_data;
+    jbyte* compare_data_buf;
 
-	themis_status_t res;
+    themis_status_t res;
 
-	if (NULL == ctx)
-	{
-		return NULL;
-	}
+    if (NULL == ctx) {
+        return NULL;
+    }
 
-	res = secure_comparator_begin_compare(ctx, NULL, &compare_data_length);
-	if (THEMIS_BUFFER_TOO_SMALL != res)
-	{
-		return NULL;
-	}
+    res = secure_comparator_begin_compare(ctx, NULL, &compare_data_length);
+    if (THEMIS_BUFFER_TOO_SMALL != res) {
+        return NULL;
+    }
 
-	compare_data = (*env)->NewByteArray(env, compare_data_length);
-	if (!compare_data)
-	{
-		return NULL;
-	}
+    compare_data = (*env)->NewByteArray(env, compare_data_length);
+    if (!compare_data) {
+        return NULL;
+    }
 
-	compare_data_buf = (*env)->GetByteArrayElements(env, compare_data, NULL);
-	if (!compare_data_buf)
-	{
-		return NULL;
-	}
+    compare_data_buf = (*env)->GetByteArrayElements(env, compare_data, NULL);
+    if (!compare_data_buf) {
+        return NULL;
+    }
 
-	res = secure_comparator_begin_compare(ctx, compare_data_buf, &compare_data_length);
+    res = secure_comparator_begin_compare(ctx, compare_data_buf, &compare_data_length);
 
-	(*env)->ReleaseByteArrayElements(env, compare_data, compare_data_buf, 0);
+    (*env)->ReleaseByteArrayElements(env, compare_data, compare_data_buf, 0);
 
-	if (THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER == res)
-	{
-		return compare_data;
-	}
-	
-	
-		return NULL;
-	
+    if (THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER == res) {
+        return compare_data;
+    }
+
+    return NULL;
 }
 
-static void throwSecureCompareException(JNIEnv *env)
+static void throwSecureCompareException(JNIEnv* env)
 {
-	jclass exception_class = (*env)->FindClass(env, "Lcom/cossacklabs/themis/SecureCompareException");
-	if (exception_class)
-	{
-		(*env)->ThrowNew(env, exception_class, "");
-	}
+    jclass exception_class = (*env)->FindClass(env, "Lcom/cossacklabs/themis/SecureCompareException");
+    if (exception_class) {
+        (*env)->ThrowNew(env, exception_class, "");
+    }
 }
 
-JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureCompare_jniProceed(JNIEnv *env, jobject thiz, jbyteArray compare_data)
+JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureCompare_jniProceed(JNIEnv* env,
+                                                                                  jobject thiz,
+                                                                                  jbyteArray compare_data)
 {
-	secure_comparator_t *ctx = get_native_ctx(env, thiz);
-	size_t compare_data_length = (*env)->GetArrayLength(env, compare_data);
+    secure_comparator_t* ctx = get_native_ctx(env, thiz);
+    size_t compare_data_length = (*env)->GetArrayLength(env, compare_data);
 
-	jbyte *compare_data_buf;
+    jbyte* compare_data_buf;
 
-	themis_status_t res = THEMIS_FAIL;
-	size_t output_length = 0;
-	jbyteArray output = NULL;
-	jbyte *output_buf = NULL;
+    themis_status_t res = THEMIS_FAIL;
+    size_t output_length = 0;
+    jbyteArray output = NULL;
+    jbyte* output_buf = NULL;
 
-	if (NULL == ctx)
-	{
-		throwSecureCompareException(env);
-		return NULL;
-	}
+    if (NULL == ctx) {
+        throwSecureCompareException(env);
+        return NULL;
+    }
 
-	compare_data_buf = (*env)->GetByteArrayElements(env, compare_data, NULL);
-	if (NULL == compare_data_buf)
-	{
-		throwSecureCompareException(env);
-		return NULL;
-	}
+    compare_data_buf = (*env)->GetByteArrayElements(env, compare_data, NULL);
+    if (NULL == compare_data_buf) {
+        throwSecureCompareException(env);
+        return NULL;
+    }
 
-	res = secure_comparator_proceed_compare(ctx, compare_data_buf, compare_data_length, NULL, &output_length);
-	if (THEMIS_BUFFER_TOO_SMALL != res)
-	{
-		goto err;
-	}
+    res = secure_comparator_proceed_compare(ctx, compare_data_buf, compare_data_length, NULL, &output_length);
+    if (THEMIS_BUFFER_TOO_SMALL != res) {
+        goto err;
+    }
 
-	output = (*env)->NewByteArray(env, output_length);
-	if (!output)
-	{
-		goto err;
-	}
+    output = (*env)->NewByteArray(env, output_length);
+    if (!output) {
+        goto err;
+    }
 
-	output_buf = (*env)->GetByteArrayElements(env, output, NULL);
-	if (!output_buf)
-	{
-		goto err;
-	}
+    output_buf = (*env)->GetByteArrayElements(env, output, NULL);
+    if (!output_buf) {
+        goto err;
+    }
 
-	res = secure_comparator_proceed_compare(ctx, compare_data_buf, compare_data_length, output_buf, &output_length);
+    res = secure_comparator_proceed_compare(ctx,
+                                            compare_data_buf,
+                                            compare_data_length,
+                                            output_buf,
+                                            &output_length);
 
 err:
 
-	if (output_buf)
-	{
-		(*env)->ReleaseByteArrayElements(env, output, output_buf, 0);
-	}
+    if (output_buf) {
+        (*env)->ReleaseByteArrayElements(env, output, output_buf, 0);
+    }
 
-	if (compare_data_buf)
-	{
-		(*env)->ReleaseByteArrayElements(env, compare_data, compare_data_buf, 0);
-	}
+    if (compare_data_buf) {
+        (*env)->ReleaseByteArrayElements(env, compare_data, compare_data_buf, 0);
+    }
 
-	if (THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER == res)
-	{
-		return output;
-	}
-	
-	
-		if (THEMIS_SUCCESS != res)
-		{
-			throwSecureCompareException(env);
-		}
+    if (THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER == res) {
+        return output;
+    }
 
-		return NULL;
-	
+    if (THEMIS_SUCCESS != res) {
+        throwSecureCompareException(env);
+    }
+
+    return NULL;
 }
 
-JNIEXPORT jint JNICALL Java_com_cossacklabs_themis_SecureCompare_jniGetResult(JNIEnv *env, jobject thiz)
+JNIEXPORT jint JNICALL Java_com_cossacklabs_themis_SecureCompare_jniGetResult(JNIEnv* env, jobject thiz)
 {
-	return (jint)secure_comparator_get_result(get_native_ctx(env, thiz));
+    return (jint)secure_comparator_get_result(get_native_ctx(env, thiz));
 }
 
-JNIEXPORT jlong JNICALL Java_com_cossacklabs_themis_SecureCompare_create(JNIEnv *env, jobject thiz)
+JNIEXPORT jlong JNICALL Java_com_cossacklabs_themis_SecureCompare_create(JNIEnv* env, jobject thiz)
 {
-	return (intptr_t)secure_comparator_create();
+    return (intptr_t)secure_comparator_create();
 }
 
-JNIEXPORT void JNICALL Java_com_cossacklabs_themis_SecureCompare_destroy(JNIEnv *env, jobject thiz)
+JNIEXPORT void JNICALL Java_com_cossacklabs_themis_SecureCompare_destroy(JNIEnv* env, jobject thiz)
 {
-	jfieldID compare_ctx_field_id = (*env)->GetFieldID(env, (*env)->GetObjectClass(env, thiz), COMPARE_CTX_FIELD_NAME, COMPARE_CTX_FIELD_SIG);
-	intptr_t compare_ctx_ptr;
+    jfieldID compare_ctx_field_id = (*env)->GetFieldID(env,
+                                                       (*env)->GetObjectClass(env, thiz),
+                                                       COMPARE_CTX_FIELD_NAME,
+                                                       COMPARE_CTX_FIELD_SIG);
+    intptr_t compare_ctx_ptr;
 
-	if (!compare_ctx_field_id)
-	{
-		return;
-	}
+    if (!compare_ctx_field_id) {
+        return;
+    }
 
-	compare_ctx_ptr = (intptr_t)((*env)->GetLongField(env, thiz, compare_ctx_field_id));
+    compare_ctx_ptr = (intptr_t)((*env)->GetLongField(env, thiz, compare_ctx_field_id));
 
-	if (compare_ctx_ptr)
-	{
-		secure_comparator_destroy((secure_comparator_t *)compare_ctx_ptr);
-		(*env)->SetLongField(env, thiz, compare_ctx_field_id, 0);
-	}
+    if (compare_ctx_ptr) {
+        secure_comparator_destroy((secure_comparator_t*)compare_ctx_ptr);
+        (*env)->SetLongField(env, thiz, compare_ctx_field_id, 0);
+    }
 }
 
-JNIEXPORT jint JNICALL Java_com_cossacklabs_themis_SecureCompare_scompareMatch(JNIEnv *env, jobject thiz){
-	return THEMIS_SCOMPARE_MATCH;
+JNIEXPORT jint JNICALL Java_com_cossacklabs_themis_SecureCompare_scompareMatch(JNIEnv* env, jobject thiz)
+{
+    return THEMIS_SCOMPARE_MATCH;
 }
 
-JNIEXPORT jint JNICALL Java_com_cossacklabs_themis_SecureCompare_scompareNoMatch(JNIEnv *env, jobject thiz){
-	return THEMIS_SCOMPARE_NO_MATCH;
+JNIEXPORT jint JNICALL Java_com_cossacklabs_themis_SecureCompare_scompareNoMatch(JNIEnv* env, jobject thiz)
+{
+    return THEMIS_SCOMPARE_NO_MATCH;
 }
 
-JNIEXPORT jint JNICALL Java_com_cossacklabs_themis_SecureCompare_scompareNotReady(JNIEnv *env, jobject thiz){
-	return THEMIS_SCOMPARE_NOT_READY;
+JNIEXPORT jint JNICALL Java_com_cossacklabs_themis_SecureCompare_scompareNotReady(JNIEnv* env,
+                                                                                  jobject thiz)
+{
+    return THEMIS_SCOMPARE_NOT_READY;
 }
-

--- a/jni/themis_compare.c
+++ b/jni/themis_compare.c
@@ -103,10 +103,10 @@ JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureCompare_jniBegin(
 	{
 		return compare_data;
 	}
-	else
-	{
+	
+	
 		return NULL;
-	}
+	
 }
 
 static void throwSecureCompareException(JNIEnv *env)
@@ -127,7 +127,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureCompare_jniProcee
 
 	themis_status_t res = THEMIS_FAIL;
 	size_t output_length = 0;
-	jbyteArray output;
+	jbyteArray output = NULL;
 	jbyte *output_buf = NULL;
 
 	if (NULL == ctx)
@@ -179,15 +179,15 @@ err:
 	{
 		return output;
 	}
-	else
-	{
+	
+	
 		if (THEMIS_SUCCESS != res)
 		{
 			throwSecureCompareException(env);
 		}
 
 		return NULL;
-	}
+	
 }
 
 JNIEXPORT jint JNICALL Java_com_cossacklabs_themis_SecureCompare_jniGetResult(JNIEnv *env, jobject thiz)

--- a/jni/themis_jni.c
+++ b/jni/themis_jni.c
@@ -1,28 +1,27 @@
 /*
-* Copyright (c) 2015 Cossack Labs Limited
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2015 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include <jni.h>
 #include <string.h>
 
 /*JavaVM *g_vm = NULL;*/
 
-jint JNI_OnLoad(JavaVM *vm, void *reserved)
+jint JNI_OnLoad(JavaVM* vm, void* reserved)
 {
-	/*g_vm = vm;*/
+    /*g_vm = vm;*/
 
-	return JNI_VERSION_1_6;
+    return JNI_VERSION_1_6;
 }
-

--- a/jni/themis_keygen.c
+++ b/jni/themis_keygen.c
@@ -1,114 +1,113 @@
 /*
-* Copyright (c) 2015 Cossack Labs Limited
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2015 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include <jni.h>
-#include <themis/themis_error.h>
 #include <themis/secure_keygen.h>
+#include <themis/themis_error.h>
 
 /* Should be same as in AsymmetricKey.java */
 #define KEYTYPE_EC 0
 #define KEYTYPE_RSA 1
 
-JNIEXPORT jobjectArray JNICALL Java_com_cossacklabs_themis_KeypairGenerator_generateKeys(JNIEnv *env, jobject thiz, jint key_type)
+JNIEXPORT jobjectArray JNICALL Java_com_cossacklabs_themis_KeypairGenerator_generateKeys(JNIEnv* env,
+                                                                                         jobject thiz,
+                                                                                         jint key_type)
 {
-	size_t private_key_length = 0;
-	size_t public_key_length = 0;
+    size_t private_key_length = 0;
+    size_t public_key_length = 0;
 
-	jbyteArray private_key;
-	jbyteArray public_key;
+    jbyteArray private_key;
+    jbyteArray public_key;
 
-	jbyte *priv_buf;
-	jbyte *pub_buf;
+    jbyte* priv_buf;
+    jbyte* pub_buf;
 
-	jobjectArray keys;
+    jobjectArray keys;
 
-	themis_status_t res;
+    themis_status_t res;
 
-	switch (key_type)
-	{
-	case KEYTYPE_EC:
-		res = themis_gen_ec_key_pair(NULL, &private_key_length, NULL, &public_key_length);
-		break;
-	case KEYTYPE_RSA:
-		res = themis_gen_rsa_key_pair(NULL, &private_key_length, NULL, &public_key_length);
-		break;
-	default:
-		return NULL;
-	}
+    switch (key_type) {
+    case KEYTYPE_EC:
+        res = themis_gen_ec_key_pair(NULL, &private_key_length, NULL, &public_key_length);
+        break;
+    case KEYTYPE_RSA:
+        res = themis_gen_rsa_key_pair(NULL, &private_key_length, NULL, &public_key_length);
+        break;
+    default:
+        return NULL;
+    }
 
-	if (THEMIS_BUFFER_TOO_SMALL != res)
-	{
-		return NULL;
-	}
+    if (THEMIS_BUFFER_TOO_SMALL != res) {
+        return NULL;
+    }
 
-	private_key = (*env)->NewByteArray(env, private_key_length);
-	if (!private_key)
-	{
-		return NULL;
-	}
+    private_key = (*env)->NewByteArray(env, private_key_length);
+    if (!private_key) {
+        return NULL;
+    }
 
-	public_key = (*env)->NewByteArray(env, public_key_length);
-	if (!public_key)
-	{
-		return NULL;
-	}
+    public_key = (*env)->NewByteArray(env, public_key_length);
+    if (!public_key) {
+        return NULL;
+    }
 
-	priv_buf = (*env)->GetByteArrayElements(env, private_key, NULL);
-	if (!priv_buf)
-	{
-		return NULL;
-	}
+    priv_buf = (*env)->GetByteArrayElements(env, private_key, NULL);
+    if (!priv_buf) {
+        return NULL;
+    }
 
-	pub_buf = (*env)->GetByteArrayElements(env, public_key, NULL);
-	if (!pub_buf)
-	{
-		(*env)->ReleaseByteArrayElements(env, private_key, priv_buf, 0);
-		return NULL;
-	}
+    pub_buf = (*env)->GetByteArrayElements(env, public_key, NULL);
+    if (!pub_buf) {
+        (*env)->ReleaseByteArrayElements(env, private_key, priv_buf, 0);
+        return NULL;
+    }
 
-	switch (key_type)
-	{
-	case KEYTYPE_EC:
-		res = themis_gen_ec_key_pair((uint8_t *)priv_buf, &private_key_length, (uint8_t *)pub_buf, &public_key_length);
-		break;
-	case KEYTYPE_RSA:
-		res = themis_gen_rsa_key_pair((uint8_t *)priv_buf, &private_key_length, (uint8_t *)pub_buf, &public_key_length);
-		break;
-	default:
-		(*env)->ReleaseByteArrayElements(env, public_key, pub_buf, 0);
-		(*env)->ReleaseByteArrayElements(env, private_key, priv_buf, 0);
-		return NULL;
-	}
+    switch (key_type) {
+    case KEYTYPE_EC:
+        res = themis_gen_ec_key_pair((uint8_t*)priv_buf,
+                                     &private_key_length,
+                                     (uint8_t*)pub_buf,
+                                     &public_key_length);
+        break;
+    case KEYTYPE_RSA:
+        res = themis_gen_rsa_key_pair((uint8_t*)priv_buf,
+                                      &private_key_length,
+                                      (uint8_t*)pub_buf,
+                                      &public_key_length);
+        break;
+    default:
+        (*env)->ReleaseByteArrayElements(env, public_key, pub_buf, 0);
+        (*env)->ReleaseByteArrayElements(env, private_key, priv_buf, 0);
+        return NULL;
+    }
 
-	(*env)->ReleaseByteArrayElements(env, public_key, pub_buf, 0);
-	(*env)->ReleaseByteArrayElements(env, private_key, priv_buf, 0);
+    (*env)->ReleaseByteArrayElements(env, public_key, pub_buf, 0);
+    (*env)->ReleaseByteArrayElements(env, private_key, priv_buf, 0);
 
-	if (THEMIS_SUCCESS != res)
-	{
-		return NULL;
-	}
+    if (THEMIS_SUCCESS != res) {
+        return NULL;
+    }
 
-	keys = (*env)->NewObjectArray(env, 2, (*env)->GetObjectClass(env, private_key), NULL);
-	if (!keys)
-	{
-		return NULL;
-	}
+    keys = (*env)->NewObjectArray(env, 2, (*env)->GetObjectClass(env, private_key), NULL);
+    if (!keys) {
+        return NULL;
+    }
 
-	(*env)->SetObjectArrayElement(env, keys, 0, private_key);
-	(*env)->SetObjectArrayElement(env, keys, 1, public_key);
+    (*env)->SetObjectArrayElement(env, keys, 0, private_key);
+    (*env)->SetObjectArrayElement(env, keys, 1, public_key);
 
-	return keys;
+    return keys;
 }

--- a/jni/themis_keygen.c
+++ b/jni/themis_keygen.c
@@ -24,11 +24,11 @@
 
 JNIEXPORT jobjectArray JNICALL Java_com_cossacklabs_themis_KeypairGenerator_generateKeys(JNIEnv *env, jobject thiz, jint key_type)
 {
-	size_t private_length = 0;
-	size_t public_length = 0;
+	size_t private_key_length = 0;
+	size_t public_key_length = 0;
 
-	jbyteArray private;
-	jbyteArray public;
+	jbyteArray private_key;
+	jbyteArray public_key;
 
 	jbyte *priv_buf;
 	jbyte *pub_buf;
@@ -40,10 +40,10 @@ JNIEXPORT jobjectArray JNICALL Java_com_cossacklabs_themis_KeypairGenerator_gene
 	switch (key_type)
 	{
 	case KEYTYPE_EC:
-		res = themis_gen_ec_key_pair(NULL, &private_length, NULL, &public_length);
+		res = themis_gen_ec_key_pair(NULL, &private_key_length, NULL, &public_key_length);
 		break;
 	case KEYTYPE_RSA:
-		res = themis_gen_rsa_key_pair(NULL, &private_length, NULL, &public_length);
+		res = themis_gen_rsa_key_pair(NULL, &private_key_length, NULL, &public_key_length);
 		break;
 	default:
 		return NULL;
@@ -54,61 +54,61 @@ JNIEXPORT jobjectArray JNICALL Java_com_cossacklabs_themis_KeypairGenerator_gene
 		return NULL;
 	}
 
-	private = (*env)->NewByteArray(env, private_length);
-	if (!private)
+	private_key = (*env)->NewByteArray(env, private_key_length);
+	if (!private_key)
 	{
 		return NULL;
 	}
 
-	public = (*env)->NewByteArray(env, public_length);
-	if (!public)
+	public_key = (*env)->NewByteArray(env, public_key_length);
+	if (!public_key)
 	{
 		return NULL;
 	}
 
-	priv_buf = (*env)->GetByteArrayElements(env, private, NULL);
+	priv_buf = (*env)->GetByteArrayElements(env, private_key, NULL);
 	if (!priv_buf)
 	{
 		return NULL;
 	}
 
-	pub_buf = (*env)->GetByteArrayElements(env, public, NULL);
+	pub_buf = (*env)->GetByteArrayElements(env, public_key, NULL);
 	if (!pub_buf)
 	{
-		(*env)->ReleaseByteArrayElements(env, private, priv_buf, 0);
+		(*env)->ReleaseByteArrayElements(env, private_key, priv_buf, 0);
 		return NULL;
 	}
 
 	switch (key_type)
 	{
 	case KEYTYPE_EC:
-		res = themis_gen_ec_key_pair((uint8_t *)priv_buf, &private_length, (uint8_t *)pub_buf, &public_length);
+		res = themis_gen_ec_key_pair((uint8_t *)priv_buf, &private_key_length, (uint8_t *)pub_buf, &public_key_length);
 		break;
 	case KEYTYPE_RSA:
-		res = themis_gen_rsa_key_pair((uint8_t *)priv_buf, &private_length, (uint8_t *)pub_buf, &public_length);
+		res = themis_gen_rsa_key_pair((uint8_t *)priv_buf, &private_key_length, (uint8_t *)pub_buf, &public_key_length);
 		break;
 	default:
-		(*env)->ReleaseByteArrayElements(env, public, pub_buf, 0);
-		(*env)->ReleaseByteArrayElements(env, private, priv_buf, 0);
+		(*env)->ReleaseByteArrayElements(env, public_key, pub_buf, 0);
+		(*env)->ReleaseByteArrayElements(env, private_key, priv_buf, 0);
 		return NULL;
 	}
 
-	(*env)->ReleaseByteArrayElements(env, public, pub_buf, 0);
-	(*env)->ReleaseByteArrayElements(env, private, priv_buf, 0);
+	(*env)->ReleaseByteArrayElements(env, public_key, pub_buf, 0);
+	(*env)->ReleaseByteArrayElements(env, private_key, priv_buf, 0);
 
 	if (THEMIS_SUCCESS != res)
 	{
 		return NULL;
 	}
 
-	keys = (*env)->NewObjectArray(env, 2, (*env)->GetObjectClass(env, private), NULL);
+	keys = (*env)->NewObjectArray(env, 2, (*env)->GetObjectClass(env, private_key), NULL);
 	if (!keys)
 	{
 		return NULL;
 	}
 
-	(*env)->SetObjectArrayElement(env, keys, 0, private);
-	(*env)->SetObjectArrayElement(env, keys, 1, public);
+	(*env)->SetObjectArrayElement(env, keys, 0, private_key);
+	(*env)->SetObjectArrayElement(env, keys, 1, public_key);
 
 	return keys;
 }

--- a/jni/themis_message.c
+++ b/jni/themis_message.c
@@ -1,160 +1,194 @@
 /*
-* Copyright (c) 2015 Cossack Labs Limited
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2015 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include <jni.h>
-#include <themis/themis_error.h>
 #include <themis/secure_message.h>
+#include <themis/themis_error.h>
 
 #define SECURE_MESSAGE_ENCRYPT 1
 #define SECURE_MESSAGE_DECRYPT 2
-#define SECURE_MESSAGE_SIGN    3
-#define SECURE_MESSAGE_VERIFY  4
+#define SECURE_MESSAGE_SIGN 3
+#define SECURE_MESSAGE_VERIFY 4
 
-JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureMessage_process(JNIEnv *env, jobject thiz, jbyteArray private_key, jbyteArray public_key, jbyteArray message, jint action)
+JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureMessage_process(JNIEnv* env,
+                                                                               jobject thiz,
+                                                                               jbyteArray private_key,
+                                                                               jbyteArray public_key,
+                                                                               jbyteArray message,
+                                                                               jint action)
 {
-	size_t private_key_length = 0;
-	size_t public_key_length = 0;
-	size_t message_length = (*env)->GetArrayLength(env, message);
-	size_t output_length = 0;
+    size_t private_key_length = 0;
+    size_t public_key_length = 0;
+    size_t message_length = (*env)->GetArrayLength(env, message);
+    size_t output_length = 0;
 
-	jbyte *priv_buf = NULL;
-	jbyte *pub_buf = NULL;
-	jbyte *message_buf = NULL;
-	jbyte *output_buf = NULL;
+    jbyte* priv_buf = NULL;
+    jbyte* pub_buf = NULL;
+    jbyte* message_buf = NULL;
+    jbyte* output_buf = NULL;
 
-	themis_status_t res = THEMIS_FAIL;
-	jbyteArray output = NULL;
+    themis_status_t res = THEMIS_FAIL;
+    jbyteArray output = NULL;
 
-	if (private_key)
-	{
-		private_key_length = (*env)->GetArrayLength(env, private_key);
-	}
+    if (private_key) {
+        private_key_length = (*env)->GetArrayLength(env, private_key);
+    }
 
-	if (public_key)
-	{
-		public_key_length = (*env)->GetArrayLength(env, public_key);
-	}
+    if (public_key) {
+        public_key_length = (*env)->GetArrayLength(env, public_key);
+    }
 
-	if (private_key)
-	{
-		priv_buf = (*env)->GetByteArrayElements(env, private_key, NULL);
-		if (!priv_buf)
-		{
-			return NULL;
-		}
-	}
+    if (private_key) {
+        priv_buf = (*env)->GetByteArrayElements(env, private_key, NULL);
+        if (!priv_buf) {
+            return NULL;
+        }
+    }
 
-	if (public_key)
-	{
-		pub_buf = (*env)->GetByteArrayElements(env, public_key, NULL);
-		if (!pub_buf)
-		{
-			goto err;
-		}
-	}
+    if (public_key) {
+        pub_buf = (*env)->GetByteArrayElements(env, public_key, NULL);
+        if (!pub_buf) {
+            goto err;
+        }
+    }
 
-	message_buf = (*env)->GetByteArrayElements(env, message, NULL);
-	if (!message_buf)
-	{
-		goto err;
-	}
+    message_buf = (*env)->GetByteArrayElements(env, message, NULL);
+    if (!message_buf) {
+        goto err;
+    }
 
-	switch (action)
-	{
-	case SECURE_MESSAGE_ENCRYPT:
-		res = themis_secure_message_encrypt((uint8_t *)priv_buf, private_key_length, (uint8_t *)pub_buf, public_key_length, (uint8_t *)message_buf, message_length, NULL, &output_length);
-		break;
-	case SECURE_MESSAGE_DECRYPT:
-		res = themis_secure_message_decrypt((uint8_t *)priv_buf, private_key_length, (uint8_t *)pub_buf, public_key_length, (uint8_t *)message_buf, message_length, NULL, &output_length);
-		break;
-	case SECURE_MESSAGE_SIGN:
-		res = themis_secure_message_sign((uint8_t *)priv_buf, private_key_length, (uint8_t *)message_buf, message_length, NULL, &output_length);
-		break;
-	case SECURE_MESSAGE_VERIFY:
-		res = themis_secure_message_verify((uint8_t *)pub_buf, public_key_length, (uint8_t *)message_buf, message_length, NULL, &output_length);
-		break;
-	default:
-		res = THEMIS_NOT_SUPPORTED;
-		break;
-	}
+    switch (action) {
+    case SECURE_MESSAGE_ENCRYPT:
+        res = themis_secure_message_encrypt((uint8_t*)priv_buf,
+                                            private_key_length,
+                                            (uint8_t*)pub_buf,
+                                            public_key_length,
+                                            (uint8_t*)message_buf,
+                                            message_length,
+                                            NULL,
+                                            &output_length);
+        break;
+    case SECURE_MESSAGE_DECRYPT:
+        res = themis_secure_message_decrypt((uint8_t*)priv_buf,
+                                            private_key_length,
+                                            (uint8_t*)pub_buf,
+                                            public_key_length,
+                                            (uint8_t*)message_buf,
+                                            message_length,
+                                            NULL,
+                                            &output_length);
+        break;
+    case SECURE_MESSAGE_SIGN:
+        res = themis_secure_message_sign((uint8_t*)priv_buf,
+                                         private_key_length,
+                                         (uint8_t*)message_buf,
+                                         message_length,
+                                         NULL,
+                                         &output_length);
+        break;
+    case SECURE_MESSAGE_VERIFY:
+        res = themis_secure_message_verify((uint8_t*)pub_buf,
+                                           public_key_length,
+                                           (uint8_t*)message_buf,
+                                           message_length,
+                                           NULL,
+                                           &output_length);
+        break;
+    default:
+        res = THEMIS_NOT_SUPPORTED;
+        break;
+    }
 
-	if (THEMIS_BUFFER_TOO_SMALL != res)
-	{
-		goto err;
-	}
+    if (THEMIS_BUFFER_TOO_SMALL != res) {
+        goto err;
+    }
 
-	output = (*env)->NewByteArray(env, output_length);
-	if (!output)
-	{
-		goto err;
-	}
+    output = (*env)->NewByteArray(env, output_length);
+    if (!output) {
+        goto err;
+    }
 
-	output_buf = (*env)->GetByteArrayElements(env, output, NULL);
-	if (!output_buf)
-	{
-		goto err;
-	}
+    output_buf = (*env)->GetByteArrayElements(env, output, NULL);
+    if (!output_buf) {
+        goto err;
+    }
 
-	switch (action)
-	{
-	case SECURE_MESSAGE_ENCRYPT:
-		res = themis_secure_message_encrypt((uint8_t *)priv_buf, private_key_length, (uint8_t *)pub_buf, public_key_length, (uint8_t *)message_buf, message_length, (uint8_t *)output_buf, &output_length);
-		break;
-	case SECURE_MESSAGE_DECRYPT:
-		res = themis_secure_message_decrypt((uint8_t *)priv_buf, private_key_length, (uint8_t *)pub_buf, public_key_length, (uint8_t *)message_buf, message_length, (uint8_t *)output_buf, &output_length);
-		break;
-	case SECURE_MESSAGE_SIGN:
-		res = themis_secure_message_sign((uint8_t *)priv_buf, private_key_length, (uint8_t *)message_buf, message_length, (uint8_t *)output_buf, &output_length);
-		break;
-	case SECURE_MESSAGE_VERIFY:
-		res = themis_secure_message_verify((uint8_t *)pub_buf, public_key_length, (uint8_t *)message_buf, message_length, (uint8_t *)output_buf, &output_length);
-		break;
-	default:
-		res = THEMIS_NOT_SUPPORTED;
-		break;
-	}
+    switch (action) {
+    case SECURE_MESSAGE_ENCRYPT:
+        res = themis_secure_message_encrypt((uint8_t*)priv_buf,
+                                            private_key_length,
+                                            (uint8_t*)pub_buf,
+                                            public_key_length,
+                                            (uint8_t*)message_buf,
+                                            message_length,
+                                            (uint8_t*)output_buf,
+                                            &output_length);
+        break;
+    case SECURE_MESSAGE_DECRYPT:
+        res = themis_secure_message_decrypt((uint8_t*)priv_buf,
+                                            private_key_length,
+                                            (uint8_t*)pub_buf,
+                                            public_key_length,
+                                            (uint8_t*)message_buf,
+                                            message_length,
+                                            (uint8_t*)output_buf,
+                                            &output_length);
+        break;
+    case SECURE_MESSAGE_SIGN:
+        res = themis_secure_message_sign((uint8_t*)priv_buf,
+                                         private_key_length,
+                                         (uint8_t*)message_buf,
+                                         message_length,
+                                         (uint8_t*)output_buf,
+                                         &output_length);
+        break;
+    case SECURE_MESSAGE_VERIFY:
+        res = themis_secure_message_verify((uint8_t*)pub_buf,
+                                           public_key_length,
+                                           (uint8_t*)message_buf,
+                                           message_length,
+                                           (uint8_t*)output_buf,
+                                           &output_length);
+        break;
+    default:
+        res = THEMIS_NOT_SUPPORTED;
+        break;
+    }
 
 err:
 
-	if (output_buf)
-	{
-		(*env)->ReleaseByteArrayElements(env, output, output_buf, 0);
-	}
+    if (output_buf) {
+        (*env)->ReleaseByteArrayElements(env, output, output_buf, 0);
+    }
 
-	if (message_buf)
-	{
-		(*env)->ReleaseByteArrayElements(env, message, message_buf, 0);
-	}
+    if (message_buf) {
+        (*env)->ReleaseByteArrayElements(env, message, message_buf, 0);
+    }
 
-	if (pub_buf)
-	{
-		(*env)->ReleaseByteArrayElements(env, public_key, pub_buf, 0);
-	}
+    if (pub_buf) {
+        (*env)->ReleaseByteArrayElements(env, public_key, pub_buf, 0);
+    }
 
-	if (priv_buf)
-	{
-		(*env)->ReleaseByteArrayElements(env, private_key, priv_buf, 0);
-	}
+    if (priv_buf) {
+        (*env)->ReleaseByteArrayElements(env, private_key, priv_buf, 0);
+    }
 
-	if (THEMIS_SUCCESS == res)
-	{
-		return output;
-	}
-	
-	
-		return NULL;
-	
+    if (THEMIS_SUCCESS == res) {
+        return output;
+    }
+
+    return NULL;
 }

--- a/jni/themis_message.c
+++ b/jni/themis_message.c
@@ -153,8 +153,8 @@ err:
 	{
 		return output;
 	}
-	else
-	{
+	
+	
 		return NULL;
-	}
+	
 }

--- a/jni/themis_message.c
+++ b/jni/themis_message.c
@@ -23,10 +23,10 @@
 #define SECURE_MESSAGE_SIGN    3
 #define SECURE_MESSAGE_VERIFY  4
 
-JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureMessage_process(JNIEnv *env, jobject thiz, jbyteArray private, jbyteArray public, jbyteArray message, jint action)
+JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureMessage_process(JNIEnv *env, jobject thiz, jbyteArray private_key, jbyteArray public_key, jbyteArray message, jint action)
 {
-	size_t private_length = 0;
-	size_t public_length = 0;
+	size_t private_key_length = 0;
+	size_t public_key_length = 0;
 	size_t message_length = (*env)->GetArrayLength(env, message);
 	size_t output_length = 0;
 
@@ -38,28 +38,28 @@ JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureMessage_process(J
 	themis_status_t res = THEMIS_FAIL;
 	jbyteArray output = NULL;
 
-	if (private)
+	if (private_key)
 	{
-		private_length = (*env)->GetArrayLength(env, private);
+		private_key_length = (*env)->GetArrayLength(env, private_key);
 	}
 
-	if (public)
+	if (public_key)
 	{
-		public_length = (*env)->GetArrayLength(env, public);
+		public_key_length = (*env)->GetArrayLength(env, public_key);
 	}
 
-	if (private)
+	if (private_key)
 	{
-		priv_buf = (*env)->GetByteArrayElements(env, private, NULL);
+		priv_buf = (*env)->GetByteArrayElements(env, private_key, NULL);
 		if (!priv_buf)
 		{
 			return NULL;
 		}
 	}
 
-	if (public)
+	if (public_key)
 	{
-		pub_buf = (*env)->GetByteArrayElements(env, public, NULL);
+		pub_buf = (*env)->GetByteArrayElements(env, public_key, NULL);
 		if (!pub_buf)
 		{
 			goto err;
@@ -75,16 +75,16 @@ JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureMessage_process(J
 	switch (action)
 	{
 	case SECURE_MESSAGE_ENCRYPT:
-		res = themis_secure_message_encrypt((uint8_t *)priv_buf, private_length, (uint8_t *)pub_buf, public_length, (uint8_t *)message_buf, message_length, NULL, &output_length);
+		res = themis_secure_message_encrypt((uint8_t *)priv_buf, private_key_length, (uint8_t *)pub_buf, public_key_length, (uint8_t *)message_buf, message_length, NULL, &output_length);
 		break;
 	case SECURE_MESSAGE_DECRYPT:
-		res = themis_secure_message_decrypt((uint8_t *)priv_buf, private_length, (uint8_t *)pub_buf, public_length, (uint8_t *)message_buf, message_length, NULL, &output_length);
+		res = themis_secure_message_decrypt((uint8_t *)priv_buf, private_key_length, (uint8_t *)pub_buf, public_key_length, (uint8_t *)message_buf, message_length, NULL, &output_length);
 		break;
 	case SECURE_MESSAGE_SIGN:
-		res = themis_secure_message_sign((uint8_t *)priv_buf, private_length, (uint8_t *)message_buf, message_length, NULL, &output_length);
+		res = themis_secure_message_sign((uint8_t *)priv_buf, private_key_length, (uint8_t *)message_buf, message_length, NULL, &output_length);
 		break;
 	case SECURE_MESSAGE_VERIFY:
-		res = themis_secure_message_verify((uint8_t *)pub_buf, public_length, (uint8_t *)message_buf, message_length, NULL, &output_length);
+		res = themis_secure_message_verify((uint8_t *)pub_buf, public_key_length, (uint8_t *)message_buf, message_length, NULL, &output_length);
 		break;
 	default:
 		res = THEMIS_NOT_SUPPORTED;
@@ -111,16 +111,16 @@ JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureMessage_process(J
 	switch (action)
 	{
 	case SECURE_MESSAGE_ENCRYPT:
-		res = themis_secure_message_encrypt((uint8_t *)priv_buf, private_length, (uint8_t *)pub_buf, public_length, (uint8_t *)message_buf, message_length, (uint8_t *)output_buf, &output_length);
+		res = themis_secure_message_encrypt((uint8_t *)priv_buf, private_key_length, (uint8_t *)pub_buf, public_key_length, (uint8_t *)message_buf, message_length, (uint8_t *)output_buf, &output_length);
 		break;
 	case SECURE_MESSAGE_DECRYPT:
-		res = themis_secure_message_decrypt((uint8_t *)priv_buf, private_length, (uint8_t *)pub_buf, public_length, (uint8_t *)message_buf, message_length, (uint8_t *)output_buf, &output_length);
+		res = themis_secure_message_decrypt((uint8_t *)priv_buf, private_key_length, (uint8_t *)pub_buf, public_key_length, (uint8_t *)message_buf, message_length, (uint8_t *)output_buf, &output_length);
 		break;
 	case SECURE_MESSAGE_SIGN:
-		res = themis_secure_message_sign((uint8_t *)priv_buf, private_length, (uint8_t *)message_buf, message_length, (uint8_t *)output_buf, &output_length);
+		res = themis_secure_message_sign((uint8_t *)priv_buf, private_key_length, (uint8_t *)message_buf, message_length, (uint8_t *)output_buf, &output_length);
 		break;
 	case SECURE_MESSAGE_VERIFY:
-		res = themis_secure_message_verify((uint8_t *)pub_buf, public_length, (uint8_t *)message_buf, message_length, (uint8_t *)output_buf, &output_length);
+		res = themis_secure_message_verify((uint8_t *)pub_buf, public_key_length, (uint8_t *)message_buf, message_length, (uint8_t *)output_buf, &output_length);
 		break;
 	default:
 		res = THEMIS_NOT_SUPPORTED;
@@ -141,12 +141,12 @@ err:
 
 	if (pub_buf)
 	{
-		(*env)->ReleaseByteArrayElements(env, public, pub_buf, 0);
+		(*env)->ReleaseByteArrayElements(env, public_key, pub_buf, 0);
 	}
 
 	if (priv_buf)
 	{
-		(*env)->ReleaseByteArrayElements(env, private, priv_buf, 0);
+		(*env)->ReleaseByteArrayElements(env, private_key, priv_buf, 0);
 	}
 
 	if (THEMIS_SUCCESS == res)

--- a/jni/themis_session.c
+++ b/jni/themis_session.c
@@ -242,10 +242,10 @@ JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureSession_jniSave(J
 	{
 		return state;
 	}
-	else
-	{
+	
+	
 		return NULL;
-	}
+	
 }
 
 JNIEXPORT jboolean JNICALL Java_com_cossacklabs_themis_SecureSession_jniIsEstablished(JNIEnv *env, jobject thiz)
@@ -261,10 +261,10 @@ JNIEXPORT jboolean JNICALL Java_com_cossacklabs_themis_SecureSession_jniIsEstabl
 	{
 		return JNI_TRUE;
 	}
-	else
-	{
+	
+	
 		return JNI_FALSE;
-	}
+	
 }
 
 JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureSession_jniWrap(JNIEnv *env, jobject thiz, jbyteArray data)

--- a/jni/themis_session.c
+++ b/jni/themis_session.c
@@ -1,24 +1,24 @@
 /*
-* Copyright (c) 2015 Cossack Labs Limited
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2015 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include <jni.h>
 #include <string.h>
-#include <themis/themis_error.h>
 #include <themis/secure_session.h>
 #include <themis/secure_session_t.h>
+#include <themis/themis_error.h>
 /*extern JavaVM *g_vm;*/
 
 #define SESSION_BUFFER_FIELD_NAME "sessionPtr"
@@ -37,573 +37,541 @@
 
 typedef struct session_with_callbacks_type session_with_callbacks_t;
 
-struct session_with_callbacks_type
-{
-	secure_session_t session;
-	secure_session_user_callbacks_t callbacks;
-	JNIEnv *env;
-	jobject thiz;
+struct session_with_callbacks_type {
+    secure_session_t session;
+    secure_session_user_callbacks_t callbacks;
+    JNIEnv* env;
+    jobject thiz;
 };
 
 /*static JNIEnv* get_env(void)
 {
-	JNIEnv* res = NULL;
+        JNIEnv* res = NULL;
 
-	if (JNI_OK == (*g_vm)->GetEnv(g_vm, (void **)&res, JNI_VERSION_1_6))
-	{
-		return res;
-	}
-	else
-	{
-		return NULL;
-	}
+        if (JNI_OK == (*g_vm)->GetEnv(g_vm, (void **)&res, JNI_VERSION_1_6))
+        {
+                return res;
+        }
+        else
+        {
+                return NULL;
+        }
 }*/
 
-static session_with_callbacks_t *get_native_session(JNIEnv *env, jobject session_obj)
+static session_with_callbacks_t* get_native_session(JNIEnv* env, jobject session_obj)
 {
-	jfieldID session_field_id = (*env)->GetFieldID(env, (*env)->GetObjectClass(env, session_obj), SESSION_BUFFER_FIELD_NAME, SESSION_BUFFER_FIELD_SIG);
-	intptr_t session_ptr;
+    jfieldID session_field_id = (*env)->GetFieldID(env,
+                                                   (*env)->GetObjectClass(env, session_obj),
+                                                   SESSION_BUFFER_FIELD_NAME,
+                                                   SESSION_BUFFER_FIELD_SIG);
+    intptr_t session_ptr;
 
-	if (!session_field_id)
-	{
-		return NULL;
-	}
+    if (!session_field_id) {
+        return NULL;
+    }
 
-	session_ptr = (intptr_t)((*env)->GetLongField(env, session_obj, session_field_id));
+    session_ptr = (intptr_t)((*env)->GetLongField(env, session_obj, session_field_id));
 
-	return (session_with_callbacks_t *)session_ptr;
+    return (session_with_callbacks_t*)session_ptr;
 }
 
 /*JNIEXPORT jint JNICALL Java_com_cossacklabs_themis_SecureSession_getSessionContextSize(JNIEnv *env, jobject thiz)
 {
-	return (jint)sizeof(session_with_callbacks_t);
+        return (jint)sizeof(session_with_callbacks_t);
 }*/
 
 /* Make sure this method is called in the context of Java thread */
-static void on_state_changed(int event, void *user_data)
+static void on_state_changed(int event, void* user_data)
 {
-	session_with_callbacks_t *ctx = (session_with_callbacks_t *)user_data;
-	jmethodID state_changed_method = NULL;
+    session_with_callbacks_t* ctx = (session_with_callbacks_t*)user_data;
+    jmethodID state_changed_method = NULL;
 
-	if (!ctx)
-	{
-		return;
-	}
+    if (!ctx) {
+        return;
+    }
 
-	state_changed_method = (*(ctx->env))->GetMethodID(ctx->env, (*(ctx->env))->GetObjectClass(ctx->env, ctx->thiz), SESSION_STATE_CHANGED_NAME, SESSION_STATE_CHANGED_SIG);
-	if (!state_changed_method)
-	{
-		return;
-	}
+    state_changed_method = (*(ctx->env))
+                               ->GetMethodID(ctx->env,
+                                             (*(ctx->env))->GetObjectClass(ctx->env, ctx->thiz),
+                                             SESSION_STATE_CHANGED_NAME,
+                                             SESSION_STATE_CHANGED_SIG);
+    if (!state_changed_method) {
+        return;
+    }
 
-	(*(ctx->env))->CallVoidMethod(ctx->env, ctx->thiz, state_changed_method, (jint)event);
+    (*(ctx->env))->CallVoidMethod(ctx->env, ctx->thiz, state_changed_method, (jint)event);
 }
 
 /* Make sure this method is called in the context of Java thread */
-static int on_get_public_key_for_id(const void *id, size_t id_length, void *key_buffer, size_t key_buffer_length, void *user_data)
+static int on_get_public_key_for_id(
+    const void* id, size_t id_length, void* key_buffer, size_t key_buffer_length, void* user_data)
 {
-	session_with_callbacks_t *ctx = (session_with_callbacks_t *)user_data;
-	jmethodID get_key_method = NULL;
-	jbyteArray public_key = NULL;
-	jbyteArray peer_id = NULL;
+    session_with_callbacks_t* ctx = (session_with_callbacks_t*)user_data;
+    jmethodID get_key_method = NULL;
+    jbyteArray public_key = NULL;
+    jbyteArray peer_id = NULL;
 
-	jbyte *peer_id_buf = NULL;
+    jbyte* peer_id_buf = NULL;
 
-	jbyte *public_key_buf = NULL;
-	jsize public_key_length = 0;
+    jbyte* public_key_buf = NULL;
+    jsize public_key_length = 0;
 
-	if (!ctx)
-	{
-		return THEMIS_FAIL;
-	}
+    if (!ctx) {
+        return THEMIS_FAIL;
+    }
 
-	if (!(ctx->env) || !(ctx->thiz))
-	{
-		return THEMIS_FAIL;
-	}
+    if (!(ctx->env) || !(ctx->thiz)) {
+        return THEMIS_FAIL;
+    }
 
-	get_key_method = (*(ctx->env))->GetMethodID(ctx->env, (*(ctx->env))->GetObjectClass(ctx->env, ctx->thiz), SESSION_GET_PUB_KEY_NAME, SESSION_GET_PUB_KEY_SIG);
-	if (!get_key_method)
-	{
-		return THEMIS_FAIL;
-	}
+    get_key_method = (*(ctx->env))
+                         ->GetMethodID(ctx->env,
+                                       (*(ctx->env))->GetObjectClass(ctx->env, ctx->thiz),
+                                       SESSION_GET_PUB_KEY_NAME,
+                                       SESSION_GET_PUB_KEY_SIG);
+    if (!get_key_method) {
+        return THEMIS_FAIL;
+    }
 
-	peer_id = (*(ctx->env))->NewByteArray(ctx->env, id_length);
-	if (!peer_id)
-	{
-		return THEMIS_FAIL;
-	}
+    peer_id = (*(ctx->env))->NewByteArray(ctx->env, id_length);
+    if (!peer_id) {
+        return THEMIS_FAIL;
+    }
 
-	peer_id_buf = (*(ctx->env))->GetByteArrayElements(ctx->env, peer_id, NULL);
-	if (!peer_id_buf)
-	{
-		return THEMIS_FAIL;
-	}
+    peer_id_buf = (*(ctx->env))->GetByteArrayElements(ctx->env, peer_id, NULL);
+    if (!peer_id_buf) {
+        return THEMIS_FAIL;
+    }
 
-	memcpy(peer_id_buf, id, id_length);
-	(*(ctx->env))->ReleaseByteArrayElements(ctx->env, peer_id, peer_id_buf, 0);
+    memcpy(peer_id_buf, id, id_length);
+    (*(ctx->env))->ReleaseByteArrayElements(ctx->env, peer_id, peer_id_buf, 0);
 
-	public_key = (*(ctx->env))->CallObjectMethod(ctx->env, ctx->thiz, get_key_method, peer_id);
-	if (!public_key)
-	{
-		return THEMIS_FAIL;
-	}
+    public_key = (*(ctx->env))->CallObjectMethod(ctx->env, ctx->thiz, get_key_method, peer_id);
+    if (!public_key) {
+        return THEMIS_FAIL;
+    }
 
-	public_key_length = (*(ctx->env))->GetArrayLength(ctx->env, public_key);
-	if (public_key_length > key_buffer_length)
-	{
-		return THEMIS_BUFFER_TOO_SMALL;
-	}
+    public_key_length = (*(ctx->env))->GetArrayLength(ctx->env, public_key);
+    if (public_key_length > key_buffer_length) {
+        return THEMIS_BUFFER_TOO_SMALL;
+    }
 
-	(*(ctx->env))->GetByteArrayRegion(ctx->env, public_key, 0, public_key_length, key_buffer);
-	return THEMIS_SUCCESS;
+    (*(ctx->env))->GetByteArrayRegion(ctx->env, public_key, 0, public_key_length, key_buffer);
+    return THEMIS_SUCCESS;
 }
 
-JNIEXPORT jlong JNICALL Java_com_cossacklabs_themis_SecureSession_jniLoad(JNIEnv *env, jobject thiz, jbyteArray state)
+JNIEXPORT jlong JNICALL Java_com_cossacklabs_themis_SecureSession_jniLoad(JNIEnv* env,
+                                                                          jobject thiz,
+                                                                          jbyteArray state)
 {
-	size_t state_length = (*env)->GetArrayLength(env, state);
+    size_t state_length = (*env)->GetArrayLength(env, state);
 
-	themis_status_t themis_status;
-	session_with_callbacks_t *ctx = NULL;
+    themis_status_t themis_status;
+    session_with_callbacks_t* ctx = NULL;
 
-	jbyte *state_buf = (*env)->GetByteArrayElements(env, state, NULL);
-	if (!state_buf)
-	{
-		return 0;
-	}
+    jbyte* state_buf = (*env)->GetByteArrayElements(env, state, NULL);
+    if (!state_buf) {
+        return 0;
+    }
 
-	ctx = malloc(sizeof(session_with_callbacks_t));
-	if (!ctx)
-	{
-		goto err;
-	}
+    ctx = malloc(sizeof(session_with_callbacks_t));
+    if (!ctx) {
+        goto err;
+    }
 
-	memset(ctx, 0, sizeof(session_with_callbacks_t));
+    memset(ctx, 0, sizeof(session_with_callbacks_t));
 
-	ctx->callbacks.get_public_key_for_id = on_get_public_key_for_id;
-	ctx->callbacks.state_changed = on_state_changed;
-	ctx->callbacks.user_data = ctx;
+    ctx->callbacks.get_public_key_for_id = on_get_public_key_for_id;
+    ctx->callbacks.state_changed = on_state_changed;
+    ctx->callbacks.user_data = ctx;
 
-	themis_status = secure_session_load(&(ctx->session), state_buf, state_length, &(ctx->callbacks));
-	if (THEMIS_SUCCESS != themis_status)
-	{
-		free(ctx);
-		ctx = NULL;
-		goto err;
-	}
+    themis_status = secure_session_load(&(ctx->session), state_buf, state_length, &(ctx->callbacks));
+    if (THEMIS_SUCCESS != themis_status) {
+        free(ctx);
+        ctx = NULL;
+        goto err;
+    }
 
 err:
 
-	if (state_buf)
-	{
-		(*env)->ReleaseByteArrayElements(env, state, state_buf, 0);
-	}
+    if (state_buf) {
+        (*env)->ReleaseByteArrayElements(env, state, state_buf, 0);
+    }
 
-	return (intptr_t)ctx;
+    return (intptr_t)ctx;
 }
 
-JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureSession_jniSave(JNIEnv *env, jobject thiz)
+JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureSession_jniSave(JNIEnv* env, jobject thiz)
 {
-	session_with_callbacks_t *ctx = get_native_session(env, thiz);
+    session_with_callbacks_t* ctx = get_native_session(env, thiz);
 
-	size_t state_length = 0;
-	jbyteArray state = NULL;
-	jbyte *state_buf = NULL;
+    size_t state_length = 0;
+    jbyteArray state = NULL;
+    jbyte* state_buf = NULL;
 
-	themis_status_t res;
+    themis_status_t res;
 
-	if (!ctx)
-	{
-		return NULL;
-	}
+    if (!ctx) {
+        return NULL;
+    }
 
-	res = secure_session_save(&(ctx->session), NULL, &state_length);
-	if (THEMIS_BUFFER_TOO_SMALL != res)
-	{
-		return NULL;
-	}
+    res = secure_session_save(&(ctx->session), NULL, &state_length);
+    if (THEMIS_BUFFER_TOO_SMALL != res) {
+        return NULL;
+    }
 
-	state = (*env)->NewByteArray(env, state_length);
-	if (!state)
-	{
-		return NULL;
-	}
+    state = (*env)->NewByteArray(env, state_length);
+    if (!state) {
+        return NULL;
+    }
 
-	state_buf = (*env)->GetByteArrayElements(env, state, NULL);
-	if (!state_buf)
-	{
-		return NULL;
-	}
+    state_buf = (*env)->GetByteArrayElements(env, state, NULL);
+    if (!state_buf) {
+        return NULL;
+    }
 
-	res = secure_session_save(&(ctx->session), state_buf, &state_length);
-	(*env)->ReleaseByteArrayElements(env, state, state_buf, 0);
+    res = secure_session_save(&(ctx->session), state_buf, &state_length);
+    (*env)->ReleaseByteArrayElements(env, state, state_buf, 0);
 
-	if (THEMIS_SUCCESS == res)
-	{
-		return state;
-	}
-	
-	
-		return NULL;
-	
+    if (THEMIS_SUCCESS == res) {
+        return state;
+    }
+
+    return NULL;
 }
 
-JNIEXPORT jboolean JNICALL Java_com_cossacklabs_themis_SecureSession_jniIsEstablished(JNIEnv *env, jobject thiz)
+JNIEXPORT jboolean JNICALL Java_com_cossacklabs_themis_SecureSession_jniIsEstablished(JNIEnv* env,
+                                                                                      jobject thiz)
 {
-	session_with_callbacks_t *ctx = get_native_session(env, thiz);
+    session_with_callbacks_t* ctx = get_native_session(env, thiz);
 
-	if (!ctx)
-	{
-		return JNI_FALSE;
-	}
+    if (!ctx) {
+        return JNI_FALSE;
+    }
 
-	if (secure_session_is_established(&(ctx->session)))
-	{
-		return JNI_TRUE;
-	}
-	
-	
-		return JNI_FALSE;
-	
+    if (secure_session_is_established(&(ctx->session))) {
+        return JNI_TRUE;
+    }
+
+    return JNI_FALSE;
 }
 
-JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureSession_jniWrap(JNIEnv *env, jobject thiz, jbyteArray data)
+JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureSession_jniWrap(JNIEnv* env,
+                                                                               jobject thiz,
+                                                                               jbyteArray data)
 {
-	size_t data_length = (*env)->GetArrayLength(env, data);
-	session_with_callbacks_t *ctx = get_native_session(env, thiz);
+    size_t data_length = (*env)->GetArrayLength(env, data);
+    session_with_callbacks_t* ctx = get_native_session(env, thiz);
 
-	size_t wrapped_data_length = 0;
+    size_t wrapped_data_length = 0;
 
-	jbyte *data_buf = NULL;
-	jbyte *wrapped_data_buf = NULL;
+    jbyte* data_buf = NULL;
+    jbyte* wrapped_data_buf = NULL;
 
-	jbyteArray output = NULL;
-	jbyteArray wrapped_data = NULL;
+    jbyteArray output = NULL;
+    jbyteArray wrapped_data = NULL;
 
-	themis_status_t res;
+    themis_status_t res;
 
-	if (!ctx)
-	{
-		return NULL;
-	}
+    if (!ctx) {
+        return NULL;
+    }
 
-	data_buf = (*env)->GetByteArrayElements(env, data, NULL);
-	if (!data_buf)
-	{
-		return NULL;
-	}
+    data_buf = (*env)->GetByteArrayElements(env, data, NULL);
+    if (!data_buf) {
+        return NULL;
+    }
 
-	ctx->env = env;
-	ctx->thiz = thiz;
+    ctx->env = env;
+    ctx->thiz = thiz;
 
-	res = secure_session_wrap(&(ctx->session), data_buf, data_length, NULL, &wrapped_data_length);
-	if (THEMIS_BUFFER_TOO_SMALL != res)
-	{
-		goto err;
-	}
+    res = secure_session_wrap(&(ctx->session), data_buf, data_length, NULL, &wrapped_data_length);
+    if (THEMIS_BUFFER_TOO_SMALL != res) {
+        goto err;
+    }
 
-	wrapped_data = (*env)->NewByteArray(env, wrapped_data_length);
-	if (!wrapped_data)
-	{
-		goto err;
-	}
+    wrapped_data = (*env)->NewByteArray(env, wrapped_data_length);
+    if (!wrapped_data) {
+        goto err;
+    }
 
-	wrapped_data_buf = (*env)->GetByteArrayElements(env, wrapped_data, NULL);
-	if (!wrapped_data_buf)
-	{
-		goto err;
-	}
+    wrapped_data_buf = (*env)->GetByteArrayElements(env, wrapped_data, NULL);
+    if (!wrapped_data_buf) {
+        goto err;
+    }
 
-	res = secure_session_wrap(&(ctx->session), data_buf, data_length, wrapped_data_buf, &wrapped_data_length);
-	if (THEMIS_SUCCESS != res)
-	{
-		goto err;
-	}
+    res = secure_session_wrap(&(ctx->session), data_buf, data_length, wrapped_data_buf, &wrapped_data_length);
+    if (THEMIS_SUCCESS != res) {
+        goto err;
+    }
 
-	output = wrapped_data;
+    output = wrapped_data;
 
 err:
 
-	if (wrapped_data_buf)
-	{
-		(*env)->ReleaseByteArrayElements(env, wrapped_data, wrapped_data_buf, 0);
-	}
+    if (wrapped_data_buf) {
+        (*env)->ReleaseByteArrayElements(env, wrapped_data, wrapped_data_buf, 0);
+    }
 
-	ctx->env = NULL;
-	ctx->thiz = NULL;
+    ctx->env = NULL;
+    ctx->thiz = NULL;
 
-	if (data_buf)
-	{
-		(*env)->ReleaseByteArrayElements(env, data, data_buf, 0);
-	}
+    if (data_buf) {
+        (*env)->ReleaseByteArrayElements(env, data, data_buf, 0);
+    }
 
-	return output;
+    return output;
 }
 
-JNIEXPORT jobjectArray JNICALL Java_com_cossacklabs_themis_SecureSession_jniUnwrap(JNIEnv *env, jobject thiz, jbyteArray wrapped_data)
+JNIEXPORT jobjectArray JNICALL Java_com_cossacklabs_themis_SecureSession_jniUnwrap(JNIEnv* env,
+                                                                                   jobject thiz,
+                                                                                   jbyteArray wrapped_data)
 {
-	size_t wrapped_data_length = (*env)->GetArrayLength(env, wrapped_data);
-	session_with_callbacks_t *ctx = get_native_session(env, thiz);
+    size_t wrapped_data_length = (*env)->GetArrayLength(env, wrapped_data);
+    session_with_callbacks_t* ctx = get_native_session(env, thiz);
 
-	size_t data_length;
+    size_t data_length;
 
-	themis_status_t res;
+    themis_status_t res;
 
-	jbyte data_type;
-	jbyteArray data_type_array = NULL;
-	jbyteArray data_array = NULL;
+    jbyte data_type;
+    jbyteArray data_type_array = NULL;
+    jbyteArray data_array = NULL;
 
-	jbyte *wrapped_data_buf = NULL;
-	jbyte *data_buf = NULL;
+    jbyte* wrapped_data_buf = NULL;
+    jbyte* data_buf = NULL;
 
-	jobjectArray unwrapped_data = NULL;
-	jobjectArray output = NULL;
+    jobjectArray unwrapped_data = NULL;
+    jobjectArray output = NULL;
 
-	if (!ctx)
-	{
-		return NULL;
-	}
+    if (!ctx) {
+        return NULL;
+    }
 
-	wrapped_data_buf = (*env)->GetByteArrayElements(env, wrapped_data, NULL);
-	if (!wrapped_data_buf)
-	{
-		return NULL;
-	}
+    wrapped_data_buf = (*env)->GetByteArrayElements(env, wrapped_data, NULL);
+    if (!wrapped_data_buf) {
+        return NULL;
+    }
 
-	unwrapped_data = (*env)->NewObjectArray(env, 2, (*env)->GetObjectClass(env, wrapped_data), NULL);
-	if (!unwrapped_data)
-	{
-		goto err;
-	}
+    unwrapped_data = (*env)->NewObjectArray(env, 2, (*env)->GetObjectClass(env, wrapped_data), NULL);
+    if (!unwrapped_data) {
+        goto err;
+    }
 
-	data_type_array = (*env)->NewByteArray(env, 1);
-	if (!data_type_array)
-	{
-		goto err;
-	}
+    data_type_array = (*env)->NewByteArray(env, 1);
+    if (!data_type_array) {
+        goto err;
+    }
 
-	ctx->env = env;
-	ctx->thiz = thiz;
+    ctx->env = env;
+    ctx->thiz = thiz;
 
-	res = secure_session_unwrap(&(ctx->session), wrapped_data_buf, wrapped_data_length, NULL, &data_length);
-	if ((THEMIS_SUCCESS == res) && (0 == data_length))
-	{
-		/* This is the end of negotiation. No return data */
-		data_type = NO_DATA;
-		(*env)->SetByteArrayRegion(env, data_type_array, 0, 1, &data_type);
-		(*env)->SetObjectArrayElement(env, unwrapped_data, 0, data_type_array);
-		output = unwrapped_data;
-		goto err;
-	}
-	else if (THEMIS_BUFFER_TOO_SMALL != res)
-	{
-		goto err;
-	}
+    res = secure_session_unwrap(&(ctx->session), wrapped_data_buf, wrapped_data_length, NULL, &data_length);
+    if ((THEMIS_SUCCESS == res) && (0 == data_length)) {
+        /* This is the end of negotiation. No return data */
+        data_type = NO_DATA;
+        (*env)->SetByteArrayRegion(env, data_type_array, 0, 1, &data_type);
+        (*env)->SetObjectArrayElement(env, unwrapped_data, 0, data_type_array);
+        output = unwrapped_data;
+        goto err;
+    } else if (THEMIS_BUFFER_TOO_SMALL != res) {
+        goto err;
+    }
 
-	data_array = (*env)->NewByteArray(env, data_length);
-	if (!data_array)
-	{
-		goto err;
-	}
+    data_array = (*env)->NewByteArray(env, data_length);
+    if (!data_array) {
+        goto err;
+    }
 
-	data_buf = (*env)->GetByteArrayElements(env, data_array, NULL);
-	if (!data_buf)
-	{
-		goto err;
-	}
+    data_buf = (*env)->GetByteArrayElements(env, data_array, NULL);
+    if (!data_buf) {
+        goto err;
+    }
 
-	res = secure_session_unwrap(&(ctx->session), wrapped_data_buf, wrapped_data_length, data_buf, &data_length);
-	if ((THEMIS_SUCCESS == res) && (0 == data_length))
-	{
-		/* This is the end of negotiation. No return data */
-		data_type = NO_DATA;
-		(*env)->SetByteArrayRegion(env, data_type_array, 0, 1, &data_type);
-		(*env)->SetObjectArrayElement(env, unwrapped_data, 0, data_type_array);
-		output = unwrapped_data;
-		goto err;
-	}
-	else if ((THEMIS_SSESSION_SEND_OUTPUT_TO_PEER == res) && (data_length > 0))
-	{
-		/* Negotiation continues. Send output to peer */
-		data_type = PROTOCOL_DATA;
-		(*env)->SetByteArrayRegion(env, data_type_array, 0, 1, &data_type);
-		(*env)->SetObjectArrayElement(env, unwrapped_data, 0, data_type_array);
-		(*env)->SetObjectArrayElement(env, unwrapped_data, 1, data_array);
-		output = unwrapped_data;
-		goto err;
-	}
-	else if ((THEMIS_SUCCESS == res) && (data_length > 0))
-	{
-		/* This is user data */
-		data_type = USER_DATA;
-		(*env)->SetByteArrayRegion(env, data_type_array, 0, 1, &data_type);
-		(*env)->SetObjectArrayElement(env, unwrapped_data, 0, data_type_array);
-		(*env)->SetObjectArrayElement(env, unwrapped_data, 1, data_array);
-		output = unwrapped_data;
-		goto err;
-	}
+    res = secure_session_unwrap(&(ctx->session), wrapped_data_buf, wrapped_data_length, data_buf, &data_length);
+    if ((THEMIS_SUCCESS == res) && (0 == data_length)) {
+        /* This is the end of negotiation. No return data */
+        data_type = NO_DATA;
+        (*env)->SetByteArrayRegion(env, data_type_array, 0, 1, &data_type);
+        (*env)->SetObjectArrayElement(env, unwrapped_data, 0, data_type_array);
+        output = unwrapped_data;
+        goto err;
+    } else if ((THEMIS_SSESSION_SEND_OUTPUT_TO_PEER == res) && (data_length > 0)) {
+        /* Negotiation continues. Send output to peer */
+        data_type = PROTOCOL_DATA;
+        (*env)->SetByteArrayRegion(env, data_type_array, 0, 1, &data_type);
+        (*env)->SetObjectArrayElement(env, unwrapped_data, 0, data_type_array);
+        (*env)->SetObjectArrayElement(env, unwrapped_data, 1, data_array);
+        output = unwrapped_data;
+        goto err;
+    } else if ((THEMIS_SUCCESS == res) && (data_length > 0)) {
+        /* This is user data */
+        data_type = USER_DATA;
+        (*env)->SetByteArrayRegion(env, data_type_array, 0, 1, &data_type);
+        (*env)->SetObjectArrayElement(env, unwrapped_data, 0, data_type_array);
+        (*env)->SetObjectArrayElement(env, unwrapped_data, 1, data_array);
+        output = unwrapped_data;
+        goto err;
+    }
 
 err:
 
-	if (data_buf)
-	{
-		(*env)->ReleaseByteArrayElements(env, data_array, data_buf, 0);
-	}
+    if (data_buf) {
+        (*env)->ReleaseByteArrayElements(env, data_array, data_buf, 0);
+    }
 
-	ctx->env = NULL;
-	ctx->thiz = NULL;
+    ctx->env = NULL;
+    ctx->thiz = NULL;
 
-	if (wrapped_data_buf)
-	{
-		(*env)->ReleaseByteArrayElements(env, wrapped_data, wrapped_data_buf, 0);
-	}
+    if (wrapped_data_buf) {
+        (*env)->ReleaseByteArrayElements(env, wrapped_data, wrapped_data_buf, 0);
+    }
 
-	return output;
+    return output;
 }
 
-JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureSession_jniGenerateConntect(JNIEnv *env, jobject thiz)
+JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureSession_jniGenerateConntect(JNIEnv* env,
+                                                                                           jobject thiz)
 {
-	size_t request_length = 0;
-	session_with_callbacks_t *ctx = get_native_session(env, thiz);
-	jbyteArray output = NULL;
-	jbyteArray request = NULL;
+    size_t request_length = 0;
+    session_with_callbacks_t* ctx = get_native_session(env, thiz);
+    jbyteArray output = NULL;
+    jbyteArray request = NULL;
 
-	jbyte *request_buf = NULL;
+    jbyte* request_buf = NULL;
 
-	themis_status_t res;
+    themis_status_t res;
 
-	if (NULL == ctx)
-	{
-		return NULL;
-	}
+    if (NULL == ctx) {
+        return NULL;
+    }
 
-	ctx->env = env;
-	ctx->thiz = thiz;
+    ctx->env = env;
+    ctx->thiz = thiz;
 
-	res = secure_session_generate_connect_request(&(ctx->session), NULL, &request_length);
-	if (THEMIS_BUFFER_TOO_SMALL != res)
-	{
-		goto err;
-	}
+    res = secure_session_generate_connect_request(&(ctx->session), NULL, &request_length);
+    if (THEMIS_BUFFER_TOO_SMALL != res) {
+        goto err;
+    }
 
-	request = (*env)->NewByteArray(env, request_length);
-	if (!request)
-	{
-		goto err;
-	}
+    request = (*env)->NewByteArray(env, request_length);
+    if (!request) {
+        goto err;
+    }
 
-	request_buf = (*env)->GetByteArrayElements(env, request, NULL);
-	if (!request_buf)
-	{
-		goto err;
-	}
+    request_buf = (*env)->GetByteArrayElements(env, request, NULL);
+    if (!request_buf) {
+        goto err;
+    }
 
-	res = secure_session_generate_connect_request(&(ctx->session), request_buf, &request_length);
-	if (THEMIS_SUCCESS != res)
-	{
-		goto err;
-	}
+    res = secure_session_generate_connect_request(&(ctx->session), request_buf, &request_length);
+    if (THEMIS_SUCCESS != res) {
+        goto err;
+    }
 
-	output = request;
+    output = request;
 
 err:
 
-	if (request_buf)
-	{
-		(*env)->ReleaseByteArrayElements(env, request, request_buf, 0);
-	}
+    if (request_buf) {
+        (*env)->ReleaseByteArrayElements(env, request, request_buf, 0);
+    }
 
-	ctx->env = NULL;
-	ctx->thiz = NULL;
+    ctx->env = NULL;
+    ctx->thiz = NULL;
 
-	return output;
+    return output;
 }
 
-JNIEXPORT jlong JNICALL Java_com_cossacklabs_themis_SecureSession_create(JNIEnv *env, jobject thiz, jbyteArray id, jbyteArray sign_key)
+JNIEXPORT jlong JNICALL Java_com_cossacklabs_themis_SecureSession_create(JNIEnv* env,
+                                                                         jobject thiz,
+                                                                         jbyteArray id,
+                                                                         jbyteArray sign_key)
 {
-	size_t id_length = (*env)->GetArrayLength(env, id);
-	size_t sign_key_length = (*env)->GetArrayLength(env, sign_key);
+    size_t id_length = (*env)->GetArrayLength(env, id);
+    size_t sign_key_length = (*env)->GetArrayLength(env, sign_key);
 
-	jbyte *id_buf = NULL;
-	jbyte *sign_key_buf = NULL;
+    jbyte* id_buf = NULL;
+    jbyte* sign_key_buf = NULL;
 
-	themis_status_t themis_status;
+    themis_status_t themis_status;
 
-	session_with_callbacks_t *ctx = NULL;
+    session_with_callbacks_t* ctx = NULL;
 
-	id_buf = (*env)->GetByteArrayElements(env, id, NULL);
-	if (!id_buf)
-	{
-		return 0;
-	}
+    id_buf = (*env)->GetByteArrayElements(env, id, NULL);
+    if (!id_buf) {
+        return 0;
+    }
 
-	sign_key_buf = (*env)->GetByteArrayElements(env, sign_key, NULL);
-	if (!sign_key_buf)
-	{
-		goto err;
-	}
+    sign_key_buf = (*env)->GetByteArrayElements(env, sign_key, NULL);
+    if (!sign_key_buf) {
+        goto err;
+    }
 
-	ctx = malloc(sizeof(session_with_callbacks_t));
-	if (!ctx)
-	{
-		goto err;
-	}
+    ctx = malloc(sizeof(session_with_callbacks_t));
+    if (!ctx) {
+        goto err;
+    }
 
-	memset(ctx, 0, sizeof(session_with_callbacks_t));
+    memset(ctx, 0, sizeof(session_with_callbacks_t));
 
-	/*ctx->thiz = (*env)->NewGlobalRef(env, thiz);
-	if (!(ctx->thiz))
-	{
-		free(ctx);
-		ctx = NULL;
-		goto err;
-	}*/
+    /*ctx->thiz = (*env)->NewGlobalRef(env, thiz);
+        if (!(ctx->thiz))
+        {
+                free(ctx);
+                ctx = NULL;
+                goto err;
+        }*/
 
-	ctx->callbacks.get_public_key_for_id = on_get_public_key_for_id;
-	ctx->callbacks.state_changed = on_state_changed;
-	ctx->callbacks.user_data = ctx;
+    ctx->callbacks.get_public_key_for_id = on_get_public_key_for_id;
+    ctx->callbacks.state_changed = on_state_changed;
+    ctx->callbacks.user_data = ctx;
 
-	themis_status = secure_session_init(&(ctx->session), id_buf, id_length, sign_key_buf, sign_key_length, &(ctx->callbacks));
-	if (THEMIS_SUCCESS != themis_status)
-	{
-		free(ctx);
-		ctx = NULL;
-		goto err;
-	}
+    themis_status = secure_session_init(&(ctx->session),
+                                        id_buf,
+                                        id_length,
+                                        sign_key_buf,
+                                        sign_key_length,
+                                        &(ctx->callbacks));
+    if (THEMIS_SUCCESS != themis_status) {
+        free(ctx);
+        ctx = NULL;
+        goto err;
+    }
 
 err:
 
-	if (sign_key_buf)
-	{
-		(*env)->ReleaseByteArrayElements(env, sign_key, sign_key_buf, 0);
-	}
+    if (sign_key_buf) {
+        (*env)->ReleaseByteArrayElements(env, sign_key, sign_key_buf, 0);
+    }
 
-	if (id_buf)
-	{
-		(*env)->ReleaseByteArrayElements(env, id, id_buf, 0);
-	}
+    if (id_buf) {
+        (*env)->ReleaseByteArrayElements(env, id, id_buf, 0);
+    }
 
-	return (intptr_t)ctx;
+    return (intptr_t)ctx;
 }
 
-JNIEXPORT void JNICALL Java_com_cossacklabs_themis_SecureSession_destroy(JNIEnv *env, jobject thiz)
+JNIEXPORT void JNICALL Java_com_cossacklabs_themis_SecureSession_destroy(JNIEnv* env, jobject thiz)
 {
-	jfieldID session_field_id = (*env)->GetFieldID(env, (*env)->GetObjectClass(env, thiz), SESSION_BUFFER_FIELD_NAME, SESSION_BUFFER_FIELD_SIG);
-	intptr_t session_ptr;
-	session_with_callbacks_t *ctx;
+    jfieldID session_field_id = (*env)->GetFieldID(env,
+                                                   (*env)->GetObjectClass(env, thiz),
+                                                   SESSION_BUFFER_FIELD_NAME,
+                                                   SESSION_BUFFER_FIELD_SIG);
+    intptr_t session_ptr;
+    session_with_callbacks_t* ctx;
 
-	if (!session_field_id)
-	{
-		/* TODO: Maybe throw RuntimeException? */
-		return;
-	}
+    if (!session_field_id) {
+        /* TODO: Maybe throw RuntimeException? */
+        return;
+    }
 
-	session_ptr = (intptr_t)((*env)->GetLongField(env, thiz, session_field_id));
-	ctx = (session_with_callbacks_t *)session_ptr;
+    session_ptr = (intptr_t)((*env)->GetLongField(env, thiz, session_field_id));
+    ctx = (session_with_callbacks_t*)session_ptr;
 
-	secure_session_cleanup(&(ctx->session));
-	(*env)->SetLongField(env, thiz, session_field_id, 0);
+    secure_session_cleanup(&(ctx->session));
+    (*env)->SetLongField(env, thiz, session_field_id, 0);
 
-	/*(*env)->DeleteGlobalRef(env, ctx->thiz);*/
-	free(ctx);
+    /*(*env)->DeleteGlobalRef(env, ctx->thiz);*/
+    free(ctx);
 }


### PR DESCRIPTION
Add JNI to the formatting target. It is a bit special because we have to specify path to JDK headers (and actually install JDK for that).

clang-tidy suggested some changes, they are applied as a separate commit for review:
- Avoid returning from both "then" and "else" branches
- Initialize possibly uninitialized variables

Also, it turned out that clang-format treats `private` and `public` as C++ keywords when formatting C code which results in dumb formatting. Rename identifiers into `private_key` to avoid this.