### PR TITLE
Deprecate incorrectly named API

### DIFF
--- a/docs/examples/Themis-server/go/ssession_server.go
+++ b/docs/examples/Themis-server/go/ssession_server.go
@@ -20,7 +20,7 @@ type clientTransportCallback struct {
 	serverID     []byte
 }
 
-func (clb *clientTransportCallback) GetPublicKeyForId(ss *session.SecureSession, id []byte) *keys.PublicKey {
+func (clb *clientTransportCallback) GetPublicKeyForID(ss *session.SecureSession, id []byte) *keys.PublicKey {
 	if bytes.Equal(id, clb.serverID) {
 		return &keys.PublicKey{Value: clb.serverPublic}
 	}

--- a/docs/examples/Themis-server/go/ssession_server.go
+++ b/docs/examples/Themis-server/go/ssession_server.go
@@ -20,7 +20,7 @@ type clientTransportCallback struct {
 	serverID     []byte
 }
 
-func (clb *clientTransportCallback) GetPublicKeyForID(ss *session.SecureSession, id []byte) *keys.PublicKey {
+func (clb *clientTransportCallback) GetPublicKeyForId(ss *session.SecureSession, id []byte) *keys.PublicKey {
 	if bytes.Equal(id, clb.serverID) {
 		return &keys.PublicKey{Value: clb.serverPublic}
 	}

--- a/docs/examples/go/secure_cell_context_imprint.go
+++ b/docs/examples/go/secure_cell_context_imprint.go
@@ -12,7 +12,7 @@ func main() {
 		fmt.Printf("usage %s <command> <password> <message> <context>\n", os.Args[0])
 		return
 	}
-	sc := cell.New([]byte(os.Args[2]), cell.CELL_MODE_CONTEXT_IMPRINT)
+	sc := cell.New([]byte(os.Args[2]), cell.ModeContextImprint)
 	if "enc" == os.Args[1] {
 		encData, _, err := sc.Protect([]byte(os.Args[3]), []byte(os.Args[4]))
 		if nil != err {

--- a/docs/examples/go/secure_cell_seal.go
+++ b/docs/examples/go/secure_cell_seal.go
@@ -12,7 +12,7 @@ func main() {
 		fmt.Printf("usage %s <command> <password> <message>\n", os.Args[0])
 		return
 	}
-	sc := cell.New([]byte(os.Args[2]), cell.CELL_MODE_SEAL)
+	sc := cell.New([]byte(os.Args[2]), cell.ModeSeal)
 	if "enc" == os.Args[1] {
 		encData, _, err := sc.Protect([]byte(os.Args[3]), nil)
 		if nil != err {

--- a/docs/examples/go/secure_cell_token_protect.go
+++ b/docs/examples/go/secure_cell_token_protect.go
@@ -12,7 +12,7 @@ func main() {
 		fmt.Printf("usage %s <command> <password> <message> [<token>]\n", os.Args[0])
 		return
 	}
-	sc := cell.New([]byte(os.Args[2]), cell.CELL_MODE_TOKEN_PROTECT)
+	sc := cell.New([]byte(os.Args[2]), cell.ModeTokenProtect)
 	if "enc" == os.Args[1] {
 		encData, token, err := sc.Protect([]byte(os.Args[3]), nil)
 		if nil != err {

--- a/docs/examples/go/secure_comparator_client.go
+++ b/docs/examples/go/secure_comparator_client.go
@@ -48,7 +48,7 @@ func main() {
 			return
 		}
 
-		if compare.COMPARE_NOT_READY == res {
+		if compare.NotReady == res {
 			buf = make([]byte, 10240)
 			readBytes, err := conn.Read(buf)
 			if err != nil {
@@ -62,7 +62,7 @@ func main() {
 			}
 			buf = buffer
 		} else {
-			if compare.COMPARE_MATCH == res {
+			if compare.Match == res {
 				fmt.Println("match")
 			} else {
 				fmt.Println("not match")

--- a/docs/examples/go/secure_comparator_server.go
+++ b/docs/examples/go/secure_comparator_server.go
@@ -25,7 +25,7 @@ func connectionHandler(c net.Conn, secret string) {
 			return
 		}
 
-		if compare.COMPARE_NOT_READY == res {
+		if compare.NotReady == res {
 			buf := make([]byte, 10240)
 			readBytes, err := c.Read(buf)
 			if err != nil {
@@ -43,7 +43,7 @@ func connectionHandler(c net.Conn, secret string) {
 				return
 			}
 		} else {
-			if compare.COMPARE_MATCH == res {
+			if compare.Match == res {
 				fmt.Println("match")
 			} else {
 				fmt.Println("not match")

--- a/docs/examples/go/secure_keygen.go
+++ b/docs/examples/go/secure_keygen.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	keyPair, err := keys.New(keys.KEYTYPE_EC)
+	keyPair, err := keys.New(keys.TypeEC)
 	if nil != err {
 		fmt.Println("Keypair generating error")
 		return

--- a/docs/examples/go/secure_session_client.go
+++ b/docs/examples/go/secure_session_client.go
@@ -11,7 +11,7 @@ import (
 type callbacks struct {
 }
 
-func (clb *callbacks) GetPublicKeyForID(ss *session.SecureSession, id []byte) *keys.PublicKey {
+func (clb *callbacks) GetPublicKeyForId(ss *session.SecureSession, id []byte) *keys.PublicKey {
 	decodedID, err := base64.StdEncoding.DecodeString(string(id[:]))
 	if nil != err {
 		return nil

--- a/docs/examples/go/secure_session_client.go
+++ b/docs/examples/go/secure_session_client.go
@@ -11,7 +11,7 @@ import (
 type callbacks struct {
 }
 
-func (clb *callbacks) GetPublicKeyForId(ss *session.SecureSession, id []byte) *keys.PublicKey {
+func (clb *callbacks) GetPublicKeyForID(ss *session.SecureSession, id []byte) *keys.PublicKey {
 	decodedID, err := base64.StdEncoding.DecodeString(string(id[:]))
 	if nil != err {
 		return nil

--- a/docs/examples/go/secure_session_client.go
+++ b/docs/examples/go/secure_session_client.go
@@ -58,7 +58,7 @@ func main() {
 		fmt.Println("connection error")
 		return
 	}
-	clientKeyPair, err := keys.New(keys.KEYTYPE_EC)
+	clientKeyPair, err := keys.New(keys.TypeEC)
 	if err != nil {
 		fmt.Println("error generating key pair")
 		return

--- a/docs/examples/go/secure_session_server.go
+++ b/docs/examples/go/secure_session_server.go
@@ -11,7 +11,7 @@ import (
 type callbacks struct {
 }
 
-func (clb *callbacks) GetPublicKeyForID(ss *session.SecureSession, id []byte) *keys.PublicKey {
+func (clb *callbacks) GetPublicKeyForId(ss *session.SecureSession, id []byte) *keys.PublicKey {
 	decodedID, err := base64.StdEncoding.DecodeString(string(id[:]))
 	if nil != err {
 		return nil

--- a/docs/examples/go/secure_session_server.go
+++ b/docs/examples/go/secure_session_server.go
@@ -11,7 +11,7 @@ import (
 type callbacks struct {
 }
 
-func (clb *callbacks) GetPublicKeyForId(ss *session.SecureSession, id []byte) *keys.PublicKey {
+func (clb *callbacks) GetPublicKeyForID(ss *session.SecureSession, id []byte) *keys.PublicKey {
 	decodedID, err := base64.StdEncoding.DecodeString(string(id[:]))
 	if nil != err {
 		return nil

--- a/docs/examples/go/secure_session_server.go
+++ b/docs/examples/go/secure_session_server.go
@@ -66,7 +66,7 @@ func main() {
 		fmt.Println("listen error")
 		return
 	}
-	serverKeyPair, err := keys.New(keys.KEYTYPE_EC)
+	serverKeyPair, err := keys.New(keys.TypeEC)
 	if err != nil {
 		fmt.Println("error generating key pair")
 		return

--- a/gothemis/cell/cell.go
+++ b/gothemis/cell/cell.go
@@ -132,9 +132,18 @@ import (
 
 // Secure Cell operation mode.
 const (
-	CELL_MODE_SEAL            = 0
-	CELL_MODE_TOKEN_PROTECT   = 1
-	CELL_MODE_CONTEXT_IMPRINT = 2
+	ModeSeal = iota
+	ModeTokenProtect
+	ModeContextImprint
+)
+
+// Secure Cell operation mode.
+//
+// Deprecated: Since 0.11. Use "cell.Mode..." constants instead.
+const (
+	CELL_MODE_SEAL            = ModeSeal
+	CELL_MODE_TOKEN_PROTECT   = ModeTokenProtect
+	CELL_MODE_CONTEXT_IMPRINT = ModeContextImprint
 )
 
 // SecureCell is a high-level cryptographic service aimed at protecting arbitrary data
@@ -155,7 +164,7 @@ func missing(data []byte) bool {
 
 // Protect encrypts or signs data with optional user context (depending on the Cell mode).
 func (sc *SecureCell) Protect(data []byte, context []byte) ([]byte, []byte, error) {
-	if (sc.mode < CELL_MODE_SEAL) || (sc.mode > CELL_MODE_CONTEXT_IMPRINT) {
+	if (sc.mode < ModeSeal) || (sc.mode > ModeContextImprint) {
 		return nil, nil, errors.New("Invalid mode specified")
 	}
 
@@ -167,7 +176,7 @@ func (sc *SecureCell) Protect(data []byte, context []byte) ([]byte, []byte, erro
 		return nil, nil, errors.New("Data was not provided")
 	}
 
-	if CELL_MODE_CONTEXT_IMPRINT == sc.mode {
+	if ModeContextImprint == sc.mode {
 		if missing(context) {
 			return nil, nil, errors.New("Context is mandatory for context imprint mode")
 		}
@@ -223,7 +232,7 @@ func (sc *SecureCell) Protect(data []byte, context []byte) ([]byte, []byte, erro
 
 // Unprotect decrypts or verify data with optional user context (depending on the Cell mode).
 func (sc *SecureCell) Unprotect(protectedData []byte, additionalData []byte, context []byte) ([]byte, error) {
-	if (sc.mode < CELL_MODE_SEAL) || (sc.mode > CELL_MODE_CONTEXT_IMPRINT) {
+	if (sc.mode < ModeSeal) || (sc.mode > ModeContextImprint) {
 		return nil, errors.New("Invalid mode specified")
 	}
 
@@ -235,13 +244,13 @@ func (sc *SecureCell) Unprotect(protectedData []byte, additionalData []byte, con
 		return nil, errors.New("Data was not provided")
 	}
 
-	if CELL_MODE_CONTEXT_IMPRINT == sc.mode {
+	if ModeContextImprint == sc.mode {
 		if missing(context) {
 			return nil, errors.New("Context is mandatory for context imprint mode")
 		}
 	}
 
-	if CELL_MODE_TOKEN_PROTECT == sc.mode {
+	if ModeTokenProtect == sc.mode {
 		if missing(additionalData) {
 			return nil, errors.New("Additional data is mandatory for token protect mode")
 		}

--- a/gothemis/cell/cell_test.go
+++ b/gothemis/cell/cell_test.go
@@ -88,11 +88,11 @@ func TestProtect(t *testing.T) {
 		t.Error(err)
 	}
 
-	testProtect(CELL_MODE_SEAL, nil, t)
-	testProtect(CELL_MODE_SEAL, context, t)
+	testProtect(ModeSeal, nil, t)
+	testProtect(ModeSeal, context, t)
 
-	testProtect(CELL_MODE_TOKEN_PROTECT, nil, t)
-	testProtect(CELL_MODE_TOKEN_PROTECT, context, t)
+	testProtect(ModeTokenProtect, nil, t)
+	testProtect(ModeTokenProtect, context, t)
 
-	testProtect(CELL_MODE_CONTEXT_IMPRINT, context, t)
+	testProtect(ModeContextImprint, context, t)
 }

--- a/gothemis/compare/compare.go
+++ b/gothemis/compare/compare.go
@@ -50,10 +50,6 @@ static int compare_result(void *ctx)
 	return (int)res;
 }
 
-const int GOTHEMIS_SCOMPARE_MATCH = THEMIS_SCOMPARE_MATCH;
-const int GOTHEMIS_SCOMPARE_NO_MATCH = THEMIS_SCOMPARE_NO_MATCH;
-const int GOTHEMIS_SCOMPARE_NOT_READY = THEMIS_SCOMPARE_NOT_READY;
-
 */
 import "C"
 import (
@@ -64,9 +60,9 @@ import (
 
 // Secure comparison result.
 const (
-	Match    = int(C.GOTHEMIS_SCOMPARE_MATCH)
-	NoMatch  = int(C.GOTHEMIS_SCOMPARE_NO_MATCH)
-	NotReady = int(C.GOTHEMIS_SCOMPARE_NOT_READY)
+	Match    = int(C.THEMIS_SCOMPARE_MATCH)
+	NoMatch  = int(C.THEMIS_SCOMPARE_NO_MATCH)
+	NotReady = int(C.THEMIS_SCOMPARE_NOT_READY)
 )
 
 // Secure comparison result.

--- a/gothemis/compare/compare.go
+++ b/gothemis/compare/compare.go
@@ -63,10 +63,19 @@ import (
 )
 
 // Secure comparison result.
-var (
-	COMPARE_MATCH     = int(C.GOTHEMIS_SCOMPARE_MATCH)
-	COMPARE_NO_MATCH  = int(C.GOTHEMIS_SCOMPARE_NO_MATCH)
-	COMPARE_NOT_READY = int(C.GOTHEMIS_SCOMPARE_NOT_READY)
+const (
+	Match    = int(C.GOTHEMIS_SCOMPARE_MATCH)
+	NoMatch  = int(C.GOTHEMIS_SCOMPARE_NO_MATCH)
+	NotReady = int(C.GOTHEMIS_SCOMPARE_NOT_READY)
+)
+
+// Secure comparison result.
+//
+// Deprecated: Since 0.11. Use "compare.Match..." constants instead.
+const (
+	COMPARE_MATCH     = Match
+	COMPARE_NO_MATCH  = NoMatch
+	COMPARE_NOT_READY = NotReady
 )
 
 // SecureCompare is an interactive protocol for two parties that compares whether
@@ -168,9 +177,9 @@ func (sc *SecureCompare) Proceed(data []byte) ([]byte, error) {
 func (sc *SecureCompare) Result() (int, error) {
 	res := int(C.compare_result(sc.ctx))
 	switch res {
-	case COMPARE_NOT_READY, COMPARE_NO_MATCH, COMPARE_MATCH:
+	case NotReady, NoMatch, Match:
 		return int(res), nil
 	}
 
-	return COMPARE_NOT_READY, errors.New("Failed to get compare result")
+	return NotReady, errors.New("Failed to get compare result")
 }

--- a/gothemis/compare/compare_test.go
+++ b/gothemis/compare/compare_test.go
@@ -29,17 +29,17 @@ func scService(sc *SecureCompare, ch chan []byte, finCh chan int, t *testing.T) 
 	res, err := sc.Result()
 	if err != nil {
 		t.Error(err)
-		finCh <- COMPARE_NOT_READY
+		finCh <- NotReady
 		return
 	}
 
-	for COMPARE_NOT_READY == res {
+	for NotReady == res {
 		buf := <-ch
 
 		buf, err := sc.Proceed(buf)
 		if err != nil {
 			t.Error(err)
-			finCh <- COMPARE_NOT_READY
+			finCh <- NotReady
 			return
 		}
 
@@ -50,7 +50,7 @@ func scService(sc *SecureCompare, ch chan []byte, finCh chan int, t *testing.T) 
 		res, err = sc.Result()
 		if err != nil {
 			t.Error(err)
-			finCh <- COMPARE_NOT_READY
+			finCh <- NotReady
 			return
 		}
 	}
@@ -123,6 +123,6 @@ func TestCompare(t *testing.T) {
 		return
 	}
 
-	compare(sec1, sec2, COMPARE_NO_MATCH, t)
-	compare(sec1, sec1, COMPARE_MATCH, t)
+	compare(sec1, sec2, NoMatch, t)
+	compare(sec1, sec1, Match, t)
 }

--- a/gothemis/keys/keypair.go
+++ b/gothemis/keys/keypair.go
@@ -60,8 +60,16 @@ import (
 
 // Type of Themis key.
 const (
-	KEYTYPE_EC  = 0
-	KEYTYPE_RSA = 1
+	TypeEC = iota
+	TypeRSA
+)
+
+// Type of Themis key.
+//
+// Deprecated: Since 0.11. Use "keys.Type..." constants instead.
+const (
+	KEYTYPE_EC  = TypeEC
+	KEYTYPE_RSA = TypeRSA
 )
 
 // PrivateKey stores a ECDSA or RSA private key.
@@ -82,7 +90,7 @@ type Keypair struct {
 
 // New generates a new random pair of keys of the specified type.
 func New(keytype int) (*Keypair, error) {
-	if (keytype != KEYTYPE_EC) && (keytype != KEYTYPE_RSA) {
+	if (keytype != TypeEC) && (keytype != TypeRSA) {
 		return nil, errors.New("Incorrect key type")
 	}
 

--- a/gothemis/keys/keypair_test.go
+++ b/gothemis/keys/keypair_test.go
@@ -5,12 +5,12 @@ import (
 )
 
 func TestNewKeypair(t *testing.T) {
-	_, err := New(KEYTYPE_EC)
+	_, err := New(TypeEC)
 	if nil != err {
 		t.Error(err)
 	}
 
-	_, err = New(KEYTYPE_RSA)
+	_, err = New(TypeRSA)
 	if nil != err {
 		t.Error(err)
 	}

--- a/gothemis/message/message_test.go
+++ b/gothemis/message/message_test.go
@@ -116,11 +116,11 @@ func testSign(keytype int, t *testing.T) {
 }
 
 func TestMessageWrap(t *testing.T) {
-	testWrap(keys.KEYTYPE_EC, t)
-	testWrap(keys.KEYTYPE_RSA, t)
+	testWrap(keys.TypeEC, t)
+	testWrap(keys.TypeRSA, t)
 }
 
 func TestMessageSign(t *testing.T) {
-	testSign(keys.KEYTYPE_EC, t)
-	testSign(keys.KEYTYPE_RSA, t)
+	testSign(keys.TypeEC, t)
+	testSign(keys.TypeRSA, t)
 }

--- a/gothemis/session/session.go
+++ b/gothemis/session/session.go
@@ -245,8 +245,8 @@ func (ss *SecureSession) Unwrap(data []byte) ([]byte, bool, error) {
 	return nil, false, errors.New("Failed to unwrap data")
 }
 
-// GetRemoteId returns ID of the remote peer.
-func (ss *SecureSession) GetRemoteId() ([]byte, error) {
+// GetRemoteID returns ID of the remote peer.
+func (ss *SecureSession) GetRemoteID() ([]byte, error) {
 	// secure_session_get_remote_id
 	var outLength C.size_t
 	if C.secure_session_get_remote_id(ss.ctx.session, nil, &outLength) != C.THEMIS_BUFFER_TOO_SMALL {
@@ -260,4 +260,11 @@ func (ss *SecureSession) GetRemoteId() ([]byte, error) {
 		return nil, errors.NewCallbackError("Failed to get session remote id")
 	}
 	return out, nil
+}
+
+// GetRemoteId returns ID of the remote peer.
+//
+// Deprecated: Since 0.11. Use GetRemoteID() instead.
+func (ss *SecureSession) GetRemoteId() ([]byte, error) {
+	return ss.GetRemoteID()
 }

--- a/gothemis/session/session.go
+++ b/gothemis/session/session.go
@@ -34,30 +34,10 @@ const (
 	STATE_ESTABLISHED = StateEstablished
 )
 
-// Callbacks implements a delegate for SecureSession.
-type Callbacks interface {
-	GetPublicKeyForID(ss *SecureSession, id []byte) *keys.PublicKey
-	StateChanged(ss *SecureSession, state int)
-}
-
 // SessionCallbacks implements a delegate for SecureSession.
-//
-// Deprecated: Since 0.11. Use "session.Callbacks" instead.
 type SessionCallbacks interface {
 	GetPublicKeyForId(ss *SecureSession, id []byte) *keys.PublicKey
 	StateChanged(ss *SecureSession, state int)
-}
-
-type sessionCallbacksAdapter struct {
-	inner SessionCallbacks
-}
-
-func (adapter *sessionCallbacksAdapter) GetPublicKeyForID(ss *SecureSession, id []byte) *keys.PublicKey {
-	return adapter.inner.GetPublicKeyForId(ss, id)
-}
-
-func (adapter *sessionCallbacksAdapter) StateChanged(ss *SecureSession, state int) {
-	adapter.inner.StateChanged(ss, state)
 }
 
 // SecureSession is a lightweight mechanism for securing any kind of network communication
@@ -65,7 +45,7 @@ func (adapter *sessionCallbacksAdapter) StateChanged(ss *SecureSession, state in
 // operates on the 5th layer of the network OSI model (the session layer).
 type SecureSession struct {
 	ctx   *C.struct_session_with_callbacks_type
-	clb   Callbacks
+	clb   SessionCallbacks
 	state int
 }
 
@@ -74,18 +54,8 @@ func finalize(ss *SecureSession) {
 }
 
 // New makes a new Secure Session with provided peer ID, private key, and callbacks.
-func New(id []byte, signKey *keys.PrivateKey, callbacks interface{}) (*SecureSession, error) {
-	// TODO: remove these dynamic type checks together with SessionCallbacks
-	realCallbacks, newInterface := callbacks.(Callbacks)
-	if !newInterface {
-		oldCallbacks, oldInterface := callbacks.(SessionCallbacks)
-		if oldInterface {
-			realCallbacks = &sessionCallbacksAdapter{inner: oldCallbacks}
-		} else {
-			return nil, errors.New("Invalid callback interface")
-		}
-	}
-	ss := &SecureSession{clb: realCallbacks}
+func New(id []byte, signKey *keys.PrivateKey, callbacks SessionCallbacks) (*SecureSession, error) {
+	ss := &SecureSession{clb: callbacks}
 
 	if nil == id || 0 == len(id) {
 		return nil, errors.New("Failed to creating secure session object with empty id")
@@ -128,7 +98,7 @@ func onPublicKeyForId(ssCtx unsafe.Pointer, idPtr unsafe.Pointer, idLen C.size_t
 	id := C.GoBytes(idPtr, C.int(idLen))
 	ss = (*SecureSession)(unsafe.Pointer(uintptr(ssCtx) - unsafe.Offsetof(ss.ctx)))
 
-	pub := ss.clb.GetPublicKeyForID(ss, id)
+	pub := ss.clb.GetPublicKeyForId(ss, id)
 	if nil == pub {
 		return int(C.GOTHEMIS_INVALID_PARAMETER)
 	}

--- a/gothemis/session/session.go
+++ b/gothemis/session/session.go
@@ -20,9 +20,18 @@ import (
 
 // Secure Session states.
 const (
-	STATE_IDLE        = 0
-	STATE_NEGOTIATING = 1
-	STATE_ESTABLISHED = 2
+	StateIdle = iota
+	StateNegotiating
+	StateEstablished
+)
+
+// Secure Session states.
+//
+// Deprecated: Since 0.11. Use "session.State..." constants instead.
+const (
+	STATE_IDLE        = StateIdle
+	STATE_NEGOTIATING = StateNegotiating
+	STATE_ESTABLISHED = StateEstablished
 )
 
 // SessionCallbacks implements a delegate for SecureSession.

--- a/gothemis/session/session_test.go
+++ b/gothemis/session/session_test.go
@@ -80,7 +80,7 @@ func clientService(client *SecureSession, ch chan []byte, finCh chan int, t *tes
 			return
 		}
 
-		remoteID, err := client.GetRemoteId()
+		remoteID, err := client.GetRemoteID()
 		if err != nil {
 			t.Error(err)
 			return
@@ -133,7 +133,7 @@ func serverService(server *SecureSession, ch chan []byte, finCh chan int, t *tes
 			t.Error(err)
 			return
 		}
-		remoteID, err := server.GetRemoteId()
+		remoteID, err := server.GetRemoteID()
 		if err != nil {
 			t.Error(err)
 			return

--- a/gothemis/session/session_test.go
+++ b/gothemis/session/session_test.go
@@ -224,5 +224,5 @@ func testSession(keytype int, t *testing.T) {
 }
 
 func TestSession(t *testing.T) {
-	testSession(keys.KEYTYPE_EC, t)
+	testSession(keys.TypeEC, t)
 }

--- a/gothemis/session/session_test.go
+++ b/gothemis/session/session_test.go
@@ -95,7 +95,7 @@ func clientService(client *SecureSession, ch chan []byte, finCh chan int, t *tes
 			continue
 		}
 
-		if client.GetState() != STATE_ESTABLISHED {
+		if client.GetState() != StateEstablished {
 			t.Error(errors.New("Incorrect secure session state"))
 		}
 
@@ -144,7 +144,7 @@ func serverService(server *SecureSession, ch chan []byte, finCh chan int, t *tes
 		}
 
 		if !sendPeer {
-			if server.GetState() != STATE_ESTABLISHED {
+			if server.GetState() != StateEstablished {
 				t.Error(errors.New("Incorrect secure session state"))
 			}
 			if isFin(buf) {

--- a/gothemis/session/session_test.go
+++ b/gothemis/session/session_test.go
@@ -17,7 +17,7 @@ type testCallbacks struct {
 var clientID = []byte("client a")
 var serverID = []byte("client b")
 
-func (clb *testCallbacks) GetPublicKeyForID(ss *SecureSession, id []byte) *keys.PublicKey {
+func (clb *testCallbacks) GetPublicKeyForId(ss *SecureSession, id []byte) *keys.PublicKey {
 	if bytes.Equal(clientID, id) {
 		return clb.a.Public
 	} else if bytes.Equal(serverID, id) {

--- a/gothemis/session/session_test.go
+++ b/gothemis/session/session_test.go
@@ -30,6 +30,25 @@ func (clb *testCallbacks) StateChanged(ss *SecureSession, state int) {
 
 }
 
+// TODO: remove together with deprecated SessionCallbacks interface
+type testCallbacksOld struct {
+	a *keys.Keypair
+	b *keys.Keypair
+}
+
+func (clb *testCallbacksOld) GetPublicKeyForId(ss *SecureSession, id []byte) *keys.PublicKey {
+	if bytes.Equal(clientID, id) {
+		return clb.a.Public
+	} else if bytes.Equal(serverID, id) {
+		return clb.b.Public
+	}
+	return nil
+}
+
+func (clb *testCallbacksOld) StateChanged(ss *SecureSession, state int) {
+
+}
+
 func genRandData() ([]byte, error) {
 	dataLength, err := rand.Int(rand.Reader, big.NewInt(2048))
 	if nil != err {
@@ -162,21 +181,8 @@ func serverService(server *SecureSession, ch chan []byte, finCh chan int, t *tes
 	}
 }
 
-func testSession(keytype int, t *testing.T) {
-	kpa, err := keys.New(keytype)
-	if nil != err {
-		t.Error(err)
-		return
-	}
-
-	kpb, err := keys.New(keytype)
-	if nil != err {
-		t.Error(err)
-		return
-	}
-
-	clb := &testCallbacks{kpa, kpb}
-
+func testSession(kpa *keys.Keypair, kpb *keys.Keypair, clb interface{}, t *testing.T) {
+	var err error
 	emptyKey := keys.PrivateKey{Value: []byte{}}
 
 	_, err = New(clientID, nil, clb)
@@ -224,5 +230,53 @@ func testSession(keytype int, t *testing.T) {
 }
 
 func TestSession(t *testing.T) {
-	testSession(keys.TypeEC, t)
+	kpa, err := keys.New(keys.TypeEC)
+	if nil != err {
+		t.Error(err)
+		return
+	}
+
+	kpb, err := keys.New(keys.TypeEC)
+	if nil != err {
+		t.Error(err)
+		return
+	}
+
+	clb := &testCallbacks{kpa, kpb}
+
+	testSession(kpa, kpb, clb, t)
+}
+
+// TODO: remove together with deprecated SessionCallbacks interface
+func TestSessionOldAPI(t *testing.T) {
+	kpa, err := keys.New(keys.TypeEC)
+	if nil != err {
+		t.Error(err)
+		return
+	}
+
+	kpb, err := keys.New(keys.TypeEC)
+	if nil != err {
+		t.Error(err)
+		return
+	}
+
+	clb := &testCallbacksOld{kpa, kpb}
+
+	testSession(kpa, kpb, clb, t)
+}
+
+// TODO: remove together with deprecated SessionCallbacks interface
+func TestSessionInvalidCallbacks(t *testing.T) {
+	keyPair, err := keys.New(keys.TypeEC)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	_, err = New(serverID, keyPair.Private, "definitely not a callback")
+	if err == nil {
+		t.Error("Expected secure.New() to fail for invalid type")
+		return
+	}
 }

--- a/gothemis/session/session_test.go
+++ b/gothemis/session/session_test.go
@@ -17,7 +17,7 @@ type testCallbacks struct {
 var clientID = []byte("client a")
 var serverID = []byte("client b")
 
-func (clb *testCallbacks) GetPublicKeyForId(ss *SecureSession, id []byte) *keys.PublicKey {
+func (clb *testCallbacks) GetPublicKeyForID(ss *SecureSession, id []byte) *keys.PublicKey {
 	if bytes.Equal(clientID, id) {
 		return clb.a.Public
 	} else if bytes.Equal(serverID, id) {

--- a/tools/afl/generate/scell_seal_decrypt.go
+++ b/tools/afl/generate/scell_seal_decrypt.go
@@ -46,7 +46,7 @@ func main() {
 		context = []byte(args[3])
 	}
 
-	sc := cell.New(key, cell.CELL_MODE_SEAL)
+	sc := cell.New(key, cell.ModeSeal)
 
 	encrypted, _, _ := sc.Protect(message, context)
 

--- a/tools/go/keygen.go
+++ b/tools/go/keygen.go
@@ -24,7 +24,7 @@ func main() {
 		public_key_path = os.Args[2]
 	}
 
-	keypair, err := keys.New(keys.KEYTYPE_EC)
+	keypair, err := keys.New(keys.TypeEC)
 	if err != nil {
 		panic(err)
 	}

--- a/tools/go/scell_context_string_echo.go
+++ b/tools/go/scell_context_string_echo.go
@@ -20,7 +20,7 @@ func main() {
 	message := args[3]
 	context := []byte(args[4])
 
-	sc := cell.New([]byte(key), cell.CELL_MODE_CONTEXT_IMPRINT)
+	sc := cell.New([]byte(key), cell.ModeContextImprint)
 
 	if "enc" == command {
 		encData, _, err := sc.Protect([]byte(message), context)

--- a/tools/go/scell_seal_string_echo.go
+++ b/tools/go/scell_seal_string_echo.go
@@ -24,7 +24,7 @@ func main() {
 		context = []byte(args[4])
 	}
 
-	sc := cell.New([]byte(key), cell.CELL_MODE_SEAL)
+	sc := cell.New([]byte(key), cell.ModeSeal)
 
 	if "enc" == command {
 		encData, _, err := sc.Protect([]byte(message), context)

--- a/tools/go/scell_token_string_echo.go
+++ b/tools/go/scell_token_string_echo.go
@@ -33,7 +33,7 @@ func main() {
 		context = []byte(args[4])
 	}
 
-	sc := cell.New([]byte(key), cell.CELL_MODE_TOKEN_PROTECT)
+	sc := cell.New([]byte(key), cell.ModeTokenProtect)
 
 	if "enc" == command {
 		encData, encToken, err := sc.Protect([]byte(message), context)


### PR DESCRIPTION
PRs #422, #423 have fixed up miscellaneous golint warnings. Some of them are for incorrectly named constants and methods. This PR renames the affected identifiers into something acceptable by golint while simultaneously deprecating the old names.

We cannot remove the old names immediately due to backwards compatibility concerns. They will be actually removed in some later release, once all existing users have migrated to the new API. But for now we keep compatibility shims of various complexity to allow usage of the old API.

Summary of changes:

* cell.CELL_MODE_SEAL → cell.ModeSeal
* compare.COMPARE_MATCH → compare.Match
* keys.KEYTYPE_EC → keys.TypeEC
* session.STATE_ESTABLISHED → session.StateEstablished
* (*session.SecureSession) GetRemoteId → GetRemoteID

---

* **Rename `cell.CELL_MODE_*` constants**
* **Rename `compare.COMPARE_*` constants**
* **Rename `keys.KEYTYPE_*` constants**
* **Rename `session.STATE_*` constants**
* **Rename `session.SecureSession.GetRemoteId` method**

Renaming constants is actually very easy:

- Provide new names that don't offend golint
- Use new names throughout the code base
- Mark the old names deprecated and redefine constants using new values

This is true for methods as well.

* ~~**Rename `session.SessionCallbacks` interface**~~
* ~~**Compatibility test for old Secure Session API**~~

(**Edit:** these two commits were removed later during code review.)

This renaming is more involved that other ones. Interfaces are hard.

First of all, introduce a new interface with identifiers that do not offend golint:

  - use `Callbacks` instead of `SessionCallbacks` to avoid stuttering when importing (it will be called `session.Callbacks` in user code)
  - use `GetPublicKeyID` method name instead of `GetPublicKeyId`

Then update all existing code to use the new interface. Secure Session itself should call the new method, accept and store `Callbacks` instance. Users of Secure Session should implement the new `GetPublicKeyID` method.

However, in order to maintain backwards compatibility we have to allow the old code to continue using the old `SessionCallbacks` interface with `GetPublicKeyId` method. We implement this using an adapter struct that translates new method calls into the old ones. Since Go does not have method overloading we have to accept an `interface {}` instance and check its type dynamically. These compatibility shims can be removed when we drop the old interface.

All these dynamic checks in `session.New()` warrant a test which verifies that we actually can handle the old interface values and reject invalid ones. This test can be removed together with the old SessionCallbacks API.