### PR TITLE
Update packages for 0.11.0: ios, macos, php, js, android, java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ publishing {
             artifact("$buildDir/outputs/aar/mainfork-release.aar")
             groupId 'com.cossacklabs.com'
             artifactId 'themis'
-            version '0.10.0'
+            version '0.11.0'
         }
     }
 }
@@ -90,7 +90,7 @@ bintray {
         vcsUrl = 'https://github.com/cossacklabs/themis.git'
         publish = true
         version {
-            name = '0.10.0'
+            name = '0.11.0'
             released  = new Date()            
             gpg {
                 sign = true

--- a/docs/examples/Themis-server/Obj-C/Podfile
+++ b/docs/examples/Themis-server/Obj-C/Podfile
@@ -23,6 +23,6 @@ use_frameworks!
 
 target :"WorkingWithThemisServer" do
 
-  pod 'themis', '0.10.4'
+  pod 'themis', '0.11'
 
 end

--- a/docs/examples/Themis-server/Obj-C/Podfile.lock
+++ b/docs/examples/Themis-server/Obj-C/Podfile.lock
@@ -1,19 +1,19 @@
 PODS:
   - GRKOpenSSLFramework (1.0.2.16)
-  - themis (0.10.4):
-    - themis/themis-openssl (= 0.10.4)
-  - themis/themis-openssl (0.10.4):
+  - themis (0.11.0):
+    - themis/themis-openssl (= 0.11.0)
+  - themis/themis-openssl (0.11.0):
     - GRKOpenSSLFramework (~> 1.0.1)
-    - themis/themis-openssl/core (= 0.10.4)
-    - themis/themis-openssl/objcwrapper (= 0.10.4)
-  - themis/themis-openssl/core (0.10.4):
+    - themis/themis-openssl/core (= 0.11.0)
+    - themis/themis-openssl/objcwrapper (= 0.11.0)
+  - themis/themis-openssl/core (0.11.0):
     - GRKOpenSSLFramework (~> 1.0.1)
-  - themis/themis-openssl/objcwrapper (0.10.4):
+  - themis/themis-openssl/objcwrapper (0.11.0):
     - GRKOpenSSLFramework (~> 1.0.1)
     - themis/themis-openssl/core
 
 DEPENDENCIES:
-  - themis (= 0.10.4)
+  - themis (= 0.11)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -22,8 +22,8 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   GRKOpenSSLFramework: 35944e317e6336b2944ad70b059d84db6b2d8532
-  themis: 56654bb58700ece55439716058943f8f435b228d
+  themis: a588aef3fef2d20c798b5b1bab94188e703bf861
 
-PODFILE CHECKSUM: b389f783512ffadadd48027dc016e72f6a8193f6
+PODFILE CHECKSUM: 883606fefad4f46b7ae4e9f8336c2f4fd3af65e6
 
 COCOAPODS: 1.5.3

--- a/docs/examples/Themis-server/swift/Podfile
+++ b/docs/examples/Themis-server/swift/Podfile
@@ -23,6 +23,6 @@ use_frameworks!
 
 target :"SwiftThemisServerExample" do
 
-  pod 'themis', '0.10.4'
+  pod 'themis', '0.11'
 
 end

--- a/docs/examples/Themis-server/swift/Podfile.lock
+++ b/docs/examples/Themis-server/swift/Podfile.lock
@@ -1,19 +1,19 @@
 PODS:
   - GRKOpenSSLFramework (1.0.2.16)
-  - themis (0.10.4):
-    - themis/themis-openssl (= 0.10.4)
-  - themis/themis-openssl (0.10.4):
+  - themis (0.11.0):
+    - themis/themis-openssl (= 0.11.0)
+  - themis/themis-openssl (0.11.0):
     - GRKOpenSSLFramework (~> 1.0.1)
-    - themis/themis-openssl/core (= 0.10.4)
-    - themis/themis-openssl/objcwrapper (= 0.10.4)
-  - themis/themis-openssl/core (0.10.4):
+    - themis/themis-openssl/core (= 0.11.0)
+    - themis/themis-openssl/objcwrapper (= 0.11.0)
+  - themis/themis-openssl/core (0.11.0):
     - GRKOpenSSLFramework (~> 1.0.1)
-  - themis/themis-openssl/objcwrapper (0.10.4):
+  - themis/themis-openssl/objcwrapper (0.11.0):
     - GRKOpenSSLFramework (~> 1.0.1)
     - themis/themis-openssl/core
 
 DEPENDENCIES:
-  - themis (= 0.10.4)
+  - themis (= 0.11)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -22,8 +22,8 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   GRKOpenSSLFramework: 35944e317e6336b2944ad70b059d84db6b2d8532
-  themis: 56654bb58700ece55439716058943f8f435b228d
+  themis: a588aef3fef2d20c798b5b1bab94188e703bf861
 
-PODFILE CHECKSUM: 3ff8298a3ab69a2271ba344f663f2e07a5540d0a
+PODFILE CHECKSUM: 47c88e6455c3bdcfd82e8a98dfda026516705074
 
 COCOAPODS: 1.5.3

--- a/docs/examples/objc/iOS-CocoaPods/Podfile
+++ b/docs/examples/objc/iOS-CocoaPods/Podfile
@@ -23,6 +23,6 @@ use_frameworks!
 
 target :"ThemisTest" do
 
-  pod 'themis', '0.10.4'
+  pod 'themis', '0.11'
 
 end

--- a/docs/examples/objc/iOS-CocoaPods/Podfile.lock
+++ b/docs/examples/objc/iOS-CocoaPods/Podfile.lock
@@ -1,19 +1,19 @@
 PODS:
   - GRKOpenSSLFramework (1.0.2.16)
-  - themis (0.10.4):
-    - themis/themis-openssl (= 0.10.4)
-  - themis/themis-openssl (0.10.4):
+  - themis (0.11.0):
+    - themis/themis-openssl (= 0.11.0)
+  - themis/themis-openssl (0.11.0):
     - GRKOpenSSLFramework (~> 1.0.1)
-    - themis/themis-openssl/core (= 0.10.4)
-    - themis/themis-openssl/objcwrapper (= 0.10.4)
-  - themis/themis-openssl/core (0.10.4):
+    - themis/themis-openssl/core (= 0.11.0)
+    - themis/themis-openssl/objcwrapper (= 0.11.0)
+  - themis/themis-openssl/core (0.11.0):
     - GRKOpenSSLFramework (~> 1.0.1)
-  - themis/themis-openssl/objcwrapper (0.10.4):
+  - themis/themis-openssl/objcwrapper (0.11.0):
     - GRKOpenSSLFramework (~> 1.0.1)
     - themis/themis-openssl/core
 
 DEPENDENCIES:
-  - themis (= 0.10.4)
+  - themis (= 0.11)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -22,8 +22,8 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   GRKOpenSSLFramework: 35944e317e6336b2944ad70b059d84db6b2d8532
-  themis: 56654bb58700ece55439716058943f8f435b228d
+  themis: a588aef3fef2d20c798b5b1bab94188e703bf861
 
-PODFILE CHECKSUM: a8a72b4b6b80993d89c70d17e9bfe0cadb882f25
+PODFILE CHECKSUM: 061bb96a1e488f5ad0543ba72bd7ef01ed04450a
 
 COCOAPODS: 1.5.3

--- a/docs/examples/swift/iOS-CocoaPods/Podfile
+++ b/docs/examples/swift/iOS-CocoaPods/Podfile
@@ -24,6 +24,6 @@ use_frameworks!
 
 target :"ThemisSwift" do
 
-  pod 'themis', '0.10.4'
+  pod 'themis', '0.11'
 
 end

--- a/docs/examples/swift/iOS-CocoaPods/Podfile.lock
+++ b/docs/examples/swift/iOS-CocoaPods/Podfile.lock
@@ -1,19 +1,19 @@
 PODS:
   - GRKOpenSSLFramework (1.0.2.16)
-  - themis (0.10.4):
-    - themis/themis-openssl (= 0.10.4)
-  - themis/themis-openssl (0.10.4):
+  - themis (0.11.0):
+    - themis/themis-openssl (= 0.11.0)
+  - themis/themis-openssl (0.11.0):
     - GRKOpenSSLFramework (~> 1.0.1)
-    - themis/themis-openssl/core (= 0.10.4)
-    - themis/themis-openssl/objcwrapper (= 0.10.4)
-  - themis/themis-openssl/core (0.10.4):
+    - themis/themis-openssl/core (= 0.11.0)
+    - themis/themis-openssl/objcwrapper (= 0.11.0)
+  - themis/themis-openssl/core (0.11.0):
     - GRKOpenSSLFramework (~> 1.0.1)
-  - themis/themis-openssl/objcwrapper (0.10.4):
+  - themis/themis-openssl/objcwrapper (0.11.0):
     - GRKOpenSSLFramework (~> 1.0.1)
     - themis/themis-openssl/core
 
 DEPENDENCIES:
-  - themis (= 0.10.4)
+  - themis (= 0.11)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -22,8 +22,8 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   GRKOpenSSLFramework: 35944e317e6336b2944ad70b059d84db6b2d8532
-  themis: 56654bb58700ece55439716058943f8f435b228d
+  themis: a588aef3fef2d20c798b5b1bab94188e703bf861
 
-PODFILE CHECKSUM: ccacdf481a158d5d83c3c7801294580d57b9928d
+PODFILE CHECKSUM: d1be3a2503e3ca6284f55245f1750b6046ad8ea7
 
 COCOAPODS: 1.5.3

--- a/src/wrappers/themis/android/AndroidManifest.xml
+++ b/src/wrappers/themis/android/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.cossacklabs.themis" android:versionCode="1" android:versionName="0.10.0">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.cossacklabs.themis" android:versionCode="1" android:versionName="0.11.0">
 </manifest>

--- a/src/wrappers/themis/jsthemis/package.json
+++ b/src/wrappers/themis/jsthemis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsthemis",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Themis is a data security library, providing users with high-quality security services for secure messaging of any kinds and flexible data storage. Themis is aimed at modern developers, with high level OOP wrappers for Ruby, Python, PHP, Java / Android and iOS / OSX. It is designed with ease of use in mind, high security and cross-platform availability.",
   "main": "build/Release/jsthemis.node",
   "scripts": {

--- a/src/wrappers/themis/php/php_themis.h
+++ b/src/wrappers/themis/php/php_themis.h
@@ -17,7 +17,7 @@
 #ifndef _PHP_THEMIS_H_
 #define _PHP_THEMIS_H_
 
-#define PHP_THEMIS_VERSION "0.10.0"
+#define PHP_THEMIS_VERSION "0.11.0"
 #define PHP_THEMIS_EXTNAME "phpthemis"
 
 PHP_FUNCTION(phpthemis_secure_message_wrap);

--- a/src/wrappers/themis/php7/php_themis.h
+++ b/src/wrappers/themis/php7/php_themis.h
@@ -17,7 +17,7 @@
 #ifndef _PHP_THEMIS_H_
 #define _PHP_THEMIS_H_
 
-#define PHP_THEMIS_VERSION "0.10.0"
+#define PHP_THEMIS_VERSION "0.11.0"
 #define PHP_THEMIS_EXTNAME "phpthemis"
 
 extern zend_module_entry phpthemis_module_entry;

--- a/themis.podspec
+++ b/themis.podspec
@@ -1,27 +1,12 @@
 Pod::Spec.new do |s|
     s.name = "themis"
-    s.version = "0.10.4"
+    s.version = "0.11.0"
     s.summary = "Data security library for network communication and data storage for iOS and mac OS"
     s.description = "Themis is a data security library, providing users with high-quality security services for secure messaging of any kinds and flexible data storage. Themis is aimed at modern development practices, with high level OOP wrappers for iOS / macOS, node,js, Go, Ruby, Python, PHP and Java / Android. It is designed with ease of use in mind, high security and cross-platform availability."
     s.homepage = "https://cossacklabs.com"
     s.license = { :type => 'Apache 2.0'}    
 
-    # will update to particular tag on next release (0.11.0)
-    #s.source = { :git => "https://github.com/cossacklabs/themis.git", :tag => "#{s.version}" }
-
-    # this commit has fixes in soter that allow to support BoringSSL for iOS,
-    # and updates in Secure Message API
-    # and updates for Swift framework
-    # more: 
-    # https://github.com/cossacklabs/themis/pull/330
-    # https://github.com/cossacklabs/themis/pull/393
-    # https://github.com/cossacklabs/themis/pull/394
-    # https://github.com/cossacklabs/themis/pull/415
-    # https://github.com/cossacklabs/themis/pull/416
-    #
-    # this is a latest master commit as for today
-    s.source = { :git => "https://github.com/cossacklabs/themis.git", :commit => '4d453c866105ec1448b3e321530ba63912eacee3'}
-  
+    s.source = { :git => "https://github.com/cossacklabs/themis.git", :tag => "#{s.version}" }  
     s.author = {'cossacklabs' => 'info@cossacklabs.com'}
 
     s.module_name = 'themis'

--- a/third_party/boringssl/AndroidManifest.xml
+++ b/third_party/boringssl/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.cossacklabs.themis.boringssl" android:versionCode="1" android:versionName="0.10.0">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.cossacklabs.themis.boringssl" android:versionCode="1" android:versionName="0.11.0">
 </manifest>


### PR DESCRIPTION
1. Android: update `build.gradle` and push new themis to 
https://bintray.com/cossacklabs/maven/themis

Update Android examples here https://github.com/cossacklabs/themis-java-examples

2. iOS: update podspec, push it, and update Cocoapods examples

3. update jsthemis

4. update php version