### PR TITLE
0.11.0: update carthage inner version; update cocoapods tests

### DIFF
--- a/src/wrappers/themis/Obj-C/Themis/Info.plist
+++ b/src/wrappers/themis/Obj-C/Themis/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.10.5</string>
+	<string>0.11.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/tests/objcthemis/Podfile.lock
+++ b/tests/objcthemis/Podfile.lock
@@ -6,42 +6,50 @@ PODS:
     - BoringSSL/Interface (= 10.0.6)
   - BoringSSL/Interface (10.0.6)
   - GRKOpenSSLFramework (1.0.2.16)
-  - themis (0.10.3):
-    - themis/themis-openssl (= 0.10.3)
-  - themis/themis-boringssl (0.10.3):
+  - themis (0.11.0):
+    - themis/themis-openssl (= 0.11.0)
+  - themis/themis-boringssl (0.11.0):
     - BoringSSL (~> 10.0)
-    - themis/themis-boringssl/core (= 0.10.3)
-    - themis/themis-boringssl/objcwrapper (= 0.10.3)
-  - themis/themis-boringssl/core (0.10.3):
+    - themis/themis-boringssl/core (= 0.11.0)
+    - themis/themis-boringssl/objcwrapper (= 0.11.0)
+  - themis/themis-boringssl/core (0.11.0):
     - BoringSSL (~> 10.0)
-  - themis/themis-boringssl/objcwrapper (0.10.3):
+  - themis/themis-boringssl/objcwrapper (0.11.0):
     - BoringSSL (~> 10.0)
     - themis/themis-boringssl/core
-  - themis/themis-openssl (0.10.3):
+  - themis/themis-openssl (0.11.0):
     - GRKOpenSSLFramework (~> 1.0.1)
-    - themis/themis-openssl/core (= 0.10.3)
-    - themis/themis-openssl/objcwrapper (= 0.10.3)
-  - themis/themis-openssl/core (0.10.3):
+    - themis/themis-openssl/core (= 0.11.0)
+    - themis/themis-openssl/objcwrapper (= 0.11.0)
+  - themis/themis-openssl/core (0.11.0):
     - GRKOpenSSLFramework (~> 1.0.1)
-  - themis/themis-openssl/objcwrapper (0.10.3):
+  - themis/themis-openssl/objcwrapper (0.11.0):
     - GRKOpenSSLFramework (~> 1.0.1)
     - themis/themis-openssl/core
 
 DEPENDENCIES:
-  - themis (= 0.10.3)
-  - themis/themis-boringssl (= 0.10.3)
+  - themis (from `https://github.com/cossacklabs/themis.git`)
+  - themis/themis-boringssl (from `https://github.com/cossacklabs/themis.git`)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - BoringSSL
     - GRKOpenSSLFramework
-    - themis
+
+EXTERNAL SOURCES:
+  themis:
+    :git: https://github.com/cossacklabs/themis.git
+
+CHECKOUT OPTIONS:
+  themis:
+    :commit: f3f84be1a4d00ed00a9b3661794bd1e14829cdfc
+    :git: https://github.com/cossacklabs/themis.git
 
 SPEC CHECKSUMS:
   BoringSSL: e10f92a27043805c01071fe815a5cd98ae8212e7
   GRKOpenSSLFramework: 35944e317e6336b2944ad70b059d84db6b2d8532
-  themis: bdbb1d0baeee19ff213dc7355e9e2b48debea359
+  themis: a588aef3fef2d20c798b5b1bab94188e703bf861
 
-PODFILE CHECKSUM: c597acee50b92cb2cbffaf8976cb442950c047fa
+PODFILE CHECKSUM: 6055c33e5731af5794dcf3d4683da518ed5f5205
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
Update version of Carthage framework
Re-link cocoapods tests to use latest 0.11.0 themis pod