### PR TITLE
Update WasmThemis dependencies

### DIFF
--- a/src/wrappers/themis/wasm/package-lock.json
+++ b/src/wrappers/themis/wasm/package-lock.json
@@ -401,9 +401,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
-      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "1.0.10",
@@ -495,9 +495,9 @@
       }
     },
     "mocha": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.1.3.tgz",
-      "integrity": "sha512-QdE/w//EPHrqgT5PNRUjRVHy6IJAzAf1R8n2O8W8K2RZ+NbPfOD5cBDp+PGa2Gptep37C/TdBiaNwakppEzEbg==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.1.4.tgz",
+      "integrity": "sha512-PN8CIy4RXsIoxoFJzS4QNnCH4psUCPWc4/rPrst/ecSJJbLBkubMiyGCP2Kj/9YnWbotFqAoeXyXMucj7gwCFg==",
       "dev": true,
       "requires": {
         "ansi-colors": "3.2.3",
@@ -509,7 +509,7 @@
         "glob": "7.1.3",
         "growl": "1.10.5",
         "he": "1.2.0",
-        "js-yaml": "3.13.0",
+        "js-yaml": "3.13.1",
         "log-symbols": "2.2.0",
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",

--- a/src/wrappers/themis/wasm/package.json
+++ b/src/wrappers/themis/wasm/package.json
@@ -24,6 +24,6 @@
   },
   "homepage": "https://github.com/cossacklabs/themis#readme",
   "devDependencies": {
-    "mocha": "^6.1.3"
+    "mocha": "^6.1.4"
   }
 }


### PR DESCRIPTION
Upgrade `mocha` dependency to pull in a newer `js-yaml` version that fixes [a possible code injection vulnerability][1].

[1]: https://github.com/nodeca/js-yaml/pull/480

WasmThemis is not public yet and this is a development dependency, so there is no need for security advisories.