### PR TITLE
Fix golint warnings

### DIFF
--- a/docs/examples/Themis-server/go/smessage_server.go
+++ b/docs/examples/Themis-server/go/smessage_server.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 )
 
-func send_message(message []byte, endpoint string) ([]byte, error) {
+func sendMessage(message []byte, endpoint string) ([]byte, error) {
 	values := url.Values{}
 	values.Add("message", base64.StdEncoding.EncodeToString(message))
 	request, err := http.NewRequest("POST", endpoint, bytes.NewBufferString(values.Encode()))
@@ -39,32 +39,32 @@ func send_message(message []byte, endpoint string) ([]byte, error) {
 }
 
 func main() {
-	input_buffer := bufio.NewReader(os.Stdin)
+	inputBuffer := bufio.NewReader(os.Stdin)
 	fmt.Println("Type your settings from https://themis.cossacklabs.com/interactive-simulator/setup/")
 
 	fmt.Println("JSON endpoint: ")
-	endpoint, err := input_buffer.ReadString('\n')
+	endpoint, err := inputBuffer.ReadString('\n')
 	endpoint = strings.TrimRight(endpoint, "\n\r")
 
 	fmt.Println("Your private key in base64 format:")
-	client_private, err := input_buffer.ReadBytes('\n')
-	client_private, err = base64.StdEncoding.DecodeString(string(client_private))
+	clientPrivate, err := inputBuffer.ReadBytes('\n')
+	clientPrivate, err = base64.StdEncoding.DecodeString(string(clientPrivate))
 	if err != nil {
 		fmt.Println("Incorrect base64 format for private key")
 		return
 	}
 
 	fmt.Println("Server public key in base64 format:")
-	server_public, err := input_buffer.ReadBytes('\n')
-	server_public = bytes.TrimRight(server_public, "\r\n")
-	server_public, err = base64.StdEncoding.DecodeString(string(server_public))
-	secure_message := message.New(
-		&keys.PrivateKey{bytes.TrimRight(client_private, "\r\n")},
-		&keys.PublicKey{server_public})
+	serverPublic, err := inputBuffer.ReadBytes('\n')
+	serverPublic = bytes.TrimRight(serverPublic, "\r\n")
+	serverPublic, err = base64.StdEncoding.DecodeString(string(serverPublic))
+	secureMessage := message.New(
+		&keys.PrivateKey{bytes.TrimRight(clientPrivate, "\r\n")},
+		&keys.PublicKey{serverPublic})
 
 	for {
 		fmt.Println("Print message to send (or quit to stop):")
-		line, _, err := input_buffer.ReadLine()
+		line, _, err := inputBuffer.ReadLine()
 		if err != nil {
 			fmt.Println(err)
 			return
@@ -73,17 +73,17 @@ func main() {
 			return
 		}
 
-		wrapped, err := secure_message.Wrap(line)
+		wrapped, err := secureMessage.Wrap(line)
 		if err != nil {
 			fmt.Println("Error in wraping", err)
 			return
 		}
-		data, err := send_message(wrapped, endpoint)
+		data, err := sendMessage(wrapped, endpoint)
 		if err != nil {
 			fmt.Println("Error occurred:", err)
 			return
 		}
-		unwrapped, err := secure_message.Unwrap(data)
+		unwrapped, err := secureMessage.Unwrap(data)
 		fmt.Println(string(unwrapped))
 	}
 }

--- a/docs/examples/Themis-server/go/ssession_server.go
+++ b/docs/examples/Themis-server/go/ssession_server.go
@@ -15,24 +15,24 @@ import (
 	"strings"
 )
 
-type client_transport_callback struct {
-	server_public []byte
-	server_id     []byte
+type clientTransportCallback struct {
+	serverPublic []byte
+	serverID     []byte
 }
 
-func (clb *client_transport_callback) GetPublicKeyForId(ss *session.SecureSession, id []byte) *keys.PublicKey {
-	if bytes.Equal(id, clb.server_id) {
-		return &keys.PublicKey{clb.server_public}
+func (clb *clientTransportCallback) GetPublicKeyForId(ss *session.SecureSession, id []byte) *keys.PublicKey {
+	if bytes.Equal(id, clb.serverID) {
+		return &keys.PublicKey{clb.serverPublic}
 	}
 	return nil
 
 }
 
-func (clb *client_transport_callback) StateChanged(ss *session.SecureSession, state int) {
+func (clb *clientTransportCallback) StateChanged(ss *session.SecureSession, state int) {
 
 }
 
-func send_message(message []byte, endpoint string) ([]byte, error) {
+func sendMessage(message []byte, endpoint string) ([]byte, error) {
 	values := url.Values{}
 	values.Add("message", base64.StdEncoding.EncodeToString(message))
 	request, err := http.NewRequest("POST", endpoint, bytes.NewBufferString(values.Encode()))
@@ -57,21 +57,21 @@ func send_message(message []byte, endpoint string) ([]byte, error) {
 }
 
 func clientService(client *session.SecureSession, ch chan []byte, finCh chan int) {
-	connection_request, err := client.ConnectRequest()
+	connectionRequest, err := client.ConnectRequest()
 	if nil != err {
 		return
 	}
 
-	ch <- connection_request
+	ch <- connectionRequest
 	for {
 		buf := <-ch
 
-		buf, is_negotiation, err := client.Unwrap(buf)
+		buf, isNegotiation, err := client.Unwrap(buf)
 		if nil != err {
 			return
 		}
 
-		if is_negotiation {
+		if isNegotiation {
 			ch <- buf
 			continue
 		}
@@ -82,39 +82,39 @@ func clientService(client *session.SecureSession, ch chan []byte, finCh chan int
 }
 
 func main() {
-	input_buffer := bufio.NewReader(os.Stdin)
+	inputBuffer := bufio.NewReader(os.Stdin)
 	fmt.Println("Type your settings from https://themis.cossacklabs.com/interactive-simulator/setup/")
 
 	fmt.Println("JSON endpoint: ")
-	endpoint, err := input_buffer.ReadString('\n')
+	endpoint, err := inputBuffer.ReadString('\n')
 	endpoint = strings.TrimRight(endpoint, "\n\r")
 
 	fmt.Println("Your private key in base64 format:")
-	client_private, err := input_buffer.ReadBytes('\n')
-	client_private, err = base64.StdEncoding.DecodeString(string(client_private))
+	clientPrivate, err := inputBuffer.ReadBytes('\n')
+	clientPrivate, err = base64.StdEncoding.DecodeString(string(clientPrivate))
 	if err != nil {
 		fmt.Println("Incorrect base64 format for private key")
 		return
 	}
 
 	fmt.Println("User_id:")
-	client_id, err := input_buffer.ReadBytes('\n')
+	clientID, err := inputBuffer.ReadBytes('\n')
 
 	fmt.Println("Server_id:")
-	server_id, err := input_buffer.ReadBytes('\n')
+	serverID, err := inputBuffer.ReadBytes('\n')
 
 	fmt.Println("Server public key in base64 format:")
-	server_public, err := input_buffer.ReadBytes('\n')
-	server_public, err = base64.StdEncoding.DecodeString(string(server_public))
+	serverPublic, err := inputBuffer.ReadBytes('\n')
+	serverPublic, err = base64.StdEncoding.DecodeString(string(serverPublic))
 	// init callback structure
-	cb := client_transport_callback{
-		server_public,
-		bytes.TrimRight(server_id, "\r\n")}
+	cb := clientTransportCallback{
+		serverPublic,
+		bytes.TrimRight(serverID, "\r\n")}
 
 	// create session object
-	client_session, err := session.New(
-		bytes.TrimRight(client_id, "\r\n"),
-		&keys.PrivateKey{bytes.TrimRight(client_private, "\r\n")},
+	clientSession, err := session.New(
+		bytes.TrimRight(clientID, "\r\n"),
+		&keys.PrivateKey{bytes.TrimRight(clientPrivate, "\r\n")},
 		&cb)
 	if err != nil {
 		fmt.Println("Session creation error")
@@ -122,27 +122,27 @@ func main() {
 	}
 
 	ch := make(chan []byte)
-	quit_channel := make(chan int)
-	go clientService(client_session, ch, quit_channel)
-	is_established := false
+	quitChannel := make(chan int)
+	go clientService(clientSession, ch, quitChannel)
+	isEstablished := false
 	fmt.Println("Initialize session")
-	for !is_established {
+	for !isEstablished {
 		select {
 		case data := <-ch:
-			data, err := send_message(data, endpoint)
+			data, err := sendMessage(data, endpoint)
 			if err != nil {
 				fmt.Println("Error -", err)
 				return
 			}
 			ch <- data
-		case <-quit_channel:
-			is_established = true
+		case <-quitChannel:
+			isEstablished = true
 		}
 	}
 	fmt.Println("Session established")
 	for {
 		fmt.Println("Print message to send (or quit to stop):")
-		line, _, err := input_buffer.ReadLine()
+		line, _, err := inputBuffer.ReadLine()
 		if err != nil {
 			fmt.Println(err)
 			return
@@ -150,13 +150,13 @@ func main() {
 		if bytes.Equal(line, []byte("quit")) {
 			return
 		}
-		wrapped, err := client_session.Wrap(line)
-		data, err := send_message(wrapped, endpoint)
+		wrapped, err := clientSession.Wrap(line)
+		data, err := sendMessage(wrapped, endpoint)
 		if err != nil {
 			fmt.Println("Error occurred:", err)
 			return
 		}
-		unwrapped, _, err := client_session.Unwrap(data)
+		unwrapped, _, err := clientSession.Unwrap(data)
 		fmt.Println(string(unwrapped))
 	}
 }

--- a/docs/examples/go/secure_cell_context_imprint.go
+++ b/docs/examples/go/secure_cell_context_imprint.go
@@ -21,12 +21,12 @@ func main() {
 		}
 		fmt.Println(base64.StdEncoding.EncodeToString(encData))
 	} else if "dec" == os.Args[1] {
-		decoded_message, err := base64.StdEncoding.DecodeString(os.Args[3])
+		decodedMessage, err := base64.StdEncoding.DecodeString(os.Args[3])
 		if nil != err {
 			fmt.Println("error decoding message")
 			return
 		}
-		decData, err := sc.Unprotect(decoded_message, nil, []byte(os.Args[4]))
+		decData, err := sc.Unprotect(decodedMessage, nil, []byte(os.Args[4]))
 		if nil != err {
 			fmt.Println("error decrypting message")
 			return

--- a/docs/examples/go/secure_cell_seal.go
+++ b/docs/examples/go/secure_cell_seal.go
@@ -21,12 +21,12 @@ func main() {
 		}
 		fmt.Println(base64.StdEncoding.EncodeToString(encData))
 	} else if "dec" == os.Args[1] {
-		decoded_message, err := base64.StdEncoding.DecodeString(os.Args[3])
+		decodedMessage, err := base64.StdEncoding.DecodeString(os.Args[3])
 		if nil != err {
 			fmt.Println("error decoding message")
 			return
 		}
-		decData, err := sc.Unprotect(decoded_message, nil, nil)
+		decData, err := sc.Unprotect(decodedMessage, nil, nil)
 		if nil != err {
 			fmt.Println("error decrypting message")
 			return

--- a/docs/examples/go/secure_cell_token_protect.go
+++ b/docs/examples/go/secure_cell_token_protect.go
@@ -26,17 +26,17 @@ func main() {
 			fmt.Println("token not set")
 			return
 		}
-		decoded_message, err := base64.StdEncoding.DecodeString(os.Args[3])
+		decodedMessage, err := base64.StdEncoding.DecodeString(os.Args[3])
 		if nil != err {
 			fmt.Println("error decoding message")
 			return
 		}
-		decoded_token, err := base64.StdEncoding.DecodeString(os.Args[4])
+		decodedToken, err := base64.StdEncoding.DecodeString(os.Args[4])
 		if nil != err {
 			fmt.Println("error decoding token")
 			return
 		}
-		decData, err := sc.Unprotect(decoded_message, decoded_token, nil)
+		decData, err := sc.Unprotect(decodedMessage, decodedToken, nil)
 		if nil != err {
 			fmt.Println("error decrypting message")
 			return

--- a/docs/examples/go/secure_comparator_client.go
+++ b/docs/examples/go/secure_comparator_client.go
@@ -50,12 +50,12 @@ func main() {
 
 		if compare.COMPARE_NOT_READY == res {
 			buf = make([]byte, 10240)
-			readed_bytes, err := conn.Read(buf)
+			readBytes, err := conn.Read(buf)
 			if err != nil {
 				fmt.Println("error reading bytes from socket")
 				return
 			}
-			buffer, err := sc.Proceed(buf[:readed_bytes])
+			buffer, err := sc.Proceed(buf[:readBytes])
 			if nil != err {
 				fmt.Println("error unwraping message")
 				return

--- a/docs/examples/go/secure_comparator_server.go
+++ b/docs/examples/go/secure_comparator_server.go
@@ -27,12 +27,12 @@ func connectionHandler(c net.Conn, secret string) {
 
 		if compare.COMPARE_NOT_READY == res {
 			buf := make([]byte, 10240)
-			readed_bytes, err := c.Read(buf)
+			readBytes, err := c.Read(buf)
 			if err != nil {
 				fmt.Println("error reading bytes from socket")
 				return
 			}
-			buf, err = sc.Proceed(buf[:readed_bytes])
+			buf, err = sc.Proceed(buf[:readBytes])
 			if nil != err {
 				fmt.Println("error proceeding message")
 				return

--- a/docs/examples/go/secure_keygen.go
+++ b/docs/examples/go/secure_keygen.go
@@ -7,12 +7,12 @@ import (
 )
 
 func main() {
-	key_pair, err := keys.New(keys.KEYTYPE_EC)
+	keyPair, err := keys.New(keys.KEYTYPE_EC)
 	if nil != err {
 		fmt.Println("Keypair generating error")
 		return
 	}
-	fmt.Println(base64.StdEncoding.EncodeToString(key_pair.Private.Value))
-	fmt.Println(base64.StdEncoding.EncodeToString(key_pair.Public.Value))
+	fmt.Println(base64.StdEncoding.EncodeToString(keyPair.Private.Value))
+	fmt.Println(base64.StdEncoding.EncodeToString(keyPair.Public.Value))
 	return
 }

--- a/docs/examples/go/secure_message.go
+++ b/docs/examples/go/secure_message.go
@@ -13,18 +13,18 @@ func main() {
 		fmt.Printf("usage: %s <command> <private key> <peer public key> <message>\n", os.Args[0])
 		return
 	}
-	decoded_key, err := base64.StdEncoding.DecodeString(os.Args[2])
+	decodedKey, err := base64.StdEncoding.DecodeString(os.Args[2])
 	if nil != err {
 		fmt.Println("error decoding private key")
 		return
 	}
-	pr := keys.PrivateKey{decoded_key}
-	decoded_key, err = base64.StdEncoding.DecodeString(os.Args[3])
+	pr := keys.PrivateKey{decodedKey}
+	decodedKey, err = base64.StdEncoding.DecodeString(os.Args[3])
 	if nil != err {
 		fmt.Println("error decoding private key")
 		return
 	}
-	pu := keys.PublicKey{decoded_key}
+	pu := keys.PublicKey{decodedKey}
 	sm := message.New(&pr, &pu)
 	if "enc" == os.Args[1] {
 		wrapped, err := sm.Wrap([]byte(os.Args[4]))
@@ -34,12 +34,12 @@ func main() {
 		}
 		fmt.Println(base64.StdEncoding.EncodeToString(wrapped))
 	} else if "dec" == os.Args[1] {
-		decoded_message, err := base64.StdEncoding.DecodeString(os.Args[4])
+		decodedMessage, err := base64.StdEncoding.DecodeString(os.Args[4])
 		if nil != err {
 			fmt.Println("error decoding message")
 			return
 		}
-		unwrapped, err := sm.Unwrap(decoded_message)
+		unwrapped, err := sm.Unwrap(decodedMessage)
 		if nil != err {
 			fmt.Println("error decrypting message")
 			return

--- a/docs/examples/go/secure_session_client.go
+++ b/docs/examples/go/secure_session_client.go
@@ -12,18 +12,18 @@ type callbacks struct {
 }
 
 func (clb *callbacks) GetPublicKeyForId(ss *session.SecureSession, id []byte) *keys.PublicKey {
-	decoded_id, err := base64.StdEncoding.DecodeString(string(id[:]))
+	decodedID, err := base64.StdEncoding.DecodeString(string(id[:]))
 	if nil != err {
 		return nil
 	}
-	return &keys.PublicKey{decoded_id}
+	return &keys.PublicKey{decodedID}
 }
 
 func (clb *callbacks) StateChanged(ss *session.SecureSession, state int) {
 
 }
 
-func send_wrapped_message(c net.Conn, ss *session.SecureSession, message string) bool {
+func sendWrappedMessage(c net.Conn, ss *session.SecureSession, message string) bool {
 	buf, err := ss.Wrap([]byte(message))
 	if nil != err {
 		fmt.Println("error wrapping message")
@@ -37,14 +37,14 @@ func send_wrapped_message(c net.Conn, ss *session.SecureSession, message string)
 	return true
 }
 
-func receive_unwrapped_message(c net.Conn, ss *session.SecureSession) string {
+func receiveUnwrappedMessage(c net.Conn, ss *session.SecureSession) string {
 	buf := make([]byte, 10240)
-	readed_bytes, err := c.Read(buf)
+	readBytes, err := c.Read(buf)
 	if err != nil {
 		fmt.Println("error reading bytes from socket")
 		return ""
 	}
-	buf, _, err = ss.Unwrap(buf[:readed_bytes])
+	buf, _, err = ss.Unwrap(buf[:readBytes])
 	if nil != err {
 		fmt.Println("error unwraping message")
 		return ""
@@ -58,12 +58,12 @@ func main() {
 		fmt.Println("connection error")
 		return
 	}
-	client_keypair, err := keys.New(keys.KEYTYPE_EC)
+	clientKeyPair, err := keys.New(keys.KEYTYPE_EC)
 	if err != nil {
 		fmt.Println("error generating key pair")
 		return
 	}
-	ss, err := session.New([]byte(base64.StdEncoding.EncodeToString(client_keypair.Public.Value)), client_keypair.Private, &callbacks{})
+	ss, err := session.New([]byte(base64.StdEncoding.EncodeToString(clientKeyPair.Public.Value)), clientKeyPair.Private, &callbacks{})
 	if err != nil {
 		fmt.Println("error creating secure session object")
 		return
@@ -83,27 +83,27 @@ func main() {
 		}
 
 		buf = make([]byte, 10240)
-		readed_bytes, err := conn.Read(buf)
+		readBytes, err := conn.Read(buf)
 		if err != nil {
 			fmt.Println("error reading bytes from socket")
 			return
 		}
-		buffer, send_peer, err := ss.Unwrap(buf[:readed_bytes])
+		buffer, sendPeer, err := ss.Unwrap(buf[:readBytes])
 		if nil != err {
 			fmt.Println("error unwraping message")
 			return
 		}
 		buf = buffer
-		if !send_peer {
+		if !sendPeer {
 			break
 		}
 	}
 
-	if send_wrapped_message(conn, ss, "This is test themis secure session message") {
-		mes := receive_unwrapped_message(conn, ss)
+	if sendWrappedMessage(conn, ss, "This is test themis secure session message") {
+		mes := receiveUnwrappedMessage(conn, ss)
 		if "" != mes {
 			fmt.Println("Received:", mes)
-			send_wrapped_message(conn, ss, "finish")
+			sendWrappedMessage(conn, ss, "finish")
 		}
 	}
 }

--- a/docs/examples/go/secure_session_server.go
+++ b/docs/examples/go/secure_session_server.go
@@ -12,36 +12,36 @@ type callbacks struct {
 }
 
 func (clb *callbacks) GetPublicKeyForId(ss *session.SecureSession, id []byte) *keys.PublicKey {
-	decoded_id, err := base64.StdEncoding.DecodeString(string(id[:]))
+	decodedID, err := base64.StdEncoding.DecodeString(string(id[:]))
 	if nil != err {
 		return nil
 	}
-	return &keys.PublicKey{decoded_id}
+	return &keys.PublicKey{decodedID}
 }
 
 func (clb *callbacks) StateChanged(ss *session.SecureSession, state int) {
 
 }
 
-func connectionHandler(c net.Conn, server_id string, server_private_key *keys.PrivateKey) {
-	ss, err := session.New([]byte(server_id), server_private_key, &callbacks{})
+func connectionHandler(c net.Conn, serverID string, serverPrivateKey *keys.PrivateKey) {
+	ss, err := session.New([]byte(serverID), serverPrivateKey, &callbacks{})
 	if err != nil {
 		fmt.Println("error creating secure session object")
 		return
 	}
 	for {
 		buf := make([]byte, 10240)
-		readed_bytes, err := c.Read(buf)
+		readBytes, err := c.Read(buf)
 		if err != nil {
 			fmt.Println("error reading bytes from socket")
 			return
 		}
-		buf, send_peer, err := ss.Unwrap(buf[:readed_bytes])
+		buf, sendPeer, err := ss.Unwrap(buf[:readBytes])
 		if nil != err {
 			fmt.Println("error unwraping message")
 			return
 		}
-		if !send_peer {
+		if !sendPeer {
 			if "finish" == string(buf[:]) {
 				return
 			}
@@ -66,7 +66,7 @@ func main() {
 		fmt.Println("listen error")
 		return
 	}
-	server_keypair, err := keys.New(keys.KEYTYPE_EC)
+	serverKeyPair, err := keys.New(keys.KEYTYPE_EC)
 	if err != nil {
 		fmt.Println("error generating key pair")
 		return
@@ -78,6 +78,6 @@ func main() {
 			return
 		}
 
-		go connectionHandler(conn, base64.StdEncoding.EncodeToString(server_keypair.Public.Value), server_keypair.Private)
+		go connectionHandler(conn, base64.StdEncoding.EncodeToString(serverKeyPair.Public.Value), serverKeyPair.Private)
 	}
 }

--- a/gothemis/cell/cell.go
+++ b/gothemis/cell/cell.go
@@ -169,8 +169,8 @@ func (sc *SecureCell) Protect(data []byte, context []byte) ([]byte, []byte, erro
 		}
 	}
 
-	var ctx unsafe.Pointer = nil
-	var ctxLen C.size_t = 0
+	var ctx unsafe.Pointer
+	var ctxLen C.size_t
 
 	if nil != context && 0 < len(context) {
 		ctx = unsafe.Pointer(&context[0])

--- a/gothemis/cell/cell.go
+++ b/gothemis/cell/cell.go
@@ -130,21 +130,26 @@ import (
 	"unsafe"
 )
 
+// Secure Cell operation mode.
 const (
 	CELL_MODE_SEAL            = 0
 	CELL_MODE_TOKEN_PROTECT   = 1
 	CELL_MODE_CONTEXT_IMPRINT = 2
 )
 
+// SecureCell is a high-level cryptographic service aimed at protecting arbitrary data
+// stored in various types of storage
 type SecureCell struct {
 	key  []byte
 	mode int
 }
 
+// New makes a new Secure Cell with master key and specified mode.
 func New(key []byte, mode int) *SecureCell {
 	return &SecureCell{key, mode}
 }
 
+// Protect encrypts or signs data with optional user context (depending on the Cell mode).
 func (sc *SecureCell) Protect(data []byte, context []byte) ([]byte, []byte, error) {
 	if (sc.mode < CELL_MODE_SEAL) || (sc.mode > CELL_MODE_CONTEXT_IMPRINT) {
 		return nil, nil, errors.New("Invalid mode specified")
@@ -212,6 +217,7 @@ func (sc *SecureCell) Protect(data []byte, context []byte) ([]byte, []byte, erro
 	return encData, addData, nil
 }
 
+// Unprotect decrypts or verify data with optional user context (depending on the Cell mode).
 func (sc *SecureCell) Unprotect(protectedData []byte, additionalData []byte, context []byte) ([]byte, error) {
 	if (sc.mode < CELL_MODE_SEAL) || (sc.mode > CELL_MODE_CONTEXT_IMPRINT) {
 		return nil, errors.New("Invalid mode specified")

--- a/gothemis/cell/cell_test.go
+++ b/gothemis/cell/cell_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 func testProtect(mode int, context []byte, t *testing.T) {
-	data_len, err := rand.Int(rand.Reader, big.NewInt(1024))
+	dataLen, err := rand.Int(rand.Reader, big.NewInt(1024))
 	if nil != err {
 		t.Error(err)
 	}
-	size := data_len.Int64()
+	size := dataLen.Int64()
 	if size == 0 {
 		size = 1
 	}

--- a/gothemis/compare/compare.go
+++ b/gothemis/compare/compare.go
@@ -62,12 +62,15 @@ import (
 	"unsafe"
 )
 
+// Secure comparison result.
 var (
 	COMPARE_MATCH = int(C.GOTHEMIS_SCOMPARE_MATCH)
 	COMPARE_NO_MATCH = int(C.GOTHEMIS_SCOMPARE_NO_MATCH)
 	COMPARE_NOT_READY = int(C.GOTHEMIS_SCOMPARE_NOT_READY)
 )
 
+// SecureCompare is an interactive protocol for two parties that compares whether
+// they share the same secret or not.
 type SecureCompare struct {
 	ctx unsafe.Pointer
 }
@@ -76,6 +79,7 @@ func finalize(sc *SecureCompare) {
 	sc.Close()
 }
 
+// New prepares a new secure comparison.
 func New() (*SecureCompare, error) {
 	ctx := C.compare_init()
 	if nil == ctx {
@@ -88,6 +92,7 @@ func New() (*SecureCompare, error) {
 	return sc, nil
 }
 
+// Close destroys Secure Comparator.
 func (sc *SecureCompare) Close() error {
 	if nil != sc.ctx {
 		if bool(C.compare_destroy(sc.ctx)) {
@@ -100,6 +105,7 @@ func (sc *SecureCompare) Close() error {
 	return nil
 }
 
+// Append adds data to be compared.
 func (sc *SecureCompare) Append(secret []byte) error {
 	if nil == secret || 0 == len(secret) {
 		return errors.New("Secret was not provided")
@@ -111,6 +117,7 @@ func (sc *SecureCompare) Append(secret []byte) error {
 	return nil
 }
 
+// Begin initiates secure comparison and returns data to be sent to the peer.
 func (sc *SecureCompare) Begin() ([]byte, error) {
 	var outLen C.size_t
 
@@ -127,6 +134,8 @@ func (sc *SecureCompare) Begin() ([]byte, error) {
 	return out, nil
 }
 
+// Proceed continues the comparison process with peer data and returns a reply.
+// Comparison is complete when this method returns nil successfully.
 func (sc *SecureCompare) Proceed(data []byte) ([]byte, error) {
 	var outLen C.size_t
 
@@ -155,6 +164,7 @@ func (sc *SecureCompare) Proceed(data []byte) ([]byte, error) {
 	return nil, errors.New("Failed to get output")
 }
 
+// Result returns the result of the comparison.
 func (sc *SecureCompare) Result() (int, error) {
 	res := int(C.compare_result(sc.ctx))
 	switch res {

--- a/gothemis/compare/compare_test.go
+++ b/gothemis/compare/compare_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 func genRandData() ([]byte, error) {
-	data_length, err := rand.Int(rand.Reader, big.NewInt(256))
+	dataLength, err := rand.Int(rand.Reader, big.NewInt(256))
 	if nil != err {
 		return nil, err
 	}
-	size := data_length.Int64()
+	size := dataLength.Int64()
 	if size == 0 {
 		size = 1
 	}

--- a/gothemis/errors/error.go
+++ b/gothemis/errors/error.go
@@ -1,25 +1,31 @@
 package errors
 
+// ThemisError is an operational error.
 type ThemisError struct {
 	msg string
 }
 
+// Error returns textual description of the error.
 func (e *ThemisError) Error() string {
 	return e.msg
 }
 
+// New makes an error with provided description.
 func New(msg string) *ThemisError {
 	return &ThemisError{msg}
 }
 
+// ThemisCallbackError is user-generated error returned from Secure Session callback.
 type ThemisCallbackError struct {
 	msg string
 }
 
+// Error returns textual description of the error.
 func (e *ThemisCallbackError) Error() string {
 	return e.msg
 }
 
+// NewCallbackError makes an error with provided description.
 func NewCallbackError(msg string) *ThemisCallbackError {
 	return &ThemisCallbackError{msg}
 }

--- a/gothemis/keys/keypair.go
+++ b/gothemis/keys/keypair.go
@@ -58,24 +58,29 @@ import (
 	"unsafe"
 )
 
+// Type of Themis key.
 const (
 	KEYTYPE_EC  = 0
 	KEYTYPE_RSA = 1
 )
 
+// PrivateKey stores a ECDSA or RSA private key.
 type PrivateKey struct {
 	Value []byte
 }
 
+// PublicKey stores a ECDSA or RSA public key.
 type PublicKey struct {
 	Value []byte
 }
 
+// Keypair stores a ECDSA or RSA key pair.
 type Keypair struct {
 	Private *PrivateKey
 	Public  *PublicKey
 }
 
+// New generates a new random pair of keys of the specified type.
 func New(keytype int) (*Keypair, error) {
 	if (keytype != KEYTYPE_EC) && (keytype != KEYTYPE_RSA) {
 		return nil, errors.New("Incorrect key type")

--- a/gothemis/message/message.go
+++ b/gothemis/message/message.go
@@ -110,7 +110,7 @@ func messageProcess(private *keys.PrivateKey, peerPublic *keys.PublicKey, messag
 		pubLen = C.size_t(len(peerPublic.Value))
 	}
 
-	var output_length C.size_t
+	var outputLength C.size_t
 	if !bool(C.get_message_size(priv,
 		privLen,
 		pub,
@@ -118,11 +118,11 @@ func messageProcess(private *keys.PrivateKey, peerPublic *keys.PublicKey, messag
 		unsafe.Pointer(&message[0]),
 		C.size_t(len(message)),
 		C.int(mode),
-		&output_length)) {
+		&outputLength)) {
 		return nil, errors.New("Failed to get output size")
 	}
 
-	output := make([]byte, int(output_length), int(output_length))
+	output := make([]byte, int(outputLength), int(outputLength))
 	if !bool(C.process(priv,
 		privLen,
 		pub,
@@ -131,7 +131,7 @@ func messageProcess(private *keys.PrivateKey, peerPublic *keys.PublicKey, messag
 		C.size_t(len(message)),
 		C.int(mode),
 		unsafe.Pointer(&output[0]),
-		output_length)) {
+		outputLength)) {
 		switch mode {
 		case secureMessageEncrypt:
 			return nil, errors.New("Failed to encrypt message")

--- a/gothemis/message/message.go
+++ b/gothemis/message/message.go
@@ -75,11 +75,15 @@ const (
 	SecureMessageVerify
 )
 
+// SecureMessage provides a sequence-independent, stateless, contextless messaging system.
 type SecureMessage struct {
 	private    *keys.PrivateKey
 	peerPublic *keys.PublicKey
 }
 
+// New makes a new Secure Message context.
+// You need to specify both keys for encrypt-decrypt mode.
+// Private key is required for signing messages. Public key is required for verifying messages
 func New(private *keys.PrivateKey, peerPublic *keys.PublicKey) *SecureMessage {
 	return &SecureMessage{private, peerPublic}
 }
@@ -145,6 +149,7 @@ func messageProcess(private *keys.PrivateKey, peerPublic *keys.PublicKey, messag
 	return output, nil
 }
 
+// Wrap encrypts the provided message.
 func (sm *SecureMessage) Wrap(message []byte) ([]byte, error) {
 	if nil == sm.private || 0 == len(sm.private.Value) {
 		return nil, errors.New("Private key was not provided")
@@ -156,6 +161,7 @@ func (sm *SecureMessage) Wrap(message []byte) ([]byte, error) {
 	return messageProcess(sm.private, sm.peerPublic, message, SecureMessageEncrypt)
 }
 
+// Unwrap decrypts the encrypted message.
 func (sm *SecureMessage) Unwrap(message []byte) ([]byte, error) {
 	if nil == sm.private || 0 == len(sm.private.Value) {
 		return nil, errors.New("Private key was not provided")
@@ -167,6 +173,7 @@ func (sm *SecureMessage) Unwrap(message []byte) ([]byte, error) {
 	return messageProcess(sm.private, sm.peerPublic, message, SecureMessageDecrypt)
 }
 
+// Sign signs the provided message and returns it signed.
 func (sm *SecureMessage) Sign(message []byte) ([]byte, error) {
 	if nil == sm.private || 0 == len(sm.private.Value) {
 		return nil, errors.New("Private key was not provided")
@@ -175,6 +182,7 @@ func (sm *SecureMessage) Sign(message []byte) ([]byte, error) {
 	return messageProcess(sm.private, nil, message, SecureMessageSign)
 }
 
+// Verify checks the signature on the message and returns the original message.
 func (sm *SecureMessage) Verify(message []byte) ([]byte, error) {
 	if nil == sm.peerPublic || 0 == len(sm.peerPublic.Value) {
 		return nil, errors.New("Peer public key was not provided")

--- a/gothemis/message/message.go
+++ b/gothemis/message/message.go
@@ -69,10 +69,10 @@ import (
 )
 
 const (
-	SecureMessageEncrypt = iota
-	SecureMessageDecrypt
-	SecureMessageSign
-	SecureMessageVerify
+	secureMessageEncrypt = iota
+	secureMessageDecrypt
+	secureMessageSign
+	secureMessageVerify
 )
 
 // SecureMessage provides a sequence-independent, stateless, contextless messaging system.
@@ -133,13 +133,13 @@ func messageProcess(private *keys.PrivateKey, peerPublic *keys.PublicKey, messag
 		unsafe.Pointer(&output[0]),
 		output_length)) {
 		switch mode {
-		case SecureMessageEncrypt:
+		case secureMessageEncrypt:
 			return nil, errors.New("Failed to encrypt message")
-		case SecureMessageDecrypt:
+		case secureMessageDecrypt:
 			return nil, errors.New("Failed to decrypt message")
-		case SecureMessageSign:
+		case secureMessageSign:
 			return nil, errors.New("Failed to sign message")
-		case SecureMessageVerify:
+		case secureMessageVerify:
 			return nil, errors.New("Failed to verify message")
 		default:
 			return nil, errors.New("Failed to process message")
@@ -158,7 +158,7 @@ func (sm *SecureMessage) Wrap(message []byte) ([]byte, error) {
 	if nil == sm.peerPublic || 0 == len(sm.peerPublic.Value) {
 		return nil, errors.New("Peer public key was not provided")
 	}
-	return messageProcess(sm.private, sm.peerPublic, message, SecureMessageEncrypt)
+	return messageProcess(sm.private, sm.peerPublic, message, secureMessageEncrypt)
 }
 
 // Unwrap decrypts the encrypted message.
@@ -170,7 +170,7 @@ func (sm *SecureMessage) Unwrap(message []byte) ([]byte, error) {
 	if nil == sm.peerPublic || 0 == len(sm.peerPublic.Value) {
 		return nil, errors.New("Peer public key was not provided")
 	}
-	return messageProcess(sm.private, sm.peerPublic, message, SecureMessageDecrypt)
+	return messageProcess(sm.private, sm.peerPublic, message, secureMessageDecrypt)
 }
 
 // Sign signs the provided message and returns it signed.
@@ -179,7 +179,7 @@ func (sm *SecureMessage) Sign(message []byte) ([]byte, error) {
 		return nil, errors.New("Private key was not provided")
 	}
 
-	return messageProcess(sm.private, nil, message, SecureMessageSign)
+	return messageProcess(sm.private, nil, message, secureMessageSign)
 }
 
 // Verify checks the signature on the message and returns the original message.
@@ -188,5 +188,5 @@ func (sm *SecureMessage) Verify(message []byte) ([]byte, error) {
 		return nil, errors.New("Peer public key was not provided")
 	}
 
-	return messageProcess(nil, sm.peerPublic, message, SecureMessageVerify)
+	return messageProcess(nil, sm.peerPublic, message, secureMessageVerify)
 }

--- a/gothemis/message/message_test.go
+++ b/gothemis/message/message_test.go
@@ -19,11 +19,11 @@ func testWrap(keytype int, t *testing.T) {
 		t.Error(err)
 	}
 
-	message_length, err := rand.Int(rand.Reader, big.NewInt(2048))
+	messageLength, err := rand.Int(rand.Reader, big.NewInt(2048))
 	if nil != err {
 		t.Error(err)
 	}
-	length := message_length.Int64()
+	length := messageLength.Int64()
 	if length == 0 {
 		length = 1
 	}
@@ -81,11 +81,11 @@ func testSign(keytype int, t *testing.T) {
 		t.Error(err)
 	}
 
-	message_length, err := rand.Int(rand.Reader, big.NewInt(2048))
+	messageLength, err := rand.Int(rand.Reader, big.NewInt(2048))
 	if nil != err {
 		t.Error(err)
 	}
-	length := message_length.Int64()
+	length := messageLength.Int64()
 	if length == 0 {
 		length = 1
 	}

--- a/gothemis/session/session.go
+++ b/gothemis/session/session.go
@@ -18,17 +18,22 @@ import (
 	"unsafe"
 )
 
+// Secure Session states.
 const (
 	STATE_IDLE        = 0
 	STATE_NEGOTIATING = 1
 	STATE_ESTABLISHED = 2
 )
 
+// SessionCallbacks implements a delegate for SecureSession.
 type SessionCallbacks interface {
 	GetPublicKeyForId(ss *SecureSession, id []byte) *keys.PublicKey
 	StateChanged(ss *SecureSession, state int)
 }
 
+// SecureSession is a lightweight mechanism for securing any kind of network communication
+// (both private and public networks, including the Internet). It is protocol-agnostic and
+// operates on the 5th layer of the network OSI model (the session layer).
 type SecureSession struct {
 	ctx   *C.struct_session_with_callbacks_type
 	clb   SessionCallbacks
@@ -39,6 +44,7 @@ func finalize(ss *SecureSession) {
 	ss.Close()
 }
 
+// New makes a new Secure Session with provided peer ID, private key, and callbacks.
 func New(id []byte, signKey *keys.PrivateKey, callbacks SessionCallbacks) (*SecureSession, error) {
 	ss := &SecureSession{clb: callbacks}
 
@@ -64,6 +70,7 @@ func New(id []byte, signKey *keys.PrivateKey, callbacks SessionCallbacks) (*Secu
 	return ss, nil
 }
 
+// Close destroys a Secure Session.
 func (ss *SecureSession) Close() error {
 	if nil != ss.ctx {
 		if bool(C.session_destroy(ss.ctx)) {
@@ -104,10 +111,12 @@ func onStateChanged(ssCtx unsafe.Pointer, event int) {
 	ss.clb.StateChanged(ss, event)
 }
 
+// GetState returns current state of Secure Session.
 func (ss *SecureSession) GetState() int {
 	return ss.state
 }
 
+// ConnectRequest generates a connection request that must be sent to the remote peer.
 func (ss *SecureSession) ConnectRequest() ([]byte, error) {
 	var reqLen C.size_t
 
@@ -126,6 +135,7 @@ func (ss *SecureSession) ConnectRequest() ([]byte, error) {
 	return req, nil
 }
 
+// Wrap encrypts the provided data for the peer.
 func (ss *SecureSession) Wrap(data []byte) ([]byte, error) {
 	var outLen C.size_t
 
@@ -152,6 +162,8 @@ func (ss *SecureSession) Wrap(data []byte) ([]byte, error) {
 	return out, nil
 }
 
+// Unwrap decrypts the encrypted data from the peer.
+// It is also used for connection negotiation.
 func (ss *SecureSession) Unwrap(data []byte) ([]byte, bool, error) {
 	var outLen C.size_t
 
@@ -194,6 +206,7 @@ func (ss *SecureSession) Unwrap(data []byte) ([]byte, bool, error) {
 	return nil, false, errors.New("Failed to unwrap data")
 }
 
+// GetRemoteId returns ID of the remote peer.
 func (ss *SecureSession) GetRemoteId()([]byte, error){
 	// secure_session_get_remote_id
 	var outLength C.size_t

--- a/gothemis/session/session_test.go
+++ b/gothemis/session/session_test.go
@@ -14,13 +14,13 @@ type testCallbacks struct {
 	b *keys.Keypair
 }
 
-var clientId = []byte("client a")
-var serverId = []byte("client b")
+var clientID = []byte("client a")
+var serverID = []byte("client b")
 
 func (clb *testCallbacks) GetPublicKeyForId(ss *SecureSession, id []byte) *keys.PublicKey {
-	if bytes.Equal(clientId, id){
+	if bytes.Equal(clientID, id){
 		return clb.a.Public
-	} else if bytes.Equal(serverId, id){
+	} else if bytes.Equal(serverID, id){
 		return clb.b.Public
 	}
 	return nil
@@ -80,12 +80,12 @@ func clientService(client *SecureSession, ch chan []byte, finCh chan int, t *tes
 			return
 		}
 
-		remoteId, err := client.GetRemoteId()
+		remoteID, err := client.GetRemoteId()
 		if err != nil{
 			t.Error(err)
 			return
 		}
-		if !bytes.Equal(remoteId, serverId){
+		if !bytes.Equal(remoteID, serverID){
 			t.Error("incorrect remote id")
 			return
 		}
@@ -133,12 +133,12 @@ func serverService(server *SecureSession, ch chan []byte, finCh chan int, t *tes
 			t.Error(err)
 			return
 		}
-		remoteId, err := server.GetRemoteId()
+		remoteID, err := server.GetRemoteId()
 		if err != nil{
 			t.Error(err)
 			return
 		}
-		if !bytes.Equal(remoteId, clientId){
+		if !bytes.Equal(remoteID, clientID){
 			t.Error("incorrect remote id")
 			return
 		}
@@ -179,13 +179,13 @@ func testSession(keytype int, t *testing.T) {
 
 	emptyKey := keys.PrivateKey{[]byte{}}
 
-	client, err := New(clientId, nil, clb)
+	client, err := New(clientID, nil, clb)
 	if nil == err {
 		t.Error("Creating Secure session object with empty private key")
 		return
 	}
 
-	client, err = New(clientId, &emptyKey, clb)
+	client, err = New(clientID, &emptyKey, clb)
 	if nil == err {
 		t.Error("Creating Secure session object with empty private key")
 		return
@@ -203,13 +203,13 @@ func testSession(keytype int, t *testing.T) {
 		return
 	}
 
-	client, err = New(clientId, kpa.Private, clb)
+	client, err = New(clientID, kpa.Private, clb)
 	if nil != err {
 		t.Error(err)
 		return
 	}
 
-	server, err := New(serverId, kpb.Private, clb)
+	server, err := New(serverID, kpb.Private, clb)
 	if nil != err {
 		t.Error(err)
 		return

--- a/gothemis/session/session_test.go
+++ b/gothemis/session/session_test.go
@@ -31,11 +31,11 @@ func (clb *testCallbacks) StateChanged(ss *SecureSession, state int) {
 }
 
 func genRandData() ([]byte, error) {
-	data_length, err := rand.Int(rand.Reader, big.NewInt(2048))
+	dataLength, err := rand.Int(rand.Reader, big.NewInt(2048))
 	if nil != err {
 		return nil, err
 	}
-	length := data_length.Int64()
+	length := dataLength.Int64()
 	if length == 0 {
 		length = 1
 	}
@@ -177,7 +177,7 @@ func testSession(keytype int, t *testing.T) {
 
 	clb := &testCallbacks{kpa, kpb}
 
-	empty_key := keys.PrivateKey{[]byte{}}
+	emptyKey := keys.PrivateKey{[]byte{}}
 
 	client, err := New(clientId, nil, clb)
 	if nil == err {
@@ -185,7 +185,7 @@ func testSession(keytype int, t *testing.T) {
 		return
 	}
 
-	client, err = New(clientId, &empty_key, clb)
+	client, err = New(clientId, &emptyKey, clb)
 	if nil == err {
 		t.Error("Creating Secure session object with empty private key")
 		return


### PR DESCRIPTION
I've installed the latest [golint](https://github.com/golang/lint) and walked through the warnings. This should improve out future [Go Report](https://goreportcard.com/report/github.com/cossacklabs/themis), but I'm not sure that we'll get 90%+ score. There are still some warnings that we can't fix without breaking backwards compatibility by renaming constants, structures and methods:

```
cell/cell.go:135:2: don't use ALL_CAPS in Go names; use CamelCase
cell/cell.go:136:2: don't use ALL_CAPS in Go names; use CamelCase
cell/cell.go:137:2: don't use ALL_CAPS in Go names; use CamelCase
compare/compare.go:67:2: don't use ALL_CAPS in Go names; use CamelCase
compare/compare.go:68:2: don't use ALL_CAPS in Go names; use CamelCase
compare/compare.go:69:2: don't use ALL_CAPS in Go names; use CamelCase
keys/keypair.go:63:2: don't use ALL_CAPS in Go names; use CamelCase
keys/keypair.go:64:2: don't use ALL_CAPS in Go names; use CamelCase
session/session.go:23:2: don't use ALL_CAPS in Go names; use CamelCase
session/session.go:24:2: don't use ALL_CAPS in Go names; use CamelCase
session/session.go:25:2: don't use ALL_CAPS in Go names; use CamelCase
session/session.go:29:6: type name will be used as session.SessionCallbacks by other packages, and that stutters; consider calling this Callbacks
session/session.go:210:26: method GetRemoteId should be GetRemoteID
session/session_test.go:20:27: method GetPublicKeyForId should be GetPublicKeyForID
```

---

* Add documentation comments

golint now requires all exported types, methods, and constants to have documentation comments on them. And the comments should have a particular style, starting with the identifier they describe. I've added some basic comments for all structs and methods.

* Unexport implementation details

Secure Message mode constants should not be exported, they are for internal use. Spell them with a lowercase initial letter instead of uppercase.

* Replace snake_case with camelCase

Go code style requires to use camelCase for variables, not snake_case.

* Spell ID as "ID", not "Id"

golint warns us about incorrect spelling, fix it where possible.

* Drop explicit zero initialization

Values are zero-initialized by default, golint warns about explicit zero initialization. Remove it in Secure Cell code.