### PR TITLE
Always ignore ldconfig failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -420,7 +420,7 @@ install_pkgconfig: err all make_install_dirs
 
 install: install_soter_headers install_themis_headers install_static_libs install_shared_libs install_pkgconfig
 ifdef IS_LINUX
-	@ldconfig || (status=$$?; if [ $$(id -u) = "0" ]; then exit $$status; else exit 0; fi)
+	-@ldconfig
 endif
 
 get_version:


### PR DESCRIPTION
[PR #346][1] has improved ldconfig handling a bit by failing the build only when ldconfig is invoked as root. However, this causes issues when building under **fakeroot** (which sets EUID but does not give permissions). Furthermore, [GNU Makefile conventions][2] expect ldconfig failures to be simply ignored.

[1]: https://github.com/cossacklabs/themis/pull/346
[2]: https://www.gnu.org/prep/standards/html_node/Utilities-in-Makefiles.html