### PR TITLE
Ignored NIST statistical tests with NO_NIST_STS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,8 @@ jobs:
       - image: cossacklabs/android-build:2019.01
     environment:
       GOTHEMIS_IMPORT: github.com/cossacklabs/themis/gothemis
-      CFLAGS: "-DCIRICLE_TEST"
+      # NIST STS tests tend to fail in Docker environment
+      NO_NIST_STS: 1
       WITH_FATAL_WARNINGS: yes
     steps:
       - run: sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get -y install libssl-dev python python-setuptools python3 python3-setuptools ruby-dev nodejs npm lcov libc6-dbg rsync software-properties-common pkg-config clang afl
@@ -130,7 +131,8 @@ jobs:
       - image: cossacklabs/android-build:2019.01
     environment:
       GOTHEMIS_IMPORT: github.com/cossacklabs/themis/gothemis
-      CFLAGS: "-DCIRICLE_TEST"
+      # NIST STS tests tend to fail in Docker environment
+      NO_NIST_STS: 1
       WITH_FATAL_WARNINGS: yes
     steps:
       # dependencies

--- a/tests/soter/soter.mk
+++ b/tests/soter/soter.mk
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+NIST_STS_DIR = tests/soter/nist-sts
+
 SOTER_TEST_SOURCES = $(wildcard tests/soter/*.c)
 SOTER_TEST_HEADERS = $(wildcard tests/soter/*.h)
 
@@ -24,9 +26,17 @@ SOTER_TEST_FMT = $(SOTER_TEST_SOURCES) $(SOTER_TEST_HEADERS)
 FMT_FIXUP += $(patsubst %,$(OBJ_PATH)/%.fmt_fixup, $(SOTER_TEST_FMT))
 FMT_CHECK += $(patsubst %,$(OBJ_PATH)/%.fmt_check, $(SOTER_TEST_FMT))
 
+ifdef NO_NIST_STS
+$(OBJ_PATH)/tests/soter/%: CFLAGS += -DNO_NIST_STS=1
+else
+$(OBJ_PATH)/tests/soter/%: CFLAGS += -DNIST_STS_EXE_PATH=$(realpath $(NIST_STS_DIR))
+
+$(TEST_BIN_PATH)/soter_test: nist_rng_test_suite
+endif
+
 $(TEST_BIN_PATH)/soter_test: CMD = $(CC) -o $@ $(filter %.o %.a, $^) $(LDFLAGS) $(CRYPTO_ENGINE_LDFLAGS)
 
-$(TEST_BIN_PATH)/soter_test: nist_rng_test_suite $(SOTER_TEST_OBJ) $(COMMON_TEST_OBJ) $(SOTER_STATIC)
+$(TEST_BIN_PATH)/soter_test: $(SOTER_TEST_OBJ) $(COMMON_TEST_OBJ) $(SOTER_STATIC)
 	@mkdir -p $(@D)
 	@echo -n "link "
 	@$(BUILD_CMD)

--- a/tests/soter/soter_rand_test.c
+++ b/tests/soter/soter_rand_test.c
@@ -20,7 +20,11 @@
 #include <string.h>
 #include <unistd.h>
 
-#ifdef NIST_STS_EXE_PATH
+#ifndef NIST_STS_EXE_PATH
+#define NO_NIST_STS 1
+#endif
+
+#ifndef NO_NIST_STS
 
 #define _TO_STRING_(_X_) (#_X_)
 #define TO_STRING(_X_) _TO_STRING_(_X_)
@@ -159,14 +163,7 @@ out:
     free(curr_work_dir);
 }
 
-#else
-
-static void test_rand_with_nist(void)
-{
-    testsuite_fail_if(true, "NIST tests");
-}
-
-#endif
+#endif /* NO_NIST_STS */
 
 static void test_api(void)
 {
@@ -180,11 +177,8 @@ void run_soter_rand_tests(void)
 {
     testsuite_enter_suite("soter rand: api");
     testsuite_run_test(test_api);
-// always fail under ci
-#ifndef CIRICLE_TEST
+#ifndef NO_NIST_STS
     testsuite_enter_suite("soter rand: NIST STS (make take some time...)");
     testsuite_run_test(test_rand_with_nist);
-#else
-    UNUSED(test_rand_with_nist);
 #endif
 }

--- a/tests/test.mk
+++ b/tests/test.mk
@@ -17,8 +17,6 @@
 COMMON_TEST_SRC = $(wildcard tests/common/*.c)
 COMMON_TEST_OBJ = $(patsubst %,$(OBJ_PATH)/%.o, $(COMMON_TEST_SRC))
 
-NIST_STS_DIR = tests/soter/nist-sts
-
 GOTHEMIS_IMPORT = github.com/cossacklabs/themis/gothemis
 
 include tests/soter/soter.mk
@@ -30,7 +28,7 @@ soter_test:    $(TEST_BIN_PATH)/soter_test
 themis_test:   $(TEST_BIN_PATH)/themis_test
 themispp_test: $(TEST_BIN_PATH)/themispp_test
 
-$(OBJ_PATH)/tests/%: CFLAGS += -I$(TEST_SRC_PATH) -DNIST_STS_EXE_PATH=$(realpath $(NIST_STS_DIR))
+$(OBJ_PATH)/tests/%: CFLAGS += -I$(TEST_SRC_PATH)
 
 PYTHON2_TEST_SCRIPT=$(BIN_PATH)/tests/pythemis2_test.sh
 PYTHON3_TEST_SCRIPT=$(BIN_PATH)/tests/pythemis3_test.sh


### PR DESCRIPTION
Unfortunately, NIST STS requires access to genuine randomness source and tends to fail in Docker environments where `/dev/random` is not accessible. That's why we have an option to disable NIST STS by setting CIRICLE_TEST (_sic!_) preprocessor variable.

Let's improve and cleanup this mechanism a bit.

  - Use more obvious `NO_NIST_STS` environment variable instead of fiddling with CFLAGS directly

    Admittedly, existing flag is more general as it allows to compile out any code when building on CI. However, it has never been used for anything other than NIST STS.

  - Do not compile "assess" test runner if we're not going to use it

  - Move NIST STS configuration to soter.mk