### PR TITLE
Common Makefile rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,9 +215,7 @@ endif
 
 ifdef COVERAGE
 	CFLAGS += -g -O0 --coverage
-	COVERLDFLAGS = --coverage
-else
-	COVERLDFLAGS =
+	LDFLAGS += --coverage
 endif
 
 ifdef DEBUG
@@ -314,7 +312,7 @@ soter_static: $(SOTER_OBJ)
 	@echo -n "link "
 	@$(BUILD_CMD)
 
-soter_shared: CMD = $(CC) -shared -o $(BIN_PATH)/lib$(SOTER_BIN).$(SHARED_EXT) $(SOTER_OBJ) $(LDFLAGS) $(COVERLDFLAGS)
+soter_shared: CMD = $(CC) -shared -o $(BIN_PATH)/lib$(SOTER_BIN).$(SHARED_EXT) $(SOTER_OBJ) $(LDFLAGS)
 
 soter_shared: $(SOTER_OBJ) $(SOTER_ENGINE_DEPS)
 	@echo -n "link "
@@ -330,7 +328,7 @@ themis_static: soter_static $(THEMIS_OBJ)
 	@echo -n "link "
 	@$(BUILD_CMD)
 
-themis_shared: CMD = $(CC) -shared -o $(BIN_PATH)/lib$(THEMIS_BIN).$(SHARED_EXT) $(THEMIS_OBJ) -L$(BIN_PATH) -l$(SOTER_BIN) $(COVERLDFLAGS)
+themis_shared: CMD = $(CC) -shared -o $(BIN_PATH)/lib$(THEMIS_BIN).$(SHARED_EXT) $(THEMIS_OBJ) -L$(BIN_PATH) -l$(SOTER_BIN) $(LDFLAGS)
 
 themis_shared: soter_shared $(THEMIS_OBJ)
 	@echo -n "link "

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,31 @@ else ifeq ($(UNAME),Linux)
 	IS_LINUX := true
 endif
 
+ifdef IS_MACOS
+    ifeq ($(MAKE_VERSION),3.81)
+        $(warning ! You seem to be running the default GNU make 3.81 on macOS.)
+        $(warning ! Unfortunately, this version is not fully supported by Themis)
+        $(warning ! and some build targets may work incorrectly with it.)
+        $(warning ! Please use GNU make 3.82 or later.)
+        $(warning ! )
+        $(warning ! On macOS you can use Homebrew (https://brew.sh) to install)
+        $(warning ! a newer version of GNU make:)
+        $(warning ! )
+        $(warning !     brew install make)
+        $(warning ! )
+        $(warning ! Then use "gmake" to run it, for example:)
+        $(warning ! )
+        $(warning !     gmake all)
+        $(warning ! )
+        $(warning ! Note that "make" will still refer to the system default make.)
+# Make sure to break the build if the user ignores the warning and tries using
+# some target that needs the "private" modifier added in GNU make 3.82
+.PHONY: private
+private:
+	$(error GNU make 3.81 is not supported. Please upgrade)
+    endif
+endif
+
 define themisecho
       @tput setaf 6
       @echo $1

--- a/Makefile
+++ b/Makefile
@@ -306,44 +306,15 @@ JSTHEMIS_PACKAGE_VERSION=$(shell cat src/wrappers/themis/jsthemis/package.json \
 all: err themis_static themis_shared themis_pkgconfig soter_pkgconfig
 	@echo $(VERSION)
 
-soter_static: CMD = $(AR) rcs $(BIN_PATH)/lib$(SOTER_BIN).a $(SOTER_OBJ)
+soter_static:  $(BIN_PATH)/$(LIBSOTER_A)
+soter_shared:  $(BIN_PATH)/$(LIBSOTER_SO)
+themis_static: $(BIN_PATH)/$(LIBTHEMIS_A)
+themis_shared: $(BIN_PATH)/$(LIBTHEMIS_SO)
+themis_jni:    $(BIN_PATH)/$(LIBTHEMISJNI_SO)
 
-soter_static: $(SOTER_OBJ)
-	@echo -n "link "
-	@$(BUILD_CMD)
-
-soter_shared: CMD = $(CC) -shared -o $(BIN_PATH)/lib$(SOTER_BIN).$(SHARED_EXT) $(SOTER_OBJ) $(LDFLAGS)
-
-soter_shared: $(SOTER_OBJ) $(SOTER_ENGINE_DEPS)
-	@echo -n "link "
-	@$(BUILD_CMD)
-ifdef IS_MACOS
-	@install_name_tool -id "$(PREFIX)/lib/lib$(SOTER_BIN).$(SHARED_EXT)" $(BIN_PATH)/lib$(SOTER_BIN).$(SHARED_EXT)
-	@install_name_tool -change "$(BIN_PATH)/lib$(SOTER_BIN).$(SHARED_EXT)" "$(PREFIX)/lib/lib(SOTER_BIN).$(SHARED_EXT)" $(BIN_PATH)/lib$(SOTER_BIN).$(SHARED_EXT)
-endif
-
-themis_static: CMD = $(AR) rcs $(BIN_PATH)/lib$(THEMIS_BIN).a $(THEMIS_OBJ)
-
-themis_static: soter_static $(THEMIS_OBJ)
-	@echo -n "link "
-	@$(BUILD_CMD)
-
-themis_shared: CMD = $(CC) -shared -o $(BIN_PATH)/lib$(THEMIS_BIN).$(SHARED_EXT) $(THEMIS_OBJ) -L$(BIN_PATH) -l$(SOTER_BIN) $(LDFLAGS)
-
-themis_shared: soter_shared $(THEMIS_OBJ)
-	@echo -n "link "
-	@$(BUILD_CMD)
-ifdef IS_MACOS
-	@install_name_tool -id "$(PREFIX)/lib/lib$(THEMIS_BIN).$(SHARED_EXT)" $(BIN_PATH)/lib$(THEMIS_BIN).$(SHARED_EXT)
-	@install_name_tool -change "$(BIN_PATH)/lib$(THEMIS_BIN).$(SHARED_EXT)" "$(PREFIX)/lib/lib$(THEMIS_BIN).$(SHARED_EXT)" $(BIN_PATH)/lib$(THEMIS_BIN).$(SHARED_EXT)
-endif
-
-themis_jni: CMD = $(CC) -shared -o $(BIN_PATH)/lib$(THEMIS_JNI_BIN).$(SHARED_EXT) $(THEMIS_JNI_OBJ) -L$(BIN_PATH) -l$(THEMIS_BIN) -l$(SOTER_BIN)
-
-themis_jni: themis_static $(THEMIS_JNI_OBJ)
-	@echo -n "link "
-	@$(BUILD_CMD)
-
+#
+# Common build rules
+#
 
 $(OBJ_PATH)/%.o: CMD = $(CC) $(CFLAGS) -c $< -o $@
 
@@ -389,6 +360,24 @@ $(AUD_PATH)/%: $(SRC_PATH)/%
 	@mkdir -p $(@D)
 	@echo -n "compile "
 	@$(BUILD_CMD)
+
+# Static libraries
+$(BIN_PATH)/lib%.a: CMD = $(AR) rcs $@ $(filter %.o,$^)
+$(BIN_PATH)/lib%.a:
+	@mkdir -p $(@D)
+	@echo -n "link "
+	@$(BUILD_CMD)
+
+# Shared libraries
+$(BIN_PATH)/lib%.$(SHARED_EXT): CMD = $(CC) -shared -o $@ $(filter %.o %.a,$^) $(LDFLAGS)
+$(BIN_PATH)/lib%.$(SHARED_EXT):
+	@mkdir -p $(@D)
+	@echo -n "link "
+	@$(BUILD_CMD)
+ifdef IS_MACOS
+	@install_name_tool -id "$(PREFIX)/lib/$(notdir $@)" $(BIN_PATH)/$(notdir $@)
+	@install_name_tool -change "$(BIN_PATH)/$(notdir $@)" "$(PREFIX)/lib/$(notdir $@)" $(BIN_PATH)/$(notdir $@)
+endif
 
 ifndef CARGO
 include tests/test.mk

--- a/jni/themis_jni.mk
+++ b/jni/themis_jni.mk
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+LIBTHEMISJNI_SO = libthemis_jni.$(SHARED_EXT)
+
 THEMIS_JNI_SRC = $(wildcard jni/*.c)
 
 THEMIS_JNI_OBJ = $(patsubst jni/%.c,$(OBJ_PATH)/jni/%.o, $(THEMIS_JNI_SRC))
@@ -32,6 +34,11 @@ ifeq ($(JDK_INCLUDE_PATH),)
 else
 	jvm_includes=$(JAVA_HOME)/include
 endif
+
+# Embed Themis, Soter, and cryptographic backed into shared JNI library
+$(BIN_PATH)/$(LIBTHEMISJNI_SO): $(THEMIS_JNI_OBJ)
+$(BIN_PATH)/$(LIBTHEMISJNI_SO): $(BIN_PATH)/$(LIBTHEMIS_A)
+$(BIN_PATH)/$(LIBTHEMISJNI_SO): $(BIN_PATH)/$(LIBSOTER_A) $(SOTER_ENGINE_DEPS)
 
 $(OBJ_PATH)/jni/%.o: jni/%.c
 	@mkdir -p $(@D)

--- a/src/soter/soter.mk
+++ b/src/soter/soter.mk
@@ -14,6 +14,9 @@
 # limitations under the License.
 #
 
+LIBSOTER_A  = libsoter.a
+LIBSOTER_SO = libsoter.$(SHARED_EXT)
+
 SOTER_SOURCES = $(wildcard $(SRC_PATH)/soter/*.c)
 SOTER_HEADERS = $(wildcard $(SRC_PATH)/soter/*.h)
 ED25519_SOURCES = $(wildcard $(SRC_PATH)/soter/ed25519/*.c)
@@ -37,7 +40,9 @@ SOTER_AUD = $(patsubst $(SRC_PATH)/%,$(AUD_PATH)/%, $(SOTER_AUD_SRC))
 SOTER_FMT_FIXUP = $(patsubst $(SRC_PATH)/%,$(OBJ_PATH)/%.fmt_fixup,$(SOTER_FMT_SRC))
 SOTER_FMT_CHECK = $(patsubst $(SRC_PATH)/%,$(OBJ_PATH)/%.fmt_check,$(SOTER_FMT_SRC))
 
-SOTER_BIN = soter
+# Embed cryptographic backed only into shared Soter library
+$(BIN_PATH)/$(LIBSOTER_A):  $(SOTER_OBJ)
+$(BIN_PATH)/$(LIBSOTER_SO): $(SOTER_OBJ) $(SOTER_ENGINE_DEPS)
 
 soter_pkgconfig:
 	@mkdir -p $(BIN_PATH)

--- a/src/themis/themis.mk
+++ b/src/themis/themis.mk
@@ -14,6 +14,9 @@
 # limitations under the License.
 #
 
+LIBTHEMIS_A  = libthemis.a
+LIBTHEMIS_SO = libthemis.$(SHARED_EXT)
+
 THEMIS_SOURCES = $(wildcard $(SRC_PATH)/themis/*.c)
 THEMIS_HEADERS = $(wildcard $(SRC_PATH)/themis/*.h)
 
@@ -28,7 +31,12 @@ THEMIS_AUD = $(patsubst $(SRC_PATH)/%,$(AUD_PATH)/%, $(THEMIS_AUD_SRC))
 THEMIS_FMT_FIXUP = $(patsubst $(SRC_PATH)/%,$(OBJ_PATH)/%.fmt_fixup,$(THEMIS_FMT_SRC))
 THEMIS_FMT_CHECK = $(patsubst $(SRC_PATH)/%,$(OBJ_PATH)/%.fmt_check,$(THEMIS_FMT_SRC))
 
-THEMIS_BIN = themis
+$(BIN_PATH)/$(LIBTHEMIS_A):  $(THEMIS_OBJ)
+$(BIN_PATH)/$(LIBTHEMIS_SO): $(THEMIS_OBJ)
+
+# Link shared Themis library against shared Soter library
+$(BIN_PATH)/$(LIBTHEMIS_SO): $(BIN_PATH)/$(LIBSOTER_SO)
+$(BIN_PATH)/$(LIBTHEMIS_SO): private LDFLAGS += -L$(BIN_PATH) -lsoter
 
 themis_pkgconfig:
 	@mkdir -p $(BIN_PATH)

--- a/tests/test.mk
+++ b/tests/test.mk
@@ -72,19 +72,19 @@ nist_rng_test_suite:
 nist_rng_test_suite_clean:
 	@$(MAKE) --quiet -C $(NIST_STS_DIR) clean
 
-soter_test: CMD = $(CC) -o $(TEST_BIN_PATH)/soter_test $(SOTER_TEST_OBJ) $(COMMON_TEST_OBJ) -L$(BIN_PATH) -lsoter $(LDFLAGS) $(COVERLDFLAGS)
+soter_test: CMD = $(CC) -o $(TEST_BIN_PATH)/soter_test $(SOTER_TEST_OBJ) $(COMMON_TEST_OBJ) -L$(BIN_PATH) -lsoter $(LDFLAGS)
 
 soter_test: nist_rng_test_suite soter_static $(SOTER_ENGINE_DEPS) $(SOTER_TEST_OBJ) $(COMMON_TEST_OBJ)
 	@echo -n "link "
 	@$(BUILD_CMD)
 
-themis_test: CMD = $(CC) -o $(TEST_BIN_PATH)/themis_test $(THEMIS_TEST_OBJ) $(COMMON_TEST_OBJ) $(CFLAGS) -L$(BIN_PATH) -lthemis -lsoter $(LDFLAGS) $(COVERLDFLAGS)
+themis_test: CMD = $(CC) -o $(TEST_BIN_PATH)/themis_test $(THEMIS_TEST_OBJ) $(COMMON_TEST_OBJ) $(CFLAGS) -L$(BIN_PATH) -lthemis -lsoter $(LDFLAGS)
 
 themis_test: themis_static $(THEMIS_TEST_OBJ) $(COMMON_TEST_OBJ)
 	@echo -n "link "
 	@$(BUILD_CMD)
 
-themispp_test: CMD = $(CXX) -o $(TEST_BIN_PATH)/themispp_test $(THEMISPP_TEST_OBJ) -L$(BIN_PATH) -lthemis -lsoter -lstdc++ $(LDFLAGS) $(COVERLDFLAGS)
+themispp_test: CMD = $(CXX) -o $(TEST_BIN_PATH)/themispp_test $(THEMISPP_TEST_OBJ) -L$(BIN_PATH) -lthemis -lsoter -lstdc++ $(LDFLAGS)
 
 themispp_test: $(THEMISPP_TEST_OBJ)
 	@echo -n "link "

--- a/tools/afl/fuzzy.mk
+++ b/tools/afl/fuzzy.mk
@@ -21,7 +21,7 @@ FUZZ_PATH = tools/afl
 FUZZ_BIN_PATH = $(BIN_PATH)/afl
 FUZZ_SRC_PATH = $(FUZZ_PATH)/src
 FUZZ_THEMIS_PATH = $(BIN_PATH)/afl-themis
-FUZZ_THEMIS_LIB = $(FUZZ_THEMIS_PATH)/lib$(THEMIS_BIN).a
+FUZZ_THEMIS_LIB = $(FUZZ_THEMIS_PATH)/$(LIBTHEMIS_A)
 
 FUZZ_SOURCES = $(wildcard $(FUZZ_SRC_PATH)/*.c)
 FUZZ_HEADERS = $(wildcard $(FUZZ_SRC_PATH)/*.h)
@@ -31,7 +31,7 @@ FUZZ_OBJS  = $(patsubst $(FUZZ_SRC_PATH)/%.c,$(FUZZ_BIN_PATH)/%.o,$(FUZZ_SOURCES
 FUZZ_UTILS = $(filter-out $(addsuffix .o,$(FUZZ_TOOLS)),$(FUZZ_OBJS))
 
 AFL_CFLAGS  += -I$(FUZZ_SRC_PATH)
-AFL_LDFLAGS += -L$(FUZZ_THEMIS_PATH) -l$(THEMIS_BIN) -l$(SOTER_BIN)
+AFL_LDFLAGS += -L$(FUZZ_THEMIS_PATH) -lthemis -lsoter
 
 # We would like to use all other compilation flags as well, but some of them
 # (like warnings) might be supported by CC but not AFL_CC. Filter them out.
@@ -76,7 +76,7 @@ $(FUZZ_BIN_PATH)/%: $(FUZZ_BIN_PATH)/%.o $(FUZZ_UTILS) $(FUZZ_THEMIS_LIB)
 	@$(PRINT_OK)
 
 $(FUZZ_THEMIS_LIB):
-	@AFL_QUIET=1 make themis_static CC=$(AFL_CC) BUILD_PATH=$(FUZZ_THEMIS_PATH)
+	@AFL_QUIET=1 make themis_static soter_static CC=$(AFL_CC) BUILD_PATH=$(FUZZ_THEMIS_PATH)
 
 FMT_FIXUP += $(patsubst $(FUZZ_SRC_PATH)/%,$(FUZZ_BIN_PATH)/%.fmt_fixup,$(FUZZ_SOURCES) $(FUZZ_HEADERS))
 FMT_CHECK += $(patsubst $(FUZZ_SRC_PATH)/%,$(FUZZ_BIN_PATH)/%.fmt_check,$(FUZZ_SOURCES) $(FUZZ_HEADERS))


### PR DESCRIPTION
Let's remove duplication across the makefile rules, starting with the ones for linking static and shared libraries.

Add fixed rules for producing _all_ libfoo.a, libfoo.so, libfoo.dylib libraries. Now we build all libraries in the same way while still respecting the dependencies. Contents of the libraries is determined from their dependencies (object files).

Note that we make sure to keep some idiosyncrasies:

  - static libraries are made from object files
  - shared libraries are made from object files and static libraries
  - shared libraries have different extensions on Linux and macOS
  - we need to apply "install_name_tool" on macOS after linkage

The most interesting thing here is how we link shared libraries against their dependencies. This is done by adding necessary flags to per-target LDFLAGS variable. Note that it uses **private** modifier. Unfortunately, this modifier has been added in GNU make 3.82, but most macOS versions have make 3.81 preinstalled by default. This means that macOS users will have to install a newer version (e.g., from Homebrew).

This refactoring also improves linkage of Themis JNI wrapper. Now we make sure to embed static libraries into the JNI shared library, not link against something installed in the system. This should make life of Java developers a bit easier.

Finally, note that we keep the old phony targets like `themis_shared`. Not only are they important for backwards compatibility, but they are genuinely useful for humans.

* **Merge COVERLDFLAGS into LDFLAGS**

Just use LDFLAGS everywhere. If we build Themis for coverage analysis then we need to add relevant flags to all compiled libraries and tools. There is no need to keep a separate variable for that.