### PR TITLE
Update Android image API 22 → 24

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@ jobs:
       - run: sed -i 's/"-GNinja"/"-DCMAKE_JOB_POOL_COMPILE=circleci_job_pool", "-GNinja"/g' third_party/boringssl/build.gradle
       - run: ./gradlew --no-daemon --no-parallel --max-workers=2 assembleDebug
       # install emulator image and create a device
-      - run: $ANDROID_HOME/tools/bin/sdkmanager 'emulator' 'system-images;android-22;default;armeabi-v7a'
-      - run: $ANDROID_HOME/tools/bin/avdmanager create avd --name nexus --device "Nexus 5" --package 'system-images;android-22;default;armeabi-v7a'
+      - run: $ANDROID_HOME/tools/bin/sdkmanager 'emulator' 'system-images;android-24;default;armeabi-v7a'
+      - run: $ANDROID_HOME/tools/bin/avdmanager create avd --name nexus --device "Nexus 5" --package 'system-images;android-24;default;armeabi-v7a'
       - run:
           command: $ANDROID_HOME/emulator/emulator -avd nexus -noaudio -no-window -gpu off -verbose -qemu
           background: true


### PR DESCRIPTION
Let's try fixing the Android build which turned red recently. 

The image distributed by SDK Manager for API 22 seems to be broken and results into issues like this during emulator startup:

    emulator: ERROR: This AVD's configuration is missing a kernel file! Please ensure the file "kernel-ranchu" is in the same location as your system image.

It seems that the distributed kernel file is named "kernel-qemu" instead of "kernel-ranchu". However, renaming the kernel file still produces issues like this:

    emulator: ERROR: New emulator backend requires minimum kernel version 3.10+ (currently got lower)
    Please make sure you've got updated system images and do not force the specific kernel image together with the engine version

Given that Android Lollipop is no longer supported by Google (support ended in March 2018), let's update to Android Nougat emulator with API level 24.