### PR TITLE
Update Emscripten SDK cleanly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,7 @@ jobs:
                 git clone https://github.com/emscripten-core/emsdk.git
             fi
             cd $HOME/emsdk
+            git reset --hard
             git pull
 
       - run:


### PR DESCRIPTION
Our CI builds started [failing](https://circleci.com/gh/cossacklabs/themis/4596) recently.

For some reason building with Emscripten changes some files in the SDK which leads to errors when trying to update with `git pull`:

    Updating 4eeff61..751355a
    error: Your local changes to the following files would be overwritten by merge:
            binaryen-tags.txt
            emscripten-tags.txt
            upstream/lkgr.json

    Please, commit your changes or stash them before you can merge.
    Aborting

Add a `git reset` before doing the pull to discard any local changes and ensure a clean merge with the updated version.