### PR TITLE
Optimize embedded BoringSSL build

### DIFF
--- a/src/soter/boringssl/soter.mk
+++ b/src/soter/boringssl/soter.mk
@@ -40,4 +40,4 @@ $(BIN_PATH)/boringssl/crypto/libcrypto.a $(BIN_PATH)/boringssl/decrepit/libdecre
 	@echo "building embedded BoringSSL..."
 	@mkdir -p $(BIN_PATH)/boringssl
 	@cd $(BIN_PATH)/boringssl && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-fpic" ../../third_party/boringssl/src
-	@$(MAKE) -C $(BIN_PATH)/boringssl
+	@$(MAKE) -C $(BIN_PATH)/boringssl crypto decrepit

--- a/third_party/boringssl/build.gradle
+++ b/third_party/boringssl/build.gradle
@@ -24,6 +24,7 @@ android {
 		                  "-DANDROID_NATIVE_API_LEVEL=21",
 		                  "-DCMAKE_BUILD_TYPE=Release",
 		                  "-GNinja"
+		        targets "crypto", "decrepit"
 		    }
 	    }
     }


### PR DESCRIPTION
Don't build unnecessary libraries, binaries, tests, etc. Build only two static libraries that we need. This results in considerable time saving during the builds: BoringSSL contains quite a few tests and tools which we do not run and use, yet they get built.

### Native

Before:

    $ time make all ENGINE=boringssl

    real    4m36.341s
    user    3m44.060s
    sys     0m33.924s

After:

    $ time make all ENGINE=boringssl

    real    1m56.910s
    user    1m29.960s
    sys     0m19.392s

Nuff said.

### Android

Before:

    $ time ./gradlew --no-daemon --no-parallel --max-workers=2 assembleDebug

    real    34m46.028s
    user    29m9.580s
    sys     6m39.280s

After:

    $ time ./gradlew --no-daemon --no-parallel --max-workers=2 assembleDebug

    real    12m46.028s
    user    9m1.880s
    sys     2m52.020s

Admittedly, the difference may be smaller—as we still have to wait for Gradle to download the whole Internet during Android build—but that's still a significant improvement because there are four architectures that we need to build BoringSSL for.