### PR TITLE
Update Carthage examples to 0.11.0

### DIFF
--- a/docs/examples/objc/iOS-Carthage/Cartfile
+++ b/docs/examples/objc/iOS-Carthage/Cartfile
@@ -1,1 +1,1 @@
-github "cossacklabs/themis" "a415c1da65105ad42d4a201e57493f1b6e38cfee"
+github "cossacklabs/themis" ~> 0.11.0

--- a/docs/examples/objc/iOS-Carthage/Cartfile.resolved
+++ b/docs/examples/objc/iOS-Carthage/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "cossacklabs/themis" "a415c1da65105ad42d4a201e57493f1b6e38cfee"
-github "ilammy/OpenSSL" "1.0.2.14.1"
+github "cossacklabs/themis" "0.11.0"
+github "krzyzanowskim/OpenSSL" "1.0.2.17"

--- a/docs/examples/objc/macOS-Carthage/Cartfile
+++ b/docs/examples/objc/macOS-Carthage/Cartfile
@@ -1,1 +1,1 @@
-github "cossacklabs/themis" "a415c1da65105ad42d4a201e57493f1b6e38cfee"
+github "cossacklabs/themis" ~> 0.11.0

--- a/docs/examples/objc/macOS-Carthage/Cartfile.resolved
+++ b/docs/examples/objc/macOS-Carthage/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "cossacklabs/themis" "a415c1da65105ad42d4a201e57493f1b6e38cfee"
-github "ilammy/OpenSSL" "1.0.2.14.1"
+github "cossacklabs/themis" "0.11.0"
+github "krzyzanowskim/OpenSSL" "1.0.2.17"

--- a/docs/examples/swift/iOS-Carthage/Cartfile
+++ b/docs/examples/swift/iOS-Carthage/Cartfile
@@ -1,1 +1,1 @@
-github "cossacklabs/themis" "a415c1da65105ad42d4a201e57493f1b6e38cfee"
+github "cossacklabs/themis" ~> 0.11.0

--- a/docs/examples/swift/iOS-Carthage/Cartfile.resolved
+++ b/docs/examples/swift/iOS-Carthage/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "cossacklabs/themis" "a415c1da65105ad42d4a201e57493f1b6e38cfee"
-github "ilammy/OpenSSL" "1.0.2.14.1"
+github "cossacklabs/themis" "0.11.0"
+github "krzyzanowskim/OpenSSL" "1.0.2.17"

--- a/docs/examples/swift/macOS-Carthage/Cartfile
+++ b/docs/examples/swift/macOS-Carthage/Cartfile
@@ -1,1 +1,1 @@
-github "cossacklabs/themis" "a415c1da65105ad42d4a201e57493f1b6e38cfee"
+github "cossacklabs/themis" ~> 0.11.0

--- a/docs/examples/swift/macOS-Carthage/Cartfile.resolved
+++ b/docs/examples/swift/macOS-Carthage/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "cossacklabs/themis" "a415c1da65105ad42d4a201e57493f1b6e38cfee"
-github "ilammy/OpenSSL" "1.0.2.14.1"
+github "cossacklabs/themis" "0.11.0"
+github "krzyzanowskim/OpenSSL" "1.0.2.17"


### PR DESCRIPTION
Update Carthage examples to use 0.11.0 tag on Themis and expected lock-files for that version.

Merge this after 0.11.0 is actually tagged and released.