### PR TITLE
Remove deprecated Gothemis API (0.11)

### DIFF
--- a/gothemis/cell/cell.go
+++ b/gothemis/cell/cell.go
@@ -137,15 +137,6 @@ const (
 	ModeContextImprint
 )
 
-// Secure Cell operation mode.
-//
-// Deprecated: Since 0.11. Use "cell.Mode..." constants instead.
-const (
-	CELL_MODE_SEAL            = ModeSeal
-	CELL_MODE_TOKEN_PROTECT   = ModeTokenProtect
-	CELL_MODE_CONTEXT_IMPRINT = ModeContextImprint
-)
-
 // SecureCell is a high-level cryptographic service aimed at protecting arbitrary data
 // stored in various types of storage
 type SecureCell struct {

--- a/gothemis/compare/compare.go
+++ b/gothemis/compare/compare.go
@@ -65,15 +65,6 @@ const (
 	NotReady = int(C.THEMIS_SCOMPARE_NOT_READY)
 )
 
-// Secure comparison result.
-//
-// Deprecated: Since 0.11. Use "compare.Match..." constants instead.
-const (
-	COMPARE_MATCH     = Match
-	COMPARE_NO_MATCH  = NoMatch
-	COMPARE_NOT_READY = NotReady
-)
-
 // SecureCompare is an interactive protocol for two parties that compares whether
 // they share the same secret or not.
 type SecureCompare struct {

--- a/gothemis/keys/keypair.go
+++ b/gothemis/keys/keypair.go
@@ -64,14 +64,6 @@ const (
 	TypeRSA
 )
 
-// Type of Themis key.
-//
-// Deprecated: Since 0.11. Use "keys.Type..." constants instead.
-const (
-	KEYTYPE_EC  = TypeEC
-	KEYTYPE_RSA = TypeRSA
-)
-
 // PrivateKey stores a ECDSA or RSA private key.
 type PrivateKey struct {
 	Value []byte

--- a/gothemis/session/session.go
+++ b/gothemis/session/session.go
@@ -25,15 +25,6 @@ const (
 	StateEstablished
 )
 
-// Secure Session states.
-//
-// Deprecated: Since 0.11. Use "session.State..." constants instead.
-const (
-	STATE_IDLE        = StateIdle
-	STATE_NEGOTIATING = StateNegotiating
-	STATE_ESTABLISHED = StateEstablished
-)
-
 // SessionCallbacks implements a delegate for SecureSession.
 type SessionCallbacks interface {
 	GetPublicKeyForId(ss *SecureSession, id []byte) *keys.PublicKey
@@ -230,11 +221,4 @@ func (ss *SecureSession) GetRemoteID() ([]byte, error) {
 		return nil, errors.NewCallbackError("Failed to get session remote id")
 	}
 	return out, nil
-}
-
-// GetRemoteId returns ID of the remote peer.
-//
-// Deprecated: Since 0.11. Use GetRemoteID() instead.
-func (ss *SecureSession) GetRemoteId() ([]byte, error) {
-	return ss.GetRemoteID()
 }


### PR DESCRIPTION
Here we actually remove the API scheduled for deprecation since Themis 0.11:

- #424 Deprecate incorrectly named API