### PR TITLE
Follow GNU conventions for installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,6 +294,7 @@ include src/soter/soter.mk
 include src/themis/themis.mk
 ifndef CARGO
 include src/wrappers/themis/jsthemis/jsthemis.mk
+include src/wrappers/themis/themispp/themispp.mk
 include jni/themis_jni.mk
 endif
 endif
@@ -349,11 +350,6 @@ $(OBJ_PATH)/%.fmt_check: %
 	@mkdir -p $(@D)
 	@echo -n "check $< "
 	@$(BUILD_CMD_)
-
-THEMISPP_HEADERS = $(wildcard $(SRC_PATH)/wrappers/themis/themispp/*.hpp)
-
-FMT_FIXUP += $(patsubst %,$(OBJ_PATH)/%.fmt_fixup, $(THEMISPP_HEADERS))
-FMT_CHECK += $(patsubst %,$(OBJ_PATH)/%.fmt_check, $(THEMISPP_HEADERS))
 
 #$(AUD_PATH)/%: CMD = $(CC) $(CFLAGS) -E -dI -dD $< -o $@
 $(AUD_PATH)/%: CMD = ./scripts/pp.sh  $< $@
@@ -519,19 +515,6 @@ ifeq ($(or $(PYTHON2_VERSION),$(PYTHON3_VERSION)),)
 	@exit 1
 endif
 	@echo -n "pythemis install "
-	@$(BUILD_CMD_)
-
-
-themispp_install: CMD = install $(SRC_PATH)/wrappers/themis/themispp/*.hpp $(PREFIX)/include/themispp
-
-themispp_install:
-	@mkdir -p $(PREFIX)/include/themispp
-	@$(BUILD_CMD)
-
-themispp_uninstall: CMD = rm -rf $(PREFIX)/include/themispp
-
-themispp_uninstall:
-	@echo -n "themispp uninstall "
 	@$(BUILD_CMD_)
 
 soter_collect_headers:

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,11 @@
 CLANG_FORMAT ?= clang-format
 CLANG_TIDY   ?= clang-tidy
 SHELL = /bin/bash
+
+INSTALL = install
+INSTALL_PROGRAM = $(INSTALL)
+INSTALL_DATA    = $(INSTALL) -m 644
+
 SRC_PATH = src
 ifneq ($(BUILD_PATH),)
 	BIN_PATH = $(BUILD_PATH)
@@ -76,6 +81,13 @@ PREFIX ?= /usr/local
 
 # default cryptographic engine
 ENGINE ?= libressl
+
+# default installation paths
+prefix          = $(PREFIX)
+exec_prefix     = $(prefix)
+includedir      = $(prefix)/include
+libdir          = $(exec_prefix)/lib
+pkgconfigdir    = $(libdir)/pkgconfig
 
 #engine selection block
 ifneq ($(ENGINE),)
@@ -298,8 +310,10 @@ all: err themis_static soter_static themis_shared soter_shared themis_pkgconfig 
 
 soter_static:  $(BIN_PATH)/$(LIBSOTER_A)
 soter_shared:  $(BIN_PATH)/$(LIBSOTER_SO)
+soter_pkgconfig: $(BIN_PATH)/libsoter.pc
 themis_static: $(BIN_PATH)/$(LIBTHEMIS_A)
 themis_shared: $(BIN_PATH)/$(LIBTHEMIS_SO)
+themis_pkgconfig: $(BIN_PATH)/libthemis.pc
 themis_jni:    $(BIN_PATH)/$(LIBTHEMISJNI_SO)
 
 #
@@ -370,43 +384,7 @@ ifdef RUST_VERSION
 	@rm -f tools/rust/*.rust
 endif
 
-make_install_dirs: CMD = mkdir -p $(PREFIX)/include/themis $(PREFIX)/include/soter $(PREFIX)/lib $(PREFIX)/lib/pkgconfig
-
-make_install_dirs:
-	@echo -n "making dirs for install "
-	@$(BUILD_CMD_)
-
-install_soter_headers: CMD = install $(SRC_PATH)/soter/*.h $(PREFIX)/include/soter
-
-install_soter_headers: err all make_install_dirs
-	@echo -n "install soter headers "
-	@$(BUILD_CMD_)
-
-install_themis_headers: CMD = install $(SRC_PATH)/themis/*.h $(PREFIX)/include/themis
-
-install_themis_headers: err all make_install_dirs
-	@echo -n "install themis headers "
-	@$(BUILD_CMD_)
-
-install_static_libs: CMD = install $(BIN_PATH)/*.a $(PREFIX)/lib
-
-install_static_libs: err all make_install_dirs
-	@echo -n "install static libraries "
-	@$(BUILD_CMD_)
-
-install_shared_libs: CMD = install $(BIN_PATH)/*.$(SHARED_EXT) $(PREFIX)/lib
-
-install_shared_libs: err all make_install_dirs
-	@echo -n "install shared libraries "
-	@$(BUILD_CMD_)
-
-install_pkgconfig: CMD = install $(BIN_PATH)/*.pc $(PREFIX)/lib/pkgconfig
-
-install_pkgconfig: err all make_install_dirs
-	@echo -n "install pkg-config files "
-	@$(BUILD_CMD_)
-
-install: install_soter_headers install_themis_headers install_static_libs install_shared_libs install_pkgconfig
+install: all install_soter install_themis
 	@echo -n "Themis installed to $(PREFIX)"
 	@$(PRINT_OK_)
 ifdef IS_LINUX
@@ -486,9 +464,7 @@ ifdef NPM_VERSION
 	@$(BUILD_CMD_)
 endif
 
-uninstall: CMD = rm -rf $(PREFIX)/include/themis && rm -rf $(PREFIX)/include/soter && rm -f $(PREFIX)/lib/libsoter.a && rm -f $(PREFIX)/lib/libthemis.a && rm -f $(PREFIX)/lib/libsoter.$(SHARED_EXT) && rm -f $(PREFIX)/lib/libthemis.$(SHARED_EXT) && rm -f $(PREFIX)/lib/pkgconfig/libsoter.pc && rm -f $(PREFIX)/lib/pkgconfig/libthemis.pc
-
-uninstall: phpthemis_uninstall rbthemis_uninstall themispp_uninstall jsthemis_uninstall
+uninstall: phpthemis_uninstall rbthemis_uninstall themispp_uninstall jsthemis_uninstall uninstall_themis uninstall_soter
 	@echo -n "Themis uninstalled from $(PREFIX) "
 	@$(BUILD_CMD_)
 

--- a/src/soter/soter.mk
+++ b/src/soter/soter.mk
@@ -60,9 +60,28 @@ ifdef IS_MACOS
 	@install_name_tool -change "$(BIN_PATH)/$(notdir $@)" "$(PREFIX)/lib/$(notdir $@)" $(BIN_PATH)/$(notdir $@)
 endif
 
-soter_pkgconfig:
+$(BIN_PATH)/libsoter.pc:
 	@mkdir -p $(BIN_PATH)
 	@sed -e "s!%prefix%!$(PREFIX)!" \
 	     -e "s!%version%!$(VERSION)!" \
 	     -e "s!%crypto-libs%!$(CRYPTO_ENGINE_LDFLAGS)!" \
 	    $(SRC_PATH)/soter/libsoter.pc.in > $(BIN_PATH)/libsoter.pc
+
+install_soter: err $(BIN_PATH)/$(LIBSOTER_A) $(BIN_PATH)/$(LIBSOTER_SO) $(BIN_PATH)/libsoter.pc
+	@echo -n "install Soter "
+	@mkdir -p $(DESTDIR)/$(includedir)/soter
+	@mkdir -p $(DESTDIR)/$(pkgconfigdir)
+	@mkdir -p $(DESTDIR)/$(libdir)
+	@$(INSTALL_DATA) $(SRC_PATH)/soter/*.h              $(DESTDIR)/$(includedir)/soter
+	@$(INSTALL_DATA) $(BIN_PATH)/libsoter.pc            $(DESTDIR)/$(pkgconfigdir)
+	@$(INSTALL_DATA) $(BIN_PATH)/$(LIBSOTER_A)          $(DESTDIR)/$(libdir)
+	@$(INSTALL_PROGRAM) $(BIN_PATH)/$(LIBSOTER_SO)      $(DESTDIR)/$(libdir)
+	@$(PRINT_OK_)
+
+uninstall_soter:
+	@echo -n "uninstall Soter "
+	@rm -rf $(DESTDIR)/$(includedir)/soter
+	@rm  -f $(DESTDIR)/$(pkgconfigdir)/libsoter.pc
+	@rm  -f $(DESTDIR)/$(libdir)/$(LIBSOTER_A)
+	@rm  -f $(DESTDIR)/$(libdir)/$(LIBSOTER_SO)
+	@$(PRINT_OK_)

--- a/src/themis/themis.mk
+++ b/src/themis/themis.mk
@@ -51,8 +51,27 @@ ifdef IS_MACOS
 	@install_name_tool -change "$(BIN_PATH)/$(notdir $@)" "$(PREFIX)/lib/$(notdir $@)" $(BIN_PATH)/$(notdir $@)
 endif
 
-themis_pkgconfig:
+$(BIN_PATH)/libthemis.pc:
 	@mkdir -p $(BIN_PATH)
 	@sed -e "s!%prefix%!$(PREFIX)!" \
 	     -e "s!%version%!$(VERSION)!" \
 	    $(SRC_PATH)/themis/libthemis.pc.in > $(BIN_PATH)/libthemis.pc
+
+install_themis: err $(BIN_PATH)/$(LIBTHEMIS_A) $(BIN_PATH)/$(LIBTHEMIS_SO) $(BIN_PATH)/libthemis.pc
+	@echo -n "install Themis "
+	@mkdir -p $(DESTDIR)/$(includedir)/themis
+	@mkdir -p $(DESTDIR)/$(pkgconfigdir)
+	@mkdir -p $(DESTDIR)/$(libdir)
+	@$(INSTALL_DATA) $(SRC_PATH)/themis/*.h             $(DESTDIR)/$(includedir)/themis
+	@$(INSTALL_DATA) $(BIN_PATH)/libthemis.pc           $(DESTDIR)/$(pkgconfigdir)
+	@$(INSTALL_DATA) $(BIN_PATH)/$(LIBTHEMIS_A)         $(DESTDIR)/$(libdir)
+	@$(INSTALL_PROGRAM) $(BIN_PATH)/$(LIBTHEMIS_SO)     $(DESTDIR)/$(libdir)
+	@$(PRINT_OK_)
+
+uninstall_themis:
+	@echo -n "uninstall Themis "
+	@rm -rf $(DESTDIR)/$(includedir)/themis
+	@rm  -f $(DESTDIR)/$(pkgconfigdir)/libthemis.pc
+	@rm  -f $(DESTDIR)/$(libdir)/$(LIBTHEMIS_A)
+	@rm  -f $(DESTDIR)/$(libdir)/$(LIBTHEMIS_SO)
+	@$(PRINT_OK_)

--- a/src/wrappers/themis/themispp/themispp.mk
+++ b/src/wrappers/themis/themispp/themispp.mk
@@ -1,0 +1,31 @@
+#
+# Copyright (c) 2019 Cossack Labs Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+THEMISPP_HEADERS = $(wildcard $(SRC_PATH)/wrappers/themis/themispp/*.hpp)
+
+FMT_FIXUP += $(patsubst %,$(OBJ_PATH)/%.fmt_fixup, $(THEMISPP_HEADERS))
+FMT_CHECK += $(patsubst %,$(OBJ_PATH)/%.fmt_check, $(THEMISPP_HEADERS))
+
+themispp_install:
+	@echo -n "install ThemisPP "
+	@mkdir -p $(DESTDIR)/$(includedir)/themispp
+	@$(INSTALL_DATA) $(SRC_PATH)/wrappers/themis/themispp/*.hpp $(DESTDIR)/$(includedir)/themispp
+	@$(PRINT_OK_)
+
+themispp_uninstall:
+	@echo -n "uninstall ThemisPP "
+	@rm -rf $(DESTDIR)/$(includedir)/themispp
+	@$(PRINT_OK_)


### PR DESCRIPTION
First of all, move Soter and Themis installation rules out from Makefile to their individual makefiles. This makes them a bit easier to maintain.

After that, reduce installation targets to just `install`, `install_themis` and `install_soter` (plus `uninstall` counterparts). No one should really be using individual targets to install only some parts of the library. These targets are not really documented, and are not standard.

* **Follow GNU conventions for installation: Soter, Themis**

Adhere to [GNU Makefile conventions][1] when installing files. This encompasses multiple aspects:

  - **`INSTALL`, `INSTALL_DATA`, `INSTALL_PROGRAM` variables**

    It's not strictly necessary, but nice to have. This allows to override the tool for installing files, and makes sure that data files are not marked executable.

  - **`DESTDIR` prefix**

    This is an important variable for packaging as it allows staged installation. It gets prefixed to each installation destination so that it could be made into a temporary directory which will get packaged later.

    Note that this variable is never set explicitly in the Makefile and is empty by default. It's also used only during installation, the library is built as if it's going to be installed to the usual location with DESTDIR preprended to it.

  - **`prefix`, `includedir`, `libdir`, etc. variables**

    These variables allow fine tuning of installation paths when packaging for distributions that have varying conventions. Most prominently, they affect the destination for libraries which may be `/lib`, `/usr/lib`, `/usr/lib64`, `/usr/lib/x86_64-linux-gnu`, or something else.

    Note that it's lowercase `prefix`, not uppercase `PREFIX`. That's how it should be by the book, but all our documentation uses the capitalized version, so we keep it for compatibility.

This teaches our Makefile to play nicely with other tools that expect GNU conventions to hold. Primarily, these are various package-building tools that rely on the variables to interpose their helper tools and override installation paths to distribution-specific places.

(We could have gotten all of that automatically by using Autotools, but no one really knows Autotools nowadays. Even these GNU conventions are arcane knowledge in the days of "curl | sudo sh" and every language having their own package manager.)

[1]: https://www.gnu.org/prep/standards/html_node/Makefile-Conventions.html

* **Follow GNU conventions for installation: ThemisPP**

Now, there are quite a few ThemisPP-specific rules in the main Makefile. Move them all into a separate one, just for ThemisPP.

After that, update ThemisPP installation targets to follow the same conventions as for Soter and Themis.