### PR TITLE
Relax compatibility constraints

### DIFF
--- a/src/wrappers/themis/rust/Cargo.toml
+++ b/src/wrappers/themis/rust/Cargo.toml
@@ -27,7 +27,7 @@ maintenance = { status = "actively-developed" }
 vendored = ["bindings/vendored"]
 
 [dependencies]
-bindings = { package = "libthemis-sys", path = "libthemis-sys", version = "=0.11.0" }
+bindings = { package = "libthemis-sys", path = "libthemis-sys", version = "0.11.0" }
 zeroize = "0.5.2"
 
 [dev-dependencies]

--- a/src/wrappers/themis/rust/libthemis-sys/Cargo.toml
+++ b/src/wrappers/themis/rust/libthemis-sys/Cargo.toml
@@ -22,7 +22,7 @@ vendored = ["libthemis-src"]
 [build-dependencies]
 bindgen = "0.46.0"
 cc = "1.0.28"
-libthemis-src = { path = "../libthemis-src", version = "=0.11.0", optional = true }
+libthemis-src = { path = "../libthemis-src", version = "0.11.0", optional = true }
 pkg-config = "0.3.14"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Initially I thought that it would be good to pin `themis` to a particular version of `libthemis-sys` package (more stability and predictability, etc.) However, if you think about it, this strategy requires updating `themis` crate whenever there is patch update in `libthemis-sys` (ditto for `libthemis-sys` and `libthemis-src`). It may become a bother so I'd rather avoid it.

We adhere to semver, therefore patch version updates should be compatible between minor versions. Relax the dependency constraints to allow patch updates between the crates.