### PR TITLE
Drop SECURE_COMPARATOR_ENABLED usage

### DIFF
--- a/docs/examples/objc/iOS-CocoaPods/Podfile
+++ b/docs/examples/objc/iOS-CocoaPods/Podfile
@@ -26,12 +26,3 @@ target :"ThemisTest" do
   pod 'themis', '0.10.4'
 
 end
-
-post_install do |installer_representation|
-    installer_representation.pods_project.targets.each do |target|
-        target.build_configurations.each do |config|
-            config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)']
-            config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'SECURE_COMPARATOR_ENABLED'
-        end
-    end
-end

--- a/docs/examples/objc/iOS-CocoaPods/ThemisTest/ThemisTest/Classes/AppDelegate.m
+++ b/docs/examples/objc/iOS-CocoaPods/ThemisTest/ThemisTest/Classes/AppDelegate.m
@@ -17,10 +17,6 @@
 #import "AppDelegate.h"
 #import <objcthemis/objcthemis.h>
 
-#define SECURE_COMPARATOR_ENABLED
-#import <objcthemis/scomparator.h>
-
-
 @interface AppDelegate ()
 
 @end

--- a/docs/examples/swift/iOS-CocoaPods/Podfile
+++ b/docs/examples/swift/iOS-CocoaPods/Podfile
@@ -27,13 +27,3 @@ target :"ThemisSwift" do
   pod 'themis', '0.10.4'
 
 end
-
-
-post_install do |installer_representation|
-    installer_representation.pods_project.targets.each do |target|
-        target.build_configurations.each do |config|
-            config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)']
-            config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'SECURE_COMPARATOR_ENABLED'
-        end
-    end
-end

--- a/tests/objcthemis/Podfile
+++ b/tests/objcthemis/Podfile
@@ -32,13 +32,3 @@ target "objthemis_boring" do
   pod 'themis/themis-boringssl', :git => "https://github.com/cossacklabs/themis.git"
 
 end
-
-
-post_install do |installer_representation|
-    installer_representation.pods_project.targets.each do |target|
-        target.build_configurations.each do |config|
-            config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)']
-            config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'SECURE_COMPARATOR_ENABLED'
-        end
-    end
-end

--- a/tests/objcthemis/objthemis/SecureComparatorTests.m
+++ b/tests/objcthemis/objthemis/SecureComparatorTests.m
@@ -8,11 +8,6 @@
 #import <XCTest/XCTest.h>
 #import <objcthemis/objcthemis.h>
 
-
-#define SECURE_COMPARATOR_ENABLED
-#import <objcthemis/scomparator.h>
-
-
 @interface SecureComparatorTests : XCTestCase
 
 @end

--- a/tests/objcthemis/objthemis/objthemis-Bridging-Header.h
+++ b/tests/objcthemis/objthemis/objthemis-Bridging-Header.h
@@ -9,7 +9,4 @@
     #import <objcthemis/objcthemis.h>
     #import "StaticKeys.h"
 
-    #define SECURE_COMPARATOR_ENABLED
-    #import <objcthemis/scomparator.h>
-
 #endif /* objcthemis_Bridging_Header_h */


### PR DESCRIPTION
This feature flag is no longer supported so there is no need to do a special dance during imports and in example Podfiles. Secure Comparator is now always a part of Obj-C Themis so it's already imported.

Commit b503b31159e62b317e0380205872775da72a9bac made Secure Comparator available without feature flags and SECURE_COMPARATOR_ENABLED is effectively useless since then.