### PR TITLE
Use dynamic linkage for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,14 @@ ifneq ($(shell $(CC) --version 2>&1 | grep -oi "Emscripten"),)
 	IS_EMSCRIPTEN := true
 endif
 
+# Detect early if we have undefined symbols due to missing exports
+ifdef IS_MACOS
+LDFLAGS += -Wl,-undefined,error
+endif
+ifdef IS_LINUX
+LDFLAGS += -Wl,--no-undefined
+endif
+
 ifdef IS_EMSCRIPTEN
 CMAKE = emconfigure cmake
 endif

--- a/tests/soter/soter.mk
+++ b/tests/soter/soter.mk
@@ -47,9 +47,16 @@ $(OBJ_PATH)/tests/soter/%: CFLAGS += -DNIST_STS_EXE_PATH=$(realpath $(NIST_STS_D
 $(SOTER_TEST_BIN): nist_rng_test_suite
 endif
 
-$(SOTER_TEST_BIN): CMD = $(CC) -o $@ $(filter %.o %.a, $^) $(LDFLAGS) $(CRYPTO_ENGINE_LDFLAGS)
+# Link dynamically against the Soter library in the build directory,
+# not the one in the standard system paths (if any).
+SOTER_TEST_LDFLAGS += -L$(BIN_PATH) -lsoter
+ifdef IS_LINUX
+SOTER_TEST_LDFLAGS += -Wl,-rpath,$(abspath $(BIN_PATH))
+endif
 
-$(SOTER_TEST_BIN): $(SOTER_TEST_OBJ) $(COMMON_TEST_OBJ) $(SOTER_STATIC)
+$(SOTER_TEST_BIN): CMD = $(CC) -o $@ $(filter %.o %.a, $^) $(LDFLAGS) $(SOTER_TEST_LDFLAGS)
+
+$(SOTER_TEST_BIN): $(SOTER_TEST_OBJ) $(COMMON_TEST_OBJ) $(BIN_PATH)/$(LIBSOTER_SO)
 	@mkdir -p $(@D)
 	@echo -n "link "
 	@$(BUILD_CMD)

--- a/tests/soter/soter.mk
+++ b/tests/soter/soter.mk
@@ -33,8 +33,6 @@ FMT_FIXUP += $(patsubst %,$(OBJ_PATH)/%.fmt_fixup, $(SOTER_TEST_FMT))
 FMT_CHECK += $(patsubst %,$(OBJ_PATH)/%.fmt_check, $(SOTER_TEST_FMT))
 
 ifdef IS_EMSCRIPTEN
-$(SOTER_TEST_BIN): LDFLAGS += -s SINGLE_FILE=1
-
 # Emscripten cannot conveniently run NIST STS therefore we disable it.
 NO_NIST_STS := true
 endif
@@ -47,20 +45,23 @@ $(OBJ_PATH)/tests/soter/%: CFLAGS += -DNIST_STS_EXE_PATH=$(realpath $(NIST_STS_D
 $(SOTER_TEST_BIN): nist_rng_test_suite
 endif
 
+ifdef IS_EMSCRIPTEN
+# Emscripten does not support dynamic linkage, do a static build for it.
+SOTER_TEST_LDFLAGS += -s SINGLE_FILE=1
+$(SOTER_TEST_BIN): $(SOTER_STATIC)
+else
 # Link dynamically against the Soter library in the build directory,
 # not the one in the standard system paths (if any).
 SOTER_TEST_LDFLAGS += -L$(BIN_PATH) -lsoter
 ifdef IS_LINUX
 SOTER_TEST_LDFLAGS += -Wl,-rpath,$(abspath $(BIN_PATH))
 endif
-# Emscripten still links statically, provide all dependencies for it
-ifdef IS_EMSCRIPTEN
-SOTER_TEST_LDFLAGS += $(CRYPTO_ENGINE_LDFLAGS)
+$(SOTER_TEST_BIN): $(BIN_PATH)/$(LIBSOTER_SO)
 endif
 
 $(SOTER_TEST_BIN): CMD = $(CC) -o $@ $(filter %.o %.a, $^) $(LDFLAGS) $(SOTER_TEST_LDFLAGS)
 
-$(SOTER_TEST_BIN): $(SOTER_TEST_OBJ) $(COMMON_TEST_OBJ) $(BIN_PATH)/$(LIBSOTER_SO)
+$(SOTER_TEST_BIN): $(SOTER_TEST_OBJ) $(COMMON_TEST_OBJ)
 	@mkdir -p $(@D)
 	@echo -n "link "
 	@$(BUILD_CMD)

--- a/tests/soter/soter.mk
+++ b/tests/soter/soter.mk
@@ -53,6 +53,10 @@ SOTER_TEST_LDFLAGS += -L$(BIN_PATH) -lsoter
 ifdef IS_LINUX
 SOTER_TEST_LDFLAGS += -Wl,-rpath,$(abspath $(BIN_PATH))
 endif
+# Emscripten still links statically, provide all dependencies for it
+ifdef IS_EMSCRIPTEN
+SOTER_TEST_LDFLAGS += $(CRYPTO_ENGINE_LDFLAGS)
+endif
 
 $(SOTER_TEST_BIN): CMD = $(CC) -o $@ $(filter %.o %.a, $^) $(LDFLAGS) $(SOTER_TEST_LDFLAGS)
 

--- a/tests/themis/themis.mk
+++ b/tests/themis/themis.mk
@@ -41,6 +41,10 @@ THEMIS_TEST_LDFLAGS += -L$(BIN_PATH) -lthemis -lsoter
 ifdef IS_LINUX
 THEMIS_TEST_LDFLAGS += -Wl,-rpath,$(abspath $(BIN_PATH))
 endif
+# Emscripten still links statically, provide all dependencies for it
+ifdef IS_EMSCRIPTEN
+THEMIS_TEST_LDFLAGS += $(CRYPTO_ENGINE_LDFLAGS)
+endif
 
 $(THEMIS_TEST_BIN): CMD = $(CC) -o $@ $(filter %.o %.a, $^) $(LDFLAGS) $(THEMIS_TEST_LDFLAGS)
 

--- a/tests/themis/themis.mk
+++ b/tests/themis/themis.mk
@@ -31,9 +31,10 @@ FMT_FIXUP += $(patsubst %,$(OBJ_PATH)/%.fmt_fixup, $(THEMIS_TEST_FMT))
 FMT_CHECK += $(patsubst %,$(OBJ_PATH)/%.fmt_check, $(THEMIS_TEST_FMT))
 
 ifdef IS_EMSCRIPTEN
+# Emscripten does not support dynamic linkage, do a static build for it.
 THEMIS_TEST_LDFLAGS += -s SINGLE_FILE=1
-endif
-
+$(THEMIS_TEST_BIN): $(THEMIS_STATIC)
+else
 # Link dynamically against the Themis library in the build directory,
 # not the one in the standard system paths (if any).
 # We also need to link against Soter explicitly because of private imports.
@@ -41,14 +42,12 @@ THEMIS_TEST_LDFLAGS += -L$(BIN_PATH) -lthemis -lsoter
 ifdef IS_LINUX
 THEMIS_TEST_LDFLAGS += -Wl,-rpath,$(abspath $(BIN_PATH))
 endif
-# Emscripten still links statically, provide all dependencies for it
-ifdef IS_EMSCRIPTEN
-THEMIS_TEST_LDFLAGS += $(CRYPTO_ENGINE_LDFLAGS)
+$(THEMIS_TEST_BIN): $(BIN_PATH)/$(LIBTHEMIS_SO)
 endif
 
 $(THEMIS_TEST_BIN): CMD = $(CC) -o $@ $(filter %.o %.a, $^) $(LDFLAGS) $(THEMIS_TEST_LDFLAGS)
 
-$(THEMIS_TEST_BIN): $(THEMIS_TEST_OBJ) $(COMMON_TEST_OBJ) $(BIN_PATH)/$(LIBTHEMIS_SO)
+$(THEMIS_TEST_BIN): $(THEMIS_TEST_OBJ) $(COMMON_TEST_OBJ)
 	@mkdir -p $(@D)
 	@echo -n "link "
 	@$(BUILD_CMD)

--- a/tests/themis/themis.mk
+++ b/tests/themis/themis.mk
@@ -31,12 +31,20 @@ FMT_FIXUP += $(patsubst %,$(OBJ_PATH)/%.fmt_fixup, $(THEMIS_TEST_FMT))
 FMT_CHECK += $(patsubst %,$(OBJ_PATH)/%.fmt_check, $(THEMIS_TEST_FMT))
 
 ifdef IS_EMSCRIPTEN
-$(THEMIS_TEST_BIN): LDFLAGS += -s SINGLE_FILE=1
+THEMIS_TEST_LDFLAGS += -s SINGLE_FILE=1
 endif
 
-$(THEMIS_TEST_BIN): CMD = $(CC) -o $@ $(filter %.o %.a, $^) $(LDFLAGS) $(CRYPTO_ENGINE_LDFLAGS)
+# Link dynamically against the Themis library in the build directory,
+# not the one in the standard system paths (if any).
+# We also need to link against Soter explicitly because of private imports.
+THEMIS_TEST_LDFLAGS += -L$(BIN_PATH) -lthemis -lsoter
+ifdef IS_LINUX
+THEMIS_TEST_LDFLAGS += -Wl,-rpath,$(abspath $(BIN_PATH))
+endif
 
-$(THEMIS_TEST_BIN): $(THEMIS_TEST_OBJ) $(COMMON_TEST_OBJ) $(THEMIS_STATIC)
+$(THEMIS_TEST_BIN): CMD = $(CC) -o $@ $(filter %.o %.a, $^) $(LDFLAGS) $(THEMIS_TEST_LDFLAGS)
+
+$(THEMIS_TEST_BIN): $(THEMIS_TEST_OBJ) $(COMMON_TEST_OBJ) $(BIN_PATH)/$(LIBTHEMIS_SO)
 	@mkdir -p $(@D)
 	@echo -n "link "
 	@$(BUILD_CMD)

--- a/tests/themispp/themispp.mk
+++ b/tests/themispp/themispp.mk
@@ -31,6 +31,10 @@ THEMISPP_TEST_LDFLAGS += -L$(BIN_PATH) -lthemis -lsoter
 ifdef IS_LINUX
 THEMISPP_TEST_LDFLAGS += -Wl,-rpath,$(abspath $(BIN_PATH))
 endif
+# Emscripten still links statically, provide all dependencies for it
+ifdef IS_EMSCRIPTEN
+THEMISPP_TEST_LDFLAGS += $(CRYPTO_ENGINE_LDFLAGS)
+endif
 
 $(TEST_BIN_PATH)/themispp_test: CMD = $(CXX) -o $@ $(filter %.o %.a, $^) $(LDFLAGS) $(THEMISPP_TEST_LDFLAGS)
 

--- a/tests/themispp/themispp.mk
+++ b/tests/themispp/themispp.mk
@@ -24,9 +24,17 @@ THEMISPP_TEST_FMT = $(THEMISPP_TEST_SOURCES) $(THEMISPP_TEST_HEADERS)
 FMT_FIXUP += $(patsubst %,$(OBJ_PATH)/%.fmt_fixup, $(THEMISPP_TEST_FMT))
 FMT_CHECK += $(patsubst %,$(OBJ_PATH)/%.fmt_check, $(THEMISPP_TEST_FMT))
 
-$(TEST_BIN_PATH)/themispp_test: CMD = $(CXX) -o $@ $(filter %.o %.a, $^) $(LDFLAGS) $(CRYPTO_ENGINE_LDFLAGS)
+# Link dynamically against Themis library in the build directory,
+# not the one in the standard system paths (if any).
+# We also need to link against Soter explicitly because of private imports.
+THEMISPP_TEST_LDFLAGS += -L$(BIN_PATH) -lthemis -lsoter
+ifdef IS_LINUX
+THEMISPP_TEST_LDFLAGS += -Wl,-rpath,$(abspath $(BIN_PATH))
+endif
 
-$(TEST_BIN_PATH)/themispp_test: $(THEMISPP_TEST_OBJ) $(COMMON_TEST_OBJ) $(THEMIS_STATIC)
+$(TEST_BIN_PATH)/themispp_test: CMD = $(CXX) -o $@ $(filter %.o %.a, $^) $(LDFLAGS) $(THEMISPP_TEST_LDFLAGS)
+
+$(TEST_BIN_PATH)/themispp_test: $(THEMISPP_TEST_OBJ) $(COMMON_TEST_OBJ) $(BIN_PATH)/$(LIBTHEMIS_SO)
 	@echo -n "link "
 	@$(BUILD_CMD)
 

--- a/tests/themispp/themispp.mk
+++ b/tests/themispp/themispp.mk
@@ -24,6 +24,11 @@ THEMISPP_TEST_FMT = $(THEMISPP_TEST_SOURCES) $(THEMISPP_TEST_HEADERS)
 FMT_FIXUP += $(patsubst %,$(OBJ_PATH)/%.fmt_fixup, $(THEMISPP_TEST_FMT))
 FMT_CHECK += $(patsubst %,$(OBJ_PATH)/%.fmt_check, $(THEMISPP_TEST_FMT))
 
+ifdef IS_EMSCRIPTEN
+# Emscripten does not support dynamic linkage, do a static build for it.
+THEMISPP_TEST_LDFLAGS += -s SINGLE_FILE=1
+$(TEST_BIN_PATH)/themispp_test: $(THEMIS_STATIC)
+else
 # Link dynamically against Themis library in the build directory,
 # not the one in the standard system paths (if any).
 # We also need to link against Soter explicitly because of private imports.
@@ -31,14 +36,12 @@ THEMISPP_TEST_LDFLAGS += -L$(BIN_PATH) -lthemis -lsoter
 ifdef IS_LINUX
 THEMISPP_TEST_LDFLAGS += -Wl,-rpath,$(abspath $(BIN_PATH))
 endif
-# Emscripten still links statically, provide all dependencies for it
-ifdef IS_EMSCRIPTEN
-THEMISPP_TEST_LDFLAGS += $(CRYPTO_ENGINE_LDFLAGS)
+$(TEST_BIN_PATH)/themispp_test: $(BIN_PATH)/$(LIBTHEMIS_SO)
 endif
 
 $(TEST_BIN_PATH)/themispp_test: CMD = $(CXX) -o $@ $(filter %.o %.a, $^) $(LDFLAGS) $(THEMISPP_TEST_LDFLAGS)
 
-$(TEST_BIN_PATH)/themispp_test: $(THEMISPP_TEST_OBJ) $(COMMON_TEST_OBJ) $(BIN_PATH)/$(LIBTHEMIS_SO)
+$(TEST_BIN_PATH)/themispp_test: $(THEMISPP_TEST_OBJ) $(COMMON_TEST_OBJ)
 	@echo -n "link "
 	@$(BUILD_CMD)
 


### PR DESCRIPTION
PR #458 has introduced explicit visibility control using `THEMIS_API`, `SOTER_API`, and `SOTER_PRIVATE_API` macros. Unfortunately, visibility has no effect on _static_ libraries. Thus if the developers forget to export a function then unit and integration tests will still pass because they are using static linkage.

Switch to using dynamic linkage for tests. In this case linkage will fail if a required function is not marked as exported, with a more or less helpful message like this:

```
link build/libthemis.so.0                                          [ERRORS]
cc -shared -o build/libthemis.so.0 build/obj/src/themis/secure_session_peer.c.o build/obj/src/themis/message.c.o build/obj/src/themis/secure_session_utils.c.o build/obj/src/themis/secure_message.c.o build/obj/src/themis/secure_session.c.o build/obj/src/themis/secure_session_serialize.c.o build/obj/src/themis/sym_enc_message.c.o build/obj/src/themis/secure_comparator.c.o build/obj/src/themis/secure_cell.c.o build/obj/src/themis/secure_keygen.c.o build/obj/src/themis/secure_message_wrapper.c.o build/obj/src/themis/secure_session_message.c.o -L/usr/local/lib -Wl,--no-undefined -Lbuild -lsoter -Wl,-soname,libthemis.so.0
/usr/bin/ld: build/obj/src/themis/secure_comparator.c.o: in function `ed_verify':
secure_comparator.c:(.text+0x28c): undefined reference to `crypto_sign_ed25519_ref10_fe_neg'
/usr/bin/ld: secure_comparator.c:(.text+0x2ad): undefined reference to `crypto_sign_ed25519_ref10_fe_neg'
/usr/bin/ld: build/obj/src/themis/secure_comparator.c.o: in function `ed_point_verify':
secure_comparator.c:(.text+0xc05): undefined reference to `crypto_sign_ed25519_ref10_fe_neg'
/usr/bin/ld: secure_comparator.c:(.text+0xc26): undefined reference to `crypto_sign_ed25519_ref10_fe_neg'
collect2: error: ld returned 1 exit status
make: *** [src/themis/themis.mk:59: build/libthemis.so.0] Error 1
``` 

And the developer will at least know what functions and files are affected, and where they forgot to add `SOTER_PRIVATE_API` or one of its friends.

---

* **Link tests dynamically: Soter**

Switch to dynamic linkage for test binaries. This will allow us to better track missing exported symbols and make sure that all public API is actually tested.

The switch itself is more or less trivial: build the dynamic library as the prerequisite, and link using `-Lbuild -lsoter` instead of adding the static library to the object list. Since now the cryptographic backend is managed by the dynamic library, we no longer have to link against it explicitly.

Caveat for Linux: we need to set `rpath` to the build directory so that the dynamic loader can locate Soter library there. Otherwise we'll have to set LD_LIBRARY_PATH when running tests.

* **Link tests dynamically: Themis**

Link Themis Core tests dynamically, just like we do for Soter now.

Caveats:

  - the tests actually use some symbols from libsoter so we have to link against it as well, not only with just libthemis

  - setting LDFLAGS will leak them to libthemis and libsoter compilation by default, avoid that by using a separate variable

* **Link tests dynamically: ThemisPP**

Link ThemisPP tests dynamically, just like we do for Themis and Soter. Overall it's just like with Themis.

* **Disallow unresolved symbols during builds**

The default behavior of linkers is to allow unresolved symbols in libraries (but not executables). This is sometimes useful for interposition but not in our case. Add a global linker flag to ensure that all imported symbols can be resolved.

(Obviously, Linux and macOS linkers use a bit different syntax: `--no-undefined` vs `-undefined,error`.)