### PR TITLE
improve SecureMessage sign/verify examples for iOS

### DIFF
--- a/docs/examples/objc/iOS-Carthage/ThemisTest/AppDelegate.m
+++ b/docs/examples/objc/iOS-Carthage/ThemisTest/AppDelegate.m
@@ -282,56 +282,46 @@
 - (void)runExampleSecureMessageSignVerify {
     NSLog(@"----------------- %s -----------------", sel_getName(_cmd));
 
-    // ---------- signing
-
     // base64 encoded keys:
-    // client private key
-    // server public key
-    NSString *serverPublicKeyString = @"VUVDMgAAAC2ELbj5Aue5xjiJWW3P2KNrBX+HkaeJAb+Z4MrK0cWZlAfpBUql";
-    NSString *clientPrivateKeyString = @"UkVDMgAAAC13PCVZAKOczZXUpvkhsC+xvwWnv3CLmlG0Wzy8ZBMnT+2yx/dg";
+    // private key
+    // public key
+    
+    NSString *publicKeyString = @"VUVDMgAAAC2ELbj5Aue5xjiJWW3P2KNrBX+HkaeJAb+Z4MrK0cWZlAfpBUql";
+    NSString *privateKeyString = @"UkVDMgAAAC1FsVa6AMGljYqtNWQ+7r4RjXTabLZxZ/14EXmi6ec2e1vrCmyR";
 
-    NSData *serverPublicKey = [[NSData alloc] initWithBase64EncodedString:serverPublicKeyString
-                                                                  options:NSDataBase64DecodingIgnoreUnknownCharacters];
-    NSData *clientPrivateKey = [[NSData alloc] initWithBase64EncodedString:clientPrivateKeyString
-                                                                   options:NSDataBase64DecodingIgnoreUnknownCharacters];
+    NSData *publicKey = [[NSData alloc] initWithBase64EncodedString:publicKeyString
+                                                            options:NSDataBase64DecodingIgnoreUnknownCharacters];
+    NSData *privateKey = [[NSData alloc] initWithBase64EncodedString:privateKeyString
+                                                             options:NSDataBase64DecodingIgnoreUnknownCharacters];
 
-    // initialize encrypter
-    TSMessage *encrypter = [[TSMessage alloc] initInSignVerifyModeWithPrivateKey:clientPrivateKey peerPublicKey:serverPublicKey];
+    
+    // ---------- signing
+    
+    // initialize signer, use private key
+    TSMessage *signer = [[TSMessage alloc] initInSignVerifyModeWithPrivateKey:privateKey peerPublicKey:nil];
 
     NSString *message = @"- Knock, knock.\n- Who’s there?\n*very long pause...*\n- Java.";
 
     NSError *themisError;
-    NSData *encryptedMessage = [encrypter wrapData:[message dataUsingEncoding:NSUTF8StringEncoding]
-                                             error:&themisError];
+    NSData *signedMessage = [signer wrapData:[message dataUsingEncoding:NSUTF8StringEncoding]
+                                       error:&themisError];
     if (themisError) {
-        NSLog(@"%s Error occurred while encrypting %@", sel_getName(_cmd), themisError);
+        NSLog(@"%s Error occurred while signing %@", sel_getName(_cmd), themisError);
         return;
     }
-    NSLog(@"%@", encryptedMessage);
 
     // -------- verification
 
-    // base64 encoded keys:
-    // server private key
-    // client public key
-    NSString *serverPrivateKeyString = @"UkVDMgAAAC1FsVa6AMGljYqtNWQ+7r4RjXTabLZxZ/14EXmi6ec2e1vrCmyR";
-    NSString *clientPublicKeyString = @"VUVDMgAAAC1SsL32Axjosnf2XXUwm/4WxPlZauQ+v+0eOOjpwMN/EO+Huh5d";
+    // initialize verifier, use public key
+    TSMessage *verifier = [[TSMessage alloc] initInSignVerifyModeWithPrivateKey:nil peerPublicKey:publicKey];
 
-    NSData *serverPrivateKey = [[NSData alloc] initWithBase64EncodedString:serverPrivateKeyString
-                                                                   options:NSDataBase64DecodingIgnoreUnknownCharacters];
-    NSData *clientPublicKey = [[NSData alloc] initWithBase64EncodedString:clientPublicKeyString
-                                                                  options:NSDataBase64DecodingIgnoreUnknownCharacters];
-
-    // initialize decrypter
-    TSMessage *decrypter = [[TSMessage alloc] initInSignVerifyModeWithPrivateKey:serverPrivateKey peerPublicKey:clientPublicKey];
-
-    NSData *decryptedMessage = [decrypter unwrapData:encryptedMessage error:&themisError];
+    NSData *verifiedMessage = [verifier unwrapData:signedMessage error:&themisError];
     if (themisError) {
-        NSLog(@"%s Error occurred while decrypting %@", sel_getName(_cmd), themisError);
+        NSLog(@"%s Error occurred while verifying %@", sel_getName(_cmd), themisError);
         return;
     }
 
-    NSString *resultString = [[NSString alloc] initWithData:decryptedMessage encoding:NSUTF8StringEncoding];
+    NSString *resultString = [[NSString alloc] initWithData:verifiedMessage encoding:NSUTF8StringEncoding];
     NSLog(@"%@", resultString);
 }
 

--- a/docs/examples/objc/iOS-CocoaPods/ThemisTest/ThemisTest/Classes/AppDelegate.m
+++ b/docs/examples/objc/iOS-CocoaPods/ThemisTest/ThemisTest/Classes/AppDelegate.m
@@ -278,59 +278,49 @@
 - (void)runExampleSecureMessageSignVerify {
     NSLog(@"----------------- %s -----------------", sel_getName(_cmd));
     
+    // base64 encoded keys:
+    // private key
+    // public key
+    
+    NSString *publicKeyString = @"VUVDMgAAAC2ELbj5Aue5xjiJWW3P2KNrBX+HkaeJAb+Z4MrK0cWZlAfpBUql";
+    NSString *privateKeyString = @"UkVDMgAAAC1FsVa6AMGljYqtNWQ+7r4RjXTabLZxZ/14EXmi6ec2e1vrCmyR";
+    
+    NSData *publicKey = [[NSData alloc] initWithBase64EncodedString:publicKeyString
+                                                            options:NSDataBase64DecodingIgnoreUnknownCharacters];
+    NSData *privateKey = [[NSData alloc] initWithBase64EncodedString:privateKeyString
+                                                             options:NSDataBase64DecodingIgnoreUnknownCharacters];
+    
+    
     // ---------- signing
-
-    // base64 encoded keys:
-    // client private key
-    // server public key
-    NSString * serverPublicKeyString = @"VUVDMgAAAC2ELbj5Aue5xjiJWW3P2KNrBX+HkaeJAb+Z4MrK0cWZlAfpBUql";
-    NSString * clientPrivateKeyString = @"UkVDMgAAAC13PCVZAKOczZXUpvkhsC+xvwWnv3CLmlG0Wzy8ZBMnT+2yx/dg";
-
-    NSData * serverPublicKey = [[NSData alloc] initWithBase64EncodedString:serverPublicKeyString
-                                                                   options:NSDataBase64DecodingIgnoreUnknownCharacters];
-    NSData * clientPrivateKey = [[NSData alloc] initWithBase64EncodedString:clientPrivateKeyString
-                                                                    options:NSDataBase64DecodingIgnoreUnknownCharacters];
-
-    // initialize encrypter
-    TSMessage * encrypter = [[TSMessage alloc] initInSignVerifyModeWithPrivateKey:clientPrivateKey peerPublicKey:serverPublicKey];
-
-    NSString * message = @"- Knock, knock.\n- Who’s there?\n*very long pause...*\n- Java.";
-
-    NSError * themisError;
-    NSData * encryptedMessage = [encrypter wrapData:[message dataUsingEncoding:NSUTF8StringEncoding]
-                                              error:&themisError];
+    
+    // initialize signer, use private key
+    TSMessage *signer = [[TSMessage alloc] initInSignVerifyModeWithPrivateKey:privateKey peerPublicKey:nil];
+    
+    NSString *message = @"- Knock, knock.\n- Who’s there?\n*very long pause...*\n- Java.";
+    
+    NSError *themisError;
+    NSData *signedMessage = [signer wrapData:[message dataUsingEncoding:NSUTF8StringEncoding]
+                                       error:&themisError];
     if (themisError) {
-        NSLog(@"%s Error occurred while encrypting %@", sel_getName(_cmd), themisError);
+        NSLog(@"%s Error occurred while signing %@", sel_getName(_cmd), themisError);
         return;
     }
-    NSLog(@"%@", encryptedMessage);
-
-
+    
     // -------- verification
-
-    // base64 encoded keys:
-    // server private key
-    // client public key
-    NSString * serverPrivateKeyString = @"UkVDMgAAAC1FsVa6AMGljYqtNWQ+7r4RjXTabLZxZ/14EXmi6ec2e1vrCmyR";
-    NSString * clientPublicKeyString = @"VUVDMgAAAC1SsL32Axjosnf2XXUwm/4WxPlZauQ+v+0eOOjpwMN/EO+Huh5d";
-
-    NSData * serverPrivateKey = [[NSData alloc] initWithBase64EncodedString:serverPrivateKeyString
-                                                                    options:NSDataBase64DecodingIgnoreUnknownCharacters];
-    NSData * clientPublicKey = [[NSData alloc] initWithBase64EncodedString:clientPublicKeyString
-                                                                   options:NSDataBase64DecodingIgnoreUnknownCharacters];
-
-    // initialize decrypter
-    TSMessage * decrypter = [[TSMessage alloc] initInSignVerifyModeWithPrivateKey:serverPrivateKey peerPublicKey:clientPublicKey];
-
-    NSData * decryptedMessage = [decrypter unwrapData:encryptedMessage error:&themisError];
+    
+    // initialize verifier, use public key
+    TSMessage *verifier = [[TSMessage alloc] initInSignVerifyModeWithPrivateKey:nil peerPublicKey:publicKey];
+    
+    NSData *verifiedMessage = [verifier unwrapData:signedMessage error:&themisError];
     if (themisError) {
-        NSLog(@"%s Error occurred while decrypting %@", sel_getName(_cmd), themisError);
+        NSLog(@"%s Error occurred while verifying %@", sel_getName(_cmd), themisError);
         return;
     }
-
-    NSString * resultString = [[NSString alloc] initWithData:decryptedMessage encoding:NSUTF8StringEncoding];
+    
+    NSString *resultString = [[NSString alloc] initWithData:verifiedMessage encoding:NSUTF8StringEncoding];
     NSLog(@"%@", resultString);
 }
+
 
 // Sometimes you will need to read keys from files
 - (void)readingKeysFromFile {

--- a/docs/examples/objc/macOS-Carthage/ThemisTest/AppDelegate.m
+++ b/docs/examples/objc/macOS-Carthage/ThemisTest/AppDelegate.m
@@ -275,57 +275,47 @@
 
 - (void)runExampleSecureMessageSignVerify {
     NSLog(@"----------------- %s -----------------", sel_getName(_cmd));
-
+    
+    // base64 encoded keys:
+    // private key
+    // public key
+    
+    NSString *publicKeyString = @"VUVDMgAAAC2ELbj5Aue5xjiJWW3P2KNrBX+HkaeJAb+Z4MrK0cWZlAfpBUql";
+    NSString *privateKeyString = @"UkVDMgAAAC1FsVa6AMGljYqtNWQ+7r4RjXTabLZxZ/14EXmi6ec2e1vrCmyR";
+    
+    NSData *publicKey = [[NSData alloc] initWithBase64EncodedString:publicKeyString
+                                                            options:NSDataBase64DecodingIgnoreUnknownCharacters];
+    NSData *privateKey = [[NSData alloc] initWithBase64EncodedString:privateKeyString
+                                                             options:NSDataBase64DecodingIgnoreUnknownCharacters];
+    
+    
     // ---------- signing
-
-    // base64 encoded keys:
-    // client private key
-    // server public key
-    NSString *serverPublicKeyString = @"VUVDMgAAAC2ELbj5Aue5xjiJWW3P2KNrBX+HkaeJAb+Z4MrK0cWZlAfpBUql";
-    NSString *clientPrivateKeyString = @"UkVDMgAAAC13PCVZAKOczZXUpvkhsC+xvwWnv3CLmlG0Wzy8ZBMnT+2yx/dg";
-
-    NSData *serverPublicKey = [[NSData alloc] initWithBase64EncodedString:serverPublicKeyString
-                                                                   options:NSDataBase64DecodingIgnoreUnknownCharacters];
-    NSData *clientPrivateKey = [[NSData alloc] initWithBase64EncodedString:clientPrivateKeyString
-                                                                    options:NSDataBase64DecodingIgnoreUnknownCharacters];
-
-    // initialize encrypter
-    TSMessage *encrypter = [[TSMessage alloc] initInSignVerifyModeWithPrivateKey:clientPrivateKey peerPublicKey:serverPublicKey];
-
+    
+    // initialize signer, use private key
+    TSMessage *signer = [[TSMessage alloc] initInSignVerifyModeWithPrivateKey:privateKey peerPublicKey:nil];
+    
     NSString *message = @"- Knock, knock.\n- Who’s there?\n*very long pause...*\n- Java.";
-
+    
     NSError *themisError;
-    NSData *encryptedMessage = [encrypter wrapData:[message dataUsingEncoding:NSUTF8StringEncoding]
-                                              error:&themisError];
+    NSData *signedMessage = [signer wrapData:[message dataUsingEncoding:NSUTF8StringEncoding]
+                                       error:&themisError];
     if (themisError) {
-        NSLog(@"%s Error occurred while encrypting %@", sel_getName(_cmd), themisError);
+        NSLog(@"%s Error occurred while signing %@", sel_getName(_cmd), themisError);
         return;
     }
-    NSLog(@"%@", encryptedMessage);
-
+    
     // -------- verification
-
-    // base64 encoded keys:
-    // server private key
-    // client public key
-    NSString *serverPrivateKeyString = @"UkVDMgAAAC1FsVa6AMGljYqtNWQ+7r4RjXTabLZxZ/14EXmi6ec2e1vrCmyR";
-    NSString *clientPublicKeyString = @"VUVDMgAAAC1SsL32Axjosnf2XXUwm/4WxPlZauQ+v+0eOOjpwMN/EO+Huh5d";
-
-    NSData *serverPrivateKey = [[NSData alloc] initWithBase64EncodedString:serverPrivateKeyString
-                                                                    options:NSDataBase64DecodingIgnoreUnknownCharacters];
-    NSData *clientPublicKey = [[NSData alloc] initWithBase64EncodedString:clientPublicKeyString
-                                                                   options:NSDataBase64DecodingIgnoreUnknownCharacters];
-
-    // initialize decrypter
-    TSMessage *decrypter = [[TSMessage alloc] initInSignVerifyModeWithPrivateKey:serverPrivateKey peerPublicKey:clientPublicKey];
-
-    NSData *decryptedMessage = [decrypter unwrapData:encryptedMessage error:&themisError];
+    
+    // initialize verifier, use public key
+    TSMessage *verifier = [[TSMessage alloc] initInSignVerifyModeWithPrivateKey:nil peerPublicKey:publicKey];
+    
+    NSData *verifiedMessage = [verifier unwrapData:signedMessage error:&themisError];
     if (themisError) {
-        NSLog(@"%s Error occurred while decrypting %@", sel_getName(_cmd), themisError);
+        NSLog(@"%s Error occurred while verifying %@", sel_getName(_cmd), themisError);
         return;
     }
-
-    NSString *resultString = [[NSString alloc] initWithData:decryptedMessage encoding:NSUTF8StringEncoding];
+    
+    NSString *resultString = [[NSString alloc] initWithData:verifiedMessage encoding:NSUTF8StringEncoding];
     NSLog(@"%@", resultString);
 }
 

--- a/docs/examples/swift/iOS-Carthage/Cartfile.resolved
+++ b/docs/examples/swift/iOS-Carthage/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "cossacklabs/themis" "0.11.0"
+github "cossacklabs/themis" "0.11.1"
 github "krzyzanowskim/OpenSSL" "1.0.2.17"

--- a/docs/examples/swift/iOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
+++ b/docs/examples/swift/iOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
@@ -354,7 +354,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis.ThemisTest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -377,7 +377,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis.ThemisTest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/docs/examples/swift/iOS-Carthage/ThemisTest/AppDelegate.swift
+++ b/docs/examples/swift/iOS-Carthage/ThemisTest/AppDelegate.swift
@@ -265,60 +265,51 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func runExampleSecureMessageSignVerify() {
         print("----------------------------------", #function)
 
-        // ---------- signing ----------------
-
         // base64 encoded keys:
-        // client private key
-        // server public key
+        // private key
+        // public key
 
-        let serverPublicKeyString: String = "VUVDMgAAAC2ELbj5Aue5xjiJWW3P2KNrBX+HkaeJAb+Z4MrK0cWZlAfpBUql"
-        let clientPrivateKeyString: String = "UkVDMgAAAC13PCVZAKOczZXUpvkhsC+xvwWnv3CLmlG0Wzy8ZBMnT+2yx/dg"
+        let publicKeyString: String = "VUVDMgAAAC2ELbj5Aue5xjiJWW3P2KNrBX+HkaeJAb+Z4MrK0cWZlAfpBUql"
+        let privateKeyString: String = "UkVDMgAAAC1FsVa6AMGljYqtNWQ+7r4RjXTabLZxZ/14EXmi6ec2e1vrCmyR"
 
-        guard let serverPublicKey: Data = Data(base64Encoded: serverPublicKeyString,
+        guard let publicKey: Data = Data(base64Encoded: publicKeyString,
                                                options: .ignoreUnknownCharacters),
-            let clientPrivateKey: Data = Data(base64Encoded: clientPrivateKeyString,
+            let privateKey: Data = Data(base64Encoded: privateKeyString,
                                               options: .ignoreUnknownCharacters) else {
                                                 print("Error occurred during base64 encoding", #function)
                                                 return
         }
 
-        let encrypter: TSMessage = TSMessage.init(inSignVerifyModeWithPrivateKey: clientPrivateKey,
-                                                  peerPublicKey: serverPublicKey)!
+        // ---------- signing ----------------
+        // use private key
+        
+        let signer: TSMessage = TSMessage.init(inSignVerifyModeWithPrivateKey: privateKey,
+                                               peerPublicKey: nil)!
 
         let message: String = "I had a problem so I though to use Java. Now I have a ProblemFactory."
 
-        var encryptedMessage: Data = Data()
+        var signedMessage: Data = Data()
         do {
-            encryptedMessage = try encrypter.wrap(message.data(using: .utf8))
-            print("encryptedMessage = \(encryptedMessage)")
+            signedMessage = try signer.wrap(message.data(using: .utf8))
+            print("signedMessage = \(signedMessage)")
 
         } catch let error as NSError {
-            print("Error occurred while encrypting \(error)", #function)
+            print("Error occurred while signing \(error)", #function)
             return
         }
 
         // ---------- verification ----------------
-        let serverPrivateKeyString: String = "UkVDMgAAAC1FsVa6AMGljYqtNWQ+7r4RjXTabLZxZ/14EXmi6ec2e1vrCmyR"
-        let clientPublicKeyString: String = "VUVDMgAAAC1SsL32Axjosnf2XXUwm/4WxPlZauQ+v+0eOOjpwMN/EO+Huh5d"
-
-        guard let serverPrivateKey: Data = Data(base64Encoded: serverPrivateKeyString,
-                                                options: .ignoreUnknownCharacters),
-            let clientPublicKey: Data = Data(base64Encoded: clientPublicKeyString,
-                                             options: .ignoreUnknownCharacters) else {
-                                                print("Error occurred during base64 encoding", #function)
-                                                return
-        }
-
-        let decrypter: TSMessage = TSMessage.init(inSignVerifyModeWithPrivateKey: serverPrivateKey,
-                                                  peerPublicKey: clientPublicKey)!
+        // use public key
+        let verifier = TSMessage.init(inSignVerifyModeWithPrivateKey: nil,
+                                      peerPublicKey: publicKey)!
 
         do {
-            let decryptedMessage: Data = try decrypter.unwrapData(encryptedMessage)
-            let resultString: String = String(data: decryptedMessage, encoding: .utf8)!
-            print("decryptedMessage->\n\(resultString)")
+            let verifiedMessage: Data = try verifier.unwrapData(signedMessage)
+            let resultString: String = String(data: verifiedMessage, encoding: .utf8)!
+            print("verifiedMessage ->\n\(resultString)")
 
         } catch let error as NSError {
-            print("Error occurred while decrypting \(error)", #function)
+            print("Error occurred while verifing \(error)", #function)
             return
         }
     }

--- a/docs/examples/swift/iOS-CocoaPods/ThemisSwift.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/docs/examples/swift/iOS-CocoaPods/ThemisSwift.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/docs/examples/swift/iOS-CocoaPods/ThemisSwift/ThemisSwift/Classes/AppDelegate.swift
+++ b/docs/examples/swift/iOS-CocoaPods/ThemisSwift/ThemisSwift/Classes/AppDelegate.swift
@@ -269,65 +269,56 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func runExampleSecureMessageSignVerify() {
         print("----------------------------------", #function)
         
-        // ---------- signing ----------------
-        
         // base64 encoded keys:
-        // client private key
-        // server public key
+        // private key
+        // public key
         
-        let serverPublicKeyString: String = "VUVDMgAAAC2ELbj5Aue5xjiJWW3P2KNrBX+HkaeJAb+Z4MrK0cWZlAfpBUql"
-        let clientPrivateKeyString: String = "UkVDMgAAAC13PCVZAKOczZXUpvkhsC+xvwWnv3CLmlG0Wzy8ZBMnT+2yx/dg"
+        let publicKeyString: String = "VUVDMgAAAC2ELbj5Aue5xjiJWW3P2KNrBX+HkaeJAb+Z4MrK0cWZlAfpBUql"
+        let privateKeyString: String = "UkVDMgAAAC1FsVa6AMGljYqtNWQ+7r4RjXTabLZxZ/14EXmi6ec2e1vrCmyR"
         
-        guard let serverPublicKey: Data = Data(base64Encoded: serverPublicKeyString,
-                                                   options: .ignoreUnknownCharacters),
-            let clientPrivateKey: Data = Data(base64Encoded: clientPrivateKeyString,
-                                                  options: .ignoreUnknownCharacters) else {
-                                                    print("Error occurred during base64 encoding", #function)
-                                                    return
+        guard let publicKey: Data = Data(base64Encoded: publicKeyString,
+                                         options: .ignoreUnknownCharacters),
+            let privateKey: Data = Data(base64Encoded: privateKeyString,
+                                        options: .ignoreUnknownCharacters) else {
+                                            print("Error occurred during base64 encoding", #function)
+                                            return
         }
         
-        let encrypter: TSMessage = TSMessage.init(inSignVerifyModeWithPrivateKey: clientPrivateKey,
-                                                  peerPublicKey: serverPublicKey)!
+        // ---------- signing ----------------
+        // use private key
+        
+        let signer: TSMessage = TSMessage.init(inSignVerifyModeWithPrivateKey: privateKey,
+                                               peerPublicKey: nil)!
         
         let message: String = "I had a problem so I though to use Java. Now I have a ProblemFactory."
         
-        var encryptedMessage: Data = Data()
+        var signedMessage: Data = Data()
         do {
-            encryptedMessage = try encrypter.wrap(message.data(using: .utf8))
-            print("encryptedMessage = \(encryptedMessage)")
+            signedMessage = try signer.wrap(message.data(using: .utf8))
+            print("signedMessage = \(signedMessage)")
             
         } catch let error as NSError {
-            print("Error occurred while encrypting \(error)", #function)
+            print("Error occurred while signing \(error)", #function)
             return
         }
         
         // ---------- verification ----------------
-        let serverPrivateKeyString: String = "UkVDMgAAAC1FsVa6AMGljYqtNWQ+7r4RjXTabLZxZ/14EXmi6ec2e1vrCmyR"
-        let clientPublicKeyString: String = "VUVDMgAAAC1SsL32Axjosnf2XXUwm/4WxPlZauQ+v+0eOOjpwMN/EO+Huh5d"
-        
-        guard let serverPrivateKey: Data = Data(base64Encoded: serverPrivateKeyString,
-                                                    options: .ignoreUnknownCharacters),
-            let clientPublicKey: Data = Data(base64Encoded: clientPublicKeyString,
-                                                 options: .ignoreUnknownCharacters) else {
-                                                    print("Error occurred during base64 encoding", #function)
-                                                    return
-        }
-        
-        let decrypter: TSMessage = TSMessage.init(inSignVerifyModeWithPrivateKey: serverPrivateKey,
-                                                  peerPublicKey: clientPublicKey)!
+        // use public key
+        let verifier = TSMessage.init(inSignVerifyModeWithPrivateKey: nil,
+                                      peerPublicKey: publicKey)!
         
         do {
-            let decryptedMessage: Data = try decrypter.unwrapData(encryptedMessage)
-            let resultString: String = String(data: decryptedMessage, encoding: .utf8)!
-            print("decryptedMessage->\n\(resultString)")
+            let verifiedMessage: Data = try verifier.unwrapData(signedMessage)
+            let resultString: String = String(data: verifiedMessage, encoding: .utf8)!
+            print("verifiedMessage ->\n\(resultString)")
             
         } catch let error as NSError {
-            print("Error occurred while decrypting \(error)", #function)
+            print("Error occurred while verifing \(error)", #function)
             return
         }
     }
-    
-    // MARK:- Secure Comparator
+
+    // MARK: - Secure Comparator
     func runExampleSecureComparator() {
         print("----------------------------------", #function)
         

--- a/docs/examples/swift/macOS-Carthage/ThemisTest/AppDelegate.swift
+++ b/docs/examples/swift/macOS-Carthage/ThemisTest/AppDelegate.swift
@@ -262,61 +262,52 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func runExampleSecureMessageSignVerify() {
         print("----------------------------------", #function)
-
-        // ---------- signing ----------------
-
+        
         // base64 encoded keys:
-        // client private key
-        // server public key
-
-        let serverPublicKeyString: String = "VUVDMgAAAC2ELbj5Aue5xjiJWW3P2KNrBX+HkaeJAb+Z4MrK0cWZlAfpBUql"
-        let clientPrivateKeyString: String = "UkVDMgAAAC13PCVZAKOczZXUpvkhsC+xvwWnv3CLmlG0Wzy8ZBMnT+2yx/dg"
-
-        guard let serverPublicKey: Data = Data(base64Encoded: serverPublicKeyString,
-                                               options: .ignoreUnknownCharacters),
-            let clientPrivateKey: Data = Data(base64Encoded: clientPrivateKeyString,
-                                              options: .ignoreUnknownCharacters) else {
-                                                print("Error occurred during base64 encoding", #function)
-                                                return
+        // private key
+        // public key
+        
+        let publicKeyString: String = "VUVDMgAAAC2ELbj5Aue5xjiJWW3P2KNrBX+HkaeJAb+Z4MrK0cWZlAfpBUql"
+        let privateKeyString: String = "UkVDMgAAAC1FsVa6AMGljYqtNWQ+7r4RjXTabLZxZ/14EXmi6ec2e1vrCmyR"
+        
+        guard let publicKey: Data = Data(base64Encoded: publicKeyString,
+                                         options: .ignoreUnknownCharacters),
+            let privateKey: Data = Data(base64Encoded: privateKeyString,
+                                        options: .ignoreUnknownCharacters) else {
+                                            print("Error occurred during base64 encoding", #function)
+                                            return
         }
-
-        let encrypter: TSMessage = TSMessage.init(inSignVerifyModeWithPrivateKey: clientPrivateKey,
-                                                  peerPublicKey: serverPublicKey)!
-
+        
+        // ---------- signing ----------------
+        // use private key
+        
+        let signer: TSMessage = TSMessage.init(inSignVerifyModeWithPrivateKey: privateKey,
+                                               peerPublicKey: nil)!
+        
         let message: String = "I had a problem so I though to use Java. Now I have a ProblemFactory."
-
-        var encryptedMessage: Data = Data()
+        
+        var signedMessage: Data = Data()
         do {
-            encryptedMessage = try encrypter.wrap(message.data(using: .utf8))
-            print("encryptedMessage = \(encryptedMessage)")
-
+            signedMessage = try signer.wrap(message.data(using: .utf8))
+            print("signedMessage = \(signedMessage)")
+            
         } catch let error as NSError {
-            print("Error occurred while encrypting \(error)", #function)
+            print("Error occurred while signing \(error)", #function)
             return
         }
-
+        
         // ---------- verification ----------------
-        let serverPrivateKeyString: String = "UkVDMgAAAC1FsVa6AMGljYqtNWQ+7r4RjXTabLZxZ/14EXmi6ec2e1vrCmyR"
-        let clientPublicKeyString: String = "VUVDMgAAAC1SsL32Axjosnf2XXUwm/4WxPlZauQ+v+0eOOjpwMN/EO+Huh5d"
-
-        guard let serverPrivateKey: Data = Data(base64Encoded: serverPrivateKeyString,
-                                                options: .ignoreUnknownCharacters),
-            let clientPublicKey: Data = Data(base64Encoded: clientPublicKeyString,
-                                             options: .ignoreUnknownCharacters) else {
-                                                print("Error occurred during base64 encoding", #function)
-                                                return
-        }
-
-        let decrypter: TSMessage = TSMessage.init(inSignVerifyModeWithPrivateKey: serverPrivateKey,
-                                                  peerPublicKey: clientPublicKey)!
-
+        // use public key
+        let verifier = TSMessage.init(inSignVerifyModeWithPrivateKey: nil,
+                                      peerPublicKey: publicKey)!
+        
         do {
-            let decryptedMessage: Data = try decrypter.unwrapData(encryptedMessage)
-            let resultString: String = String(data: decryptedMessage, encoding: .utf8)!
-            print("decryptedMessage->\n\(resultString)")
-
+            let verifiedMessage: Data = try verifier.unwrapData(signedMessage)
+            let resultString: String = String(data: verifiedMessage, encoding: .utf8)!
+            print("verifiedMessage ->\n\(resultString)")
+            
         } catch let error as NSError {
-            print("Error occurred while decrypting \(error)", #function)
+            print("Error occurred while verifing \(error)", #function)
             return
         }
     }


### PR DESCRIPTION
Based on #464 and #465 I've checked & refreshed iOS examples for SecureMessage in sign/verify mode, and tests.

- swift iOS cocoapods
- swift iOS carthage
- swift macos carthage
- objc iOS cocoapods
- objc iOS carthage
- objc macos carthage