### PR TITLE
Themis Carthage: fix linking issue with OpenSSL 1.0.2.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       - image: cossacklabs/android-build:2019.01
     steps:
       - checkout
-      - run: git submodule update --init
+      - run: git reset HEAD && git submodule sync && git submodule update --init
       # limit CMake/Ninja build concurrency when building BoringSSL
       # otherwise we hit the 4GB memory limit for the build container
       - run: echo 'set_property(GLOBAL APPEND PROPERTY JOB_POOLS circleci_job_pool=4)' >> third_party/boringssl/src/CMakeLists.txt
@@ -33,7 +33,7 @@ jobs:
     steps:
       - run: sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get -y install default-jdk nodejs npm
       - checkout
-      - run: git submodule update --init
+      - run: git reset HEAD && git submodule sync && git submodule update --init
       - run: make fmt_check ENGINE=boringssl
       - run: make fmt_check ENGINE=openssl
 
@@ -80,7 +80,7 @@ jobs:
             - ~/valgrind
 
       - checkout
-      - run: git submodule update --init
+      - run: git reset HEAD && git submodule sync && git submodule update --init
       - run: make
       - run: make JAVA_HOME=/usr/lib/jvm/default-java themis_jni
       - run: sudo make install

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,8 @@
-github "krzyzanowskim/OpenSSL" ~> 1.0.2
+# temporary use our fork due to errors in krzyzanowskim/OpenSSL 1.0.2.18
+# https://github.com/krzyzanowskim/OpenSSL/issues/64
+# https://github.com/krzyzanowskim/OpenSSL/issues/63
+# latest tag is 1.0.2.17
+github "vixentael/OpenSSL" ~> 1.0.2
+
+# broken tag is 1.0.2.18
+# github "krzyzanowskim/OpenSSL" ~> 1.0.2

--- a/Cartfile
+++ b/Cartfile
@@ -1,8 +1,9 @@
 # temporary use our fork due to errors in krzyzanowskim/OpenSSL 1.0.2.18
 # https://github.com/krzyzanowskim/OpenSSL/issues/64
 # https://github.com/krzyzanowskim/OpenSSL/issues/63
-# latest tag is 1.0.2.17
-github "vixentael/OpenSSL" ~> 1.0.2
+# hash of 1.0.2.17 tag
+github "krzyzanowskim/OpenSSL" "990bd88"
 
 # broken tag is 1.0.2.18
 # github "krzyzanowskim/OpenSSL" ~> 1.0.2
+

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "vixentael/OpenSSL" "1.0.2.17"
+github "krzyzanowskim/OpenSSL" "990bd88219da80d7a77289aeae245b3eb400d834"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "krzyzanowskim/OpenSSL" "1.0.2.17"
+github "vixentael/OpenSSL" "1.0.2.17"


### PR DESCRIPTION
Hotfix.

## The problem

Recently https://github.com/krzyzanowskim/OpenSSL pushed `1.0.2.18` tag with linking errors (https://github.com/krzyzanowskim/OpenSSL/issues/63). This change breaks Themis Carthage and projects that depend on it.

```
carthage bootstrap themis --platform iOS

...

In file included from <redacted>/iOS-Carthage/Carthage/Checkouts/themis/Carthage/Build/iOS/openssl.framework/Headers/e_os2.h:56:
<redacted>/iOS-Carthage/Carthage/Checkouts/themis/Carthage/Build/iOS/openssl.framework/Headers/opensslconf.h:8:11: fatal error: 'openssl/opensslconf-armv7.h' file not found
# include <openssl/opensslconf-armv7.h>
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~

** ARCHIVE FAILED **

```

## Using 1.0.2.17 from Cartfile is impossible

Unfortunately OpenSSL versioning doesn't use semver, but stick to 4-parts versions. Carthage doesn't support 4-parts versions, so we can't just use `== 1.0.2.17` in Cartfile (`Parse error: found more than 3 dot-separated components in version in line: github "krzyzanowskim/OpenSSL" == 1.0.2.17`).


## Hotfix solution

I re-linked Themis Carthage to the hash of commit that corresponds to `1.0.2.17` tag.

I will put `0.11.2` tag on stable branch after merging.

## CocoaPods

This doesn't affect CocoaPods, because latest version available there is `1.0.2.16`.