### PR TITLE
NSIS installer for Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -542,16 +542,23 @@ unpack_dist:
 nsis_installer: $(BIN_PATH)/InstallThemis.exe
 
 $(BIN_PATH)/InstallThemis.exe: FORCE
-	@$(MAKE) install PREFIX=/ DESTDIR="$(BIN_PATH)/install"
-# Windows users will need MSYS runtime libraries, so copy dependencies
-# into the installation directory as well
 ifdef IS_MSYS
+	@$(MAKE) install PREFIX=/ DESTDIR="$(BIN_PATH)/install"
 	@ldd "$(BIN_PATH)/install/bin"/*.dll | \
 	 awk '$$3 ~ "^/usr/bin" { print $$3}' | sort --uniq | \
 	 xargs -I % cp % "$(BIN_PATH)/install/bin"
-endif
 	@makensis Themis.nsi
 	@rm -r "$(BIN_PATH)/install"
+else
+	@echo "NSIS installers can only be build in MSYS environment on Windows."
+	@echo
+	@echo "Please make sure that you are using MSYS terminal session which"
+	@echo "is usually available as 'MSYS2 MSYS' shortcut in the MSYS group"
+	@echo "of the Start menu."
+	@exit 1
+endif
+
+endif
 
 FORCE:
 

--- a/Makefile
+++ b/Makefile
@@ -539,6 +539,21 @@ endif
 unpack_dist:
 	@tar -xf $(THEMIS_DIST_FILENAME)
 
+nsis_installer: $(BIN_PATH)/InstallThemis.exe
+
+$(BIN_PATH)/InstallThemis.exe: FORCE
+	@$(MAKE) install PREFIX=/ DESTDIR="$(BIN_PATH)/install"
+# Windows users will need MSYS runtime libraries, so copy dependencies
+# into the installation directory as well
+ifdef IS_MSYS
+	@ldd "$(BIN_PATH)/install/bin"/*.dll | \
+	 awk '$$3 ~ "^/usr/bin" { print $$3}' | sort --uniq | \
+	 xargs -I % cp % "$(BIN_PATH)/install/bin"
+endif
+	@makensis Themis.nsi
+	@rm -r "$(BIN_PATH)/install"
+
+FORCE:
 
 COSSACKLABS_URL = https://www.cossacklabs.com
 MAINTAINER = "Cossack Labs Limited <dev@cossacklabs.com>"

--- a/Makefile
+++ b/Makefile
@@ -558,8 +558,6 @@ else
 	@exit 1
 endif
 
-endif
-
 FORCE:
 
 COSSACKLABS_URL = https://www.cossacklabs.com

--- a/Themis.nsi
+++ b/Themis.nsi
@@ -1,0 +1,35 @@
+Name "Themis"
+OutFile "build\InstallThemis.exe"
+LicenseData "LICENSE"
+InstallDir "$PROGRAMFILES\Themis"
+
+VIAddVersionKey "ProductName"     "Themis"
+VIAddVersionKey "CompanyName"     "Cossack Labs Limited"
+VIAddVersionKey "LegalCopyright"  "(c) Cossack Labs Limited"
+VIAddVersionKey "FileDescription" "Themis library installer"
+VIAddVersionKey "FileVersion"     "0.11.2"
+VIAddVersionKey "ProductVersion"  "0.11.2"
+VIFileVersion    0.11.2.0
+VIProductVersion 0.11.2.0
+
+Page license
+Page directory
+Page instfiles
+UninstPage uninstConfirm
+UninstPage instfiles
+
+Section "Install"
+	SetOutPath $INSTDIR
+	File LICENSE
+	File /r /x pkgconfig build\install\*
+	WriteUninstaller $INSTDIR\Uninstall.exe
+SectionEnd
+
+Section "Uninstall"
+	Delete $INSTDIR\Uninstall.exe
+	Delete $INSTDIR\LICENSE
+	RmDir /r /REBOOTOK $INSTDIR\bin
+	RmDir /r           $INSTDIR\include
+	RmDir /r           $INSTDIR\lib
+	RmDir              $INSTDIR
+SectionEnd


### PR DESCRIPTION
Having MSYS2 packages is nice, but there are those weird Windows devs who insist on building their software using native Windows tools like Microsoft Visual Studio instead of building everything in MSYS. There are also other environments like Node.js which insist on using Visual Studio toolchain on Windows. Let's provide them with a way to install Themis into system so that they can build their software the way they want to.

[NullSoft Scriptable Install System](https://nsis.sourceforge.io/Main_Page) is a venerable and straightforward installation toolkit. Moreover, it's available in MSYS so it's very easy to integrate into our build system. Provide an initial script for building an installer and a makefile target `nsis_installer` which produces **InstallThemis.exe** in the build directory. Piggyback on the `make install` target to figure out what files need to be distributed. Include our licensing information as well. Also include MSYS2 runtime libraries which are necessary to use Themis outside of MSYS2.

We get these cool Win95-style installers as a reward:

![License confirmation page](https://user-images.githubusercontent.com/1256587/58165701-fa6b9480-7c90-11e9-8cd3-15c6e4794d27.png)

![Installation directory page](https://user-images.githubusercontent.com/1256587/58165705-fccdee80-7c90-11e9-99fa-d2a7728d5b40.png)

![Final page](https://user-images.githubusercontent.com/1256587/58165709-ffc8df00-7c90-11e9-85c8-1a3a021a2a23.png)
