### PR TITLE
Fix Clippy warnings

### DIFF
--- a/tools/rust/keygen_tool.rs
+++ b/tools/rust/keygen_tool.rs
@@ -28,10 +28,9 @@ fn main() {
         (@arg public: "Public key file (default: key.pub)")
     )
     .get_matches();
-    let private_path = matches.value_of("private").unwrap_or("key").to_owned();
-    let public_path = matches
-        .value_of("public")
-        .map_or_else(|| private_path.clone() + ".pub", |s| s.to_owned());
+    let private_path = matches.value_of("private").unwrap_or("key");
+    let default_path = private_path.to_owned() + ".pub";
+    let public_path = matches.value_of("public").unwrap_or(&default_path);
 
     let (private_key, public_key) = gen_ec_key_pair().split();
 


### PR DESCRIPTION
New Clippy does not like when you write `|s| s.to_owned()` because making a new closure here is reduntant (you can pass the function std::borrow::ToOwned::to_owned there directly). This causes a warning and we treat warnings as errors, [which breaks the builds](https://circleci.com/gh/cossacklabs/themis/4481).

Anyway, it's not like we need to avoid this computation here with a closure so rewrite the code to compute the default path in a more straightforward way and thus avoid the wrath of our resident god of static analysis.