### PR TITLE
Make "all" the default target again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@
 # limitations under the License.
 #
 
+# Make sure that "all" is the default target no matter what
+all:
+
 #CC = clang
 CLANG_FORMAT ?= clang-format
 CLANG_TIDY   ?= clang-tidy


### PR DESCRIPTION
Recent additions to included makefiles have changed the default target from `all` to something unexpected (Soter's static library, if you're lucky). Let's make sure that `all` is the default target—the first one in the Makefile—when users are simply running
```
make
```