### PR TITLE
Include "tools" into source tarball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -467,6 +467,7 @@ dist:
 	rsync -avz gradle $(VERSION)
 	rsync -avz jni $(VERSION)
 	rsync -avz --exclude 'tests/soter/nist-sts/assess' tests $(VERSION)
+	rsync -avz tools $(VERSION)
 	rsync -avz CHANGELOG.md $(VERSION)
 	rsync -avz LICENSE $(VERSION)
 	rsync -avz Makefile $(VERSION)


### PR DESCRIPTION
The Makefile now includes AFL support files which require the "tools" directory to be present in the distribution tarball. Well, we should put integration testing tools there anyway for all make targets to work. So just add this directory to tarball.

This fixes distribution packaging.