### PR TITLE
Rust-Themis 0.11

### DIFF
--- a/src/wrappers/themis/rust/CHANGELOG.md
+++ b/src/wrappers/themis/rust/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 The version currently in development.
 
+Version 0.11.0 — 2019-03-28
+===========================
+
+The first stable release of Rust-Themis.
+
 ## Breaking changes
 
 - `SecureCell` interface has been overhauled for better usability and

--- a/src/wrappers/themis/rust/Cargo.toml
+++ b/src/wrappers/themis/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "themis"
-version = "0.0.3"
+version = "0.11.0"
 edition = "2018"
 authors = ["rust-themis developers"]
 description = "High-level cryptographic services for storage and messaging"
@@ -27,7 +27,7 @@ maintenance = { status = "actively-developed" }
 vendored = ["bindings/vendored"]
 
 [dependencies]
-bindings = { package = "libthemis-sys", path = "libthemis-sys", version = "=0.0.3" }
+bindings = { package = "libthemis-sys", path = "libthemis-sys", version = "=0.11.0" }
 zeroize = "0.5.2"
 
 [dev-dependencies]

--- a/src/wrappers/themis/rust/libthemis-src/Cargo.toml
+++ b/src/wrappers/themis/rust/libthemis-src/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libthemis-src"
-version = "0.0.3"
+version = "0.11.0"
 edition = "2018"
 authors = ["rust-themis developers"]
 description = "Building native Themis library"

--- a/src/wrappers/themis/rust/libthemis-sys/Cargo.toml
+++ b/src/wrappers/themis/rust/libthemis-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libthemis-sys"
-version = "0.0.3"
+version = "0.11.0"
 edition = "2018"
 authors = ["rust-themis developers"]
 description = "FFI binding to libthemis"
@@ -22,7 +22,7 @@ vendored = ["libthemis-src"]
 [build-dependencies]
 bindgen = "0.46.0"
 cc = "1.0.28"
-libthemis-src = { path = "../libthemis-src", version = "=0.0.3", optional = true }
+libthemis-src = { path = "../libthemis-src", version = "=0.11.0", optional = true }
 pkg-config = "0.3.14"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
* **Bump Rust-Themis version to 0.11**

---

[Published on crates.io](https://crates.io/crates/themis).

Confirmed locally that the package works with Themis 0.11.