### PR TITLE
Merging Themis Carthage changes, and minor docs update to master

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,9 @@
-github "krzyzanowskim/OpenSSL" ~> 1.0.2
+# temporary use our fork due to errors in krzyzanowskim/OpenSSL 1.0.2.18
+# https://github.com/krzyzanowskim/OpenSSL/issues/64
+# https://github.com/krzyzanowskim/OpenSSL/issues/63
+# hash of 1.0.2.17 tag
+github "krzyzanowskim/OpenSSL" "990bd88"
+
+# broken tag is 1.0.2.18
+# github "krzyzanowskim/OpenSSL" ~> 1.0.2
+

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "krzyzanowskim/OpenSSL" "1.0.2.17"
+github "krzyzanowskim/OpenSSL" "990bd88219da80d7a77289aeae245b3eb400d834"

--- a/docs/examples/objc/iOS-Carthage/Cartfile.resolved
+++ b/docs/examples/objc/iOS-Carthage/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "cossacklabs/themis" "0.11.0"
-github "krzyzanowskim/OpenSSL" "1.0.2.17"
+github "cossacklabs/themis" "0.11.2"
+github "krzyzanowskim/OpenSSL" "990bd88219da80d7a77289aeae245b3eb400d834"

--- a/docs/examples/objc/macOS-Carthage/Cartfile.resolved
+++ b/docs/examples/objc/macOS-Carthage/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "cossacklabs/themis" "0.11.0"
-github "krzyzanowskim/OpenSSL" "1.0.2.17"
+github "cossacklabs/themis" "0.11.2"
+github "krzyzanowskim/OpenSSL" "990bd88219da80d7a77289aeae245b3eb400d834"

--- a/docs/examples/swift/macOS-Carthage/Cartfile.resolved
+++ b/docs/examples/swift/macOS-Carthage/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "cossacklabs/themis" "0.11.0"
-github "krzyzanowskim/OpenSSL" "1.0.2.17"
+github "cossacklabs/themis" "0.11.2"
+github "krzyzanowskim/OpenSSL" "990bd88219da80d7a77289aeae245b3eb400d834"

--- a/src/soter/soter_sym.h
+++ b/src/soter/soter_sym.h
@@ -389,10 +389,10 @@ soter_status_t soter_sym_aead_decrypt_aad(soter_sym_ctx_t* ctx, const void* plai
  * @param [in] ctx pointer to symmetric decryption context prerviosly created by
  * soter_sym_decrypt_create
  * @param [in] cipher_data pointer to data buffer to decrypt
- * @param [in] cipher_data_length length of cipher_data
+ * @param [in] data_length length of cipher_data
  * @param [out] plain_data pointer to buffer to plain data store, may be set to NULL for plain data
  * length determination
- * @param [in, out] data_length length of plain_data
+ * @param [in, out] plain_data_length length of plain_data
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure.
  * @note If plain_data==NULL or plain_data_length less then need to store plain data, @ref
  * SOTER_BUFFER_TOO_SMALL will return and plain_data_length will contain length of buffer thet need

--- a/src/themis/secure_cell.h
+++ b/src/themis/secure_cell.h
@@ -113,9 +113,9 @@ themis_status_t themis_secure_cell_decrypt_seal(const uint8_t* master_key,
  * @param [in] user_context_length length of user_context
  * @param [in] message message to encrypt
  * @param [in] message_length length of message
- * @param [out] token additional authentication info. May be set to NULL for additional
+ * @param [out] context additional authentication info. May be set to NULL for additional
  * authentication info length determination
- * @param [in, out] token_length length of additional authentication info
+ * @param [in, out] context_length length of additional authentication info
  * @param [out] encrypted_message buffer for encrypted message store. May be set to NULL for
  * encrypted message length determination
  * @param [in, out] encrypted_message_length length of encrypted_message
@@ -146,8 +146,8 @@ themis_status_t themis_secure_cell_encrypt_token_protect(const uint8_t* master_k
  * @param [in] user_context_length length of user_context
  * @param [in] encrypted_message message to decrypt
  * @param [in] encrypted_message_length length of encrypted_message
- * @param [in] token additional authentication info
- * @param [in] token_length length of additional authentication info
+ * @param [in] context additional authentication info
+ * @param [in] context_length length of additional authentication info
  * @param [out] plain_message buffer for plain message store. May be set to NULL for plain message
  * length determination
  * @param [in, out] plain_message_length length of plain_message


### PR DESCRIPTION
Cherry pick changes from https://github.com/cossacklabs/themis/pull/483 (re-link Themis Carthage to `1.0.2.17` OpenSSL), and add some minor docs updates.

Regarding linkage – on next release I plan to switch Themis Carthage back to `~> 1.0.2` notation.