### PR TITLE
PyThemis 0.11

### DIFF
--- a/src/wrappers/themis/python/PKG-INFO
+++ b/src/wrappers/themis/python/PKG-INFO
@@ -22,7 +22,6 @@ Classifier: Operating System :: MacOS :: MacOS X
 Classifier: Operating System :: POSIX
 Classifier: Operating System :: POSIX :: BSD
 Classifier: Operating System :: POSIX :: Linux
-Classifier: Operating System :: Microsoft :: Windows
 Classifier: Programming Language :: Python
 Classifier: Programming Language :: Python :: 2
 Classifier: Programming Language :: Python :: 2.6

--- a/src/wrappers/themis/python/PKG-INFO
+++ b/src/wrappers/themis/python/PKG-INFO
@@ -1,6 +1,6 @@
-Metadata-Version: 0.10.0
+Metadata-Version: 0.11.0
 Name: pythemis
-Version: 0.10.0
+Version: 0.11.0
 Summary: Data security library for network communication and data storage for Python
 Home-page: https://cossacklabs.com
 Author: CossackLabs

--- a/src/wrappers/themis/python/PKG-INFO
+++ b/src/wrappers/themis/python/PKG-INFO
@@ -10,8 +10,8 @@ Description: themis
         =====
         Themis is a data security library, providing users with high-quality security 
 	services for secure messaging of any kinds and flexible data storage. Themis 
-	is aimed at modern developers, with high level OOP wrappers for Ruby, Python, 
-	PHP, Java / Android and iOS / OSX. It is designed with ease of use in mind, 
+	is aimed at modern developers, with high level OOP wrappers for multiple
+ 	languages and environments. It is designed with ease of use in mind, 
 	high security and cross-platform availability.
 
 Platform: UNKNOWN

--- a/src/wrappers/themis/python/README.rst
+++ b/src/wrappers/themis/python/README.rst
@@ -3,6 +3,5 @@ themis
 Themis is a data security library, providing users with high-quality 
 security services for secure messaging of any kinds and flexible data 
 storage. Themis is aimed at modern developers, with high level OOP 
-wrappers for Ruby, Python, PHP, Java / Android and iOS / OSX. It is d
-esigned with ease of use in mind, high security and cross-platform 
-availability.
+wrappers for multiple languages and environments. It is designed with
+ease of use in mind, high security and cross-platform availability.

--- a/src/wrappers/themis/python/setup.py
+++ b/src/wrappers/themis/python/setup.py
@@ -41,7 +41,6 @@ setup(
         "Operating System :: POSIX",
         "Operating System :: POSIX :: BSD",
         "Operating System :: POSIX :: Linux",
-        "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.6",

--- a/src/wrappers/themis/python/setup.py
+++ b/src/wrappers/themis/python/setup.py
@@ -23,7 +23,7 @@ if sys.version_info < (3, 4):
 
 setup(
     name='pythemis',
-    version='0.10.0',
+    version='0.11.0',
 
     description='',
     long_description=open("README.rst").read(),


### PR DESCRIPTION
* **Bump PyThemis version to 0.11**

* **Drop Windows support from PyPi package**

  Themis no longer officially support Windows, therefore we should not claim that we do in PyPi package metadata.

* **Remove explicit language list from README**

  Do not bother maintaining it accurate in the future.

---

[Published on PyPi](https://pypi.org/project/pythemis/#history).

Confirmed locally that the package works with Themis 0.11.