### PR TITLE
Windows support in JsThemis

### DIFF
--- a/src/wrappers/themis/jsthemis/binding.gyp
+++ b/src/wrappers/themis/jsthemis/binding.gyp
@@ -2,11 +2,48 @@
   "targets": [
     {
       "target_name": "jsthemis",
-      "sources": [ "addon.cpp", "errors.cpp", "secure_message.cpp", "secure_keygen.cpp", "secure_session.cpp", "secure_cell_seal.cpp", "secure_cell_context_imprint.cpp", "secure_cell_token_protect.cpp", "secure_comparator.cpp" ],
-      "libraries": ["-L/usr/local/lib/", "-L/usr/lib/", "-lsoter", "-lthemis"],
+      "sources": [
+        "addon.cpp",
+        "errors.cpp",
+        "secure_message.cpp",
+        "secure_keygen.cpp",
+        "secure_session.cpp",
+        "secure_cell_seal.cpp",
+        "secure_cell_context_imprint.cpp",
+        "secure_cell_token_protect.cpp",
+        "secure_comparator.cpp",
+      ],
       "include_dirs": [
-         "<!(node -e \"require('nan')\")"
-      ]
+         "<!(node -e \"require('nan')\")",
+      ],
+      "conditions": [
+        [ "OS=='linux' or OS=='mac'", {
+          "libraries": [
+            "-L/usr/local/lib",
+            "-L/usr/lib",
+            "-lsoter",
+            "-lthemis",
+          ],
+        }],
+        [ "OS=='win'", {
+          "libraries": [
+            "libsoter.dll.a",
+            "libthemis.dll.a",
+          ],
+          "msvs_settings": {
+            "VCCLCompilerTool": {
+              "AdditionalIncludeDirectories": [
+                "<!(echo %ProgramFiles%)\\Themis\\include",
+              ],
+            },
+            "VCLinkerTool": {
+              "AdditionalLibraryDirectories": [
+                "<!(echo %ProgramFiles%)\\Themis\\lib",
+              ],
+            },
+          },
+        }],
+      ],
     }
   ]
 }


### PR DESCRIPTION
Update **binding.gyp** file for Windows. This allows users to install JsThemis on Windows provided that Themis Core is installed under `C:\Program Files\Themis`. We expect MSYS2-based build of Themis Core to be installed there and use its naming convention and directory layout. Unfortunately, Windows does not have a notion of standard directories for development libraries and headers so we have to tell MSBuild exactly where to look for the library.