### PR TITLE
Xcode project for Carthage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ docs/examples/objc/Pods
 /target
 **/*.rs.bk
 Cargo.lock
+
+# Carthage
+Carthage/

--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,1 @@
+github "ilammy/OpenSSL" ~> 1.0.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,0 +1,1 @@
+github "ilammy/OpenSSL" "1.0.2.14.1"

--- a/Themis.xcodeproj/project.pbxproj
+++ b/Themis.xcodeproj/project.pbxproj
@@ -1,0 +1,1235 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		9F00E8DF223C19D900EC1EF3 /* themis.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A24AB223A8E15005CB63A /* themis.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F00E8E0223C19E000EC1EF3 /* themis.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A24AB223A8E15005CB63A /* themis.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F00E8E2223C1A3300EC1EF3 /* objcthemis.h in Headers: objcthemis */ = {isa = PBXBuildFile; fileRef = 9F4A24B5223A8FA8005CB63A /* objcthemis.h */; };
+		9F00E8E3223C1A3300EC1EF3 /* scell_context_imprint.h in Headers: objcthemis */ = {isa = PBXBuildFile; fileRef = 9F4A24B9223A8FA8005CB63A /* scell_context_imprint.h */; };
+		9F00E8E4223C1A3300EC1EF3 /* scell_seal.h in Headers: objcthemis */ = {isa = PBXBuildFile; fileRef = 9F4A24BC223A8FA8005CB63A /* scell_seal.h */; };
+		9F00E8E5223C1A3300EC1EF3 /* scell_token.h in Headers: objcthemis */ = {isa = PBXBuildFile; fileRef = 9F4A24C3223A8FA8005CB63A /* scell_token.h */; };
+		9F00E8E6223C1A3300EC1EF3 /* scell.h in Headers: objcthemis */ = {isa = PBXBuildFile; fileRef = 9F4A24B3223A8FA7005CB63A /* scell.h */; };
+		9F00E8E7223C1A3300EC1EF3 /* scomparator.h in Headers: objcthemis */ = {isa = PBXBuildFile; fileRef = 9F4A24C0223A8FA8005CB63A /* scomparator.h */; };
+		9F00E8E8223C1A3300EC1EF3 /* serror.h in Headers: objcthemis */ = {isa = PBXBuildFile; fileRef = 9F4A24BB223A8FA8005CB63A /* serror.h */; };
+		9F00E8E9223C1A3300EC1EF3 /* skeygen.h in Headers: objcthemis */ = {isa = PBXBuildFile; fileRef = 9F4A24C1223A8FA8005CB63A /* skeygen.h */; };
+		9F00E8EA223C1A3300EC1EF3 /* smessage.h in Headers: objcthemis */ = {isa = PBXBuildFile; fileRef = 9F4A24C2223A8FA8005CB63A /* smessage.h */; };
+		9F00E8EB223C1A3300EC1EF3 /* ssession_transport_interface.h in Headers: objcthemis */ = {isa = PBXBuildFile; fileRef = 9F4A24BF223A8FA8005CB63A /* ssession_transport_interface.h */; };
+		9F00E8EC223C1A3300EC1EF3 /* ssession.h in Headers: objcthemis */ = {isa = PBXBuildFile; fileRef = 9F4A24B1223A8FA7005CB63A /* ssession.h */; };
+		9F00E8EE223C1A8C00EC1EF3 /* scell_context_imprint.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24B4223A8FA8005CB63A /* scell_context_imprint.m */; };
+		9F00E8EF223C1A8C00EC1EF3 /* scell_seal.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24B0223A8FA7005CB63A /* scell_seal.m */; };
+		9F00E8F0223C1A8C00EC1EF3 /* scell_token.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24BD223A8FA8005CB63A /* scell_token.m */; };
+		9F00E8F1223C1A8C00EC1EF3 /* scell.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24BE223A8FA8005CB63A /* scell.m */; };
+		9F00E8F2223C1A8C00EC1EF3 /* scomparator.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24B6223A8FA8005CB63A /* scomparator.m */; };
+		9F00E8F3223C1A8C00EC1EF3 /* skeygen.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24B7223A8FA8005CB63A /* skeygen.m */; };
+		9F00E8F4223C1A8C00EC1EF3 /* smessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24B8223A8FA8005CB63A /* smessage.m */; };
+		9F00E8F5223C1A8C00EC1EF3 /* ssession_transport_interface.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24B2223A8FA7005CB63A /* ssession_transport_interface.m */; };
+		9F00E8F6223C1A8C00EC1EF3 /* ssession.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24BA223A8FA8005CB63A /* ssession.m */; };
+		9F00E8F7223C1A9600EC1EF3 /* fe_0.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B3223A745B005CB63A /* fe_0.c */; };
+		9F00E8F8223C1A9600EC1EF3 /* fe_1.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23CF223A745C005CB63A /* fe_1.c */; };
+		9F00E8F9223C1A9600EC1EF3 /* fe_add.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B1223A745A005CB63A /* fe_add.c */; };
+		9F00E8FA223C1A9600EC1EF3 /* fe_cmov.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23A8223A745A005CB63A /* fe_cmov.c */; };
+		9F00E8FB223C1A9600EC1EF3 /* fe_copy.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B6223A745B005CB63A /* fe_copy.c */; };
+		9F00E8FC223C1A9600EC1EF3 /* fe_frombytes.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23AC223A745A005CB63A /* fe_frombytes.c */; };
+		9F00E8FD223C1A9600EC1EF3 /* fe_invert.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23D3223A745D005CB63A /* fe_invert.c */; };
+		9F00E8FE223C1A9600EC1EF3 /* fe_isnegative.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23BE223A745B005CB63A /* fe_isnegative.c */; };
+		9F00E8FF223C1A9600EC1EF3 /* fe_isnonzero.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B9223A745B005CB63A /* fe_isnonzero.c */; };
+		9F00E900223C1A9600EC1EF3 /* fe_mul.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23D1223A745C005CB63A /* fe_mul.c */; };
+		9F00E901223C1A9600EC1EF3 /* fe_neg.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23BC223A745B005CB63A /* fe_neg.c */; };
+		9F00E902223C1A9600EC1EF3 /* fe_pow22523.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23DD223A745D005CB63A /* fe_pow22523.c */; };
+		9F00E903223C1A9600EC1EF3 /* fe_sq.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23E0223A745D005CB63A /* fe_sq.c */; };
+		9F00E904223C1A9600EC1EF3 /* fe_sq2.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B8223A745B005CB63A /* fe_sq2.c */; };
+		9F00E905223C1A9600EC1EF3 /* fe_sub.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23A9223A745A005CB63A /* fe_sub.c */; };
+		9F00E906223C1A9600EC1EF3 /* fe_tobytes.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23D2223A745D005CB63A /* fe_tobytes.c */; };
+		9F00E907223C1A9600EC1EF3 /* ge_add.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23DA223A745D005CB63A /* ge_add.c */; };
+		9F00E908223C1AA500EC1EF3 /* ge_cmp.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23C0223A745B005CB63A /* ge_cmp.c */; };
+		9F00E909223C1AA500EC1EF3 /* ge_double_scalarmult.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23BA223A745B005CB63A /* ge_double_scalarmult.c */; };
+		9F00E90A223C1AA500EC1EF3 /* ge_frombytes_no_negate.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23D5223A745D005CB63A /* ge_frombytes_no_negate.c */; };
+		9F00E90B223C1AA500EC1EF3 /* ge_frombytes.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23A7223A745A005CB63A /* ge_frombytes.c */; };
+		9F00E90C223C1AA500EC1EF3 /* ge_madd.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23DB223A745D005CB63A /* ge_madd.c */; };
+		9F00E90D223C1AA500EC1EF3 /* ge_msub.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23C6223A745C005CB63A /* ge_msub.c */; };
+		9F00E90E223C1AA500EC1EF3 /* ge_p1p1_to_p2.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23CC223A745C005CB63A /* ge_p1p1_to_p2.c */; };
+		9F00E90F223C1AA500EC1EF3 /* ge_p1p1_to_p3.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23DC223A745D005CB63A /* ge_p1p1_to_p3.c */; };
+		9F00E910223C1AA500EC1EF3 /* ge_p2_0.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23D7223A745D005CB63A /* ge_p2_0.c */; };
+		9F00E911223C1AA500EC1EF3 /* ge_p2_dbl.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B4223A745B005CB63A /* ge_p2_dbl.c */; };
+		9F00E912223C1AB100EC1EF3 /* ge_p2_to_p3.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B2223A745A005CB63A /* ge_p2_to_p3.c */; };
+		9F00E913223C1AB100EC1EF3 /* ge_p3_0.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23BB223A745B005CB63A /* ge_p3_0.c */; };
+		9F00E914223C1AB100EC1EF3 /* ge_p3_dbl.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B0223A745A005CB63A /* ge_p3_dbl.c */; };
+		9F00E915223C1AB100EC1EF3 /* ge_p3_sub.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23AA223A745A005CB63A /* ge_p3_sub.c */; };
+		9F00E916223C1AB100EC1EF3 /* ge_p3_to_cached.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B7223A745B005CB63A /* ge_p3_to_cached.c */; };
+		9F00E917223C1AB100EC1EF3 /* ge_p3_to_p2.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23C7223A745C005CB63A /* ge_p3_to_p2.c */; };
+		9F00E918223C1AB100EC1EF3 /* ge_p3_tobytes.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23C9223A745C005CB63A /* ge_p3_tobytes.c */; };
+		9F00E919223C1AB100EC1EF3 /* ge_precomp_0.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23BF223A745B005CB63A /* ge_precomp_0.c */; };
+		9F00E91A223C1AB100EC1EF3 /* ge_scalarmult_base.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23DF223A745D005CB63A /* ge_scalarmult_base.c */; };
+		9F00E91B223C1AB100EC1EF3 /* ge_scalarmult.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23E1223A745E005CB63A /* ge_scalarmult.c */; };
+		9F00E91C223C1AB100EC1EF3 /* ge_sub.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B5223A745B005CB63A /* ge_sub.c */; };
+		9F00E91D223C1AB100EC1EF3 /* ge_tobytes.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23AD223A745A005CB63A /* ge_tobytes.c */; };
+		9F00E91E223C1AB100EC1EF3 /* gen_rand_32.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23D8223A745D005CB63A /* gen_rand_32.c */; };
+		9F00E91F223C1AB100EC1EF3 /* sc_muladd.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23CE223A745C005CB63A /* sc_muladd.c */; };
+		9F00E920223C1AB100EC1EF3 /* sc_reduce.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23C2223A745B005CB63A /* sc_reduce.c */; };
+		9F00E921223C1AC000EC1EF3 /* soter_asym_cipher.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A238F223A7426005CB63A /* soter_asym_cipher.c */; };
+		9F00E922223C1AC000EC1EF3 /* soter_asym_ka.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2388223A7425005CB63A /* soter_asym_ka.c */; };
+		9F00E923223C1AC000EC1EF3 /* soter_ec_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2392223A7426005CB63A /* soter_ec_key.c */; };
+		9F00E924223C1AC000EC1EF3 /* soter_ecdsa_common.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2387223A7425005CB63A /* soter_ecdsa_common.c */; };
+		9F00E925223C1AC000EC1EF3 /* soter_hash.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2390223A7426005CB63A /* soter_hash.c */; };
+		9F00E926223C1AC000EC1EF3 /* soter_rand.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A238E223A7426005CB63A /* soter_rand.c */; };
+		9F00E927223C1AC000EC1EF3 /* soter_rsa_common.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2386223A7425005CB63A /* soter_rsa_common.c */; };
+		9F00E928223C1AC000EC1EF3 /* soter_rsa_key_pair_gen.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A238A223A7425005CB63A /* soter_rsa_key_pair_gen.c */; };
+		9F00E929223C1AC000EC1EF3 /* soter_rsa_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2385223A7425005CB63A /* soter_rsa_key.c */; };
+		9F00E92A223C1AC000EC1EF3 /* soter_sign_ecdsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2389223A7425005CB63A /* soter_sign_ecdsa.c */; };
+		9F00E92B223C1AC000EC1EF3 /* soter_sign_rsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A238C223A7425005CB63A /* soter_sign_rsa.c */; };
+		9F00E92C223C1AC000EC1EF3 /* soter_sym.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2394223A7426005CB63A /* soter_sym.c */; };
+		9F00E92D223C1AC000EC1EF3 /* soter_verify_ecdsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2393223A7426005CB63A /* soter_verify_ecdsa.c */; };
+		9F00E92E223C1AC000EC1EF3 /* soter_verify_rsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A238D223A7426005CB63A /* soter_verify_rsa.c */; };
+		9F00E92F223C1ACF00EC1EF3 /* soter_container.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2348223A73B0005CB63A /* soter_container.c */; };
+		9F00E930223C1ACF00EC1EF3 /* soter_crc32.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A234D223A73B0005CB63A /* soter_crc32.c */; };
+		9F00E931223C1ACF00EC1EF3 /* soter_hmac.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2353223A73B1005CB63A /* soter_hmac.c */; };
+		9F00E932223C1ACF00EC1EF3 /* soter_kdf.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2357223A73B1005CB63A /* soter_kdf.c */; };
+		9F00E933223C1ACF00EC1EF3 /* soter_sign.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2351223A73B1005CB63A /* soter_sign.c */; };
+		9F00E934223C1AE600EC1EF3 /* message.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A242A223A74AF005CB63A /* message.c */; };
+		9F00E935223C1AE600EC1EF3 /* secure_cell.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A241E223A74AE005CB63A /* secure_cell.c */; };
+		9F00E936223C1AE600EC1EF3 /* secure_comparator.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2432223A74AF005CB63A /* secure_comparator.c */; };
+		9F00E937223C1AE600EC1EF3 /* secure_keygen.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2427223A74AE005CB63A /* secure_keygen.c */; };
+		9F00E938223C1AE600EC1EF3 /* secure_message_wrapper.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2422223A74AE005CB63A /* secure_message_wrapper.c */; };
+		9F00E939223C1AE600EC1EF3 /* secure_message.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2437223A74AF005CB63A /* secure_message.c */; };
+		9F00E93A223C1AE600EC1EF3 /* secure_session_message.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2435223A74AF005CB63A /* secure_session_message.c */; };
+		9F00E93B223C1AE600EC1EF3 /* secure_session_peer.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2429223A74AF005CB63A /* secure_session_peer.c */; };
+		9F00E93C223C1AE600EC1EF3 /* secure_session_serialize.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2425223A74AE005CB63A /* secure_session_serialize.c */; };
+		9F00E93D223C1AE600EC1EF3 /* secure_session_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A242E223A74AF005CB63A /* secure_session_utils.c */; };
+		9F00E93E223C1AE600EC1EF3 /* secure_session.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2438223A74AF005CB63A /* secure_session.c */; };
+		9F00E93F223C1AE600EC1EF3 /* sym_enc_message.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2431223A74AF005CB63A /* sym_enc_message.c */; };
+		9F00E941223C1AFA00EC1EF3 /* openssl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E940223C1AFA00EC1EF3 /* openssl.framework */; };
+		9F4A24C4223A8FA9005CB63A /* scell_seal.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24B0223A8FA7005CB63A /* scell_seal.m */; };
+		9F4A24C6223A8FA9005CB63A /* ssession_transport_interface.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24B2223A8FA7005CB63A /* ssession_transport_interface.m */; };
+		9F4A24C8223A8FA9005CB63A /* scell_context_imprint.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24B4223A8FA8005CB63A /* scell_context_imprint.m */; };
+		9F4A24CA223A8FA9005CB63A /* scomparator.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24B6223A8FA8005CB63A /* scomparator.m */; };
+		9F4A24CB223A8FA9005CB63A /* skeygen.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24B7223A8FA8005CB63A /* skeygen.m */; };
+		9F4A24CC223A8FA9005CB63A /* smessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24B8223A8FA8005CB63A /* smessage.m */; };
+		9F4A24CE223A8FA9005CB63A /* ssession.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24BA223A8FA8005CB63A /* ssession.m */; };
+		9F4A24D1223A8FA9005CB63A /* scell_token.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24BD223A8FA8005CB63A /* scell_token.m */; };
+		9F4A24D2223A8FA9005CB63A /* scell.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24BE223A8FA8005CB63A /* scell.m */; };
+		9F4A24DA223A918A005CB63A /* objcthemis.h in Headers: objcthemis */ = {isa = PBXBuildFile; fileRef = 9F4A24B5223A8FA8005CB63A /* objcthemis.h */; };
+		9F4A24DB223A918A005CB63A /* scell_context_imprint.h in Headers: objcthemis */ = {isa = PBXBuildFile; fileRef = 9F4A24B9223A8FA8005CB63A /* scell_context_imprint.h */; };
+		9F4A24DC223A918A005CB63A /* scell_seal.h in Headers: objcthemis */ = {isa = PBXBuildFile; fileRef = 9F4A24BC223A8FA8005CB63A /* scell_seal.h */; };
+		9F4A24DD223A918A005CB63A /* scell_token.h in Headers: objcthemis */ = {isa = PBXBuildFile; fileRef = 9F4A24C3223A8FA8005CB63A /* scell_token.h */; };
+		9F4A24DE223A918A005CB63A /* scell.h in Headers: objcthemis */ = {isa = PBXBuildFile; fileRef = 9F4A24B3223A8FA7005CB63A /* scell.h */; };
+		9F4A24DF223A918A005CB63A /* scomparator.h in Headers: objcthemis */ = {isa = PBXBuildFile; fileRef = 9F4A24C0223A8FA8005CB63A /* scomparator.h */; };
+		9F4A24E0223A918A005CB63A /* serror.h in Headers: objcthemis */ = {isa = PBXBuildFile; fileRef = 9F4A24BB223A8FA8005CB63A /* serror.h */; };
+		9F4A24E1223A918A005CB63A /* skeygen.h in Headers: objcthemis */ = {isa = PBXBuildFile; fileRef = 9F4A24C1223A8FA8005CB63A /* skeygen.h */; };
+		9F4A24E2223A918A005CB63A /* smessage.h in Headers: objcthemis */ = {isa = PBXBuildFile; fileRef = 9F4A24C2223A8FA8005CB63A /* smessage.h */; };
+		9F4A24E3223A918A005CB63A /* ssession_transport_interface.h in Headers: objcthemis */ = {isa = PBXBuildFile; fileRef = 9F4A24BF223A8FA8005CB63A /* ssession_transport_interface.h */; };
+		9F4A24E4223A918A005CB63A /* ssession.h in Headers: objcthemis */ = {isa = PBXBuildFile; fileRef = 9F4A24B1223A8FA7005CB63A /* ssession.h */; };
+		9F4A25DA223ABEB6005CB63A /* fe_0.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B3223A745B005CB63A /* fe_0.c */; };
+		9F4A25DB223ABEB6005CB63A /* fe_1.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23CF223A745C005CB63A /* fe_1.c */; };
+		9F4A25DC223ABEB6005CB63A /* fe_add.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B1223A745A005CB63A /* fe_add.c */; };
+		9F4A25DD223ABEB6005CB63A /* fe_cmov.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23A8223A745A005CB63A /* fe_cmov.c */; };
+		9F4A25DE223ABEB6005CB63A /* fe_copy.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B6223A745B005CB63A /* fe_copy.c */; };
+		9F4A25DF223ABEB6005CB63A /* fe_frombytes.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23AC223A745A005CB63A /* fe_frombytes.c */; };
+		9F4A25E0223ABEB6005CB63A /* fe_invert.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23D3223A745D005CB63A /* fe_invert.c */; };
+		9F4A25E1223ABEB6005CB63A /* fe_isnegative.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23BE223A745B005CB63A /* fe_isnegative.c */; };
+		9F4A25E2223ABEB6005CB63A /* fe_isnonzero.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B9223A745B005CB63A /* fe_isnonzero.c */; };
+		9F4A25E3223ABEB6005CB63A /* fe_mul.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23D1223A745C005CB63A /* fe_mul.c */; };
+		9F4A25E4223ABEB6005CB63A /* fe_neg.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23BC223A745B005CB63A /* fe_neg.c */; };
+		9F4A25E5223ABEB6005CB63A /* fe_pow22523.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23DD223A745D005CB63A /* fe_pow22523.c */; };
+		9F4A25E6223ABEB6005CB63A /* fe_sq.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23E0223A745D005CB63A /* fe_sq.c */; };
+		9F4A25E7223ABEB6005CB63A /* fe_sq2.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B8223A745B005CB63A /* fe_sq2.c */; };
+		9F4A25E8223ABEB6005CB63A /* fe_sub.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23A9223A745A005CB63A /* fe_sub.c */; };
+		9F4A25E9223ABEB6005CB63A /* fe_tobytes.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23D2223A745D005CB63A /* fe_tobytes.c */; };
+		9F4A25EA223ABEB6005CB63A /* ge_add.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23DA223A745D005CB63A /* ge_add.c */; };
+		9F4A25EB223ABEB6005CB63A /* ge_cmp.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23C0223A745B005CB63A /* ge_cmp.c */; };
+		9F4A25EC223ABEB6005CB63A /* ge_double_scalarmult.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23BA223A745B005CB63A /* ge_double_scalarmult.c */; };
+		9F4A25ED223ABEB6005CB63A /* ge_frombytes_no_negate.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23D5223A745D005CB63A /* ge_frombytes_no_negate.c */; };
+		9F4A25EE223ABEB6005CB63A /* ge_frombytes.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23A7223A745A005CB63A /* ge_frombytes.c */; };
+		9F4A25EF223ABEB6005CB63A /* ge_madd.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23DB223A745D005CB63A /* ge_madd.c */; };
+		9F4A25F0223ABEB6005CB63A /* ge_msub.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23C6223A745C005CB63A /* ge_msub.c */; };
+		9F4A25F1223ABEB6005CB63A /* ge_p1p1_to_p2.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23CC223A745C005CB63A /* ge_p1p1_to_p2.c */; };
+		9F4A25F2223ABEB6005CB63A /* ge_p1p1_to_p3.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23DC223A745D005CB63A /* ge_p1p1_to_p3.c */; };
+		9F4A25F3223ABEB6005CB63A /* ge_p2_0.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23D7223A745D005CB63A /* ge_p2_0.c */; };
+		9F4A25F4223ABEB6005CB63A /* ge_p2_dbl.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B4223A745B005CB63A /* ge_p2_dbl.c */; };
+		9F4A25F5223ABEB6005CB63A /* ge_p2_to_p3.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B2223A745A005CB63A /* ge_p2_to_p3.c */; };
+		9F4A25F6223ABEB6005CB63A /* ge_p3_0.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23BB223A745B005CB63A /* ge_p3_0.c */; };
+		9F4A25F7223ABEB6005CB63A /* ge_p3_dbl.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B0223A745A005CB63A /* ge_p3_dbl.c */; };
+		9F4A25F8223ABEB6005CB63A /* ge_p3_sub.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23AA223A745A005CB63A /* ge_p3_sub.c */; };
+		9F4A25F9223ABEB6005CB63A /* ge_p3_to_cached.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B7223A745B005CB63A /* ge_p3_to_cached.c */; };
+		9F4A25FA223ABEB6005CB63A /* ge_p3_to_p2.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23C7223A745C005CB63A /* ge_p3_to_p2.c */; };
+		9F4A25FB223ABEB6005CB63A /* ge_p3_tobytes.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23C9223A745C005CB63A /* ge_p3_tobytes.c */; };
+		9F4A25FC223ABEB6005CB63A /* ge_precomp_0.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23BF223A745B005CB63A /* ge_precomp_0.c */; };
+		9F4A25FD223ABEB6005CB63A /* ge_scalarmult_base.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23DF223A745D005CB63A /* ge_scalarmult_base.c */; };
+		9F4A25FE223ABEB6005CB63A /* ge_scalarmult.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23E1223A745E005CB63A /* ge_scalarmult.c */; };
+		9F4A25FF223ABEB6005CB63A /* ge_sub.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B5223A745B005CB63A /* ge_sub.c */; };
+		9F4A2600223ABEB6005CB63A /* ge_tobytes.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23AD223A745A005CB63A /* ge_tobytes.c */; };
+		9F4A2601223ABEB6005CB63A /* gen_rand_32.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23D8223A745D005CB63A /* gen_rand_32.c */; };
+		9F4A2602223ABEB6005CB63A /* sc_muladd.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23CE223A745C005CB63A /* sc_muladd.c */; };
+		9F4A2603223ABEB6005CB63A /* sc_reduce.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23C2223A745B005CB63A /* sc_reduce.c */; };
+		9F4A2604223ABECC005CB63A /* soter_asym_cipher.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A238F223A7426005CB63A /* soter_asym_cipher.c */; };
+		9F4A2605223ABECC005CB63A /* soter_asym_ka.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2388223A7425005CB63A /* soter_asym_ka.c */; };
+		9F4A2606223ABECC005CB63A /* soter_ec_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2392223A7426005CB63A /* soter_ec_key.c */; };
+		9F4A2607223ABECC005CB63A /* soter_ecdsa_common.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2387223A7425005CB63A /* soter_ecdsa_common.c */; };
+		9F4A2608223ABECC005CB63A /* soter_hash.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2390223A7426005CB63A /* soter_hash.c */; };
+		9F4A2609223ABECC005CB63A /* soter_rand.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A238E223A7426005CB63A /* soter_rand.c */; };
+		9F4A260A223ABECC005CB63A /* soter_rsa_common.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2386223A7425005CB63A /* soter_rsa_common.c */; };
+		9F4A260B223ABECC005CB63A /* soter_rsa_key_pair_gen.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A238A223A7425005CB63A /* soter_rsa_key_pair_gen.c */; };
+		9F4A260C223ABECC005CB63A /* soter_rsa_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2385223A7425005CB63A /* soter_rsa_key.c */; };
+		9F4A260D223ABECC005CB63A /* soter_sign_ecdsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2389223A7425005CB63A /* soter_sign_ecdsa.c */; };
+		9F4A260E223ABECC005CB63A /* soter_sign_rsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A238C223A7425005CB63A /* soter_sign_rsa.c */; };
+		9F4A260F223ABECC005CB63A /* soter_sym.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2394223A7426005CB63A /* soter_sym.c */; };
+		9F4A2610223ABECC005CB63A /* soter_verify_ecdsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2393223A7426005CB63A /* soter_verify_ecdsa.c */; };
+		9F4A2611223ABECC005CB63A /* soter_verify_rsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A238D223A7426005CB63A /* soter_verify_rsa.c */; };
+		9F4A2612223ABEDF005CB63A /* soter_container.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2348223A73B0005CB63A /* soter_container.c */; };
+		9F4A2613223ABEDF005CB63A /* soter_crc32.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A234D223A73B0005CB63A /* soter_crc32.c */; };
+		9F4A2614223ABEDF005CB63A /* soter_hmac.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2353223A73B1005CB63A /* soter_hmac.c */; };
+		9F4A2615223ABEDF005CB63A /* soter_kdf.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2357223A73B1005CB63A /* soter_kdf.c */; };
+		9F4A2616223ABEDF005CB63A /* soter_sign.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2351223A73B1005CB63A /* soter_sign.c */; };
+		9F4A2617223ABEF2005CB63A /* message.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A242A223A74AF005CB63A /* message.c */; };
+		9F4A2618223ABEF2005CB63A /* secure_cell.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A241E223A74AE005CB63A /* secure_cell.c */; };
+		9F4A2619223ABEF2005CB63A /* secure_comparator.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2432223A74AF005CB63A /* secure_comparator.c */; };
+		9F4A261A223ABEF2005CB63A /* secure_keygen.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2427223A74AE005CB63A /* secure_keygen.c */; };
+		9F4A261B223ABEF2005CB63A /* secure_message_wrapper.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2422223A74AE005CB63A /* secure_message_wrapper.c */; };
+		9F4A261C223ABEF2005CB63A /* secure_message.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2437223A74AF005CB63A /* secure_message.c */; };
+		9F4A261D223ABEF2005CB63A /* secure_session_message.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2435223A74AF005CB63A /* secure_session_message.c */; };
+		9F4A261E223ABEF2005CB63A /* secure_session_peer.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2429223A74AF005CB63A /* secure_session_peer.c */; };
+		9F4A261F223ABEF2005CB63A /* secure_session_serialize.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2425223A74AE005CB63A /* secure_session_serialize.c */; };
+		9F4A2620223ABEF2005CB63A /* secure_session_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A242E223A74AF005CB63A /* secure_session_utils.c */; };
+		9F4A2621223ABEF2005CB63A /* secure_session.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2438223A74AF005CB63A /* secure_session.c */; };
+		9F4A2622223ABEF2005CB63A /* sym_enc_message.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2431223A74AF005CB63A /* sym_enc_message.c */; };
+		9FBD853D223BFB5E009EAEB3 /* openssl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FBD853C223BFB5E009EAEB3 /* openssl.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		9F00E8E1223C1A0A00EC1EF3 /* Headers: objcthemis */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(PUBLIC_HEADERS_FOLDER_PATH)/objcthemis";
+			dstSubfolderSpec = 16;
+			files = (
+				9F00E8E2223C1A3300EC1EF3 /* objcthemis.h in Headers: objcthemis */,
+				9F00E8E3223C1A3300EC1EF3 /* scell_context_imprint.h in Headers: objcthemis */,
+				9F00E8E4223C1A3300EC1EF3 /* scell_seal.h in Headers: objcthemis */,
+				9F00E8E5223C1A3300EC1EF3 /* scell_token.h in Headers: objcthemis */,
+				9F00E8E6223C1A3300EC1EF3 /* scell.h in Headers: objcthemis */,
+				9F00E8E7223C1A3300EC1EF3 /* scomparator.h in Headers: objcthemis */,
+				9F00E8E8223C1A3300EC1EF3 /* serror.h in Headers: objcthemis */,
+				9F00E8E9223C1A3300EC1EF3 /* skeygen.h in Headers: objcthemis */,
+				9F00E8EA223C1A3300EC1EF3 /* smessage.h in Headers: objcthemis */,
+				9F00E8EB223C1A3300EC1EF3 /* ssession_transport_interface.h in Headers: objcthemis */,
+				9F00E8EC223C1A3300EC1EF3 /* ssession.h in Headers: objcthemis */,
+			);
+			name = "Headers: objcthemis";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9F4A24D9223A915E005CB63A /* Headers: objcthemis */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(PUBLIC_HEADERS_FOLDER_PATH)/objcthemis";
+			dstSubfolderSpec = 16;
+			files = (
+				9F4A24DA223A918A005CB63A /* objcthemis.h in Headers: objcthemis */,
+				9F4A24DB223A918A005CB63A /* scell_context_imprint.h in Headers: objcthemis */,
+				9F4A24DC223A918A005CB63A /* scell_seal.h in Headers: objcthemis */,
+				9F4A24DD223A918A005CB63A /* scell_token.h in Headers: objcthemis */,
+				9F4A24DE223A918A005CB63A /* scell.h in Headers: objcthemis */,
+				9F4A24DF223A918A005CB63A /* scomparator.h in Headers: objcthemis */,
+				9F4A24E0223A918A005CB63A /* serror.h in Headers: objcthemis */,
+				9F4A24E1223A918A005CB63A /* skeygen.h in Headers: objcthemis */,
+				9F4A24E2223A918A005CB63A /* smessage.h in Headers: objcthemis */,
+				9F4A24E3223A918A005CB63A /* ssession_transport_interface.h in Headers: objcthemis */,
+				9F4A24E4223A918A005CB63A /* ssession.h in Headers: objcthemis */,
+			);
+			name = "Headers: objcthemis";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		9F00E8D7223C197900EC1EF3 /* themis.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = themis.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9F00E940223C1AFA00EC1EF3 /* openssl.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = openssl.framework; path = Carthage/Build/Mac/openssl.framework; sourceTree = "<group>"; };
+		9F4A2342223A73B0005CB63A /* soter_hash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = soter_hash.h; path = src/soter/soter_hash.h; sourceTree = "<group>"; };
+		9F4A2343223A73B0005CB63A /* soter_asym_cipher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = soter_asym_cipher.h; path = src/soter/soter_asym_cipher.h; sourceTree = "<group>"; };
+		9F4A2344223A73B0005CB63A /* soter_sign_rsa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = soter_sign_rsa.h; path = src/soter/soter_sign_rsa.h; sourceTree = "<group>"; };
+		9F4A2345223A73B0005CB63A /* soter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = soter.h; path = src/soter/soter.h; sourceTree = "<group>"; };
+		9F4A2346223A73B0005CB63A /* soter_t.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = soter_t.h; path = src/soter/soter_t.h; sourceTree = "<group>"; };
+		9F4A2347223A73B0005CB63A /* soter_rsa_key.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = soter_rsa_key.h; path = src/soter/soter_rsa_key.h; sourceTree = "<group>"; };
+		9F4A2348223A73B0005CB63A /* soter_container.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = soter_container.c; path = src/soter/soter_container.c; sourceTree = "<group>"; };
+		9F4A2349223A73B0005CB63A /* soter_hmac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = soter_hmac.h; path = src/soter/soter_hmac.h; sourceTree = "<group>"; };
+		9F4A234A223A73B0005CB63A /* soter_rsa_key_pair_gen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = soter_rsa_key_pair_gen.h; path = src/soter/soter_rsa_key_pair_gen.h; sourceTree = "<group>"; };
+		9F4A234B223A73B0005CB63A /* soter_asym_ka.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = soter_asym_ka.h; path = src/soter/soter_asym_ka.h; sourceTree = "<group>"; };
+		9F4A234C223A73B0005CB63A /* soter_error.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = soter_error.h; path = src/soter/soter_error.h; sourceTree = "<group>"; };
+		9F4A234D223A73B0005CB63A /* soter_crc32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = soter_crc32.c; path = src/soter/soter_crc32.c; sourceTree = "<group>"; };
+		9F4A234E223A73B0005CB63A /* soter_crc32.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = soter_crc32.h; path = src/soter/soter_crc32.h; sourceTree = "<group>"; };
+		9F4A234F223A73B1005CB63A /* soter_kdf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = soter_kdf.h; path = src/soter/soter_kdf.h; sourceTree = "<group>"; };
+		9F4A2350223A73B1005CB63A /* soter_asym_sign.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = soter_asym_sign.h; path = src/soter/soter_asym_sign.h; sourceTree = "<group>"; };
+		9F4A2351223A73B1005CB63A /* soter_sign.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = soter_sign.c; path = src/soter/soter_sign.c; sourceTree = "<group>"; };
+		9F4A2352223A73B1005CB63A /* soter_ec_key.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = soter_ec_key.h; path = src/soter/soter_ec_key.h; sourceTree = "<group>"; };
+		9F4A2353223A73B1005CB63A /* soter_hmac.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = soter_hmac.c; path = src/soter/soter_hmac.c; sourceTree = "<group>"; };
+		9F4A2354223A73B1005CB63A /* soter_rand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = soter_rand.h; path = src/soter/soter_rand.h; sourceTree = "<group>"; };
+		9F4A2355223A73B1005CB63A /* soter_sign_ecdsa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = soter_sign_ecdsa.h; path = src/soter/soter_sign_ecdsa.h; sourceTree = "<group>"; };
+		9F4A2356223A73B1005CB63A /* soter_sym.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = soter_sym.h; path = src/soter/soter_sym.h; sourceTree = "<group>"; };
+		9F4A2357223A73B1005CB63A /* soter_kdf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = soter_kdf.c; path = src/soter/soter_kdf.c; sourceTree = "<group>"; };
+		9F4A2358223A73B1005CB63A /* soter_container.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = soter_container.h; path = src/soter/soter_container.h; sourceTree = "<group>"; };
+		9F4A2384223A7425005CB63A /* soter_ecdsa_common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = soter_ecdsa_common.h; path = src/soter/openssl/soter_ecdsa_common.h; sourceTree = "<group>"; };
+		9F4A2385223A7425005CB63A /* soter_rsa_key.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = soter_rsa_key.c; path = src/soter/openssl/soter_rsa_key.c; sourceTree = "<group>"; };
+		9F4A2386223A7425005CB63A /* soter_rsa_common.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = soter_rsa_common.c; path = src/soter/openssl/soter_rsa_common.c; sourceTree = "<group>"; };
+		9F4A2387223A7425005CB63A /* soter_ecdsa_common.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = soter_ecdsa_common.c; path = src/soter/openssl/soter_ecdsa_common.c; sourceTree = "<group>"; };
+		9F4A2388223A7425005CB63A /* soter_asym_ka.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = soter_asym_ka.c; path = src/soter/openssl/soter_asym_ka.c; sourceTree = "<group>"; };
+		9F4A2389223A7425005CB63A /* soter_sign_ecdsa.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = soter_sign_ecdsa.c; path = src/soter/openssl/soter_sign_ecdsa.c; sourceTree = "<group>"; };
+		9F4A238A223A7425005CB63A /* soter_rsa_key_pair_gen.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = soter_rsa_key_pair_gen.c; path = src/soter/openssl/soter_rsa_key_pair_gen.c; sourceTree = "<group>"; };
+		9F4A238B223A7425005CB63A /* soter_engine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = soter_engine.h; path = src/soter/openssl/soter_engine.h; sourceTree = "<group>"; };
+		9F4A238C223A7425005CB63A /* soter_sign_rsa.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = soter_sign_rsa.c; path = src/soter/openssl/soter_sign_rsa.c; sourceTree = "<group>"; };
+		9F4A238D223A7426005CB63A /* soter_verify_rsa.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = soter_verify_rsa.c; path = src/soter/openssl/soter_verify_rsa.c; sourceTree = "<group>"; };
+		9F4A238E223A7426005CB63A /* soter_rand.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = soter_rand.c; path = src/soter/openssl/soter_rand.c; sourceTree = "<group>"; };
+		9F4A238F223A7426005CB63A /* soter_asym_cipher.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = soter_asym_cipher.c; path = src/soter/openssl/soter_asym_cipher.c; sourceTree = "<group>"; };
+		9F4A2390223A7426005CB63A /* soter_hash.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = soter_hash.c; path = src/soter/openssl/soter_hash.c; sourceTree = "<group>"; };
+		9F4A2391223A7426005CB63A /* soter_rsa_common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = soter_rsa_common.h; path = src/soter/openssl/soter_rsa_common.h; sourceTree = "<group>"; };
+		9F4A2392223A7426005CB63A /* soter_ec_key.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = soter_ec_key.c; path = src/soter/openssl/soter_ec_key.c; sourceTree = "<group>"; };
+		9F4A2393223A7426005CB63A /* soter_verify_ecdsa.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = soter_verify_ecdsa.c; path = src/soter/openssl/soter_verify_ecdsa.c; sourceTree = "<group>"; };
+		9F4A2394223A7426005CB63A /* soter_sym.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = soter_sym.c; path = src/soter/openssl/soter_sym.c; sourceTree = "<group>"; };
+		9F4A23A7223A745A005CB63A /* ge_frombytes.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ge_frombytes.c; path = src/soter/ed25519/ge_frombytes.c; sourceTree = "<group>"; };
+		9F4A23A8223A745A005CB63A /* fe_cmov.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fe_cmov.c; path = src/soter/ed25519/fe_cmov.c; sourceTree = "<group>"; };
+		9F4A23A9223A745A005CB63A /* fe_sub.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fe_sub.c; path = src/soter/ed25519/fe_sub.c; sourceTree = "<group>"; };
+		9F4A23AA223A745A005CB63A /* ge_p3_sub.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ge_p3_sub.c; path = src/soter/ed25519/ge_p3_sub.c; sourceTree = "<group>"; };
+		9F4A23AB223A745A005CB63A /* ge_p2_dbl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ge_p2_dbl.h; path = src/soter/ed25519/ge_p2_dbl.h; sourceTree = "<group>"; };
+		9F4A23AC223A745A005CB63A /* fe_frombytes.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fe_frombytes.c; path = src/soter/ed25519/fe_frombytes.c; sourceTree = "<group>"; };
+		9F4A23AD223A745A005CB63A /* ge_tobytes.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ge_tobytes.c; path = src/soter/ed25519/ge_tobytes.c; sourceTree = "<group>"; };
+		9F4A23AE223A745A005CB63A /* pow22523.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pow22523.h; path = src/soter/ed25519/pow22523.h; sourceTree = "<group>"; };
+		9F4A23AF223A745A005CB63A /* pow225521.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pow225521.h; path = src/soter/ed25519/pow225521.h; sourceTree = "<group>"; };
+		9F4A23B0223A745A005CB63A /* ge_p3_dbl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ge_p3_dbl.c; path = src/soter/ed25519/ge_p3_dbl.c; sourceTree = "<group>"; };
+		9F4A23B1223A745A005CB63A /* fe_add.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fe_add.c; path = src/soter/ed25519/fe_add.c; sourceTree = "<group>"; };
+		9F4A23B2223A745A005CB63A /* ge_p2_to_p3.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ge_p2_to_p3.c; path = src/soter/ed25519/ge_p2_to_p3.c; sourceTree = "<group>"; };
+		9F4A23B3223A745B005CB63A /* fe_0.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fe_0.c; path = src/soter/ed25519/fe_0.c; sourceTree = "<group>"; };
+		9F4A23B4223A745B005CB63A /* ge_p2_dbl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ge_p2_dbl.c; path = src/soter/ed25519/ge_p2_dbl.c; sourceTree = "<group>"; };
+		9F4A23B5223A745B005CB63A /* ge_sub.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ge_sub.c; path = src/soter/ed25519/ge_sub.c; sourceTree = "<group>"; };
+		9F4A23B6223A745B005CB63A /* fe_copy.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fe_copy.c; path = src/soter/ed25519/fe_copy.c; sourceTree = "<group>"; };
+		9F4A23B7223A745B005CB63A /* ge_p3_to_cached.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ge_p3_to_cached.c; path = src/soter/ed25519/ge_p3_to_cached.c; sourceTree = "<group>"; };
+		9F4A23B8223A745B005CB63A /* fe_sq2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fe_sq2.c; path = src/soter/ed25519/fe_sq2.c; sourceTree = "<group>"; };
+		9F4A23B9223A745B005CB63A /* fe_isnonzero.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fe_isnonzero.c; path = src/soter/ed25519/fe_isnonzero.c; sourceTree = "<group>"; };
+		9F4A23BA223A745B005CB63A /* ge_double_scalarmult.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ge_double_scalarmult.c; path = src/soter/ed25519/ge_double_scalarmult.c; sourceTree = "<group>"; };
+		9F4A23BB223A745B005CB63A /* ge_p3_0.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ge_p3_0.c; path = src/soter/ed25519/ge_p3_0.c; sourceTree = "<group>"; };
+		9F4A23BC223A745B005CB63A /* fe_neg.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fe_neg.c; path = src/soter/ed25519/fe_neg.c; sourceTree = "<group>"; };
+		9F4A23BD223A745B005CB63A /* d2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = d2.h; path = src/soter/ed25519/d2.h; sourceTree = "<group>"; };
+		9F4A23BE223A745B005CB63A /* fe_isnegative.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fe_isnegative.c; path = src/soter/ed25519/fe_isnegative.c; sourceTree = "<group>"; };
+		9F4A23BF223A745B005CB63A /* ge_precomp_0.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ge_precomp_0.c; path = src/soter/ed25519/ge_precomp_0.c; sourceTree = "<group>"; };
+		9F4A23C0223A745B005CB63A /* ge_cmp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ge_cmp.c; path = src/soter/ed25519/ge_cmp.c; sourceTree = "<group>"; };
+		9F4A23C1223A745B005CB63A /* ge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ge.h; path = src/soter/ed25519/ge.h; sourceTree = "<group>"; };
+		9F4A23C2223A745B005CB63A /* sc_reduce.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sc_reduce.c; path = src/soter/ed25519/sc_reduce.c; sourceTree = "<group>"; };
+		9F4A23C3223A745B005CB63A /* sc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sc.h; path = src/soter/ed25519/sc.h; sourceTree = "<group>"; };
+		9F4A23C4223A745C005CB63A /* sqrtm1.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sqrtm1.h; path = src/soter/ed25519/sqrtm1.h; sourceTree = "<group>"; };
+		9F4A23C5223A745C005CB63A /* ge_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ge_utils.h; path = src/soter/ed25519/ge_utils.h; sourceTree = "<group>"; };
+		9F4A23C6223A745C005CB63A /* ge_msub.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ge_msub.c; path = src/soter/ed25519/ge_msub.c; sourceTree = "<group>"; };
+		9F4A23C7223A745C005CB63A /* ge_p3_to_p2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ge_p3_to_p2.c; path = src/soter/ed25519/ge_p3_to_p2.c; sourceTree = "<group>"; };
+		9F4A23C8223A745C005CB63A /* base2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = base2.h; path = src/soter/ed25519/base2.h; sourceTree = "<group>"; };
+		9F4A23C9223A745C005CB63A /* ge_p3_tobytes.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ge_p3_tobytes.c; path = src/soter/ed25519/ge_p3_tobytes.c; sourceTree = "<group>"; };
+		9F4A23CA223A745C005CB63A /* ge_sub.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ge_sub.h; path = src/soter/ed25519/ge_sub.h; sourceTree = "<group>"; };
+		9F4A23CB223A745C005CB63A /* ge_add.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ge_add.h; path = src/soter/ed25519/ge_add.h; sourceTree = "<group>"; };
+		9F4A23CC223A745C005CB63A /* ge_p1p1_to_p2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ge_p1p1_to_p2.c; path = src/soter/ed25519/ge_p1p1_to_p2.c; sourceTree = "<group>"; };
+		9F4A23CD223A745C005CB63A /* ge_madd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ge_madd.h; path = src/soter/ed25519/ge_madd.h; sourceTree = "<group>"; };
+		9F4A23CE223A745C005CB63A /* sc_muladd.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sc_muladd.c; path = src/soter/ed25519/sc_muladd.c; sourceTree = "<group>"; };
+		9F4A23CF223A745C005CB63A /* fe_1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fe_1.c; path = src/soter/ed25519/fe_1.c; sourceTree = "<group>"; };
+		9F4A23D0223A745C005CB63A /* ge_msub.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ge_msub.h; path = src/soter/ed25519/ge_msub.h; sourceTree = "<group>"; };
+		9F4A23D1223A745C005CB63A /* fe_mul.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fe_mul.c; path = src/soter/ed25519/fe_mul.c; sourceTree = "<group>"; };
+		9F4A23D2223A745D005CB63A /* fe_tobytes.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fe_tobytes.c; path = src/soter/ed25519/fe_tobytes.c; sourceTree = "<group>"; };
+		9F4A23D3223A745D005CB63A /* fe_invert.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fe_invert.c; path = src/soter/ed25519/fe_invert.c; sourceTree = "<group>"; };
+		9F4A23D4223A745D005CB63A /* base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = base.h; path = src/soter/ed25519/base.h; sourceTree = "<group>"; };
+		9F4A23D5223A745D005CB63A /* ge_frombytes_no_negate.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ge_frombytes_no_negate.c; path = src/soter/ed25519/ge_frombytes_no_negate.c; sourceTree = "<group>"; };
+		9F4A23D6223A745D005CB63A /* api.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = api.h; path = src/soter/ed25519/api.h; sourceTree = "<group>"; };
+		9F4A23D7223A745D005CB63A /* ge_p2_0.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ge_p2_0.c; path = src/soter/ed25519/ge_p2_0.c; sourceTree = "<group>"; };
+		9F4A23D8223A745D005CB63A /* gen_rand_32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = gen_rand_32.c; path = src/soter/ed25519/gen_rand_32.c; sourceTree = "<group>"; };
+		9F4A23D9223A745D005CB63A /* d.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = d.h; path = src/soter/ed25519/d.h; sourceTree = "<group>"; };
+		9F4A23DA223A745D005CB63A /* ge_add.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ge_add.c; path = src/soter/ed25519/ge_add.c; sourceTree = "<group>"; };
+		9F4A23DB223A745D005CB63A /* ge_madd.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ge_madd.c; path = src/soter/ed25519/ge_madd.c; sourceTree = "<group>"; };
+		9F4A23DC223A745D005CB63A /* ge_p1p1_to_p3.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ge_p1p1_to_p3.c; path = src/soter/ed25519/ge_p1p1_to_p3.c; sourceTree = "<group>"; };
+		9F4A23DD223A745D005CB63A /* fe_pow22523.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fe_pow22523.c; path = src/soter/ed25519/fe_pow22523.c; sourceTree = "<group>"; };
+		9F4A23DE223A745D005CB63A /* fe.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fe.h; path = src/soter/ed25519/fe.h; sourceTree = "<group>"; };
+		9F4A23DF223A745D005CB63A /* ge_scalarmult_base.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ge_scalarmult_base.c; path = src/soter/ed25519/ge_scalarmult_base.c; sourceTree = "<group>"; };
+		9F4A23E0223A745D005CB63A /* fe_sq.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fe_sq.c; path = src/soter/ed25519/fe_sq.c; sourceTree = "<group>"; };
+		9F4A23E1223A745E005CB63A /* ge_scalarmult.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ge_scalarmult.c; path = src/soter/ed25519/ge_scalarmult.c; sourceTree = "<group>"; };
+		9F4A241E223A74AE005CB63A /* secure_cell.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = secure_cell.c; path = src/themis/secure_cell.c; sourceTree = "<group>"; };
+		9F4A241F223A74AE005CB63A /* secure_comparator_t.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = secure_comparator_t.h; path = src/themis/secure_comparator_t.h; sourceTree = "<group>"; };
+		9F4A2420223A74AE005CB63A /* secure_message_wrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = secure_message_wrapper.h; path = src/themis/secure_message_wrapper.h; sourceTree = "<group>"; };
+		9F4A2421223A74AE005CB63A /* secure_message.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = secure_message.h; path = src/themis/secure_message.h; sourceTree = "<group>"; };
+		9F4A2422223A74AE005CB63A /* secure_message_wrapper.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = secure_message_wrapper.c; path = src/themis/secure_message_wrapper.c; sourceTree = "<group>"; };
+		9F4A2423223A74AE005CB63A /* portable_endian.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = portable_endian.h; path = src/themis/portable_endian.h; sourceTree = "<group>"; };
+		9F4A2424223A74AE005CB63A /* secure_keygen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = secure_keygen.h; path = src/themis/secure_keygen.h; sourceTree = "<group>"; };
+		9F4A2425223A74AE005CB63A /* secure_session_serialize.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = secure_session_serialize.c; path = src/themis/secure_session_serialize.c; sourceTree = "<group>"; };
+		9F4A2426223A74AE005CB63A /* secure_session_t.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = secure_session_t.h; path = src/themis/secure_session_t.h; sourceTree = "<group>"; };
+		9F4A2427223A74AE005CB63A /* secure_keygen.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = secure_keygen.c; path = src/themis/secure_keygen.c; sourceTree = "<group>"; };
+		9F4A2428223A74AE005CB63A /* secure_session_peer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = secure_session_peer.h; path = src/themis/secure_session_peer.h; sourceTree = "<group>"; };
+		9F4A2429223A74AF005CB63A /* secure_session_peer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = secure_session_peer.c; path = src/themis/secure_session_peer.c; sourceTree = "<group>"; };
+		9F4A242A223A74AF005CB63A /* message.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = message.c; path = src/themis/message.c; sourceTree = "<group>"; };
+		9F4A242B223A74AF005CB63A /* sym_enc_message.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sym_enc_message.h; path = src/themis/sym_enc_message.h; sourceTree = "<group>"; };
+		9F4A242C223A74AF005CB63A /* secure_cell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = secure_cell.h; path = src/themis/secure_cell.h; sourceTree = "<group>"; };
+		9F4A242D223A74AF005CB63A /* secure_session.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = secure_session.h; path = src/themis/secure_session.h; sourceTree = "<group>"; };
+		9F4A242E223A74AF005CB63A /* secure_session_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = secure_session_utils.c; path = src/themis/secure_session_utils.c; sourceTree = "<group>"; };
+		9F4A242F223A74AF005CB63A /* themis_error.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = themis_error.h; path = src/themis/themis_error.h; sourceTree = "<group>"; };
+		9F4A2430223A74AF005CB63A /* secure_cell_alg.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = secure_cell_alg.h; path = src/themis/secure_cell_alg.h; sourceTree = "<group>"; };
+		9F4A2431223A74AF005CB63A /* sym_enc_message.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sym_enc_message.c; path = src/themis/sym_enc_message.c; sourceTree = "<group>"; };
+		9F4A2432223A74AF005CB63A /* secure_comparator.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = secure_comparator.c; path = src/themis/secure_comparator.c; sourceTree = "<group>"; };
+		9F4A2433223A74AF005CB63A /* themis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = themis.h; path = src/themis/themis.h; sourceTree = "<group>"; };
+		9F4A2434223A74AF005CB63A /* secure_comparator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = secure_comparator.h; path = src/themis/secure_comparator.h; sourceTree = "<group>"; };
+		9F4A2435223A74AF005CB63A /* secure_session_message.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = secure_session_message.c; path = src/themis/secure_session_message.c; sourceTree = "<group>"; };
+		9F4A2436223A74AF005CB63A /* message.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = message.h; path = src/themis/message.h; sourceTree = "<group>"; };
+		9F4A2437223A74AF005CB63A /* secure_message.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = secure_message.c; path = src/themis/secure_message.c; sourceTree = "<group>"; };
+		9F4A2438223A74AF005CB63A /* secure_session.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = secure_session.c; path = src/themis/secure_session.c; sourceTree = "<group>"; };
+		9F4A2439223A74AF005CB63A /* secure_session_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = secure_session_utils.h; path = src/themis/secure_session_utils.h; sourceTree = "<group>"; };
+		9F4A24A1223A8D7F005CB63A /* themis.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = themis.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9F4A24AA223A8E15005CB63A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = "src/wrappers/themis/Obj-C/Themis/Info.plist"; sourceTree = "<group>"; };
+		9F4A24AB223A8E15005CB63A /* themis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = themis.h; path = "src/wrappers/themis/Obj-C/Themis/themis.h"; sourceTree = "<group>"; };
+		9F4A24B0223A8FA7005CB63A /* scell_seal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = scell_seal.m; path = "src/wrappers/themis/Obj-C/objcthemis/scell_seal.m"; sourceTree = "<group>"; };
+		9F4A24B1223A8FA7005CB63A /* ssession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ssession.h; path = "src/wrappers/themis/Obj-C/objcthemis/ssession.h"; sourceTree = "<group>"; };
+		9F4A24B2223A8FA7005CB63A /* ssession_transport_interface.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ssession_transport_interface.m; path = "src/wrappers/themis/Obj-C/objcthemis/ssession_transport_interface.m"; sourceTree = "<group>"; };
+		9F4A24B3223A8FA7005CB63A /* scell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = scell.h; path = "src/wrappers/themis/Obj-C/objcthemis/scell.h"; sourceTree = "<group>"; };
+		9F4A24B4223A8FA8005CB63A /* scell_context_imprint.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = scell_context_imprint.m; path = "src/wrappers/themis/Obj-C/objcthemis/scell_context_imprint.m"; sourceTree = "<group>"; };
+		9F4A24B5223A8FA8005CB63A /* objcthemis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = objcthemis.h; path = "src/wrappers/themis/Obj-C/objcthemis/objcthemis.h"; sourceTree = "<group>"; };
+		9F4A24B6223A8FA8005CB63A /* scomparator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = scomparator.m; path = "src/wrappers/themis/Obj-C/objcthemis/scomparator.m"; sourceTree = "<group>"; };
+		9F4A24B7223A8FA8005CB63A /* skeygen.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = skeygen.m; path = "src/wrappers/themis/Obj-C/objcthemis/skeygen.m"; sourceTree = "<group>"; };
+		9F4A24B8223A8FA8005CB63A /* smessage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = smessage.m; path = "src/wrappers/themis/Obj-C/objcthemis/smessage.m"; sourceTree = "<group>"; };
+		9F4A24B9223A8FA8005CB63A /* scell_context_imprint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = scell_context_imprint.h; path = "src/wrappers/themis/Obj-C/objcthemis/scell_context_imprint.h"; sourceTree = "<group>"; };
+		9F4A24BA223A8FA8005CB63A /* ssession.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ssession.m; path = "src/wrappers/themis/Obj-C/objcthemis/ssession.m"; sourceTree = "<group>"; };
+		9F4A24BB223A8FA8005CB63A /* serror.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = serror.h; path = "src/wrappers/themis/Obj-C/objcthemis/serror.h"; sourceTree = "<group>"; };
+		9F4A24BC223A8FA8005CB63A /* scell_seal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = scell_seal.h; path = "src/wrappers/themis/Obj-C/objcthemis/scell_seal.h"; sourceTree = "<group>"; };
+		9F4A24BD223A8FA8005CB63A /* scell_token.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = scell_token.m; path = "src/wrappers/themis/Obj-C/objcthemis/scell_token.m"; sourceTree = "<group>"; };
+		9F4A24BE223A8FA8005CB63A /* scell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = scell.m; path = "src/wrappers/themis/Obj-C/objcthemis/scell.m"; sourceTree = "<group>"; };
+		9F4A24BF223A8FA8005CB63A /* ssession_transport_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ssession_transport_interface.h; path = "src/wrappers/themis/Obj-C/objcthemis/ssession_transport_interface.h"; sourceTree = "<group>"; };
+		9F4A24C0223A8FA8005CB63A /* scomparator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = scomparator.h; path = "src/wrappers/themis/Obj-C/objcthemis/scomparator.h"; sourceTree = "<group>"; };
+		9F4A24C1223A8FA8005CB63A /* skeygen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = skeygen.h; path = "src/wrappers/themis/Obj-C/objcthemis/skeygen.h"; sourceTree = "<group>"; };
+		9F4A24C2223A8FA8005CB63A /* smessage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = smessage.h; path = "src/wrappers/themis/Obj-C/objcthemis/smessage.h"; sourceTree = "<group>"; };
+		9F4A24C3223A8FA8005CB63A /* scell_token.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = scell_token.h; path = "src/wrappers/themis/Obj-C/objcthemis/scell_token.h"; sourceTree = "<group>"; };
+		9FBD853C223BFB5E009EAEB3 /* openssl.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = openssl.framework; path = Carthage/Build/iOS/openssl.framework; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		9F00E8D4223C197900EC1EF3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9F00E941223C1AFA00EC1EF3 /* openssl.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9F4A249E223A8D7F005CB63A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9FBD853D223BFB5E009EAEB3 /* openssl.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		738B81052239809D00A9947C = {
+			isa = PBXGroup;
+			children = (
+				9F4A24A9223A8E01005CB63A /* Themis */,
+				738B81102239809D00A9947C /* Products */,
+				9F4A2476223A885F005CB63A /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		738B81102239809D00A9947C /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				9F4A24A1223A8D7F005CB63A /* themis.framework */,
+				9F00E8D7223C197900EC1EF3 /* themis.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		9F4A2370223A73B6005CB63A /* soter */ = {
+			isa = PBXGroup;
+			children = (
+				9F4A23A6223A742F005CB63A /* ed25519 */,
+				9F4A2383223A740E005CB63A /* openssl */,
+				9F4A2343223A73B0005CB63A /* soter_asym_cipher.h */,
+				9F4A234B223A73B0005CB63A /* soter_asym_ka.h */,
+				9F4A2350223A73B1005CB63A /* soter_asym_sign.h */,
+				9F4A2348223A73B0005CB63A /* soter_container.c */,
+				9F4A2358223A73B1005CB63A /* soter_container.h */,
+				9F4A234D223A73B0005CB63A /* soter_crc32.c */,
+				9F4A234E223A73B0005CB63A /* soter_crc32.h */,
+				9F4A2352223A73B1005CB63A /* soter_ec_key.h */,
+				9F4A234C223A73B0005CB63A /* soter_error.h */,
+				9F4A2342223A73B0005CB63A /* soter_hash.h */,
+				9F4A2353223A73B1005CB63A /* soter_hmac.c */,
+				9F4A2349223A73B0005CB63A /* soter_hmac.h */,
+				9F4A2357223A73B1005CB63A /* soter_kdf.c */,
+				9F4A234F223A73B1005CB63A /* soter_kdf.h */,
+				9F4A2354223A73B1005CB63A /* soter_rand.h */,
+				9F4A234A223A73B0005CB63A /* soter_rsa_key_pair_gen.h */,
+				9F4A2347223A73B0005CB63A /* soter_rsa_key.h */,
+				9F4A2355223A73B1005CB63A /* soter_sign_ecdsa.h */,
+				9F4A2344223A73B0005CB63A /* soter_sign_rsa.h */,
+				9F4A2351223A73B1005CB63A /* soter_sign.c */,
+				9F4A2356223A73B1005CB63A /* soter_sym.h */,
+				9F4A2346223A73B0005CB63A /* soter_t.h */,
+				9F4A2345223A73B0005CB63A /* soter.h */,
+			);
+			name = soter;
+			sourceTree = "<group>";
+		};
+		9F4A2383223A740E005CB63A /* openssl */ = {
+			isa = PBXGroup;
+			children = (
+				9F4A238F223A7426005CB63A /* soter_asym_cipher.c */,
+				9F4A2388223A7425005CB63A /* soter_asym_ka.c */,
+				9F4A2392223A7426005CB63A /* soter_ec_key.c */,
+				9F4A2387223A7425005CB63A /* soter_ecdsa_common.c */,
+				9F4A2384223A7425005CB63A /* soter_ecdsa_common.h */,
+				9F4A238B223A7425005CB63A /* soter_engine.h */,
+				9F4A2390223A7426005CB63A /* soter_hash.c */,
+				9F4A238E223A7426005CB63A /* soter_rand.c */,
+				9F4A2386223A7425005CB63A /* soter_rsa_common.c */,
+				9F4A2391223A7426005CB63A /* soter_rsa_common.h */,
+				9F4A238A223A7425005CB63A /* soter_rsa_key_pair_gen.c */,
+				9F4A2385223A7425005CB63A /* soter_rsa_key.c */,
+				9F4A2389223A7425005CB63A /* soter_sign_ecdsa.c */,
+				9F4A238C223A7425005CB63A /* soter_sign_rsa.c */,
+				9F4A2394223A7426005CB63A /* soter_sym.c */,
+				9F4A2393223A7426005CB63A /* soter_verify_ecdsa.c */,
+				9F4A238D223A7426005CB63A /* soter_verify_rsa.c */,
+			);
+			name = openssl;
+			sourceTree = "<group>";
+		};
+		9F4A23A6223A742F005CB63A /* ed25519 */ = {
+			isa = PBXGroup;
+			children = (
+				9F4A23D6223A745D005CB63A /* api.h */,
+				9F4A23D4223A745D005CB63A /* base.h */,
+				9F4A23C8223A745C005CB63A /* base2.h */,
+				9F4A23D9223A745D005CB63A /* d.h */,
+				9F4A23BD223A745B005CB63A /* d2.h */,
+				9F4A23B3223A745B005CB63A /* fe_0.c */,
+				9F4A23CF223A745C005CB63A /* fe_1.c */,
+				9F4A23B1223A745A005CB63A /* fe_add.c */,
+				9F4A23A8223A745A005CB63A /* fe_cmov.c */,
+				9F4A23B6223A745B005CB63A /* fe_copy.c */,
+				9F4A23AC223A745A005CB63A /* fe_frombytes.c */,
+				9F4A23D3223A745D005CB63A /* fe_invert.c */,
+				9F4A23BE223A745B005CB63A /* fe_isnegative.c */,
+				9F4A23B9223A745B005CB63A /* fe_isnonzero.c */,
+				9F4A23D1223A745C005CB63A /* fe_mul.c */,
+				9F4A23BC223A745B005CB63A /* fe_neg.c */,
+				9F4A23DD223A745D005CB63A /* fe_pow22523.c */,
+				9F4A23E0223A745D005CB63A /* fe_sq.c */,
+				9F4A23B8223A745B005CB63A /* fe_sq2.c */,
+				9F4A23A9223A745A005CB63A /* fe_sub.c */,
+				9F4A23D2223A745D005CB63A /* fe_tobytes.c */,
+				9F4A23DE223A745D005CB63A /* fe.h */,
+				9F4A23DA223A745D005CB63A /* ge_add.c */,
+				9F4A23CB223A745C005CB63A /* ge_add.h */,
+				9F4A23C0223A745B005CB63A /* ge_cmp.c */,
+				9F4A23BA223A745B005CB63A /* ge_double_scalarmult.c */,
+				9F4A23D5223A745D005CB63A /* ge_frombytes_no_negate.c */,
+				9F4A23A7223A745A005CB63A /* ge_frombytes.c */,
+				9F4A23DB223A745D005CB63A /* ge_madd.c */,
+				9F4A23CD223A745C005CB63A /* ge_madd.h */,
+				9F4A23C6223A745C005CB63A /* ge_msub.c */,
+				9F4A23D0223A745C005CB63A /* ge_msub.h */,
+				9F4A23CC223A745C005CB63A /* ge_p1p1_to_p2.c */,
+				9F4A23DC223A745D005CB63A /* ge_p1p1_to_p3.c */,
+				9F4A23D7223A745D005CB63A /* ge_p2_0.c */,
+				9F4A23B4223A745B005CB63A /* ge_p2_dbl.c */,
+				9F4A23AB223A745A005CB63A /* ge_p2_dbl.h */,
+				9F4A23B2223A745A005CB63A /* ge_p2_to_p3.c */,
+				9F4A23BB223A745B005CB63A /* ge_p3_0.c */,
+				9F4A23B0223A745A005CB63A /* ge_p3_dbl.c */,
+				9F4A23AA223A745A005CB63A /* ge_p3_sub.c */,
+				9F4A23B7223A745B005CB63A /* ge_p3_to_cached.c */,
+				9F4A23C7223A745C005CB63A /* ge_p3_to_p2.c */,
+				9F4A23C9223A745C005CB63A /* ge_p3_tobytes.c */,
+				9F4A23BF223A745B005CB63A /* ge_precomp_0.c */,
+				9F4A23DF223A745D005CB63A /* ge_scalarmult_base.c */,
+				9F4A23E1223A745E005CB63A /* ge_scalarmult.c */,
+				9F4A23B5223A745B005CB63A /* ge_sub.c */,
+				9F4A23CA223A745C005CB63A /* ge_sub.h */,
+				9F4A23AD223A745A005CB63A /* ge_tobytes.c */,
+				9F4A23C5223A745C005CB63A /* ge_utils.h */,
+				9F4A23C1223A745B005CB63A /* ge.h */,
+				9F4A23D8223A745D005CB63A /* gen_rand_32.c */,
+				9F4A23AE223A745A005CB63A /* pow22523.h */,
+				9F4A23AF223A745A005CB63A /* pow225521.h */,
+				9F4A23CE223A745C005CB63A /* sc_muladd.c */,
+				9F4A23C2223A745B005CB63A /* sc_reduce.c */,
+				9F4A23C3223A745B005CB63A /* sc.h */,
+				9F4A23C4223A745C005CB63A /* sqrtm1.h */,
+			);
+			name = ed25519;
+			sourceTree = "<group>";
+		};
+		9F4A241D223A7493005CB63A /* themis */ = {
+			isa = PBXGroup;
+			children = (
+				9F4A242A223A74AF005CB63A /* message.c */,
+				9F4A2436223A74AF005CB63A /* message.h */,
+				9F4A2423223A74AE005CB63A /* portable_endian.h */,
+				9F4A2430223A74AF005CB63A /* secure_cell_alg.h */,
+				9F4A241E223A74AE005CB63A /* secure_cell.c */,
+				9F4A242C223A74AF005CB63A /* secure_cell.h */,
+				9F4A241F223A74AE005CB63A /* secure_comparator_t.h */,
+				9F4A2432223A74AF005CB63A /* secure_comparator.c */,
+				9F4A2434223A74AF005CB63A /* secure_comparator.h */,
+				9F4A2427223A74AE005CB63A /* secure_keygen.c */,
+				9F4A2424223A74AE005CB63A /* secure_keygen.h */,
+				9F4A2422223A74AE005CB63A /* secure_message_wrapper.c */,
+				9F4A2420223A74AE005CB63A /* secure_message_wrapper.h */,
+				9F4A2437223A74AF005CB63A /* secure_message.c */,
+				9F4A2421223A74AE005CB63A /* secure_message.h */,
+				9F4A2435223A74AF005CB63A /* secure_session_message.c */,
+				9F4A2429223A74AF005CB63A /* secure_session_peer.c */,
+				9F4A2428223A74AE005CB63A /* secure_session_peer.h */,
+				9F4A2425223A74AE005CB63A /* secure_session_serialize.c */,
+				9F4A2426223A74AE005CB63A /* secure_session_t.h */,
+				9F4A242E223A74AF005CB63A /* secure_session_utils.c */,
+				9F4A2439223A74AF005CB63A /* secure_session_utils.h */,
+				9F4A2438223A74AF005CB63A /* secure_session.c */,
+				9F4A242D223A74AF005CB63A /* secure_session.h */,
+				9F4A2431223A74AF005CB63A /* sym_enc_message.c */,
+				9F4A242B223A74AF005CB63A /* sym_enc_message.h */,
+				9F4A242F223A74AF005CB63A /* themis_error.h */,
+				9F4A2433223A74AF005CB63A /* themis.h */,
+			);
+			name = themis;
+			sourceTree = "<group>";
+		};
+		9F4A2476223A885F005CB63A /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				9F00E940223C1AFA00EC1EF3 /* openssl.framework */,
+				9FBD853C223BFB5E009EAEB3 /* openssl.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		9F4A24A9223A8E01005CB63A /* Themis */ = {
+			isa = PBXGroup;
+			children = (
+				9F4A24AF223A8F85005CB63A /* objcthemis */,
+				9F4A2370223A73B6005CB63A /* soter */,
+				9F4A241D223A7493005CB63A /* themis */,
+				9F4A24AA223A8E15005CB63A /* Info.plist */,
+				9F4A24AB223A8E15005CB63A /* themis.h */,
+			);
+			name = Themis;
+			sourceTree = "<group>";
+		};
+		9F4A24AF223A8F85005CB63A /* objcthemis */ = {
+			isa = PBXGroup;
+			children = (
+				9F4A24B5223A8FA8005CB63A /* objcthemis.h */,
+				9F4A24B9223A8FA8005CB63A /* scell_context_imprint.h */,
+				9F4A24B4223A8FA8005CB63A /* scell_context_imprint.m */,
+				9F4A24BC223A8FA8005CB63A /* scell_seal.h */,
+				9F4A24B0223A8FA7005CB63A /* scell_seal.m */,
+				9F4A24C3223A8FA8005CB63A /* scell_token.h */,
+				9F4A24BD223A8FA8005CB63A /* scell_token.m */,
+				9F4A24B3223A8FA7005CB63A /* scell.h */,
+				9F4A24BE223A8FA8005CB63A /* scell.m */,
+				9F4A24C0223A8FA8005CB63A /* scomparator.h */,
+				9F4A24B6223A8FA8005CB63A /* scomparator.m */,
+				9F4A24BB223A8FA8005CB63A /* serror.h */,
+				9F4A24C1223A8FA8005CB63A /* skeygen.h */,
+				9F4A24B7223A8FA8005CB63A /* skeygen.m */,
+				9F4A24C2223A8FA8005CB63A /* smessage.h */,
+				9F4A24B8223A8FA8005CB63A /* smessage.m */,
+				9F4A24BF223A8FA8005CB63A /* ssession_transport_interface.h */,
+				9F4A24B2223A8FA7005CB63A /* ssession_transport_interface.m */,
+				9F4A24B1223A8FA7005CB63A /* ssession.h */,
+				9F4A24BA223A8FA8005CB63A /* ssession.m */,
+			);
+			name = objcthemis;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		9F00E8D2223C197900EC1EF3 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9F00E8E0223C19E000EC1EF3 /* themis.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9F4A249C223A8D7F005CB63A /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9F00E8DF223C19D900EC1EF3 /* themis.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		9F00E8D6223C197900EC1EF3 /* Themis (macOS) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9F00E8DE223C197A00EC1EF3 /* Build configuration list for PBXNativeTarget "Themis (macOS)" */;
+			buildPhases = (
+				9F00E8D2223C197900EC1EF3 /* Headers */,
+				9F00E8E1223C1A0A00EC1EF3 /* Headers: objcthemis */,
+				9F00E8D3223C197900EC1EF3 /* Sources */,
+				9F00E8D4223C197900EC1EF3 /* Frameworks */,
+				9F00E8D5223C197900EC1EF3 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Themis (macOS)";
+			productName = "Themis (macOS)";
+			productReference = 9F00E8D7223C197900EC1EF3 /* themis.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		9F4A24A0223A8D7F005CB63A /* Themis (iOS) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9F4A24A6223A8D7F005CB63A /* Build configuration list for PBXNativeTarget "Themis (iOS)" */;
+			buildPhases = (
+				9F4A249C223A8D7F005CB63A /* Headers */,
+				9F4A24D9223A915E005CB63A /* Headers: objcthemis */,
+				9F4A249D223A8D7F005CB63A /* Sources */,
+				9F4A249E223A8D7F005CB63A /* Frameworks */,
+				9F4A249F223A8D7F005CB63A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Themis (iOS)";
+			productName = Themis;
+			productReference = 9F4A24A1223A8D7F005CB63A /* themis.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		738B81062239809D00A9947C /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1010;
+				ORGANIZATIONNAME = "Cossack Labs";
+				TargetAttributes = {
+					9F00E8D6223C197900EC1EF3 = {
+						CreatedOnToolsVersion = 10.1;
+					};
+					9F4A24A0223A8D7F005CB63A = {
+						CreatedOnToolsVersion = 10.1;
+					};
+				};
+			};
+			buildConfigurationList = 738B81092239809D00A9947C /* Build configuration list for PBXProject "Themis" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 738B81052239809D00A9947C;
+			productRefGroup = 738B81102239809D00A9947C /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				9F4A24A0223A8D7F005CB63A /* Themis (iOS) */,
+				9F00E8D6223C197900EC1EF3 /* Themis (macOS) */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		9F00E8D5223C197900EC1EF3 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9F4A249F223A8D7F005CB63A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		9F00E8D3223C197900EC1EF3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9F00E934223C1AE600EC1EF3 /* message.c in Sources */,
+				9F00E935223C1AE600EC1EF3 /* secure_cell.c in Sources */,
+				9F00E936223C1AE600EC1EF3 /* secure_comparator.c in Sources */,
+				9F00E937223C1AE600EC1EF3 /* secure_keygen.c in Sources */,
+				9F00E938223C1AE600EC1EF3 /* secure_message_wrapper.c in Sources */,
+				9F00E939223C1AE600EC1EF3 /* secure_message.c in Sources */,
+				9F00E93A223C1AE600EC1EF3 /* secure_session_message.c in Sources */,
+				9F00E93B223C1AE600EC1EF3 /* secure_session_peer.c in Sources */,
+				9F00E93C223C1AE600EC1EF3 /* secure_session_serialize.c in Sources */,
+				9F00E93D223C1AE600EC1EF3 /* secure_session_utils.c in Sources */,
+				9F00E93E223C1AE600EC1EF3 /* secure_session.c in Sources */,
+				9F00E93F223C1AE600EC1EF3 /* sym_enc_message.c in Sources */,
+				9F00E92F223C1ACF00EC1EF3 /* soter_container.c in Sources */,
+				9F00E930223C1ACF00EC1EF3 /* soter_crc32.c in Sources */,
+				9F00E931223C1ACF00EC1EF3 /* soter_hmac.c in Sources */,
+				9F00E932223C1ACF00EC1EF3 /* soter_kdf.c in Sources */,
+				9F00E933223C1ACF00EC1EF3 /* soter_sign.c in Sources */,
+				9F00E921223C1AC000EC1EF3 /* soter_asym_cipher.c in Sources */,
+				9F00E922223C1AC000EC1EF3 /* soter_asym_ka.c in Sources */,
+				9F00E923223C1AC000EC1EF3 /* soter_ec_key.c in Sources */,
+				9F00E924223C1AC000EC1EF3 /* soter_ecdsa_common.c in Sources */,
+				9F00E925223C1AC000EC1EF3 /* soter_hash.c in Sources */,
+				9F00E926223C1AC000EC1EF3 /* soter_rand.c in Sources */,
+				9F00E927223C1AC000EC1EF3 /* soter_rsa_common.c in Sources */,
+				9F00E928223C1AC000EC1EF3 /* soter_rsa_key_pair_gen.c in Sources */,
+				9F00E929223C1AC000EC1EF3 /* soter_rsa_key.c in Sources */,
+				9F00E92A223C1AC000EC1EF3 /* soter_sign_ecdsa.c in Sources */,
+				9F00E92B223C1AC000EC1EF3 /* soter_sign_rsa.c in Sources */,
+				9F00E92C223C1AC000EC1EF3 /* soter_sym.c in Sources */,
+				9F00E92D223C1AC000EC1EF3 /* soter_verify_ecdsa.c in Sources */,
+				9F00E92E223C1AC000EC1EF3 /* soter_verify_rsa.c in Sources */,
+				9F00E912223C1AB100EC1EF3 /* ge_p2_to_p3.c in Sources */,
+				9F00E913223C1AB100EC1EF3 /* ge_p3_0.c in Sources */,
+				9F00E914223C1AB100EC1EF3 /* ge_p3_dbl.c in Sources */,
+				9F00E915223C1AB100EC1EF3 /* ge_p3_sub.c in Sources */,
+				9F00E916223C1AB100EC1EF3 /* ge_p3_to_cached.c in Sources */,
+				9F00E917223C1AB100EC1EF3 /* ge_p3_to_p2.c in Sources */,
+				9F00E918223C1AB100EC1EF3 /* ge_p3_tobytes.c in Sources */,
+				9F00E919223C1AB100EC1EF3 /* ge_precomp_0.c in Sources */,
+				9F00E91A223C1AB100EC1EF3 /* ge_scalarmult_base.c in Sources */,
+				9F00E91B223C1AB100EC1EF3 /* ge_scalarmult.c in Sources */,
+				9F00E91C223C1AB100EC1EF3 /* ge_sub.c in Sources */,
+				9F00E91D223C1AB100EC1EF3 /* ge_tobytes.c in Sources */,
+				9F00E91E223C1AB100EC1EF3 /* gen_rand_32.c in Sources */,
+				9F00E91F223C1AB100EC1EF3 /* sc_muladd.c in Sources */,
+				9F00E920223C1AB100EC1EF3 /* sc_reduce.c in Sources */,
+				9F00E908223C1AA500EC1EF3 /* ge_cmp.c in Sources */,
+				9F00E909223C1AA500EC1EF3 /* ge_double_scalarmult.c in Sources */,
+				9F00E90A223C1AA500EC1EF3 /* ge_frombytes_no_negate.c in Sources */,
+				9F00E90B223C1AA500EC1EF3 /* ge_frombytes.c in Sources */,
+				9F00E90C223C1AA500EC1EF3 /* ge_madd.c in Sources */,
+				9F00E90D223C1AA500EC1EF3 /* ge_msub.c in Sources */,
+				9F00E90E223C1AA500EC1EF3 /* ge_p1p1_to_p2.c in Sources */,
+				9F00E90F223C1AA500EC1EF3 /* ge_p1p1_to_p3.c in Sources */,
+				9F00E910223C1AA500EC1EF3 /* ge_p2_0.c in Sources */,
+				9F00E911223C1AA500EC1EF3 /* ge_p2_dbl.c in Sources */,
+				9F00E8F7223C1A9600EC1EF3 /* fe_0.c in Sources */,
+				9F00E8F8223C1A9600EC1EF3 /* fe_1.c in Sources */,
+				9F00E8F9223C1A9600EC1EF3 /* fe_add.c in Sources */,
+				9F00E8FA223C1A9600EC1EF3 /* fe_cmov.c in Sources */,
+				9F00E8FB223C1A9600EC1EF3 /* fe_copy.c in Sources */,
+				9F00E8FC223C1A9600EC1EF3 /* fe_frombytes.c in Sources */,
+				9F00E8FD223C1A9600EC1EF3 /* fe_invert.c in Sources */,
+				9F00E8FE223C1A9600EC1EF3 /* fe_isnegative.c in Sources */,
+				9F00E8FF223C1A9600EC1EF3 /* fe_isnonzero.c in Sources */,
+				9F00E900223C1A9600EC1EF3 /* fe_mul.c in Sources */,
+				9F00E901223C1A9600EC1EF3 /* fe_neg.c in Sources */,
+				9F00E902223C1A9600EC1EF3 /* fe_pow22523.c in Sources */,
+				9F00E903223C1A9600EC1EF3 /* fe_sq.c in Sources */,
+				9F00E904223C1A9600EC1EF3 /* fe_sq2.c in Sources */,
+				9F00E905223C1A9600EC1EF3 /* fe_sub.c in Sources */,
+				9F00E906223C1A9600EC1EF3 /* fe_tobytes.c in Sources */,
+				9F00E907223C1A9600EC1EF3 /* ge_add.c in Sources */,
+				9F00E8EE223C1A8C00EC1EF3 /* scell_context_imprint.m in Sources */,
+				9F00E8EF223C1A8C00EC1EF3 /* scell_seal.m in Sources */,
+				9F00E8F0223C1A8C00EC1EF3 /* scell_token.m in Sources */,
+				9F00E8F1223C1A8C00EC1EF3 /* scell.m in Sources */,
+				9F00E8F2223C1A8C00EC1EF3 /* scomparator.m in Sources */,
+				9F00E8F3223C1A8C00EC1EF3 /* skeygen.m in Sources */,
+				9F00E8F4223C1A8C00EC1EF3 /* smessage.m in Sources */,
+				9F00E8F5223C1A8C00EC1EF3 /* ssession_transport_interface.m in Sources */,
+				9F00E8F6223C1A8C00EC1EF3 /* ssession.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9F4A249D223A8D7F005CB63A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9F4A2617223ABEF2005CB63A /* message.c in Sources */,
+				9F4A2618223ABEF2005CB63A /* secure_cell.c in Sources */,
+				9F4A2619223ABEF2005CB63A /* secure_comparator.c in Sources */,
+				9F4A261A223ABEF2005CB63A /* secure_keygen.c in Sources */,
+				9F4A261B223ABEF2005CB63A /* secure_message_wrapper.c in Sources */,
+				9F4A261C223ABEF2005CB63A /* secure_message.c in Sources */,
+				9F4A261D223ABEF2005CB63A /* secure_session_message.c in Sources */,
+				9F4A261E223ABEF2005CB63A /* secure_session_peer.c in Sources */,
+				9F4A261F223ABEF2005CB63A /* secure_session_serialize.c in Sources */,
+				9F4A2620223ABEF2005CB63A /* secure_session_utils.c in Sources */,
+				9F4A2621223ABEF2005CB63A /* secure_session.c in Sources */,
+				9F4A2622223ABEF2005CB63A /* sym_enc_message.c in Sources */,
+				9F4A2612223ABEDF005CB63A /* soter_container.c in Sources */,
+				9F4A2613223ABEDF005CB63A /* soter_crc32.c in Sources */,
+				9F4A2614223ABEDF005CB63A /* soter_hmac.c in Sources */,
+				9F4A2615223ABEDF005CB63A /* soter_kdf.c in Sources */,
+				9F4A2616223ABEDF005CB63A /* soter_sign.c in Sources */,
+				9F4A2604223ABECC005CB63A /* soter_asym_cipher.c in Sources */,
+				9F4A2605223ABECC005CB63A /* soter_asym_ka.c in Sources */,
+				9F4A2606223ABECC005CB63A /* soter_ec_key.c in Sources */,
+				9F4A2607223ABECC005CB63A /* soter_ecdsa_common.c in Sources */,
+				9F4A2608223ABECC005CB63A /* soter_hash.c in Sources */,
+				9F4A2609223ABECC005CB63A /* soter_rand.c in Sources */,
+				9F4A260A223ABECC005CB63A /* soter_rsa_common.c in Sources */,
+				9F4A260B223ABECC005CB63A /* soter_rsa_key_pair_gen.c in Sources */,
+				9F4A260C223ABECC005CB63A /* soter_rsa_key.c in Sources */,
+				9F4A260D223ABECC005CB63A /* soter_sign_ecdsa.c in Sources */,
+				9F4A260E223ABECC005CB63A /* soter_sign_rsa.c in Sources */,
+				9F4A260F223ABECC005CB63A /* soter_sym.c in Sources */,
+				9F4A2610223ABECC005CB63A /* soter_verify_ecdsa.c in Sources */,
+				9F4A2611223ABECC005CB63A /* soter_verify_rsa.c in Sources */,
+				9F4A25DA223ABEB6005CB63A /* fe_0.c in Sources */,
+				9F4A25DB223ABEB6005CB63A /* fe_1.c in Sources */,
+				9F4A25DC223ABEB6005CB63A /* fe_add.c in Sources */,
+				9F4A25DD223ABEB6005CB63A /* fe_cmov.c in Sources */,
+				9F4A25DE223ABEB6005CB63A /* fe_copy.c in Sources */,
+				9F4A25DF223ABEB6005CB63A /* fe_frombytes.c in Sources */,
+				9F4A25E0223ABEB6005CB63A /* fe_invert.c in Sources */,
+				9F4A25E1223ABEB6005CB63A /* fe_isnegative.c in Sources */,
+				9F4A25E2223ABEB6005CB63A /* fe_isnonzero.c in Sources */,
+				9F4A25E3223ABEB6005CB63A /* fe_mul.c in Sources */,
+				9F4A25E4223ABEB6005CB63A /* fe_neg.c in Sources */,
+				9F4A25E5223ABEB6005CB63A /* fe_pow22523.c in Sources */,
+				9F4A25E6223ABEB6005CB63A /* fe_sq.c in Sources */,
+				9F4A25E7223ABEB6005CB63A /* fe_sq2.c in Sources */,
+				9F4A25E8223ABEB6005CB63A /* fe_sub.c in Sources */,
+				9F4A25E9223ABEB6005CB63A /* fe_tobytes.c in Sources */,
+				9F4A25EA223ABEB6005CB63A /* ge_add.c in Sources */,
+				9F4A25EB223ABEB6005CB63A /* ge_cmp.c in Sources */,
+				9F4A25EC223ABEB6005CB63A /* ge_double_scalarmult.c in Sources */,
+				9F4A25ED223ABEB6005CB63A /* ge_frombytes_no_negate.c in Sources */,
+				9F4A25EE223ABEB6005CB63A /* ge_frombytes.c in Sources */,
+				9F4A25EF223ABEB6005CB63A /* ge_madd.c in Sources */,
+				9F4A25F0223ABEB6005CB63A /* ge_msub.c in Sources */,
+				9F4A25F1223ABEB6005CB63A /* ge_p1p1_to_p2.c in Sources */,
+				9F4A25F2223ABEB6005CB63A /* ge_p1p1_to_p3.c in Sources */,
+				9F4A25F3223ABEB6005CB63A /* ge_p2_0.c in Sources */,
+				9F4A25F4223ABEB6005CB63A /* ge_p2_dbl.c in Sources */,
+				9F4A25F5223ABEB6005CB63A /* ge_p2_to_p3.c in Sources */,
+				9F4A25F6223ABEB6005CB63A /* ge_p3_0.c in Sources */,
+				9F4A25F7223ABEB6005CB63A /* ge_p3_dbl.c in Sources */,
+				9F4A25F8223ABEB6005CB63A /* ge_p3_sub.c in Sources */,
+				9F4A25F9223ABEB6005CB63A /* ge_p3_to_cached.c in Sources */,
+				9F4A25FA223ABEB6005CB63A /* ge_p3_to_p2.c in Sources */,
+				9F4A25FB223ABEB6005CB63A /* ge_p3_tobytes.c in Sources */,
+				9F4A25FC223ABEB6005CB63A /* ge_precomp_0.c in Sources */,
+				9F4A25FD223ABEB6005CB63A /* ge_scalarmult_base.c in Sources */,
+				9F4A25FE223ABEB6005CB63A /* ge_scalarmult.c in Sources */,
+				9F4A25FF223ABEB6005CB63A /* ge_sub.c in Sources */,
+				9F4A2600223ABEB6005CB63A /* ge_tobytes.c in Sources */,
+				9F4A2601223ABEB6005CB63A /* gen_rand_32.c in Sources */,
+				9F4A2602223ABEB6005CB63A /* sc_muladd.c in Sources */,
+				9F4A2603223ABEB6005CB63A /* sc_reduce.c in Sources */,
+				9F4A24D2223A8FA9005CB63A /* scell.m in Sources */,
+				9F4A24C6223A8FA9005CB63A /* ssession_transport_interface.m in Sources */,
+				9F4A24CC223A8FA9005CB63A /* smessage.m in Sources */,
+				9F4A24CE223A8FA9005CB63A /* ssession.m in Sources */,
+				9F4A24D1223A8FA9005CB63A /* scell_token.m in Sources */,
+				9F4A24C8223A8FA9005CB63A /* scell_context_imprint.m in Sources */,
+				9F4A24C4223A8FA9005CB63A /* scell_seal.m in Sources */,
+				9F4A24CB223A8FA9005CB63A /* skeygen.m in Sources */,
+				9F4A24CA223A8FA9005CB63A /* scomparator.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		738B81152239809D00A9947C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		738B81162239809D00A9947C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		9F00E8DC223C197A00EC1EF3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
+				FRAMEWORK_VERSION = A;
+				HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/src",
+					"$(PROJECT_DIR)/src/wrappers/themis/Obj-C",
+				);
+				INFOPLIST_FILE = "src/wrappers/themis/Obj-c/Themis/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis.Themis;
+				PRODUCT_NAME = themis;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		9F00E8DD223C197A00EC1EF3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
+				FRAMEWORK_VERSION = A;
+				HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/src",
+					"$(PROJECT_DIR)/src/wrappers/themis/Obj-C",
+				);
+				INFOPLIST_FILE = "src/wrappers/themis/Obj-c/Themis/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis.Themis;
+				PRODUCT_NAME = themis;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		9F4A24A7223A8D7F005CB63A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/src",
+					"$(PROJECT_DIR)/src/wrappers/themis/Obj-C",
+				);
+				INFOPLIST_FILE = "src/wrappers/themis/Obj-c/Themis/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis.Themis;
+				PRODUCT_NAME = themis;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		9F4A24A8223A8D7F005CB63A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/src",
+					"$(PROJECT_DIR)/src/wrappers/themis/Obj-C",
+				);
+				INFOPLIST_FILE = "src/wrappers/themis/Obj-c/Themis/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis.Themis;
+				PRODUCT_NAME = themis;
+				SKIP_INSTALL = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		738B81092239809D00A9947C /* Build configuration list for PBXProject "Themis" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				738B81152239809D00A9947C /* Debug */,
+				738B81162239809D00A9947C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9F00E8DE223C197A00EC1EF3 /* Build configuration list for PBXNativeTarget "Themis (macOS)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9F00E8DC223C197A00EC1EF3 /* Debug */,
+				9F00E8DD223C197A00EC1EF3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9F4A24A6223A8D7F005CB63A /* Build configuration list for PBXNativeTarget "Themis (iOS)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9F4A24A7223A8D7F005CB63A /* Debug */,
+				9F4A24A8223A8D7F005CB63A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 738B81062239809D00A9947C /* Project object */;
+}

--- a/Themis.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Themis.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:themis.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Themis.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Themis.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Themis.xcodeproj/xcshareddata/xcschemes/Themis (iOS).xcscheme
+++ b/Themis.xcodeproj/xcshareddata/xcschemes/Themis (iOS).xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9F4A24A0223A8D7F005CB63A"
+               BuildableName = "themis.framework"
+               BlueprintName = "Themis (iOS)"
+               ReferencedContainer = "container:Themis.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "738B810E2239809D00A9947C"
+            BuildableName = "ThemisCore.framework"
+            BlueprintName = "ThemisCore"
+            ReferencedContainer = "container:Themis.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9F4A24A0223A8D7F005CB63A"
+            BuildableName = "themis.framework"
+            BlueprintName = "Themis (iOS)"
+            ReferencedContainer = "container:Themis.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Themis.xcodeproj/xcshareddata/xcschemes/Themis (macOS).xcscheme
+++ b/Themis.xcodeproj/xcshareddata/xcschemes/Themis (macOS).xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9F00E8D6223C197900EC1EF3"
+               BuildableName = "themis.framework"
+               BlueprintName = "Themis (macOS)"
+               ReferencedContainer = "container:Themis.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9F00E8D6223C197900EC1EF3"
+            BuildableName = "themis.framework"
+            BlueprintName = "Themis (macOS)"
+            ReferencedContainer = "container:Themis.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9F00E8D6223C197900EC1EF3"
+            BuildableName = "themis.framework"
+            BlueprintName = "Themis (macOS)"
+            ReferencedContainer = "container:Themis.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/src/wrappers/themis/Obj-C/Themis/Info.plist
+++ b/src/wrappers/themis/Obj-C/Themis/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.10.5</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/src/wrappers/themis/Obj-C/Themis/themis.h
+++ b/src/wrappers/themis/Obj-C/Themis/themis.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2019 Cossack Labs Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for Themis.
+FOUNDATION_EXPORT double themisVersionNumber;
+
+//! Project version string for Themis.
+FOUNDATION_EXPORT const unsigned char themisVersionString[];
+
+#import "objcthemis/objcthemis.h"


### PR DESCRIPTION
This adds an Xcode project to build Themis, enabling distribution via Carthage. This requires an Xcode project in the root repo directory with shared build schemes.

<img width="442" alt="Xcode project structure" src="https://user-images.githubusercontent.com/1256587/54609765-42392a00-4a5c-11e9-8606-d9a32a62938f.png">

### Build structure

As it was easier to do, and as it probably provides better debug information for Xcode users, Themis build for Xcode is a completely new one. We *do not* (re)use existing Makefiles, but this should be possible in theory. However, currently the Xcode project replicates the existing build and compiles Soter, Themis, and Obj-C Themis files manually.

Themis is compiled with OpenSSL as a backend. We pull in the dependency via Carthage as well. Currently we use our own fork of the library, but later it will be updated to the proper upstream once Carthage support lands there.

The project file provides two distinct targets and build schemes: for macOS and iOS, and their frameworks have slightly different structure. Though, we reuse as many files as possible. For example, the umbrella header Themis.h is the same for both platforms. Note that the build schemes are *shared*. This is important for Cartage.

Actual framework names are in lowercase: **themis.framework**. This is for compatibility with existing CocoaPods builds which use such naming.

<img width="560" alt="Info.plist and code signing" src="https://user-images.githubusercontent.com/1256587/54609794-4e24ec00-4a5c-11e9-83ef-e61c9030f4da.png">

We do not code-sign the resulting frameworks. It is expected that the applications using Themis will sign all external framework code that they use.

Finally, framework bundles use 'stuttering' identifiers `com.cossacklabs.themis.Themis`. This is because later we will need to name our documentation examples and it would be nice to put them under the same namespace "com.cossacklabs.themis".

The framework version is provisional 0.10.5 (which is actually a preview of 0.11).

### How to test this

Before building Themis you have to pull in dependencies (OpenSSL):

```
carthage bootstrap
```

After that you can proceed with building via Xcode.

Alternatively, you can use Carthage for testing the command-line build:

```
carthage build --no-skip-current
```

Examples that actually use Carthage build will be added soon in a separate PR.

### File layout and maintenance

New files and their functions:

- `Cartfile` — list of our Carthage dependencies
- `Cartfile.resolved` — 'lock file' that pins specific versions of dependencies
- `Themis.xcodeproj/` — directory with all Xcode project stuff
- `src/wrappers/themis/Obj-C/Themis/Info.plist` — framework Info.plist file
- `src/wrappers/themis/Obj-C/Themis/themis.h` — framework umbrella header file

If you wish to update dependencies:

- you may need to update `Cartfile`
- run `carthage update` to pull in new versions and update the lock file
- commit both `Cartfile` _and_ `Cartfile.resolved`

If you wish to update Themis framework version then edit it in `Info.plist`.

Carthage uses git tags to manage package versions, so every official Themis release is simultaneously a new Carthage version.