### PR TITLE
Update OpenSSL version for Carthage

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "krzyzanowskim/OpenSSL" "6e0992c4d95eba1251909a3b2ef0d76ce22d39c4"
+github "krzyzanowskim/OpenSSL" ~> 1.0.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "krzyzanowskim/OpenSSL" "6e0992c4d95eba1251909a3b2ef0d76ce22d39c4"
+github "krzyzanowskim/OpenSSL" "1.0.2.17"


### PR DESCRIPTION
OpenSSL package has been updated and tagged, now we can use `~>` dependencies using proper versions instead of git commit hashes. Update Cartfiles and lock files accordingly.