### PR TITLE
Rust-Themis 0.11.1

### DIFF
--- a/src/wrappers/themis/rust/CHANGELOG.md
+++ b/src/wrappers/themis/rust/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 The version currently in development.
 
+Version 0.11.1 - 2019-04-01
+===========================
+
 ## Internal improvements
 
 - `libthemis-sys` is now able to use core Themis library installed in

--- a/src/wrappers/themis/rust/Cargo.toml
+++ b/src/wrappers/themis/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "themis"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2018"
 authors = ["rust-themis developers"]
 description = "High-level cryptographic services for storage and messaging"
@@ -27,7 +27,7 @@ maintenance = { status = "actively-developed" }
 vendored = ["bindings/vendored"]
 
 [dependencies]
-bindings = { package = "libthemis-sys", path = "libthemis-sys", version = "0.11.0" }
+bindings = { package = "libthemis-sys", path = "libthemis-sys", version = "0.11.1" }
 zeroize = "0.5.2"
 
 [dev-dependencies]

--- a/src/wrappers/themis/rust/libthemis-sys/Cargo.toml
+++ b/src/wrappers/themis/rust/libthemis-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libthemis-sys"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2018"
 authors = ["rust-themis developers"]
 description = "FFI binding to libthemis"


### PR DESCRIPTION
Cut a new patch release which fixes package installation. We need to update only `libthemis-sys`, but due to old dependencies `themis` crate also requires an update.