### PR TITLE
RubyThemis 0.11

### DIFF
--- a/src/wrappers/themis/ruby/rbthemis.gemspec
+++ b/src/wrappers/themis/ruby/rbthemis.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'rbthemis'
-  s.version     = '0.10.0'
-  s.date        = '2018-02-06'
+  s.version     = '0.11.0'
+  s.date        = '2019-03-28'
   s.summary     = 'Data security library for network communication and data storage for Ruby'
   s.description = 'Themis is a data security library, providing users with high-quality security services for secure messaging of any kinds and flexible data storage. Themis is aimed at modern developers, with high level OOP wrappers for Ruby, Python, PHP, Java / Android and iOS / OSX. It is designed with ease of use in mind, high security and cross-platform availability.'
   s.authors     = ['CossackLabs']
@@ -10,6 +10,6 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://cossacklabs.com/'
   s.license     = 'Apache-2.0'
   s.add_runtime_dependency 'ffi', '~> 1.9', '>= 1.9.8'
-  s.requirements << 'libthemis, v0.10.0'
+  s.requirements << 'libthemis, v0.11.0'
   s.post_install_message = 'If you were using rubythemis before, please uninstall it from your system using `gem uninstall rubythemis`'
 end


### PR DESCRIPTION
* **Bump RubyThemis version to 0.11**

---

[Pushed on RubyGems](https://rubygems.org/gems/rbthemis).

Confirmed locally that the package works with Themis 0.11.