### PR TITLE
Explicitly export public API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,6 +271,9 @@ endif
 # strict checks for docs
 #CFLAGS += -Wdocumentation -Wno-error=documentation
 
+# Explicitly list all exports
+CFLAGS += -fvisibility=hidden
+
 # fixing compatibility between x64 0.9.6 and x64 0.10.0
 # https://github.com/cossacklabs/themis/pull/279
 ifeq ($(NO_SCELL_COMPAT),)

--- a/Themis.xcodeproj/project.pbxproj
+++ b/Themis.xcodeproj/project.pbxproj
@@ -398,6 +398,8 @@
 		9F4A24C2223A8FA8005CB63A /* smessage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = smessage.h; path = "src/wrappers/themis/Obj-C/objcthemis/smessage.h"; sourceTree = "<group>"; };
 		9F4A24C3223A8FA8005CB63A /* scell_token.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = scell_token.h; path = "src/wrappers/themis/Obj-C/objcthemis/scell_token.h"; sourceTree = "<group>"; };
 		9FBD853C223BFB5E009EAEB3 /* openssl.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = openssl.framework; path = Carthage/Build/iOS/openssl.framework; sourceTree = "<group>"; };
+		9FD4C3522260D41700132A88 /* soter_api.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = soter_api.h; path = src/soter/soter_api.h; sourceTree = "<group>"; };
+		9FD4C3532260D43B00132A88 /* themis_api.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = themis_api.h; path = src/themis/themis_api.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -443,6 +445,7 @@
 			children = (
 				9F4A23A6223A742F005CB63A /* ed25519 */,
 				9F4A2383223A740E005CB63A /* openssl */,
+				9FD4C3522260D41700132A88 /* soter_api.h */,
 				9F4A2343223A73B0005CB63A /* soter_asym_cipher.h */,
 				9F4A234B223A73B0005CB63A /* soter_asym_ka.h */,
 				9F4A2350223A73B1005CB63A /* soter_asym_sign.h */,
@@ -589,6 +592,7 @@
 				9F4A242D223A74AF005CB63A /* secure_session.h */,
 				9F4A2431223A74AF005CB63A /* sym_enc_message.c */,
 				9F4A242B223A74AF005CB63A /* sym_enc_message.h */,
+				9FD4C3532260D43B00132A88 /* themis_api.h */,
 				9F4A242F223A74AF005CB63A /* themis_error.h */,
 				9F4A2433223A74AF005CB63A /* themis.h */,
 			);

--- a/src/soter/boringssl/soter_asym_cipher.c
+++ b/src/soter/boringssl/soter_asym_cipher.c
@@ -20,6 +20,7 @@
 #include <openssl/rsa.h>
 
 #include "soter/boringssl/soter_engine.h"
+#include "soter/soter_api.h"
 #include "soter/soter_rsa_key.h"
 
 #define OAEP_HASH_SIZE 20
@@ -70,6 +71,7 @@ soter_status_t soter_asym_cipher_import_key(soter_asym_cipher_t* asym_cipher_ctx
 
 /* Padding is ignored. We use OAEP by default. Parameter is to support more paddings in the future
  */
+SOTER_PRIVATE_API
 soter_status_t soter_asym_cipher_init(soter_asym_cipher_t* asym_cipher,
                                       const void* key,
                                       const size_t key_length,
@@ -102,6 +104,7 @@ soter_status_t soter_asym_cipher_init(soter_asym_cipher_t* asym_cipher,
     return SOTER_SUCCESS;
 }
 
+SOTER_PRIVATE_API
 soter_status_t soter_asym_cipher_cleanup(soter_asym_cipher_t* asym_cipher)
 {
     if (!asym_cipher) {

--- a/src/soter/boringssl/soter_asym_ka.c
+++ b/src/soter/boringssl/soter_asym_ka.c
@@ -19,6 +19,7 @@
 #include <openssl/ec.h>
 
 #include "soter/boringssl/soter_engine.h"
+#include "soter/soter_api.h"
 #include "soter/soter_ec_key.h"
 
 static int soter_alg_to_curve_nid(soter_asym_ka_alg_t alg)
@@ -31,6 +32,7 @@ static int soter_alg_to_curve_nid(soter_asym_ka_alg_t alg)
     }
 }
 
+SOTER_PRIVATE_API
 soter_status_t soter_asym_ka_init(soter_asym_ka_t* asym_ka_ctx, soter_asym_ka_alg_t alg)
 {
     EVP_PKEY* pkey;
@@ -70,6 +72,7 @@ soter_status_t soter_asym_ka_init(soter_asym_ka_t* asym_ka_ctx, soter_asym_ka_al
     return SOTER_SUCCESS;
 }
 
+SOTER_PRIVATE_API
 soter_status_t soter_asym_ka_cleanup(soter_asym_ka_t* asym_ka_ctx)
 {
     if (!asym_ka_ctx) {

--- a/src/soter/boringssl/soter_hash.c
+++ b/src/soter/boringssl/soter_hash.c
@@ -19,6 +19,7 @@
 #include <openssl/evp.h>
 
 #include "soter/boringssl/soter_engine.h"
+#include "soter/soter_api.h"
 
 static const EVP_MD* soter_algo_to_evp_md(soter_hash_algo_t algo)
 {
@@ -32,6 +33,7 @@ static const EVP_MD* soter_algo_to_evp_md(soter_hash_algo_t algo)
     }
 }
 
+SOTER_PRIVATE_API
 soter_status_t soter_hash_init(soter_hash_ctx_t* hash_ctx, soter_hash_algo_t algo)
 {
     const EVP_MD* md = soter_algo_to_evp_md(algo);

--- a/src/soter/ed25519/fe.h
+++ b/src/soter/ed25519/fe.h
@@ -4,6 +4,8 @@
 /* #include "crypto_int32.h" */
 #include <stdint.h>
 
+#include <soter/soter_api.h>
+
 typedef int32_t crypto_int32;
 typedef int64_t crypto_int64;
 typedef uint32_t crypto_uint32;

--- a/src/soter/ed25519/fe_isnonzero.c
+++ b/src/soter/ed25519/fe_isnonzero.c
@@ -9,6 +9,7 @@ Preconditions:
    |f| bounded by 1.1*2^26,1.1*2^25,1.1*2^26,1.1*2^25,etc.
 */
 
+SOTER_PRIVATE_API
 int crypto_verify_32(const unsigned char *x,const unsigned char *y)
 {
   unsigned int differentbits = 0;
@@ -48,6 +49,7 @@ int crypto_verify_32(const unsigned char *x,const unsigned char *y)
   return (1 & ((differentbits - 1) >> 8)) - 1;
 }
 
+SOTER_PRIVATE_API
 int fe_isnonzero(const fe f)
 {
   static const unsigned char zero[32] = {0};

--- a/src/soter/ed25519/fe_neg.c
+++ b/src/soter/ed25519/fe_neg.c
@@ -10,6 +10,7 @@ Postconditions:
    |h| bounded by 1.1*2^25,1.1*2^24,1.1*2^25,1.1*2^24,etc.
 */
 
+SOTER_PRIVATE_API
 void fe_neg(fe h,const fe f)
 {
   crypto_int32 f0 = f[0];

--- a/src/soter/ed25519/fe_tobytes.c
+++ b/src/soter/ed25519/fe_tobytes.c
@@ -25,6 +25,7 @@ Proof:
   so floor(2^(-255)(h + 19 2^(-25) h9 + 2^(-1))) = q.
 */
 
+SOTER_PRIVATE_API
 void fe_tobytes(unsigned char *s,const fe h)
 {
   crypto_int32 h0 = h[0];

--- a/src/soter/ed25519/ge.h
+++ b/src/soter/ed25519/ge.h
@@ -15,6 +15,8 @@ Representations:
   ge_precomp (Duif): (y+x,y-x,2dxy)
 */
 
+#include <soter/soter_api.h>
+
 #include "fe.h"
 
 typedef struct {

--- a/src/soter/ed25519/ge_cmp.c
+++ b/src/soter/ed25519/ge_cmp.c
@@ -18,6 +18,7 @@
 #include <string.h>
 #include <stdint.h>
 
+SOTER_PRIVATE_API
 int ge_cmp(const ge_p3 *a, const ge_p3 *b)
 {
 	unsigned char a_comp[ED25519_GE_LENGTH];

--- a/src/soter/ed25519/ge_double_scalarmult.c
+++ b/src/soter/ed25519/ge_double_scalarmult.c
@@ -43,6 +43,7 @@ and b = b[0]+256*b[1]+...+256^31 b[31].
 B is the Ed25519 base point (x,4/5) with x positive.
 */
 
+SOTER_PRIVATE_API
 void ge_double_scalarmult_vartime(ge_p2 *r,const unsigned char *a,const ge_p3 *A,const unsigned char *b)
 {
   signed char aslide[256];

--- a/src/soter/ed25519/ge_frombytes_no_negate.c
+++ b/src/soter/ed25519/ge_frombytes_no_negate.c
@@ -16,6 +16,7 @@
 
 #include "ge_utils.h"
 
+SOTER_PRIVATE_API
 int ge_frombytes_vartime(ge_p3 *h, const unsigned char *s)
 {
 	int res = ge_frombytes_negate_vartime(h, s);

--- a/src/soter/ed25519/ge_p2_to_p3.c
+++ b/src/soter/ed25519/ge_p2_to_p3.c
@@ -16,6 +16,7 @@
 
 #include "ge_utils.h"
 
+SOTER_PRIVATE_API
 void ge_p2_to_p3(ge_p3 *r, const ge_p2 *p)
 {
 	if (p != (const ge_p2 *)r)

--- a/src/soter/ed25519/ge_p3_sub.c
+++ b/src/soter/ed25519/ge_p3_sub.c
@@ -16,6 +16,7 @@
 
 #include "ge_utils.h"
 
+SOTER_PRIVATE_API
 void ge_p3_sub(ge_p3 *r, const ge_p3 *p, const ge_p3 *q)
 {
 	ge_cached q_cached;

--- a/src/soter/ed25519/ge_p3_tobytes.c
+++ b/src/soter/ed25519/ge_p3_tobytes.c
@@ -1,5 +1,6 @@
 #include "ge.h"
 
+SOTER_PRIVATE_API
 void ge_p3_tobytes(unsigned char *s,const ge_p3 *h)
 {
   fe recip;

--- a/src/soter/ed25519/ge_scalarmult.c
+++ b/src/soter/ed25519/ge_scalarmult.c
@@ -16,6 +16,7 @@
 
 #include "ge_utils.h"
 
+SOTER_PRIVATE_API
 void ge_scalarmult_blinded(ge_p3 *r, const unsigned char *a, const ge_p3 *A)
 {
 	unsigned char rnd[32];

--- a/src/soter/ed25519/ge_scalarmult_base.c
+++ b/src/soter/ed25519/ge_scalarmult_base.c
@@ -61,6 +61,7 @@ Preconditions:
   a[31] <= 127
 */
 
+SOTER_PRIVATE_API
 void ge_scalarmult_base(ge_p3 *h,const unsigned char *a)
 {
   signed char e[64];

--- a/src/soter/ed25519/ge_tobytes.c
+++ b/src/soter/ed25519/ge_tobytes.c
@@ -1,5 +1,6 @@
 #include "ge.h"
 
+SOTER_PRIVATE_API
 void ge_tobytes(unsigned char *s,const ge_p2 *h)
 {
   fe recip;

--- a/src/soter/ed25519/ge_utils.h
+++ b/src/soter/ed25519/ge_utils.h
@@ -19,6 +19,8 @@
 #ifndef GE_UTILS_H
 #define GE_UTILS_H
 
+#include <soter/soter_api.h>
+
 #include "ge.h"
 
 #define ED25519_GE_LENGTH 32

--- a/src/soter/ed25519/gen_rand_32.c
+++ b/src/soter/ed25519/gen_rand_32.c
@@ -17,6 +17,7 @@
 #include "ge_utils.h"
 #include <soter/soter.h>
 
+SOTER_PRIVATE_API
 void clip_random_32(unsigned char *r)
 {
     r[0] &= 248;
@@ -24,6 +25,7 @@ void clip_random_32(unsigned char *r)
     r[31] |= 64;
 }
 
+SOTER_PRIVATE_API
 void generate_random_32(unsigned char *r)
 {
 	soter_status_t res = soter_rand(r, ED25519_GE_LENGTH);

--- a/src/soter/ed25519/sc.h
+++ b/src/soter/ed25519/sc.h
@@ -1,6 +1,8 @@
 #ifndef SC_H
 #define SC_H
 
+#include <soter/soter_api.h>
+
 /*
 The set of scalars is \Z/l
 where l = 2^252 + 27742317777372353535851937790883648493.

--- a/src/soter/ed25519/sc_muladd.c
+++ b/src/soter/ed25519/sc_muladd.c
@@ -34,6 +34,7 @@ Output:
   where l = 2^252 + 27742317777372353535851937790883648493.
 */
 
+SOTER_PRIVATE_API
 void sc_muladd(unsigned char *s,const unsigned char *a,const unsigned char *b,const unsigned char *c)
 {
   crypto_int64 a0 = 2097151 & load_3(a);

--- a/src/soter/ed25519/sc_reduce.c
+++ b/src/soter/ed25519/sc_reduce.c
@@ -33,6 +33,7 @@ Output:
   Overwrites s in place.
 */
 
+SOTER_PRIVATE_API
 void sc_reduce(unsigned char *s)
 {
   crypto_int64 s0 = 2097151 & load_3(s);

--- a/src/soter/openssl/soter_asym_cipher.c
+++ b/src/soter/openssl/soter_asym_cipher.c
@@ -20,6 +20,7 @@
 #include <openssl/rsa.h>
 
 #include "soter/openssl/soter_engine.h"
+#include "soter/soter_api.h"
 #include "soter/soter_rsa_key.h"
 
 /* We use only SHA1 for now */
@@ -71,6 +72,7 @@ soter_status_t soter_asym_cipher_import_key(soter_asym_cipher_t* asym_cipher_ctx
 
 /* Padding is ignored. We use OAEP by default. Parameter is to support more paddings in the future
  */
+SOTER_PRIVATE_API
 soter_status_t soter_asym_cipher_init(soter_asym_cipher_t* asym_cipher,
                                       const void* key,
                                       const size_t key_length,
@@ -106,6 +108,7 @@ soter_status_t soter_asym_cipher_init(soter_asym_cipher_t* asym_cipher,
     return SOTER_SUCCESS;
 }
 
+SOTER_PRIVATE_API
 soter_status_t soter_asym_cipher_cleanup(soter_asym_cipher_t* asym_cipher)
 {
     if (!asym_cipher) {

--- a/src/soter/openssl/soter_asym_ka.c
+++ b/src/soter/openssl/soter_asym_ka.c
@@ -19,6 +19,7 @@
 #include <openssl/ec.h>
 
 #include "soter/openssl/soter_engine.h"
+#include "soter/soter_api.h"
 #include "soter/soter_ec_key.h"
 
 static int soter_alg_to_curve_nid(soter_asym_ka_alg_t alg)
@@ -31,6 +32,7 @@ static int soter_alg_to_curve_nid(soter_asym_ka_alg_t alg)
     }
 }
 
+SOTER_PRIVATE_API
 soter_status_t soter_asym_ka_init(soter_asym_ka_t* asym_ka_ctx, soter_asym_ka_alg_t alg)
 {
     EVP_PKEY* pkey;
@@ -80,6 +82,7 @@ soter_status_t soter_asym_ka_init(soter_asym_ka_t* asym_ka_ctx, soter_asym_ka_al
     return SOTER_SUCCESS;
 }
 
+SOTER_PRIVATE_API
 soter_status_t soter_asym_ka_cleanup(soter_asym_ka_t* asym_ka_ctx)
 {
     if (!asym_ka_ctx) {

--- a/src/soter/openssl/soter_hash.c
+++ b/src/soter/openssl/soter_hash.c
@@ -19,6 +19,7 @@
 #include <openssl/evp.h>
 
 #include "soter/openssl/soter_engine.h"
+#include "soter/soter_api.h"
 
 static const EVP_MD* soter_algo_to_evp_md(soter_hash_algo_t algo)
 {
@@ -32,6 +33,7 @@ static const EVP_MD* soter_algo_to_evp_md(soter_hash_algo_t algo)
     }
 }
 
+SOTER_PRIVATE_API
 soter_status_t soter_hash_init(soter_hash_ctx_t* hash_ctx, soter_hash_algo_t algo)
 {
     const EVP_MD* md = soter_algo_to_evp_md(algo);

--- a/src/soter/soter.mk
+++ b/src/soter/soter.mk
@@ -42,6 +42,8 @@ FMT_CHECK += $(patsubst %,$(OBJ_PATH)/%.fmt_check, $(SOTER_FMT_SRC))
 
 SOTER_STATIC = $(BIN_PATH)/$(LIBSOTER_A) $(SOTER_ENGINE_DEPS)
 
+$(SOTER_OBJ): CFLAGS += -DSOTER_EXPORT
+
 $(BIN_PATH)/$(LIBSOTER_A): CMD = $(AR) rcs $@ $(filter %.o, $^)
 
 $(BIN_PATH)/$(LIBSOTER_A): $(SOTER_OBJ)

--- a/src/soter/soter_api.h
+++ b/src/soter/soter_api.h
@@ -23,4 +23,10 @@
 #define SOTER_API
 #endif
 
+/*
+ * Marks API that needs to be exported for technical reasons, but otherwise
+ * is not intended for user consumption.
+ */
+#define SOTER_PRIVATE_API SOTER_API
+
 #endif /* SOTER_API_H */

--- a/src/soter/soter_api.h
+++ b/src/soter/soter_api.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2019 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SOTER_API_H
+#define SOTER_API_H
+
+#if defined(__GNUC__) || defined(__clang__)
+#define SOTER_API __attribute__((visibility("default")))
+#else
+#define SOTER_API
+#endif
+
+#endif /* SOTER_API_H */

--- a/src/soter/soter_api.h
+++ b/src/soter/soter_api.h
@@ -19,6 +19,12 @@
 
 #if defined(__GNUC__) || defined(__clang__)
 #define SOTER_API __attribute__((visibility("default")))
+#elif defined(_WIN32) || defined(_WIN64) || defined(__CYGWIN__)
+#ifdef SOTER_EXPORT
+#define SOTER_API __declspec(dllexport)
+#else
+#define SOTER_API __declspec(dllimport)
+#endif
 #else
 #define SOTER_API
 #endif

--- a/src/soter/soter_asym_cipher.h
+++ b/src/soter/soter_asym_cipher.h
@@ -21,6 +21,7 @@
 #ifndef SOTER_ASYM_CIPHER_H
 #define SOTER_ASYM_CIPHER_H
 
+#include <soter/soter_api.h>
 #include <soter/soter_error.h>
 
 /**
@@ -53,6 +54,7 @@ typedef struct soter_asym_cipher_type soter_asym_cipher_t;
  * @param [in] pad padding algorithm to be used. See @ref soter_asym_cipher_padding_type
  * @return pointer to created asymmetric encription/decription context on success or NULL on failure
  */
+SOTER_API
 soter_asym_cipher_t* soter_asym_cipher_create(const void* key,
                                               size_t key_length,
                                               soter_asym_cipher_padding_t pad);
@@ -71,6 +73,7 @@ soter_asym_cipher_t* soter_asym_cipher_create(const void* key,
  * SOTER_BUFFER_TOO_SMALL will return and cipher_data_length will contain length of buffer thet need
  * to store cipher data.
  */
+SOTER_API
 soter_status_t soter_asym_cipher_encrypt(soter_asym_cipher_t* asym_cipher_ctx,
                                          const void* plain_data,
                                          size_t plain_data_length,
@@ -91,6 +94,7 @@ soter_status_t soter_asym_cipher_encrypt(soter_asym_cipher_t* asym_cipher_ctx,
  * SOTER_BUFFER_TOO_SMALL will return and plain_data_length will contain length of buffer thet need
  * to store plain data.
  */
+SOTER_API
 soter_status_t soter_asym_cipher_decrypt(soter_asym_cipher_t* asym_cipher_ctx,
                                          const void* cipher_data,
                                          size_t cipher_data_length,
@@ -114,6 +118,7 @@ soter_status_t soter_asym_cipher_decrypt(soter_asym_cipher_t* asym_cipher_ctx,
  * created by soter_asym_cipher_create
  * @return result of operation, @ref SOTER_SUCESS on success or @ref SOTER_FAIL on failure
  */
+SOTER_API
 soter_status_t soter_asym_cipher_destroy(soter_asym_cipher_t* asym_cipher_ctx);
 
 /** @} */

--- a/src/soter/soter_asym_ka.h
+++ b/src/soter/soter_asym_ka.h
@@ -21,6 +21,7 @@
 #ifndef SOTER_ASYM_KA_H
 #define SOTER_ASYM_KA_H
 
+#include <soter/soter_api.h>
 #include <soter/soter_error.h>
 
 /** @addtogroup SOTER
@@ -45,6 +46,7 @@ typedef struct soter_asym_ka_type soter_asym_ka_t;
  * @param [in] alg algorithm to use. See @ref soter_asym_ka_alg_type
  * @return pointer to created key agreement context on success or NULL on failure
  */
+SOTER_API
 soter_asym_ka_t* soter_asym_ka_create(soter_asym_ka_alg_t alg);
 
 /**
@@ -53,6 +55,7 @@ soter_asym_ka_t* soter_asym_ka_create(soter_asym_ka_alg_t alg);
  * soter_asym_ka_create
  * @return result of operation, @ref SOTER_SUCESS on success or @ref SOTER_FAIL on failure
  */
+SOTER_API
 soter_status_t soter_asym_ka_gen_key(soter_asym_ka_t* asym_ka_ctx);
 
 /**
@@ -66,6 +69,7 @@ soter_status_t soter_asym_ka_gen_key(soter_asym_ka_t* asym_ka_ctx);
  * @note If key==NULL or key_length less then need to store key, @ref SOTER_BUFFER_TOO_SMALL will
  * return and key_length will contain length of buffer thet need to store key.
  */
+SOTER_API
 soter_status_t soter_asym_ka_export_key(soter_asym_ka_t* asym_ka_ctx,
                                         void* key,
                                         size_t* key_length,
@@ -79,6 +83,7 @@ soter_status_t soter_asym_ka_export_key(soter_asym_ka_t* asym_ka_ctx,
  * @param [in] key_length length of key
  * @return result of operation, @ref SOTER_SUCESS on success or @ref SOTER_FAIL on failure
  */
+SOTER_API
 soter_status_t soter_asym_ka_import_key(soter_asym_ka_t* asym_ka_ctx, const void* key, size_t key_length);
 
 /**
@@ -95,6 +100,7 @@ soter_status_t soter_asym_ka_import_key(soter_asym_ka_t* asym_ka_ctx, const void
  * SOTER_BUFFER_TOO_SMALL will return and shared_secret_length will contain length of buffer thet
  * need to store shared secret.
  */
+SOTER_API
 soter_status_t soter_asym_ka_derive(soter_asym_ka_t* asym_ka_ctx,
                                     const void* peer_key,
                                     size_t peer_key_length,
@@ -107,6 +113,7 @@ soter_status_t soter_asym_ka_derive(soter_asym_ka_t* asym_ka_ctx,
  * soter_asym_ka_create
  * @return result of operation, @ref SOTER_SUCESS on success or @ref SOTER_FAIL on failure
  */
+SOTER_API
 soter_status_t soter_asym_ka_destroy(soter_asym_ka_t* asym_ka_ctx);
 
 /** @} */

--- a/src/soter/soter_asym_sign.h
+++ b/src/soter/soter_asym_sign.h
@@ -21,6 +21,7 @@
 #ifndef SOTER_ASYM_SIGN_H
 #define SOTER_ASYM_SIGN_H
 
+#include <soter/soter_api.h>
 #include <soter/soter_error.h>
 
 /** @addtogroup SOTER
@@ -58,6 +59,7 @@ typedef struct soter_sign_ctx_type soter_sign_ctx_t;
  * @note If private_key==NULL and public_key==NULL with creating of sign context will be generated
  * new key pair.
  */
+SOTER_API
 soter_sign_ctx_t* soter_sign_create(soter_sign_alg_t alg,
                                     const void* private_key,
                                     size_t private_key_length,
@@ -70,6 +72,7 @@ soter_sign_ctx_t* soter_sign_create(soter_sign_alg_t alg,
  * @param [in] data_length length of data
  * @return result of operation, @ref SOTER_SUCCESS on success or SOTER_FAIL on failure
  */
+SOTER_API
 soter_status_t soter_sign_update(soter_sign_ctx_t* ctx, const void* data, size_t data_length);
 
 /** @brief final sign context
@@ -82,6 +85,7 @@ soter_status_t soter_sign_update(soter_sign_ctx_t* ctx, const void* data, size_t
  * SOTER_BUFFER_TOO_SMALL will return and signature_length will contain length of buffer thet need
  * to store signature.
  */
+SOTER_API
 soter_status_t soter_sign_final(soter_sign_ctx_t* ctx, void* signature, size_t* signature_length);
 
 /** @brief export key from sign context
@@ -93,12 +97,14 @@ soter_status_t soter_sign_final(soter_sign_ctx_t* ctx, void* signature, size_t* 
  * @note If key==NULL or key_length less then need to store key, @ref SOTER_BUFFER_TOO_SMALL will
  * return and key_length will contain length of buffer thet need to store key.
  */
+SOTER_API
 soter_status_t soter_sign_export_key(soter_sign_ctx_t* ctx, void* key, size_t* key_length, bool isprivate);
 
 /** @brief destroy sign context
  * @param [in] ctx pointer to sign context previously created by soter_sign_create
  * @return result of operation, @ref SOTER_SUCCESS on success or @ref SOTER_FAIL on failure
  */
+SOTER_API
 soter_status_t soter_sign_destroy(soter_sign_ctx_t* ctx);
 
 /** @brief get used algorithm id from sign context
@@ -106,6 +112,7 @@ soter_status_t soter_sign_destroy(soter_sign_ctx_t* ctx);
  * @return used algorithm id (see @ref soter_sign_alg_type) on success or @ref SOTER_SIGN_undefined
  * on failure
  */
+SOTER_API
 soter_sign_alg_t soter_sign_get_alg_id(soter_sign_ctx_t* ctx);
 /** @}*/
 
@@ -125,6 +132,7 @@ typedef struct soter_sign_ctx_type soter_verify_ctx_t;
  * @param [in] public_key_length length of public_key
  * @return result of operation, @ref SOTER_SUCCESS on success or @ref SOTER_FAIL on failure
  */
+SOTER_API
 soter_verify_ctx_t* soter_verify_create(soter_sign_alg_t alg,
                                         const void* private_key,
                                         size_t private_key_length,
@@ -137,6 +145,7 @@ soter_verify_ctx_t* soter_verify_create(soter_sign_alg_t alg,
  * @param [in] data_length length of data
  * @return result of operation, @ref SOTER_SUCCESS on success or @ref SOTER_FAIL on failure
  */
+SOTER_API
 soter_status_t soter_verify_update(soter_verify_ctx_t* ctx, const void* data, size_t data_length);
 
 /** @brief final verify context
@@ -146,12 +155,14 @@ soter_status_t soter_verify_update(soter_verify_ctx_t* ctx, const void* data, si
  * @return result of operation, @ref SOTER_SUCCESS on success or @ref SOTER_INVALID_SIGNATURE on
  * incorrect signature or @ref SOTER_FAIL on other failure
  */
+SOTER_API
 soter_status_t soter_verify_final(soter_verify_ctx_t* ctx, const void* signature, size_t signature_length);
 
 /** @brief destroy verify context
  * @param [in] ctx pointer to verify context previously created by soter_verify_create
  * @return result of operation, @ref SOTER_SUCCESS on success or @ref SOTER_FAIL on failure
  */
+SOTER_API
 soter_status_t soter_verify_destroy(soter_verify_ctx_t* ctx);
 
 /** @brief get used algorithm id from verify context
@@ -159,6 +170,7 @@ soter_status_t soter_verify_destroy(soter_verify_ctx_t* ctx);
  * @return used algorithm id (see @ref soter_sign_alg_type) on success or @ref SOTER_SIGN_undefined
  * on failure
  */
+SOTER_API
 soter_sign_alg_t soter_verify_get_alg_id(soter_verify_ctx_t* ctx);
 
 /** @} */

--- a/src/soter/soter_container.h
+++ b/src/soter/soter_container.h
@@ -17,6 +17,7 @@
 #ifndef SOTER_CONTAINER_H
 #define SOTER_CONTAINER_H
 
+#include <soter/soter_api.h>
 #include <soter/soter_error.h>
 
 #define SOTER_CONTAINER_TAG_LENGTH 4
@@ -30,7 +31,10 @@ struct soter_container_hdr_type {
 
 typedef struct soter_container_hdr_type soter_container_hdr_t;
 
+SOTER_API
 soter_status_t soter_update_container_checksum(soter_container_hdr_t* hdr);
+
+SOTER_API
 soter_status_t soter_verify_container_checksum(const soter_container_hdr_t* hdr);
 
 #define soter_container_data(_HDR_) ((uint8_t*)((_HDR_) + 1))

--- a/src/soter/soter_hash.h
+++ b/src/soter/soter_hash.h
@@ -22,6 +22,7 @@
 #ifndef SOTER_HASH_H
 #define SOTER_HASH_H
 
+#include <soter/soter_api.h>
 #include <soter/soter_error.h>
 
 /**
@@ -84,6 +85,7 @@ typedef struct soter_hash_ctx_type soter_hash_ctx_t;
  * @param [in] algo hash algorithm to be used; see @ref soter_hash_algo_type
  * @return pointer to hash context on sussecc and  NULL on failure
  */
+SOTER_API
 soter_hash_ctx_t* soter_hash_create(soter_hash_algo_t algo);
 
 /**
@@ -91,7 +93,10 @@ soter_hash_ctx_t* soter_hash_create(soter_hash_algo_t algo);
  * @param [in] hash_ctx pointer to hash context previosly created by @ref soter_hash_create
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure
  */
+SOTER_API
 soter_status_t soter_hash_destroy(soter_hash_ctx_t* hash_ctx);
+
+SOTER_API
 soter_status_t soter_hash_cleanup(soter_hash_ctx_t* hash_ctx);
 
 /**
@@ -101,6 +106,7 @@ soter_status_t soter_hash_cleanup(soter_hash_ctx_t* hash_ctx);
  * @param [in] length of data buffer
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure
  */
+SOTER_API
 soter_status_t soter_hash_update(soter_hash_ctx_t* hash_ctx, const void* data, size_t length);
 
 /**
@@ -114,6 +120,7 @@ soter_status_t soter_hash_update(soter_hash_ctx_t* hash_ctx, const void* data, s
  * SOTER_BUFFER_TOO_SMALL will return and hash_length will contain length of buffer thet need to
  * store hash value.
  */
+SOTER_API
 soter_status_t soter_hash_final(soter_hash_ctx_t* hash_ctx, uint8_t* hash_value, size_t* hash_length);
 
 /**@}@}*/

--- a/src/soter/soter_hmac.c
+++ b/src/soter/soter_hmac.c
@@ -33,6 +33,7 @@ static size_t hash_block_size(soter_hash_algo_t algo)
     }
 }
 
+SOTER_PRIVATE_API
 soter_status_t soter_hmac_init(soter_hmac_ctx_t* hmac_ctx,
                                soter_hash_algo_t algo,
                                const uint8_t* key,
@@ -108,6 +109,7 @@ soter_status_t soter_hmac_init(soter_hmac_ctx_t* hmac_ctx,
     return SOTER_SUCCESS;
 }
 
+SOTER_PRIVATE_API
 soter_status_t soter_hmac_cleanup(soter_hmac_ctx_t* hmac_ctx)
 {
     if (NULL == hmac_ctx) {

--- a/src/soter/soter_hmac.h
+++ b/src/soter/soter_hmac.h
@@ -21,6 +21,7 @@
 #ifndef SOTER_HMAC_H
 #define SOTER_HMAC_H
 
+#include <soter/soter_api.h>
 #include <soter/soter_error.h>
 #include <soter/soter_hash.h>
 
@@ -70,6 +71,7 @@ typedef struct soter_hmac_ctx_type soter_hmac_ctx_t;
  * @param [in] algo hash algorithm to be used; see @ref soter_hash_algo_type
  * @return pointer to HMAC context on sussecc and  NULL on failure
  */
+SOTER_API
 soter_hmac_ctx_t* soter_hmac_create(soter_hash_algo_t algo, const uint8_t* key, size_t key_length);
 
 /**
@@ -77,6 +79,7 @@ soter_hmac_ctx_t* soter_hmac_create(soter_hash_algo_t algo, const uint8_t* key, 
  * @param [in] hmac_ctx pointer to HMAC context previosly created by @ref soter_hmac_create
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure
  */
+SOTER_API
 soter_status_t soter_hmac_destroy(soter_hmac_ctx_t* hmac_ctx);
 
 /**
@@ -86,6 +89,7 @@ soter_status_t soter_hmac_destroy(soter_hmac_ctx_t* hmac_ctx);
  * @param [in] length of data buffer
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure
  */
+SOTER_API
 soter_status_t soter_hmac_update(soter_hmac_ctx_t* hmac_ctx, const void* data, size_t length);
 
 /**
@@ -99,6 +103,7 @@ soter_status_t soter_hmac_update(soter_hmac_ctx_t* hmac_ctx, const void* data, s
  * SOTER_BUFFER_TOO_SMALL will return and hmac_length will contain length of buffer thet need to
  * store HMAC value.
  */
+SOTER_API
 soter_status_t soter_hmac_final(soter_hmac_ctx_t* hmac_ctx, uint8_t* hmac_value, size_t* hmac_length);
 
 /**@}@}*/

--- a/src/soter/soter_kdf.h
+++ b/src/soter/soter_kdf.h
@@ -21,6 +21,7 @@
 #ifndef SOTER_KDF_H
 #define SOTER_KDF_H
 
+#include <soter/soter_api.h>
 #include <soter/soter_error.h>
 
 /** @addtogroup SOTER
@@ -48,6 +49,7 @@ typedef struct soter_kdf_context_buf_type soter_kdf_context_buf_t;
  * @param [in] output_length length of data to derive
  * @return SOTER_SUCCESS on success or SOTER_FAIL on failure
  */
+SOTER_API
 soter_status_t soter_kdf(const void* key,
                          size_t key_length,
                          const char* label,

--- a/src/soter/soter_rand.h
+++ b/src/soter/soter_rand.h
@@ -22,6 +22,7 @@
 #ifndef SOTER_RAND_H
 #define SOTER_RAND_H
 
+#include <soter/soter_api.h>
 #include <soter/soter_error.h>
 
 /**
@@ -44,6 +45,7 @@ extern "C" {
  *
  * This function generates random bits and puts them in memory pointed by buffer.
  */
+SOTER_API
 soter_status_t soter_rand(uint8_t* buffer, size_t length);
 
 #ifdef __cplusplus

--- a/src/soter/soter_rsa_key_pair_gen.h
+++ b/src/soter/soter_rsa_key_pair_gen.h
@@ -17,14 +17,22 @@
 #ifndef SOTER_RSA_KEY_PAIR_GEN_H
 #define SOTER_RSA_KEY_PAIR_GEN_H
 
+#include <soter/soter_api.h>
 #include <soter/soter_error.h>
 #include <soter/soter_rsa_key.h>
 
 typedef struct soter_rsa_key_pair_gen_type soter_rsa_key_pair_gen_t;
 
+SOTER_API
 soter_rsa_key_pair_gen_t* soter_rsa_key_pair_gen_create(unsigned key_length);
+
+SOTER_API
 soter_status_t soter_rsa_key_pair_gen_init(soter_rsa_key_pair_gen_t* ctx, unsigned key_length);
+
+SOTER_API
 soter_status_t soter_rsa_key_pair_gen_destroy(soter_rsa_key_pair_gen_t* ctx);
+
+SOTER_API
 soter_status_t soter_rsa_key_pair_gen_export_key(soter_rsa_key_pair_gen_t* ctx,
                                                  void* key,
                                                  size_t* key_length,

--- a/src/soter/soter_sign.c
+++ b/src/soter/soter_sign.c
@@ -25,6 +25,8 @@
 #include <soter/openssl/soter_engine.h>
 #endif
 
+#include "soter/soter_api.h"
+
 #define SOTER_SIGN_ALGS             \
     SOTER_SIGN_ALG(rsa, pss, pkcs8) \
     SOTER_SIGN_ALG(ecdsa, none, pkcs8)
@@ -36,6 +38,7 @@
                                                          private_key_length, \
                                                          public_key,         \
                                                          public_key_length);
+SOTER_PRIVATE_API
 soter_status_t soter_sign_init(soter_sign_ctx_t* ctx,
                                soter_sign_alg_t algId,
                                const void* private_key,
@@ -64,6 +67,7 @@ soter_status_t soter_sign_init(soter_sign_ctx_t* ctx,
                                                            private_key_length, \
                                                            public_key,         \
                                                            public_key_length);
+SOTER_PRIVATE_API
 soter_status_t soter_verify_init(soter_sign_ctx_t* ctx,
                                  soter_sign_alg_t algId,
                                  const void* private_key,

--- a/src/soter/soter_sym.h
+++ b/src/soter/soter_sym.h
@@ -22,6 +22,7 @@
 #ifndef SOTER_SYM_H
 #define SOTER_SYM_H
 
+#include <soter/soter_api.h>
 #include <soter/soter_error.h>
 
 /**
@@ -129,6 +130,7 @@ typedef struct soter_sym_ctx_type soter_sym_ctx_t;
  * @param [in] iv_length length of iv
  * @return pointer to new symmetric encryption context on success or NULL on failure
  */
+SOTER_API
 soter_sym_ctx_t* soter_sym_encrypt_create(uint32_t alg,
                                           const void* key,
                                           size_t key_length,
@@ -151,6 +153,7 @@ soter_sym_ctx_t* soter_sym_encrypt_create(uint32_t alg,
  * SOTER_BUFFER_TOO_SMALL will return and cipher_data_length will contain length of buffer thet need
  * to store cipher data.
  */
+SOTER_API
 soter_status_t soter_sym_encrypt_update(soter_sym_ctx_t* ctx,
                                         const void* plain_data,
                                         size_t data_length,
@@ -169,6 +172,7 @@ soter_status_t soter_sym_encrypt_update(soter_sym_ctx_t* ctx,
  * SOTER_BUFFER_TOO_SMALL will return and cipher_data_length will contain length of buffer thet need
  * to store cipher data.
  */
+SOTER_API
 soter_status_t soter_sym_encrypt_final(soter_sym_ctx_t* ctx, void* cipher_data, size_t* cipher_data_length);
 
 /**
@@ -177,6 +181,7 @@ soter_status_t soter_sym_encrypt_final(soter_sym_ctx_t* ctx, void* cipher_data, 
  * soter_sym_encrypt_create
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure.
  */
+SOTER_API
 soter_status_t soter_sym_encrypt_destroy(soter_sym_ctx_t* ctx);
 /** @} */
 
@@ -197,6 +202,7 @@ soter_status_t soter_sym_encrypt_destroy(soter_sym_ctx_t* ctx);
  * @param [in] iv_length length of iv
  * @return pointer to new symmetric decryption context on success or NULL on failure
  */
+SOTER_API
 soter_sym_ctx_t* soter_sym_decrypt_create(uint32_t alg,
                                           const void* key,
                                           size_t key_length,
@@ -219,6 +225,7 @@ soter_sym_ctx_t* soter_sym_decrypt_create(uint32_t alg,
  * SOTER_BUFFER_TOO_SMALL will return and plain_data_length will contain length of buffer thet need
  * to store plain data.
  */
+SOTER_API
 soter_status_t soter_sym_decrypt_update(soter_sym_ctx_t* ctx,
                                         const void* cipher_data,
                                         size_t data_length,
@@ -237,6 +244,7 @@ soter_status_t soter_sym_decrypt_update(soter_sym_ctx_t* ctx,
  * SOTER_BUFFER_TOO_SMALL will return and plain_data_length will contain length of buffer thet need
  * to store plain data.
  */
+SOTER_API
 soter_status_t soter_sym_decrypt_final(soter_sym_ctx_t* ctx, void* plain_data, size_t* plain_data_length);
 
 /**
@@ -245,6 +253,7 @@ soter_status_t soter_sym_decrypt_final(soter_sym_ctx_t* ctx, void* plain_data, s
  * soter_sym_decrypt_create
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure.
  */
+SOTER_API
 soter_status_t soter_sym_decrypt_destroy(soter_sym_ctx_t* ctx);
 /** @} */
 /** @} */
@@ -272,6 +281,7 @@ soter_status_t soter_sym_decrypt_destroy(soter_sym_ctx_t* ctx);
  * @param [in] iv_length length of iv
  * @return pointer to new symmetric encryption context on success or NULL on failure
  */
+SOTER_API
 soter_sym_ctx_t* soter_sym_aead_encrypt_create(uint32_t alg,
                                                const void* key,
                                                size_t key_length,
@@ -288,6 +298,7 @@ soter_sym_ctx_t* soter_sym_aead_encrypt_create(uint32_t alg,
  * @param [in] data_length length of AAD data
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure.
  */
+SOTER_API
 soter_status_t soter_sym_aead_encrypt_aad(soter_sym_ctx_t* ctx, const void* plain_data, size_t data_length);
 
 /**
@@ -304,6 +315,7 @@ soter_status_t soter_sym_aead_encrypt_aad(soter_sym_ctx_t* ctx, const void* plai
  * SOTER_BUFFER_TOO_SMALL will return and cipher_data_length will contain length of buffer thet need
  * to store cipher data.
  */
+SOTER_API
 soter_status_t soter_sym_aead_encrypt_update(soter_sym_ctx_t* ctx,
                                              const void* plain_data,
                                              size_t data_length,
@@ -322,6 +334,7 @@ soter_status_t soter_sym_aead_encrypt_update(soter_sym_ctx_t* ctx,
  * SOTER_BUFFER_TOO_SMALL will return and auth_tag_length will contain length of buffer thet need to
  * store auth_tag.
  */
+SOTER_API
 soter_status_t soter_sym_aead_encrypt_final(soter_sym_ctx_t* ctx, void* auth_tag, size_t* auth_tag_length);
 
 /**
@@ -330,6 +343,7 @@ soter_status_t soter_sym_aead_encrypt_final(soter_sym_ctx_t* ctx, void* auth_tag
  * soter_sym_encrypt_create
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure.
  */
+SOTER_API
 soter_status_t soter_sym_aead_encrypt_destroy(soter_sym_ctx_t* ctx);
 /** @} */
 
@@ -350,6 +364,7 @@ soter_status_t soter_sym_aead_encrypt_destroy(soter_sym_ctx_t* ctx);
  * @param [in] iv_length length of iv
  * @return pointer to new symmetric decryption context on success or NULL on failure
  */
+SOTER_API
 soter_sym_ctx_t* soter_sym_aead_decrypt_create(uint32_t alg,
                                                const void* key,
                                                size_t key_length,
@@ -366,6 +381,7 @@ soter_sym_ctx_t* soter_sym_aead_decrypt_create(uint32_t alg,
  * @param [in] data_length length of AAD data
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure.
  */
+SOTER_API
 soter_status_t soter_sym_aead_decrypt_aad(soter_sym_ctx_t* ctx, const void* plain_data, size_t data_length);
 
 /**
@@ -382,6 +398,7 @@ soter_status_t soter_sym_aead_decrypt_aad(soter_sym_ctx_t* ctx, const void* plai
  * SOTER_BUFFER_TOO_SMALL will return and plain_data_length will contain length of buffer thet need
  * to store plain data.
  */
+SOTER_API
 soter_status_t soter_sym_aead_decrypt_update(soter_sym_ctx_t* ctx,
                                              const void* cipher_data,
                                              size_t data_length,
@@ -396,6 +413,7 @@ soter_status_t soter_sym_aead_decrypt_update(soter_sym_ctx_t* ctx,
  * @param [in] auth_tag_length length of auth_tag
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure.
  */
+SOTER_API
 soter_status_t soter_sym_aead_decrypt_final(soter_sym_ctx_t* ctx,
                                             const void* auth_tag,
                                             size_t auth_tag_length);
@@ -406,6 +424,7 @@ soter_status_t soter_sym_aead_decrypt_final(soter_sym_ctx_t* ctx,
  * soter_sym_decrypt_create
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure.
  */
+SOTER_API
 soter_status_t soter_sym_aead_decrypt_destroy(soter_sym_ctx_t* ctx);
 /** @} */
 /** @} */

--- a/src/themis/secure_cell.h
+++ b/src/themis/secure_cell.h
@@ -23,6 +23,7 @@
 #ifndef THEMIS_SECURE_CELL_H
 #define THEMIS_SECURE_CELL_H
 
+#include <themis/themis_api.h>
 #include <themis/themis_error.h>
 
 #ifdef __cplusplus
@@ -57,6 +58,7 @@ extern "C" {
  * store then THEMIS_BUFFER_TOO_SMALL will return and encrypted_message_length will store length of
  * buffer needed for encrypted message store
  */
+THEMIS_API
 themis_status_t themis_secure_cell_encrypt_seal(const uint8_t* master_key,
                                                 size_t master_key_length,
                                                 const uint8_t* user_context,
@@ -82,6 +84,7 @@ themis_status_t themis_secure_cell_encrypt_seal(const uint8_t* master_key,
  * THEMIS_BUFFER_TOO_SMALL will return and plain_message_length will store length of buffer needed
  * for plain1 message store
  */
+THEMIS_API
 themis_status_t themis_secure_cell_decrypt_seal(const uint8_t* master_key,
                                                 size_t master_key_length,
                                                 const uint8_t* user_context,
@@ -123,6 +126,7 @@ themis_status_t themis_secure_cell_decrypt_seal(const uint8_t* master_key,
  * needed for encrypted message store and context_length will store length of buuffer needed for
  * additional authentication info store
  */
+THEMIS_API
 themis_status_t themis_secure_cell_encrypt_token_protect(const uint8_t* master_key,
                                                          size_t master_key_length,
                                                          const uint8_t* user_context,
@@ -152,6 +156,7 @@ themis_status_t themis_secure_cell_encrypt_token_protect(const uint8_t* master_k
  * THEMIS_BUFFER_TOO_SMALL will return and plain_message_length will store length of buffer needed
  * for plain1 message store
  */
+THEMIS_API
 themis_status_t themis_secure_cell_decrypt_token_protect(const uint8_t* master_key,
                                                          size_t master_key_length,
                                                          const uint8_t* user_context,
@@ -188,6 +193,7 @@ themis_status_t themis_secure_cell_decrypt_token_protect(const uint8_t* master_k
  * store then THEMIS_BUFFER_TOO_SMALL will return and encrypted_message_length will store length of
  * buffer needed for encrypted message store
  */
+THEMIS_API
 themis_status_t themis_secure_cell_encrypt_context_imprint(const uint8_t* master_key,
                                                            size_t master_key_length,
                                                            const uint8_t* message,
@@ -213,6 +219,7 @@ themis_status_t themis_secure_cell_encrypt_context_imprint(const uint8_t* master
  * THEMIS_BUFFER_TOO_SMALL will return and plain_message_length will store length of buffer needed
  * for plain1 message store
  */
+THEMIS_API
 themis_status_t themis_secure_cell_decrypt_context_imprint(const uint8_t* master_key,
                                                            size_t master_key_length,
                                                            const uint8_t* encrypted_message,

--- a/src/themis/secure_comparator.h
+++ b/src/themis/secure_comparator.h
@@ -17,6 +17,7 @@
 #ifndef THEMIS_SECURE_COMPARATOR_H
 #define THEMIS_SECURE_COMPARATOR_H
 
+#include <themis/themis_api.h>
 #include <themis/themis_error.h>
 
 #define THEMIS_SCOMPARE_MATCH 21
@@ -29,22 +30,30 @@ extern "C" {
 
 typedef struct secure_comparator_type secure_comparator_t;
 
+THEMIS_API
 secure_comparator_t* secure_comparator_create(void);
+
+THEMIS_API
 themis_status_t secure_comparator_destroy(secure_comparator_t* comp_ctx);
 
+THEMIS_API
 themis_status_t secure_comparator_append_secret(secure_comparator_t* comp_ctx,
                                                 const void* secret_data,
                                                 size_t secret_data_length);
 
+THEMIS_API
 themis_status_t secure_comparator_begin_compare(secure_comparator_t* comp_ctx,
                                                 void* compare_data,
                                                 size_t* compare_data_length);
+
+THEMIS_API
 themis_status_t secure_comparator_proceed_compare(secure_comparator_t* comp_ctx,
                                                   const void* peer_compare_data,
                                                   size_t peer_compare_data_length,
                                                   void* compare_data,
                                                   size_t* compare_data_length);
 
+THEMIS_API
 themis_status_t secure_comparator_get_result(const secure_comparator_t* comp_ctx);
 
 #ifdef __cplusplus

--- a/src/themis/secure_keygen.h
+++ b/src/themis/secure_keygen.h
@@ -22,6 +22,7 @@
 #ifndef THEMIS_SECURE_KEYGEN_H
 #define THEMIS_SECURE_KEYGEN_H
 
+#include <themis/themis_api.h>
 #include <themis/themis_error.h>
 
 #ifdef __cplusplus
@@ -50,6 +51,7 @@ extern "C" {
  * THEMIS_BUFFER_TOO_SMALL will return and private_key_length and public_key_length will store
  * lengths of buffers needed for private key and public key store respectively
  */
+THEMIS_API
 themis_status_t themis_gen_rsa_key_pair(uint8_t* private_key,
                                         size_t* private_key_length,
                                         uint8_t* public_key,
@@ -69,6 +71,7 @@ themis_status_t themis_gen_rsa_key_pair(uint8_t* private_key,
  * THEMIS_BUFFER_TOO_SMALL will return and private_key_length and public_key_length will store
  * lengths of buffers needed for private key and public key store respectively
  */
+THEMIS_API
 themis_status_t themis_gen_ec_key_pair(uint8_t* private_key,
                                        size_t* private_key_length,
                                        uint8_t* public_key,
@@ -90,6 +93,7 @@ typedef enum themis_key_kind themis_key_kind_t;
  * @param [in]  length  length of key
  * @return corresponding key kind if the buffer contains a key, or THEMIS_KEY_INVALID otherwise
  */
+THEMIS_API
 themis_key_kind_t themis_get_asym_key_kind(const uint8_t* key, size_t length);
 
 /**
@@ -98,6 +102,7 @@ themis_key_kind_t themis_get_asym_key_kind(const uint8_t* key, size_t length);
  * @param [in]  length  length of key
  * @return THEMIS_SUCCESS if the buffer contains a valid Themis key, or an error code otherwise
  */
+THEMIS_API
 themis_status_t themis_is_valid_asym_key(const uint8_t* key, size_t length);
 
 /** @} */

--- a/src/themis/secure_message.h
+++ b/src/themis/secure_message.h
@@ -154,9 +154,9 @@ themis_status_t themis_secure_message_verify(const uint8_t* public_key,
  * storage then THEMIS_BUFFER_TOO_SMALL will return and wrapped_message_length will store length of
  * buffer needed for wrapped message store
  */
-THEMIS_API
 DEPRECATED("use 'themis_secure_message_encrypt' with private and public keys to encrypt message, "
            "or 'themis_secure_message_sign' with private key to sign message")
+THEMIS_API
 themis_status_t themis_secure_message_wrap(const uint8_t* private_key,
                                            size_t private_key_length,
                                            const uint8_t* public_key,
@@ -182,9 +182,9 @@ themis_status_t themis_secure_message_wrap(const uint8_t* private_key,
  * THEMIS_BUFFER_TOO_SMALL will return and message_length will store length of buffer needed for
  * plain message store
  */
-THEMIS_API
 DEPRECATED("use 'themis_secure_message_decrypt' with private and public key to decrypt message or "
            "'themis_secure_message_verify' with public key to verify signed message")
+THEMIS_API
 themis_status_t themis_secure_message_unwrap(const uint8_t* private_key,
                                              size_t private_key_length,
                                              const uint8_t* public_key,

--- a/src/themis/secure_message.h
+++ b/src/themis/secure_message.h
@@ -22,6 +22,7 @@
 #ifndef THEMIS_SECURE_MESSAGE_H
 #define THEMIS_SECURE_MESSAGE_H
 
+#include <themis/themis_api.h>
 #include <themis/themis_error.h>
 
 #ifdef __cplusplus
@@ -54,6 +55,7 @@ extern "C" {
  * encrypted message then THEMIS_BUFFER_TOO_SMALL will be returned and encrypted_message_length will
  * contain the length of the buffer needed to store the encrypted message.
  */
+THEMIS_API
 themis_status_t themis_secure_message_encrypt(const uint8_t* private_key,
                                               size_t private_key_length,
                                               const uint8_t* public_key,
@@ -80,6 +82,7 @@ themis_status_t themis_secure_message_encrypt(const uint8_t* private_key,
  *       then THEMIS_BUFFER_TOO_SMALL will be returned and message_length will contain
  *       the length of the buffer needed to store the encrypted message.
  */
+THEMIS_API
 themis_status_t themis_secure_message_decrypt(const uint8_t* private_key,
                                               size_t private_key_length,
                                               const uint8_t* public_key,
@@ -104,6 +107,7 @@ themis_status_t themis_secure_message_decrypt(const uint8_t* private_key,
  * message then THEMIS_BUFFER_TOO_SMALL will be returned and signed_message_length will contain the
  * length of the buffer needed to store the signed message.
  */
+THEMIS_API
 themis_status_t themis_secure_message_sign(const uint8_t* private_key,
                                            size_t private_key_length,
                                            const uint8_t* message,
@@ -126,6 +130,7 @@ themis_status_t themis_secure_message_sign(const uint8_t* private_key,
  *       then THEMIS_BUFFER_TOO_SMALL will be returned and message_length will contain
  *       the length of the buffer needed to store the original message.
  */
+THEMIS_API
 themis_status_t themis_secure_message_verify(const uint8_t* public_key,
                                              size_t public_key_length,
                                              const uint8_t* signed_message,
@@ -149,6 +154,7 @@ themis_status_t themis_secure_message_verify(const uint8_t* public_key,
  * storage then THEMIS_BUFFER_TOO_SMALL will return and wrapped_message_length will store length of
  * buffer needed for wrapped message store
  */
+THEMIS_API
 DEPRECATED("use 'themis_secure_message_encrypt' with private and public keys to encrypt message, "
            "or 'themis_secure_message_sign' with private key to sign message")
 themis_status_t themis_secure_message_wrap(const uint8_t* private_key,
@@ -176,6 +182,7 @@ themis_status_t themis_secure_message_wrap(const uint8_t* private_key,
  * THEMIS_BUFFER_TOO_SMALL will return and message_length will store length of buffer needed for
  * plain message store
  */
+THEMIS_API
 DEPRECATED("use 'themis_secure_message_decrypt' with private and public key to decrypt message or "
            "'themis_secure_message_verify' with public key to verify signed message")
 themis_status_t themis_secure_message_unwrap(const uint8_t* private_key,

--- a/src/themis/secure_session.h
+++ b/src/themis/secure_session.h
@@ -26,6 +26,7 @@
 
 #include <soter/soter.h>
 
+#include <themis/themis_api.h>
 #include <themis/themis_error.h>
 
 #ifdef __cplusplus
@@ -137,23 +138,32 @@ themis_status_t secure_session_init(secure_session_t *session_ctx, const void *i
 const void *sign_key, size_t sign_key_length, const secure_session_user_callbacks_t
 *user_callbacks); themis_status_t secure_session_cleanup(secure_session_t *session_ctx);
 */
+THEMIS_API
 secure_session_t* secure_session_create(const void* id,
                                         size_t id_length,
                                         const void* sign_key,
                                         size_t sign_key_length,
                                         const secure_session_user_callbacks_t* user_callbacks);
+
+THEMIS_API
 themis_status_t secure_session_destroy(secure_session_t* session_ctx);
 
+THEMIS_API
 themis_status_t secure_session_connect(secure_session_t* session_ctx);
+
+THEMIS_API
 themis_status_t secure_session_generate_connect_request(secure_session_t* session_ctx,
                                                         void* output,
                                                         size_t* output_length);
 
+THEMIS_API
 themis_status_t secure_session_wrap(secure_session_t* session_ctx,
                                     const void* message,
                                     size_t message_length,
                                     void* wrapped_message,
                                     size_t* wrapped_message_length);
+
+THEMIS_API
 themis_status_t secure_session_unwrap(secure_session_t* session_ctx,
                                       const void* wrapped_message,
                                       size_t wrapped_message_length,
@@ -161,16 +171,25 @@ themis_status_t secure_session_unwrap(secure_session_t* session_ctx,
                                       size_t* message_length);
 
 /* Trying to mimic socket functions */
+THEMIS_API
 ssize_t secure_session_send(secure_session_t* session_ctx, const void* message, size_t message_length);
+
+THEMIS_API
 ssize_t secure_session_receive(secure_session_t* session_ctx, void* message, size_t message_length);
 
+THEMIS_API
 themis_status_t secure_session_save(const secure_session_t* session_ctx, void* out, size_t* out_length);
+
+THEMIS_API
 themis_status_t secure_session_load(secure_session_t* session_ctx,
                                     const void* in,
                                     size_t in_length,
                                     const secure_session_user_callbacks_t* user_callbacks);
 
+THEMIS_API
 bool secure_session_is_established(const secure_session_t* session_ctx);
+
+THEMIS_API
 themis_status_t secure_session_get_remote_id(const secure_session_t* session_ctx,
                                              uint8_t* id,
                                              size_t* id_length);

--- a/src/themis/themis.mk
+++ b/src/themis/themis.mk
@@ -33,6 +33,8 @@ FMT_CHECK += $(patsubst %,$(OBJ_PATH)/%.fmt_check, $(THEMIS_FMT_SRC))
 
 THEMIS_STATIC = $(BIN_PATH)/$(LIBTHEMIS_A) $(SOTER_STATIC)
 
+$(THEMIS_OBJ): CFLAGS += -DTHEMIS_EXPORT
+
 $(BIN_PATH)/$(LIBTHEMIS_A): CMD = $(AR) rcs $@ $(filter %.o, $^)
 
 $(BIN_PATH)/$(LIBTHEMIS_A): $(THEMIS_OBJ)

--- a/src/themis/themis_api.h
+++ b/src/themis/themis_api.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2019 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef THEMIS_API_H
+#define THEMIS_API_H
+
+#if defined(__GNUC__) || defined(__clang__)
+#define THEMIS_API __attribute__((visibility("default")))
+#else
+#define THEMIS_API
+#endif
+
+#endif /* THEMIS_API_H */

--- a/src/themis/themis_api.h
+++ b/src/themis/themis_api.h
@@ -19,6 +19,12 @@
 
 #if defined(__GNUC__) || defined(__clang__)
 #define THEMIS_API __attribute__((visibility("default")))
+#elif defined(_WIN32) || defined(_WIN64) || defined(__CYGWIN__)
+#ifdef THEMIS_EXPORT
+#define THEMIS_API __declspec(dllexport)
+#else
+#define THEMIS_API __declspec(dllimport)
+#endif
 #else
 #define THEMIS_API
 #endif


### PR DESCRIPTION
Historically, Themis did not manage public API exports at all. We exported _all_ non-static functions and that's it. WebAssembly builds with Emscripten will require marking exported functions with `EMSCRIPTEN_KEEPALIVE` attribute so now is a good moment to explicitly define our public API.

Only functions explicitly marked as `THEMIS_API` and `SOTER_API` will be exported from libraries and available to users. Everything else will be hidden and not available (even if the users include some private header and try calling a function).

Here are details on functions that are **removed** from publicly visible exports with these changes:

<details>
<summary>Soter</summary>

||Function|
|-|-|
|:no_entry_sign:| algid_to_evp |
|:no_entry_sign:| algid_to_evp_aead |
|| clip_random_32 |
|:no_entry_sign:| crypto_sign_ed25519_ref10_fe_0 |
|:no_entry_sign:| crypto_sign_ed25519_ref10_fe_1 |
|:no_entry_sign:| crypto_sign_ed25519_ref10_fe_add |
|:no_entry_sign:| crypto_sign_ed25519_ref10_fe_cmov |
|:no_entry_sign:| crypto_sign_ed25519_ref10_fe_copy |
|:no_entry_sign:| crypto_sign_ed25519_ref10_fe_frombytes |
|:no_entry_sign:| crypto_sign_ed25519_ref10_fe_invert |
|:no_entry_sign:| crypto_sign_ed25519_ref10_fe_isnegative |
|| crypto_sign_ed25519_ref10_fe_isnonzero |
|:no_entry_sign:| crypto_sign_ed25519_ref10_fe_mul |
|| crypto_sign_ed25519_ref10_fe_neg |
|:no_entry_sign:| crypto_sign_ed25519_ref10_fe_pow22523 |
|:no_entry_sign:| crypto_sign_ed25519_ref10_fe_sq |
|:no_entry_sign:| crypto_sign_ed25519_ref10_fe_sq2 |
|:no_entry_sign:| crypto_sign_ed25519_ref10_fe_sub |
|| crypto_sign_ed25519_ref10_fe_tobytes |
|:no_entry_sign:| crypto_sign_ed25519_ref10_ge_add |
|| crypto_sign_ed25519_ref10_ge_double_scalarmult_vartime |
|:no_entry_sign:| crypto_sign_ed25519_ref10_ge_frombytes_negate_vartime |
|:no_entry_sign:| crypto_sign_ed25519_ref10_ge_madd |
|:no_entry_sign:| crypto_sign_ed25519_ref10_ge_msub |
|:no_entry_sign:| crypto_sign_ed25519_ref10_ge_p1p1_to_p2 |
|:no_entry_sign:| crypto_sign_ed25519_ref10_ge_p1p1_to_p3 |
|:no_entry_sign:| crypto_sign_ed25519_ref10_ge_p2_0 |
|:no_entry_sign:| crypto_sign_ed25519_ref10_ge_p2_dbl |
|:no_entry_sign:| crypto_sign_ed25519_ref10_ge_p3_0 |
|:no_entry_sign:| crypto_sign_ed25519_ref10_ge_p3_dbl |
|| crypto_sign_ed25519_ref10_ge_p3_tobytes |
|:no_entry_sign:| crypto_sign_ed25519_ref10_ge_p3_to_cached |
|:no_entry_sign:| crypto_sign_ed25519_ref10_ge_p3_to_p2 |
|:no_entry_sign:| crypto_sign_ed25519_ref10_ge_precomp_0 |
|| crypto_sign_ed25519_ref10_ge_scalarmult_base |
|:no_entry_sign:| crypto_sign_ed25519_ref10_ge_sub |
|| crypto_sign_ed25519_ref10_ge_tobytes |
|| crypto_sign_ed25519_ref10_sc_muladd |
|| crypto_sign_ed25519_ref10_sc_reduce |
|| crypto_verify_32 |
|| ge_cmp |
|| ge_frombytes_vartime |
|| generate_random_32 |
|| ge_p2_to_p3 |
|| ge_p3_sub |
|| ge_scalarmult_blinded |
|| soter_asym_cipher_cleanup |
|| soter_asym_cipher_create |
|| soter_asym_cipher_decrypt |
|| soter_asym_cipher_destroy |
|| soter_asym_cipher_encrypt |
|:no_entry_sign:| soter_asym_cipher_import_key |
|| soter_asym_cipher_init |
|| soter_asym_ka_cleanup |
|| soter_asym_ka_create |
|| soter_asym_ka_derive |
|| soter_asym_ka_destroy |
|| soter_asym_ka_export_key |
|| soter_asym_ka_gen_key |
|| soter_asym_ka_import_key |
|| soter_asym_ka_init |
|:no_entry_sign:| soter_crc32 |
|:no_entry_sign:| soter_crc32_create |
|:no_entry_sign:| soter_crc32_final |
|:no_entry_sign:| soter_crc32_update |
|:no_entry_sign:| soter_ec_export_key |
|:no_entry_sign:| soter_ec_gen_key |
|:no_entry_sign:| soter_ec_import_key |
|:no_entry_sign:| soter_ec_priv_key_to_engine_specific |
|:no_entry_sign:| soter_ec_pub_key_to_engine_specific |
|:no_entry_sign:| soter_engine_specific_to_ec_priv_key |
|:no_entry_sign:| soter_engine_specific_to_ec_pub_key |
|:no_entry_sign:| soter_engine_specific_to_rsa_priv_key |
|:no_entry_sign:| soter_engine_specific_to_rsa_pub_key |
|| soter_hash_cleanup |
|| soter_hash_create |
|| soter_hash_destroy |
|| soter_hash_final |
|| soter_hash_init |
|| soter_hash_update |
|| soter_hmac_cleanup |
|| soter_hmac_create |
|| soter_hmac_destroy |
|| soter_hmac_final |
|| soter_hmac_init |
|| soter_hmac_update |
|| soter_kdf |
|:no_entry_sign:| soter_nokdf |
|:no_entry_sign:| soter_pbkdf2 |
|| soter_rand |
|:no_entry_sign:| soter_rsa_export_key |
|:no_entry_sign:| soter_rsa_gen_key |
|:no_entry_sign:| soter_rsa_import_key |
|:no_entry_sign:| soter_rsa_key_pair_gen_cleanup |
|| soter_rsa_key_pair_gen_create |
|| soter_rsa_key_pair_gen_destroy |
|| soter_rsa_key_pair_gen_export_key |
|| soter_rsa_key_pair_gen_init |
|:no_entry_sign:| soter_rsa_priv_key_to_engine_specific |
|:no_entry_sign:| soter_rsa_pub_key_to_engine_specific |
|:no_entry_sign:| soter_sign_cleanup |
|:no_entry_sign:| soter_sign_cleanup_ecdsa_none_pkcs8 |
|:no_entry_sign:| soter_sign_cleanup_rsa_pss_pkcs8 |
|| soter_sign_create |
|| soter_sign_destroy |
|| soter_sign_export_key |
|:no_entry_sign:| soter_sign_export_key_ecdsa_none_pkcs8 |
|:no_entry_sign:| soter_sign_export_key_rsa_pss_pkcs8 |
|| soter_sign_final |
|:no_entry_sign:| soter_sign_final_ecdsa_none_pkcs8 |
|:no_entry_sign:| soter_sign_final_rsa_pss_pkcs8 |
|| soter_sign_get_alg_id |
|| soter_sign_init |
|:no_entry_sign:| soter_sign_init_ecdsa_none_pkcs8 |
|:no_entry_sign:| soter_sign_init_rsa_pss_pkcs8 |
|| soter_sign_update |
|:no_entry_sign:| soter_sign_update_ecdsa_none_pkcs8 |
|:no_entry_sign:| soter_sign_update_rsa_pss_pkcs8 |
|:no_entry_sign:| soter_sym_aead_ctx_final |
|:no_entry_sign:| soter_sym_aead_ctx_init |
|| soter_sym_aead_decrypt_aad |
|| soter_sym_aead_decrypt_create |
|| soter_sym_aead_decrypt_destroy |
|| soter_sym_aead_decrypt_final |
|| soter_sym_aead_decrypt_update |
|| soter_sym_aead_encrypt_aad |
|| soter_sym_aead_encrypt_create |
|| soter_sym_aead_encrypt_destroy |
|| soter_sym_aead_encrypt_final |
|| soter_sym_aead_encrypt_update |
|:no_entry_sign:| soter_sym_ctx_destroy |
|:no_entry_sign:| soter_sym_ctx_final |
|:no_entry_sign:| soter_sym_ctx_init |
|:no_entry_sign:| soter_sym_ctx_update |
|| soter_sym_decrypt_create |
|| soter_sym_decrypt_destroy |
|| soter_sym_decrypt_final |
|| soter_sym_decrypt_update |
|| soter_sym_encrypt_create |
|| soter_sym_encrypt_destroy |
|| soter_sym_encrypt_final |
|| soter_sym_encrypt_update |
|| soter_update_container_checksum |
|:no_entry_sign:| soter_verify_cleanup |
|:no_entry_sign:| soter_verify_cleanup_ecdsa_none_pkcs8 |
|:no_entry_sign:| soter_verify_cleanup_rsa_pss_pkcs8 |
|| soter_verify_container_checksum |
|| soter_verify_create |
|| soter_verify_destroy |
|| soter_verify_final |
|:no_entry_sign:| soter_verify_final_ecdsa_none_pkcs8 |
|:no_entry_sign:| soter_verify_final_rsa_pss_pkcs8 |
|| soter_verify_get_alg_id |
|| soter_verify_init |
|:no_entry_sign:| soter_verify_init_ecdsa_none_pkcs8 |
|:no_entry_sign:| soter_verify_init_rsa_pss_pkcs8 |
|| soter_verify_update |
|:no_entry_sign:| soter_verify_update_ecdsa_none_pkcs8 |
|:no_entry_sign:| soter_verify_update_rsa_pss_pkcs8 |
|:no_entry_sign:| soter_withkdf |

</details>

<details>
<summary>Themis</summary>

||Function|
|-|-|
|:no_entry_sign:| compute_mac |
|:no_entry_sign:| compute_signature |
|:no_entry_sign:| encrypt_gcm |
|:no_entry_sign:| get_alg_id |
|:no_entry_sign:| get_key_sign_type |
|:no_entry_sign:| get_peer_key_sign_type |
|| secure_comparator_append_secret |
|| secure_comparator_begin_compare |
|:no_entry_sign:| secure_comparator_cleanup |
|| secure_comparator_create |
|| secure_comparator_destroy |
|| secure_comparator_get_result |
|:no_entry_sign:| secure_comparator_init |
|| secure_comparator_proceed_compare |
|:no_entry_sign:| secure_session_cleanup |
|| secure_session_connect |
|| secure_session_create |
|:no_entry_sign:| secure_session_derive_message_keys |
|| secure_session_destroy |
|| secure_session_generate_connect_request |
|| secure_session_get_remote_id |
|:no_entry_sign:| secure_session_init |
|| secure_session_is_established |
|| secure_session_load |
|:no_entry_sign:| secure_session_peer_cleanup |
|:no_entry_sign:| secure_session_peer_init |
|| secure_session_receive |
|| secure_session_save |
|| secure_session_send |
|| secure_session_unwrap |
|| secure_session_wrap |
|:no_entry_sign:| themis_auth_sym_decrypt_message |
|:no_entry_sign:| themis_auth_sym_decrypt_message_ |
|:no_entry_sign:| themis_auth_sym_encrypt_message |
|:no_entry_sign:| themis_auth_sym_encrypt_message_ |
|:no_entry_sign:| themis_auth_sym_plain_decrypt |
|:no_entry_sign:| themis_auth_sym_plain_encrypt |
|| themis_gen_ec_key_pair |
|:no_entry_sign:| themis_gen_key_pair |
|| themis_gen_rsa_key_pair |
|| themis_get_asym_key_kind |
|| themis_is_valid_asym_key |
|:no_entry_sign:| themis_message_destroy |
|:no_entry_sign:| themis_message_get_data |
|:no_entry_sign:| themis_message_get_length |
|:no_entry_sign:| themis_message_init |
|:no_entry_sign:| themis_message_set |
|| themis_secure_cell_decrypt_context_imprint |
|| themis_secure_cell_decrypt_seal |
|| themis_secure_cell_decrypt_token_protect |
|| themis_secure_cell_encrypt_context_imprint |
|| themis_secure_cell_encrypt_seal |
|| themis_secure_cell_encrypt_token_protect |
|| themis_secure_message_decrypt |
|:no_entry_sign:| themis_secure_message_decrypter_destroy |
|:no_entry_sign:| themis_secure_message_decrypter_init |
|:no_entry_sign:| themis_secure_message_decrypter_proceed |
|:no_entry_sign:| themis_secure_message_ec_decrypter_destroy |
|:no_entry_sign:| themis_secure_message_ec_decrypter_init |
|:no_entry_sign:| themis_secure_message_ec_decrypter_proceed |
|:no_entry_sign:| themis_secure_message_ec_encrypter_destroy |
|:no_entry_sign:| themis_secure_message_ec_encrypter_init |
|:no_entry_sign:| themis_secure_message_ec_encrypter_proceed |
|| themis_secure_message_encrypt |
|:no_entry_sign:| themis_secure_message_encrypter_destroy |
|:no_entry_sign:| themis_secure_message_encrypter_init |
|:no_entry_sign:| themis_secure_message_encrypter_proceed |
|:no_entry_sign:| themis_secure_message_rsa_decrypter_destroy |
|:no_entry_sign:| themis_secure_message_rsa_decrypter_init |
|:no_entry_sign:| themis_secure_message_rsa_decrypter_proceed |
|:no_entry_sign:| themis_secure_message_rsa_encrypter_destroy |
|:no_entry_sign:| themis_secure_message_rsa_encrypter_init |
|:no_entry_sign:| themis_secure_message_rsa_encrypter_proceed |
|| themis_secure_message_sign |
|:no_entry_sign:| themis_secure_message_signer_destroy |
|:no_entry_sign:| themis_secure_message_signer_init |
|:no_entry_sign:| themis_secure_message_signer_proceed |
|| themis_secure_message_unwrap |
|:no_entry_sign:| themis_secure_message_verifier_destroy |
|:no_entry_sign:| themis_secure_message_verifier_init |
|:no_entry_sign:| themis_secure_message_verifier_proceed |
|| themis_secure_message_verify |
|| themis_secure_message_wrap |
|:no_entry_sign:| themis_sym_decrypt_message_u |
|:no_entry_sign:| themis_sym_decrypt_message_u_ |
|:no_entry_sign:| themis_sym_encrypt_message_u |
|:no_entry_sign:| themis_sym_encrypt_message_u_ |
|:no_entry_sign:| themis_sym_kdf |
|:no_entry_sign:| themis_sym_plain_decrypt |
|:no_entry_sign:| themis_sym_plain_encrypt |
|:no_entry_sign:| verify_mac |
|:no_entry_sign:| verify_signature |

</details>

All these functions are _not_ accessible normally, via `<soter/soter.h>` or `<themis/themis.h>`.

Note that some functions from private headers are required to be exported due to hysterical raisins. These ones are marked with `SOTER_PRIVATE_API` and are exceptional by all means.

----

* **Explicitly mark public API of Themis**

Introduce a new header `<themis/themis_api.h>` which defines a function attribute marker `THEMIS_API`. It is used to explicitly mark API that is considered public. These functions will be exported from the library.

Themis does not really provide separate public header files so it's not immediately obvious which functions have to be marked public. We go with functions visible when including `<themis/themis.h>`.

Currently we support only UNIX-like systems so we can limit ourselves to just Clang and GCC. MSVC requires slightly different syntax but we'll get back to that when we start supporting Windows again.


* **Explicitly mark public API of Soter**

Just like with Themis, introduce `<soter/soter_api.h>` with `SOTER_API` and mark all public declarations as such.

Note that Soter also has a... complicated story with header files. It's not apparent which headers are public and which are private. We consider public those ones included from `<soter/soter.h>`.


* **Export additional private-use API from Soter**

Due to historically sloppy export management, many functions in Themis (as well as in unit-tests) rely on not-so-public API to be available. Normally you cannot get access to these functions, but you can if you import `<soter/soter_t.h>` or some other internal header files.

Introduce a new marker `SOTER_PRIVATE_API` to distinguish such functions from normal exports, and mark all of them exported. There are quite a few of functions, yeah...

Note that while public functions are marked in header files, private export functions are marked at definition site. This is required because some of the source files do not actually include corresponding headers. Plus, this way this definitions are ugly to look at and discourage from adding new 'private' exports.


* **Set default symbol visibility to hidden**

Finally, compile all source code with default symbol visibility set to "hidden". With this only symbols marked with `THEMIS_API`, `SOTER_API`, or `SOTER_PRIVATE_API` will get exported from libraries. `static` functions will never be exported, and non-static functions are also not exported by default unless explicitly marked as public.

---

Before merge:

- [x] Add new headers to Xcode project for Carthage
- [x] ~~Make sure API mistakes are caught by automatic tests~~ (will do later)