### PR TITLE
Improve Windows compatibility

### DIFF
--- a/src/soter/ed25519/fe_cmov.c
+++ b/src/soter/ed25519/fe_cmov.c
@@ -1,5 +1,7 @@
 #include "fe.h"
 
+#include <limits.h>
+
 /*
 Replace (f,g) with (g,g) if b == 1;
 replace (f,g) with (f,g) if b == 0.
@@ -39,7 +41,7 @@ void fe_cmov(fe f,const fe g,unsigned int b)
   crypto_int32 x7 = f7 ^ g7;
   crypto_int32 x8 = f8 ^ g8;
   crypto_int32 x9 = f9 ^ g9;
-  b = -b;
+  b = UINT_MAX - b + 1;
   x0 &= b;
   x1 &= b;
   x2 &= b;

--- a/src/themis/secure_session.h
+++ b/src/themis/secure_session.h
@@ -22,7 +22,21 @@
 #ifndef THEMIS_SECURE_SESSION_H
 #define THEMIS_SECURE_SESSION_H
 
+/*
+ * ssize_t is POSIX-specific (as is <sys/types.h>).
+ * Explicitly define ssize_t as signed counterpart of size_t on Windows.
+ */
+#if _WIN32
+#include <stddef.h>
+#include <stdint.h>
+#ifdef _WIN64
+typedef signed __int64 ssize_t;
+#else
+typedef signed int ssize_t;
+#endif
+#else
 #include <sys/types.h>
+#endif
 
 #include <soter/soter.h>
 

--- a/tests/soter/soter_rand_test.c
+++ b/tests/soter/soter_rand_test.c
@@ -18,13 +18,14 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <unistd.h>
 
 #ifndef NIST_STS_EXE_PATH
 #define NO_NIST_STS 1
 #endif
 
 #ifndef NO_NIST_STS
+
+#include <unistd.h>
 
 #define _TO_STRING_(_X_) (#_X_)
 #define TO_STRING(_X_) _TO_STRING_(_X_)

--- a/tests/themis/themis_secure_session.c
+++ b/tests/themis/themis_secure_session.c
@@ -72,7 +72,13 @@ static client_info_t client = {
     client_pub,
     sizeof(client_pub),
     NULL,
-    {},
+    {
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+    },
 };
 static client_info_t server = {
     "server",
@@ -81,7 +87,13 @@ static client_info_t server = {
     server_pub,
     sizeof(server_pub),
     NULL,
-    {},
+    {
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+    },
 };
 
 /* Peers will communicate using shared memory */


### PR DESCRIPTION
There are miscellaneous changes to ensure that Themis code can be compiled with Microsoft Visual Studio C Compiler.

* **soter/ed25519:** fix incorrect unsigned negation

MSVC produces an error for this line. It may be okay with gcc and clang, but actually negating an unsigned value does not make sense, though it's not clear what effect it should have according to the standard.

gcc and clang on x86_64 compile this:

```c
unsigned int b;
b = -b;
```

into this:

```asm
negl %eax
```

So they treat unsigned negation as two's complement, as if the number was signed). Replace the current expression with its equivalent.

The algorithm implies that `b` may only have 0 and 1 as values. Thus this line should be equivalent to

```c
b = b ? UINT_MAX : 0;
```

but who knows what weird code paths lead here, so let's play it safe and use something completely equivalent. _My little crypto: C is magic._

* **themis/secure_session:** provide `ssize_t` on Windows

Fun fact: Windows does not have `<sys/types.h>` header and does not provide `ssize_t` in `<WinSock2.h>`. It is completely POSIX-specific. However, we use this type in Secure Session API.

Provide our definition of ssize_t on Windows. We use actual size_t types from MSVC's <stddef.h>, but mark them as `signed`.

An alternative approach is to replace ssize_t with something else, like int32_t. However, this will require massive changes in all language wrappers which all expect ssize_t. This might actually become necessary when we will be supporting Windows in language wrappers, but some of them may provide ssize_t in their FFI libraries so let's not jump the gun.

* **tests/soter:** include `<unistd.h>` only for NIST

Currently NIST test suite runner is POSIX-specific (due to popen(), pathconf(), etc.) It does not compile on Windows with MSVC. Furthermore, Windows does not have <unistd.h> header.

Include <unistd.h> only when compiling NIST test runner. With this we can build Soter tests on Windows with NO_NIST_STS=1. We can add Windows support later.

* **tests/themis:** fix implicit default initialization

MSVC does not support default initialization syntax. Initialize Secure Session callbacks explicitly to avoid compilation errors on Windows.