### PR TITLE
Move SOTER_PRIVATE_API declarations to headers

### DIFF
--- a/src/soter/ed25519/fe.h
+++ b/src/soter/ed25519/fe.h
@@ -41,9 +41,11 @@ Bounds on each t[i] vary depending on context.
 #define fe_pow22523 crypto_sign_ed25519_ref10_fe_pow22523
 
 extern void fe_frombytes(fe,const unsigned char *);
+SOTER_PRIVATE_API
 extern void fe_tobytes(unsigned char *,const fe);
 
 extern void fe_copy(fe,const fe);
+SOTER_PRIVATE_API
 extern int fe_isnonzero(const fe);
 extern int fe_isnegative(const fe);
 extern void fe_0(fe);
@@ -53,6 +55,7 @@ extern void fe_cmov(fe,const fe,unsigned int);
 
 extern void fe_add(fe,const fe,const fe);
 extern void fe_sub(fe,const fe,const fe);
+SOTER_PRIVATE_API
 extern void fe_neg(fe,const fe);
 extern void fe_mul(fe,const fe,const fe);
 extern void fe_sq(fe,const fe);

--- a/src/soter/ed25519/fe_isnonzero.c
+++ b/src/soter/ed25519/fe_isnonzero.c
@@ -49,7 +49,6 @@ int crypto_verify_32(const unsigned char *x,const unsigned char *y)
   return (1 & ((differentbits - 1) >> 8)) - 1;
 }
 
-SOTER_PRIVATE_API
 int fe_isnonzero(const fe f)
 {
   static const unsigned char zero[32] = {0};

--- a/src/soter/ed25519/fe_neg.c
+++ b/src/soter/ed25519/fe_neg.c
@@ -10,7 +10,6 @@ Postconditions:
    |h| bounded by 1.1*2^25,1.1*2^24,1.1*2^25,1.1*2^24,etc.
 */
 
-SOTER_PRIVATE_API
 void fe_neg(fe h,const fe f)
 {
   crypto_int32 f0 = f[0];

--- a/src/soter/ed25519/fe_tobytes.c
+++ b/src/soter/ed25519/fe_tobytes.c
@@ -25,7 +25,6 @@ Proof:
   so floor(2^(-255)(h + 19 2^(-25) h9 + 2^(-1))) = q.
 */
 
-SOTER_PRIVATE_API
 void fe_tobytes(unsigned char *s,const fe h)
 {
   crypto_int32 h0 = h[0];

--- a/src/soter/ed25519/ge.h
+++ b/src/soter/ed25519/ge.h
@@ -73,7 +73,9 @@ typedef struct {
 #define ge_scalarmult_base crypto_sign_ed25519_ref10_ge_scalarmult_base
 #define ge_double_scalarmult_vartime crypto_sign_ed25519_ref10_ge_double_scalarmult_vartime
 
+SOTER_PRIVATE_API
 extern void ge_tobytes(unsigned char *,const ge_p2 *);
+SOTER_PRIVATE_API
 extern void ge_p3_tobytes(unsigned char *,const ge_p3 *);
 extern int ge_frombytes_negate_vartime(ge_p3 *,const unsigned char *);
 
@@ -91,7 +93,9 @@ extern void ge_madd(ge_p1p1 *,const ge_p3 *,const ge_precomp *);
 extern void ge_msub(ge_p1p1 *,const ge_p3 *,const ge_precomp *);
 extern void ge_add(ge_p1p1 *,const ge_p3 *,const ge_cached *);
 extern void ge_sub(ge_p1p1 *,const ge_p3 *,const ge_cached *);
+SOTER_PRIVATE_API
 extern void ge_scalarmult_base(ge_p3 *,const unsigned char *);
+SOTER_PRIVATE_API
 extern void ge_double_scalarmult_vartime(ge_p2 *,const unsigned char *,const ge_p3 *,const unsigned char *);
 
 #endif

--- a/src/soter/ed25519/ge_cmp.c
+++ b/src/soter/ed25519/ge_cmp.c
@@ -18,7 +18,6 @@
 #include <string.h>
 #include <stdint.h>
 
-SOTER_PRIVATE_API
 int ge_cmp(const ge_p3 *a, const ge_p3 *b)
 {
 	unsigned char a_comp[ED25519_GE_LENGTH];

--- a/src/soter/ed25519/ge_double_scalarmult.c
+++ b/src/soter/ed25519/ge_double_scalarmult.c
@@ -43,7 +43,6 @@ and b = b[0]+256*b[1]+...+256^31 b[31].
 B is the Ed25519 base point (x,4/5) with x positive.
 */
 
-SOTER_PRIVATE_API
 void ge_double_scalarmult_vartime(ge_p2 *r,const unsigned char *a,const ge_p3 *A,const unsigned char *b)
 {
   signed char aslide[256];

--- a/src/soter/ed25519/ge_frombytes_no_negate.c
+++ b/src/soter/ed25519/ge_frombytes_no_negate.c
@@ -16,7 +16,6 @@
 
 #include "ge_utils.h"
 
-SOTER_PRIVATE_API
 int ge_frombytes_vartime(ge_p3 *h, const unsigned char *s)
 {
 	int res = ge_frombytes_negate_vartime(h, s);

--- a/src/soter/ed25519/ge_p2_to_p3.c
+++ b/src/soter/ed25519/ge_p2_to_p3.c
@@ -16,7 +16,6 @@
 
 #include "ge_utils.h"
 
-SOTER_PRIVATE_API
 void ge_p2_to_p3(ge_p3 *r, const ge_p2 *p)
 {
 	if (p != (const ge_p2 *)r)

--- a/src/soter/ed25519/ge_p3_sub.c
+++ b/src/soter/ed25519/ge_p3_sub.c
@@ -16,7 +16,6 @@
 
 #include "ge_utils.h"
 
-SOTER_PRIVATE_API
 void ge_p3_sub(ge_p3 *r, const ge_p3 *p, const ge_p3 *q)
 {
 	ge_cached q_cached;

--- a/src/soter/ed25519/ge_p3_tobytes.c
+++ b/src/soter/ed25519/ge_p3_tobytes.c
@@ -1,6 +1,5 @@
 #include "ge.h"
 
-SOTER_PRIVATE_API
 void ge_p3_tobytes(unsigned char *s,const ge_p3 *h)
 {
   fe recip;

--- a/src/soter/ed25519/ge_scalarmult.c
+++ b/src/soter/ed25519/ge_scalarmult.c
@@ -16,7 +16,6 @@
 
 #include "ge_utils.h"
 
-SOTER_PRIVATE_API
 void ge_scalarmult_blinded(ge_p3 *r, const unsigned char *a, const ge_p3 *A)
 {
 	unsigned char rnd[32];

--- a/src/soter/ed25519/ge_scalarmult_base.c
+++ b/src/soter/ed25519/ge_scalarmult_base.c
@@ -61,7 +61,6 @@ Preconditions:
   a[31] <= 127
 */
 
-SOTER_PRIVATE_API
 void ge_scalarmult_base(ge_p3 *h,const unsigned char *a)
 {
   signed char e[64];

--- a/src/soter/ed25519/ge_tobytes.c
+++ b/src/soter/ed25519/ge_tobytes.c
@@ -1,6 +1,5 @@
 #include "ge.h"
 
-SOTER_PRIVATE_API
 void ge_tobytes(unsigned char *s,const ge_p2 *h)
 {
   fe recip;

--- a/src/soter/ed25519/ge_utils.h
+++ b/src/soter/ed25519/ge_utils.h
@@ -26,13 +26,20 @@
 #define ED25519_GE_LENGTH 32
 
 /* Generates valid ed25519 private key. r should be 32 bytes */
+SOTER_PRIVATE_API
 extern void generate_random_32(unsigned char *r);
+SOTER_PRIVATE_API
 extern void clip_random_32(unsigned char *r);
 
+SOTER_PRIVATE_API
 extern int ge_frombytes_vartime(ge_p3 *h, const unsigned char *s);
+SOTER_PRIVATE_API
 extern void ge_p2_to_p3(ge_p3 *r, const ge_p2 *p);
+SOTER_PRIVATE_API
 extern void ge_p3_sub(ge_p3 *r, const ge_p3 *p, const ge_p3 *q);
+SOTER_PRIVATE_API
 extern void ge_scalarmult_blinded(ge_p3 *r, const unsigned char *a, const ge_p3 *A);
+SOTER_PRIVATE_API
 extern int ge_cmp(const ge_p3 *a, const ge_p3 *b);
 
 int crypto_verify_32(const unsigned char *x,const unsigned char *y);

--- a/src/soter/ed25519/gen_rand_32.c
+++ b/src/soter/ed25519/gen_rand_32.c
@@ -17,7 +17,6 @@
 #include "ge_utils.h"
 #include <soter/soter.h>
 
-SOTER_PRIVATE_API
 void clip_random_32(unsigned char *r)
 {
     r[0] &= 248;
@@ -25,7 +24,6 @@ void clip_random_32(unsigned char *r)
     r[31] |= 64;
 }
 
-SOTER_PRIVATE_API
 void generate_random_32(unsigned char *r)
 {
 	soter_status_t res = soter_rand(r, ED25519_GE_LENGTH);

--- a/src/soter/ed25519/sc.h
+++ b/src/soter/ed25519/sc.h
@@ -11,7 +11,9 @@ where l = 2^252 + 27742317777372353535851937790883648493.
 #define sc_reduce crypto_sign_ed25519_ref10_sc_reduce
 #define sc_muladd crypto_sign_ed25519_ref10_sc_muladd
 
+SOTER_PRIVATE_API
 extern void sc_reduce(unsigned char *);
+SOTER_PRIVATE_API
 extern void sc_muladd(unsigned char *,const unsigned char *,const unsigned char *,const unsigned char *);
 
 #endif

--- a/src/soter/ed25519/sc_muladd.c
+++ b/src/soter/ed25519/sc_muladd.c
@@ -34,7 +34,6 @@ Output:
   where l = 2^252 + 27742317777372353535851937790883648493.
 */
 
-SOTER_PRIVATE_API
 void sc_muladd(unsigned char *s,const unsigned char *a,const unsigned char *b,const unsigned char *c)
 {
   crypto_int64 a0 = 2097151 & load_3(a);

--- a/src/soter/ed25519/sc_reduce.c
+++ b/src/soter/ed25519/sc_reduce.c
@@ -33,7 +33,6 @@ Output:
   Overwrites s in place.
 */
 
-SOTER_PRIVATE_API
 void sc_reduce(unsigned char *s)
 {
   crypto_int64 s0 = 2097151 & load_3(s);

--- a/src/soter/soter_hmac.c
+++ b/src/soter/soter_hmac.c
@@ -33,7 +33,6 @@ static size_t hash_block_size(soter_hash_algo_t algo)
     }
 }
 
-SOTER_PRIVATE_API
 soter_status_t soter_hmac_init(soter_hmac_ctx_t* hmac_ctx,
                                soter_hash_algo_t algo,
                                const uint8_t* key,
@@ -109,7 +108,6 @@ soter_status_t soter_hmac_init(soter_hmac_ctx_t* hmac_ctx,
     return SOTER_SUCCESS;
 }
 
-SOTER_PRIVATE_API
 soter_status_t soter_hmac_cleanup(soter_hmac_ctx_t* hmac_ctx)
 {
     if (NULL == hmac_ctx) {

--- a/src/soter/soter_t.h
+++ b/src/soter/soter_t.h
@@ -66,10 +66,12 @@ struct soter_hmac_ctx_type {
     soter_hash_ctx_t* hash_ctx;
 };
 
+SOTER_PRIVATE_API
 soter_status_t soter_hmac_init(soter_hmac_ctx_t* hmac_ctx,
                                soter_hash_algo_t algo,
                                const uint8_t* key,
                                size_t key_length);
+SOTER_PRIVATE_API
 soter_status_t soter_hmac_cleanup(soter_hmac_ctx_t* hmac_ctx);
 
 #endif /* SOTER_T_H */


### PR DESCRIPTION
Microsoft Visual Studio C Compiler cannot handle attributes added to definitions of functions, it expects `__declspec`s to be located at declaration sites. Move all macros to headers in order to avoid linkage errors on Windows.