### PR TITLE
Improve key validity checks

### DIFF
--- a/Themis.xcodeproj/project.pbxproj
+++ b/Themis.xcodeproj/project.pbxproj
@@ -198,6 +198,10 @@
 		9F4A2622223ABEF2005CB63A /* sym_enc_message.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2431223A74AF005CB63A /* sym_enc_message.c */; };
 		9F5391F12293F2D90051DA66 /* portable_endian.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F5391F02293F2D90051DA66 /* portable_endian.h */; };
 		9F5391F22293F2D90051DA66 /* portable_endian.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F5391F02293F2D90051DA66 /* portable_endian.h */; };
+		9F874AB322CCB0D100E8DECA /* soter_ec_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F874AB122CCB0D100E8DECA /* soter_ec_key.c */; };
+		9F874AB422CCB0D100E8DECA /* soter_ec_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F874AB122CCB0D100E8DECA /* soter_ec_key.c */; };
+		9F874AB522CCB0D100E8DECA /* soter_rsa_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F874AB222CCB0D100E8DECA /* soter_rsa_key.c */; };
+		9F874AB622CCB0D100E8DECA /* soter_rsa_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F874AB222CCB0D100E8DECA /* soter_rsa_key.c */; };
 		9FBD853D223BFB5E009EAEB3 /* openssl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FBD853C223BFB5E009EAEB3 /* openssl.framework */; };
 /* End PBXBuildFile section */
 
@@ -400,6 +404,8 @@
 		9F4A24C2223A8FA8005CB63A /* smessage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = smessage.h; path = "src/wrappers/themis/Obj-C/objcthemis/smessage.h"; sourceTree = "<group>"; };
 		9F4A24C3223A8FA8005CB63A /* scell_token.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = scell_token.h; path = "src/wrappers/themis/Obj-C/objcthemis/scell_token.h"; sourceTree = "<group>"; };
 		9F5391F02293F2D90051DA66 /* portable_endian.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = portable_endian.h; path = src/soter/portable_endian.h; sourceTree = "<group>"; };
+		9F874AB122CCB0D100E8DECA /* soter_ec_key.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = soter_ec_key.c; path = src/soter/soter_ec_key.c; sourceTree = "<group>"; };
+		9F874AB222CCB0D100E8DECA /* soter_rsa_key.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = soter_rsa_key.c; path = src/soter/soter_rsa_key.c; sourceTree = "<group>"; };
 		9FBD853C223BFB5E009EAEB3 /* openssl.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = openssl.framework; path = Carthage/Build/iOS/openssl.framework; sourceTree = "<group>"; };
 		9FD4C3522260D41700132A88 /* soter_api.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = soter_api.h; path = src/soter/soter_api.h; sourceTree = "<group>"; };
 		9FD4C3532260D43B00132A88 /* themis_api.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = themis_api.h; path = src/themis/themis_api.h; sourceTree = "<group>"; };
@@ -457,6 +463,7 @@
 				9F4A2358223A73B1005CB63A /* soter_container.h */,
 				9F4A234D223A73B0005CB63A /* soter_crc32.c */,
 				9F4A234E223A73B0005CB63A /* soter_crc32.h */,
+				9F874AB122CCB0D100E8DECA /* soter_ec_key.c */,
 				9F4A2352223A73B1005CB63A /* soter_ec_key.h */,
 				9F4A234C223A73B0005CB63A /* soter_error.h */,
 				9F4A2342223A73B0005CB63A /* soter_hash.h */,
@@ -466,6 +473,7 @@
 				9F4A234F223A73B1005CB63A /* soter_kdf.h */,
 				9F4A2354223A73B1005CB63A /* soter_rand.h */,
 				9F4A234A223A73B0005CB63A /* soter_rsa_key_pair_gen.h */,
+				9F874AB222CCB0D100E8DECA /* soter_rsa_key.c */,
 				9F4A2347223A73B0005CB63A /* soter_rsa_key.h */,
 				9F4A2355223A73B1005CB63A /* soter_sign_ecdsa.h */,
 				9F4A2344223A73B0005CB63A /* soter_sign_rsa.h */,
@@ -793,6 +801,7 @@
 				9F00E924223C1AC000EC1EF3 /* soter_ecdsa_common.c in Sources */,
 				9F00E925223C1AC000EC1EF3 /* soter_hash.c in Sources */,
 				9F00E926223C1AC000EC1EF3 /* soter_rand.c in Sources */,
+				9F874AB422CCB0D100E8DECA /* soter_ec_key.c in Sources */,
 				9F00E927223C1AC000EC1EF3 /* soter_rsa_common.c in Sources */,
 				9F00E928223C1AC000EC1EF3 /* soter_rsa_key_pair_gen.c in Sources */,
 				9F00E929223C1AC000EC1EF3 /* soter_rsa_key.c in Sources */,
@@ -803,6 +812,7 @@
 				9F00E92E223C1AC000EC1EF3 /* soter_verify_rsa.c in Sources */,
 				9F00E912223C1AB100EC1EF3 /* ge_p2_to_p3.c in Sources */,
 				9F00E913223C1AB100EC1EF3 /* ge_p3_0.c in Sources */,
+				9F874AB622CCB0D100E8DECA /* soter_rsa_key.c in Sources */,
 				9F00E914223C1AB100EC1EF3 /* ge_p3_dbl.c in Sources */,
 				9F00E915223C1AB100EC1EF3 /* ge_p3_sub.c in Sources */,
 				9F00E916223C1AB100EC1EF3 /* ge_p3_to_cached.c in Sources */,
@@ -882,6 +892,7 @@
 				9F4A2607223ABECC005CB63A /* soter_ecdsa_common.c in Sources */,
 				9F4A2608223ABECC005CB63A /* soter_hash.c in Sources */,
 				9F4A2609223ABECC005CB63A /* soter_rand.c in Sources */,
+				9F874AB322CCB0D100E8DECA /* soter_ec_key.c in Sources */,
 				9F4A260A223ABECC005CB63A /* soter_rsa_common.c in Sources */,
 				9F4A260B223ABECC005CB63A /* soter_rsa_key_pair_gen.c in Sources */,
 				9F4A260C223ABECC005CB63A /* soter_rsa_key.c in Sources */,
@@ -892,6 +903,7 @@
 				9F4A2611223ABECC005CB63A /* soter_verify_rsa.c in Sources */,
 				9F4A25DA223ABEB6005CB63A /* fe_0.c in Sources */,
 				9F4A25DB223ABEB6005CB63A /* fe_1.c in Sources */,
+				9F874AB522CCB0D100E8DECA /* soter_rsa_key.c in Sources */,
 				9F4A25DC223ABEB6005CB63A /* fe_add.c in Sources */,
 				9F4A25DD223ABEB6005CB63A /* fe_cmov.c in Sources */,
 				9F4A25DE223ABEB6005CB63A /* fe_copy.c in Sources */,

--- a/src/soter/boringssl/soter_ec_key.c
+++ b/src/soter/boringssl/soter_ec_key.c
@@ -208,6 +208,10 @@ soter_status_t soter_engine_specific_to_ec_priv_key(const soter_engine_specific_
         goto err;
     }
 
+    /*
+     * Note that we use a buffer suitable for a public key to store a private
+     * key. This was a historical mistake, now preserved for compatibility.
+     */
     output_length = ec_pub_key_size(curve);
     if ((!key) || (output_length > *key_length)) {
         *key_length = output_length;

--- a/src/soter/boringssl/soter_ec_key.c
+++ b/src/soter/boringssl/soter_ec_key.c
@@ -275,13 +275,13 @@ soter_status_t soter_ec_pub_key_to_engine_specific(const soter_container_hdr_t* 
     }
 
     switch (key->tag[3]) {
-    case '2':
+    case EC_SIZE_TAG_256:
         curve = NID_X9_62_prime256v1;
         break;
-    case '3':
+    case EC_SIZE_TAG_384:
         curve = NID_secp384r1;
         break;
-    case '5':
+    case EC_SIZE_TAG_521:
         curve = NID_secp521r1;
         break;
     default:
@@ -372,13 +372,13 @@ soter_status_t soter_ec_priv_key_to_engine_specific(const soter_container_hdr_t*
     }
 
     switch (key->tag[3]) {
-    case '2':
+    case EC_SIZE_TAG_256:
         curve = NID_X9_62_prime256v1;
         break;
-    case '3':
+    case EC_SIZE_TAG_384:
         curve = NID_secp384r1;
         break;
-    case '5':
+    case EC_SIZE_TAG_521:
         curve = NID_secp521r1;
         break;
     default:

--- a/src/soter/boringssl/soter_ec_key.c
+++ b/src/soter/boringssl/soter_ec_key.c
@@ -208,7 +208,7 @@ soter_status_t soter_engine_specific_to_ec_priv_key(const soter_engine_specific_
         goto err;
     }
 
-    output_length = ec_priv_key_size(curve);
+    output_length = ec_pub_key_size(curve);
     if ((!key) || (output_length > *key_length)) {
         *key_length = output_length;
         res = SOTER_BUFFER_TOO_SMALL;

--- a/src/soter/boringssl/soter_ec_key.c
+++ b/src/soter/boringssl/soter_ec_key.c
@@ -208,7 +208,7 @@ soter_status_t soter_engine_specific_to_ec_priv_key(const soter_engine_specific_
         goto err;
     }
 
-    output_length = ec_pub_key_size(curve);
+    output_length = ec_priv_key_size(curve);
     if ((!key) || (output_length > *key_length)) {
         *key_length = output_length;
         res = SOTER_BUFFER_TOO_SMALL;

--- a/src/soter/boringssl/soter_rsa_key.c
+++ b/src/soter/boringssl/soter_rsa_key.c
@@ -326,16 +326,16 @@ soter_status_t soter_rsa_pub_key_to_engine_specific(const soter_container_hdr_t*
     }
 
     switch (key->tag[3]) {
-    case '1':
+    case RSA_SIZE_TAG_1024:
         rsa_mod_size = 128;
         break;
-    case '2':
+    case RSA_SIZE_TAG_2048:
         rsa_mod_size = 256;
         break;
-    case '4':
+    case RSA_SIZE_TAG_4096:
         rsa_mod_size = 512;
         break;
-    case '8':
+    case RSA_SIZE_TAG_8192:
         rsa_mod_size = 1024;
         break;
     default:
@@ -415,16 +415,16 @@ soter_status_t soter_rsa_priv_key_to_engine_specific(const soter_container_hdr_t
     }
 
     switch (key->tag[3]) {
-    case '1':
+    case RSA_SIZE_TAG_1024:
         rsa_mod_size = 128;
         break;
-    case '2':
+    case RSA_SIZE_TAG_2048:
         rsa_mod_size = 256;
         break;
-    case '4':
+    case RSA_SIZE_TAG_4096:
         rsa_mod_size = 512;
         break;
-    case '8':
+    case RSA_SIZE_TAG_8192:
         rsa_mod_size = 1024;
         break;
     default:

--- a/src/soter/openssl/soter_ec_key.c
+++ b/src/soter/openssl/soter_ec_key.c
@@ -207,7 +207,7 @@ soter_status_t soter_engine_specific_to_ec_priv_key(const soter_engine_specific_
         goto err;
     }
 
-    output_length = ec_pub_key_size(curve);
+    output_length = ec_priv_key_size(curve);
     if ((!key) || (output_length > *key_length)) {
         *key_length = output_length;
         res = SOTER_BUFFER_TOO_SMALL;

--- a/src/soter/openssl/soter_ec_key.c
+++ b/src/soter/openssl/soter_ec_key.c
@@ -207,7 +207,7 @@ soter_status_t soter_engine_specific_to_ec_priv_key(const soter_engine_specific_
         goto err;
     }
 
-    output_length = ec_priv_key_size(curve);
+    output_length = ec_pub_key_size(curve);
     if ((!key) || (output_length > *key_length)) {
         *key_length = output_length;
         res = SOTER_BUFFER_TOO_SMALL;

--- a/src/soter/openssl/soter_ec_key.c
+++ b/src/soter/openssl/soter_ec_key.c
@@ -274,13 +274,13 @@ soter_status_t soter_ec_pub_key_to_engine_specific(const soter_container_hdr_t* 
     }
 
     switch (key->tag[3]) {
-    case '2':
+    case EC_SIZE_TAG_256:
         curve = NID_X9_62_prime256v1;
         break;
-    case '3':
+    case EC_SIZE_TAG_384:
         curve = NID_secp384r1;
         break;
-    case '5':
+    case EC_SIZE_TAG_521:
         curve = NID_secp521r1;
         break;
     default:
@@ -371,13 +371,13 @@ soter_status_t soter_ec_priv_key_to_engine_specific(const soter_container_hdr_t*
     }
 
     switch (key->tag[3]) {
-    case '2':
+    case EC_SIZE_TAG_256:
         curve = NID_X9_62_prime256v1;
         break;
-    case '3':
+    case EC_SIZE_TAG_384:
         curve = NID_secp384r1;
         break;
-    case '5':
+    case EC_SIZE_TAG_521:
         curve = NID_secp521r1;
         break;
     default:

--- a/src/soter/openssl/soter_ec_key.c
+++ b/src/soter/openssl/soter_ec_key.c
@@ -207,6 +207,10 @@ soter_status_t soter_engine_specific_to_ec_priv_key(const soter_engine_specific_
         goto err;
     }
 
+    /*
+     * Note that we use a buffer suitable for a public key to store a private
+     * key. This was a historical mistake, now preserved for compatibility.
+     */
     output_length = ec_pub_key_size(curve);
     if ((!key) || (output_length > *key_length)) {
         *key_length = output_length;

--- a/src/soter/openssl/soter_rsa_key.c
+++ b/src/soter/openssl/soter_rsa_key.c
@@ -363,16 +363,16 @@ soter_status_t soter_rsa_pub_key_to_engine_specific(const soter_container_hdr_t*
     }
 
     switch (key->tag[3]) {
-    case '1':
+    case RSA_SIZE_TAG_1024:
         rsa_mod_size = 128;
         break;
-    case '2':
+    case RSA_SIZE_TAG_2048:
         rsa_mod_size = 256;
         break;
-    case '4':
+    case RSA_SIZE_TAG_4096:
         rsa_mod_size = 512;
         break;
-    case '8':
+    case RSA_SIZE_TAG_8192:
         rsa_mod_size = 1024;
         break;
     default:
@@ -463,16 +463,16 @@ soter_status_t soter_rsa_priv_key_to_engine_specific(const soter_container_hdr_t
     }
 
     switch (key->tag[3]) {
-    case '1':
+    case RSA_SIZE_TAG_1024:
         rsa_mod_size = 128;
         break;
-    case '2':
+    case RSA_SIZE_TAG_2048:
         rsa_mod_size = 256;
         break;
-    case '4':
+    case RSA_SIZE_TAG_4096:
         rsa_mod_size = 512;
         break;
-    case '8':
+    case RSA_SIZE_TAG_8192:
         rsa_mod_size = 1024;
         break;
     default:

--- a/src/soter/soter_ec_key.c
+++ b/src/soter/soter_ec_key.c
@@ -53,19 +53,9 @@ soter_status_t soter_ec_pub_key_check_length(const soter_container_hdr_t* key, s
 SOTER_PRIVATE_API
 soter_status_t soter_ec_priv_key_check_length(const soter_container_hdr_t* key, size_t key_length)
 {
-    /*
-     * Due to a mistake in historical key exporting implementation, private
-     * keys were exported into slightly bigger buffers suitable for public
-     * keys. Allow such buffer lengths as well because there might exist
-     * perfectly valid keys in the wild that are stored with extra garbage
-     * appended to them.
-     */
     switch (key->tag[3]) {
     case '2':
         if (key_length == sizeof(soter_container_hdr_t) + EC_PRIV_SIZE(256)) {
-            return SOTER_SUCCESS;
-        }
-        if (key_length == sizeof(soter_container_hdr_t) + EC_PUB_SIZE(256)) {
             return SOTER_SUCCESS;
         }
         return SOTER_INVALID_PARAMETER;
@@ -74,16 +64,10 @@ soter_status_t soter_ec_priv_key_check_length(const soter_container_hdr_t* key, 
         if (key_length == sizeof(soter_container_hdr_t) + EC_PRIV_SIZE(384)) {
             return SOTER_SUCCESS;
         }
-        if (key_length == sizeof(soter_container_hdr_t) + EC_PUB_SIZE(384)) {
-            return SOTER_SUCCESS;
-        }
         return SOTER_INVALID_PARAMETER;
 
     case '5':
         if (key_length == sizeof(soter_container_hdr_t) + EC_PRIV_SIZE(521)) {
-            return SOTER_SUCCESS;
-        }
-        if (key_length == sizeof(soter_container_hdr_t) + EC_PUB_SIZE(521)) {
             return SOTER_SUCCESS;
         }
         return SOTER_INVALID_PARAMETER;

--- a/src/soter/soter_ec_key.c
+++ b/src/soter/soter_ec_key.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2019 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "soter/soter_ec_key.h"
+
+#include <soter/soter_api.h>
+
+/*
+ * EC data is appended directly to soter_container_hdr_t when exporting EC keys,
+ * so that's the length we should expect. sizeof(soter_ec_pub_key_256_t) structs
+ * may be slightly bigger than required size due compiler alignment, so we check
+ * the length directly instead of comparing to sizeof (like we do with RSA keys).
+ */
+
+SOTER_PRIVATE_API
+soter_status_t soter_ec_pub_key_check_length(const soter_container_hdr_t* key, size_t key_length)
+{
+    switch (key->tag[3]) {
+    case '2':
+        if (key_length == sizeof(soter_container_hdr_t) + EC_PUB_SIZE(256)) {
+            return SOTER_SUCCESS;
+        }
+        return SOTER_INVALID_PARAMETER;
+
+    case '3':
+        if (key_length == sizeof(soter_container_hdr_t) + EC_PUB_SIZE(384)) {
+            return SOTER_SUCCESS;
+        }
+        return SOTER_INVALID_PARAMETER;
+
+    case '5':
+        if (key_length == sizeof(soter_container_hdr_t) + EC_PUB_SIZE(521)) {
+            return SOTER_SUCCESS;
+        }
+        return SOTER_INVALID_PARAMETER;
+    }
+    return SOTER_INVALID_PARAMETER;
+}
+
+SOTER_PRIVATE_API
+soter_status_t soter_ec_priv_key_check_length(const soter_container_hdr_t* key, size_t key_length)
+{
+    switch (key->tag[3]) {
+    case '2':
+        if (key_length == sizeof(soter_container_hdr_t) + EC_PRIV_SIZE(256)) {
+            return SOTER_SUCCESS;
+        }
+        return SOTER_INVALID_PARAMETER;
+
+    case '3':
+        if (key_length == sizeof(soter_container_hdr_t) + EC_PRIV_SIZE(384)) {
+            return SOTER_SUCCESS;
+        }
+        return SOTER_INVALID_PARAMETER;
+
+    case '5':
+        if (key_length == sizeof(soter_container_hdr_t) + EC_PRIV_SIZE(521)) {
+            return SOTER_SUCCESS;
+        }
+        return SOTER_INVALID_PARAMETER;
+    }
+    return SOTER_INVALID_PARAMETER;
+}

--- a/src/soter/soter_ec_key.c
+++ b/src/soter/soter_ec_key.c
@@ -29,19 +29,19 @@ SOTER_PRIVATE_API
 soter_status_t soter_ec_pub_key_check_length(const soter_container_hdr_t* key, size_t key_length)
 {
     switch (key->tag[3]) {
-    case '2':
+    case EC_SIZE_TAG_256:
         if (key_length == sizeof(soter_container_hdr_t) + EC_PUB_SIZE(256)) {
             return SOTER_SUCCESS;
         }
         return SOTER_INVALID_PARAMETER;
 
-    case '3':
+    case EC_SIZE_TAG_384:
         if (key_length == sizeof(soter_container_hdr_t) + EC_PUB_SIZE(384)) {
             return SOTER_SUCCESS;
         }
         return SOTER_INVALID_PARAMETER;
 
-    case '5':
+    case EC_SIZE_TAG_521:
         if (key_length == sizeof(soter_container_hdr_t) + EC_PUB_SIZE(521)) {
             return SOTER_SUCCESS;
         }

--- a/src/soter/soter_ec_key.c
+++ b/src/soter/soter_ec_key.c
@@ -53,9 +53,19 @@ soter_status_t soter_ec_pub_key_check_length(const soter_container_hdr_t* key, s
 SOTER_PRIVATE_API
 soter_status_t soter_ec_priv_key_check_length(const soter_container_hdr_t* key, size_t key_length)
 {
+    /*
+     * Due to a mistake in historical key exporting implementation, private
+     * keys were exported into slightly bigger buffers suitable for public
+     * keys. Allow such buffer lengths as well because there might exist
+     * perfectly valid keys in the wild that are stored with extra garbage
+     * appended to them.
+     */
     switch (key->tag[3]) {
     case '2':
         if (key_length == sizeof(soter_container_hdr_t) + EC_PRIV_SIZE(256)) {
+            return SOTER_SUCCESS;
+        }
+        if (key_length == sizeof(soter_container_hdr_t) + EC_PUB_SIZE(256)) {
             return SOTER_SUCCESS;
         }
         return SOTER_INVALID_PARAMETER;
@@ -64,10 +74,16 @@ soter_status_t soter_ec_priv_key_check_length(const soter_container_hdr_t* key, 
         if (key_length == sizeof(soter_container_hdr_t) + EC_PRIV_SIZE(384)) {
             return SOTER_SUCCESS;
         }
+        if (key_length == sizeof(soter_container_hdr_t) + EC_PUB_SIZE(384)) {
+            return SOTER_SUCCESS;
+        }
         return SOTER_INVALID_PARAMETER;
 
     case '5':
         if (key_length == sizeof(soter_container_hdr_t) + EC_PRIV_SIZE(521)) {
+            return SOTER_SUCCESS;
+        }
+        if (key_length == sizeof(soter_container_hdr_t) + EC_PUB_SIZE(521)) {
             return SOTER_SUCCESS;
         }
         return SOTER_INVALID_PARAMETER;

--- a/src/soter/soter_ec_key.c
+++ b/src/soter/soter_ec_key.c
@@ -53,24 +53,10 @@ soter_status_t soter_ec_pub_key_check_length(const soter_container_hdr_t* key, s
 SOTER_PRIVATE_API
 soter_status_t soter_ec_priv_key_check_length(const soter_container_hdr_t* key, size_t key_length)
 {
-    switch (key->tag[3]) {
-    case '2':
-        if (key_length == sizeof(soter_container_hdr_t) + EC_PRIV_SIZE(256)) {
-            return SOTER_SUCCESS;
-        }
-        return SOTER_INVALID_PARAMETER;
-
-    case '3':
-        if (key_length == sizeof(soter_container_hdr_t) + EC_PRIV_SIZE(384)) {
-            return SOTER_SUCCESS;
-        }
-        return SOTER_INVALID_PARAMETER;
-
-    case '5':
-        if (key_length == sizeof(soter_container_hdr_t) + EC_PRIV_SIZE(521)) {
-            return SOTER_SUCCESS;
-        }
-        return SOTER_INVALID_PARAMETER;
-    }
-    return SOTER_INVALID_PARAMETER;
+    /*
+     * Due to a historical mistake, EC private keys in Themis have the same
+     * length as public keys, not EC_PRIV_SIZE(bits). That's one byte more
+     * than necessary and that last byte is always zero.
+     */
+    return soter_ec_pub_key_check_length(key, key_length);
 }

--- a/src/soter/soter_ec_key.h
+++ b/src/soter/soter_ec_key.h
@@ -32,6 +32,10 @@
 /** @brief elliptic curve header part for 521bits key*/
 #define EC_521 "5"
 
+#define EC_SIZE_TAG_256 '2'
+#define EC_SIZE_TAG_384 '3'
+#define EC_SIZE_TAG_521 '5'
+
 #define EC_KEY_SUF(_KEY_SIZE_) EC_##_KEY_SIZE_
 
 #define EC_PRIV_KEY_TAG(_KEY_SIZE_) (EC_PRIV_KEY_PREF EC_KEY_SUF(_KEY_SIZE_))

--- a/src/soter/soter_ec_key.h
+++ b/src/soter/soter_ec_key.h
@@ -83,4 +83,7 @@ soter_status_t soter_engine_specific_to_ec_pub_key(const soter_engine_specific_e
                                                    soter_container_hdr_t* key,
                                                    size_t* key_length);
 
+soter_status_t soter_ec_pub_key_check_length(const soter_container_hdr_t* key, size_t key_length);
+soter_status_t soter_ec_priv_key_check_length(const soter_container_hdr_t* key, size_t key_length);
+
 #endif /* SOTER_EC_KEY_H */

--- a/src/soter/soter_rsa_key.c
+++ b/src/soter/soter_rsa_key.c
@@ -22,25 +22,25 @@ SOTER_PRIVATE_API
 soter_status_t soter_rsa_pub_key_check_length(const soter_container_hdr_t* key, size_t key_length)
 {
     switch (key->tag[3]) {
-    case '1':
+    case RSA_SIZE_TAG_1024:
         if (key_length == sizeof(soter_rsa_pub_key_1024_t)) {
             return SOTER_SUCCESS;
         }
         return SOTER_INVALID_PARAMETER;
 
-    case '2':
+    case RSA_SIZE_TAG_2048:
         if (key_length == sizeof(soter_rsa_pub_key_2048_t)) {
             return SOTER_SUCCESS;
         }
         return SOTER_INVALID_PARAMETER;
 
-    case '4':
+    case RSA_SIZE_TAG_4096:
         if (key_length == sizeof(soter_rsa_pub_key_4096_t)) {
             return SOTER_SUCCESS;
         }
         return SOTER_INVALID_PARAMETER;
 
-    case '8':
+    case RSA_SIZE_TAG_8192:
         if (key_length == sizeof(soter_rsa_pub_key_8192_t)) {
             return SOTER_SUCCESS;
         }
@@ -53,25 +53,25 @@ SOTER_PRIVATE_API
 soter_status_t soter_rsa_priv_key_check_length(const soter_container_hdr_t* key, size_t key_length)
 {
     switch (key->tag[3]) {
-    case '1':
+    case RSA_SIZE_TAG_1024:
         if (key_length == sizeof(soter_rsa_priv_key_1024_t)) {
             return SOTER_SUCCESS;
         }
         return SOTER_INVALID_PARAMETER;
 
-    case '2':
+    case RSA_SIZE_TAG_2048:
         if (key_length == sizeof(soter_rsa_priv_key_2048_t)) {
             return SOTER_SUCCESS;
         }
         return SOTER_INVALID_PARAMETER;
 
-    case '4':
+    case RSA_SIZE_TAG_4096:
         if (key_length == sizeof(soter_rsa_priv_key_4096_t)) {
             return SOTER_SUCCESS;
         }
         return SOTER_INVALID_PARAMETER;
 
-    case '8':
+    case RSA_SIZE_TAG_8192:
         if (key_length == sizeof(soter_rsa_priv_key_8192_t)) {
             return SOTER_SUCCESS;
         }

--- a/src/soter/soter_rsa_key.c
+++ b/src/soter/soter_rsa_key.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2019 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "soter/soter_rsa_key.h"
+
+#include <soter/soter_api.h>
+
+SOTER_PRIVATE_API
+soter_status_t soter_rsa_pub_key_check_length(const soter_container_hdr_t* key, size_t key_length)
+{
+    switch (key->tag[3]) {
+    case '1':
+        if (key_length == sizeof(soter_rsa_pub_key_1024_t)) {
+            return SOTER_SUCCESS;
+        }
+        return SOTER_INVALID_PARAMETER;
+
+    case '2':
+        if (key_length == sizeof(soter_rsa_pub_key_2048_t)) {
+            return SOTER_SUCCESS;
+        }
+        return SOTER_INVALID_PARAMETER;
+
+    case '4':
+        if (key_length == sizeof(soter_rsa_pub_key_4096_t)) {
+            return SOTER_SUCCESS;
+        }
+        return SOTER_INVALID_PARAMETER;
+
+    case '8':
+        if (key_length == sizeof(soter_rsa_pub_key_8192_t)) {
+            return SOTER_SUCCESS;
+        }
+        return SOTER_INVALID_PARAMETER;
+    }
+    return SOTER_INVALID_PARAMETER;
+}
+
+SOTER_PRIVATE_API
+soter_status_t soter_rsa_priv_key_check_length(const soter_container_hdr_t* key, size_t key_length)
+{
+    switch (key->tag[3]) {
+    case '1':
+        if (key_length == sizeof(soter_rsa_priv_key_1024_t)) {
+            return SOTER_SUCCESS;
+        }
+        return SOTER_INVALID_PARAMETER;
+
+    case '2':
+        if (key_length == sizeof(soter_rsa_priv_key_2048_t)) {
+            return SOTER_SUCCESS;
+        }
+        return SOTER_INVALID_PARAMETER;
+
+    case '4':
+        if (key_length == sizeof(soter_rsa_priv_key_4096_t)) {
+            return SOTER_SUCCESS;
+        }
+        return SOTER_INVALID_PARAMETER;
+
+    case '8':
+        if (key_length == sizeof(soter_rsa_priv_key_8192_t)) {
+            return SOTER_SUCCESS;
+        }
+        return SOTER_INVALID_PARAMETER;
+    }
+    return SOTER_INVALID_PARAMETER;
+}

--- a/src/soter/soter_rsa_key.h
+++ b/src/soter/soter_rsa_key.h
@@ -28,6 +28,11 @@
 #define RSA_4096 "4"
 #define RSA_8192 "8"
 
+#define RSA_SIZE_TAG_1024 '1'
+#define RSA_SIZE_TAG_2048 '2'
+#define RSA_SIZE_TAG_4096 '4'
+#define RSA_SIZE_TAG_8192 '8'
+
 #define RSA_KEY_LENGTH_1024 1
 #define RSA_KEY_LENGTH_2048 2
 #define RSA_KEY_LENGTH_4096 3

--- a/src/soter/soter_rsa_key.h
+++ b/src/soter/soter_rsa_key.h
@@ -92,4 +92,7 @@ soter_status_t soter_engine_specific_to_rsa_pub_key(const soter_engine_specific_
                                                     soter_container_hdr_t* key,
                                                     size_t* key_length);
 
+soter_status_t soter_rsa_pub_key_check_length(const soter_container_hdr_t* key, size_t key_length);
+soter_status_t soter_rsa_priv_key_check_length(const soter_container_hdr_t* key, size_t key_length);
+
 #endif /* SOTER_RSA_KEY_H */

--- a/src/soter/soter_sign.c
+++ b/src/soter/soter_sign.c
@@ -27,17 +27,6 @@
 
 #include "soter/soter_api.h"
 
-#define SOTER_SIGN_ALGS             \
-    SOTER_SIGN_ALG(rsa, pss, pkcs8) \
-    SOTER_SIGN_ALG(ecdsa, none, pkcs8)
-
-#define SOTER_SIGN_ALG(alg, padding, kdf)                                    \
-    case SOTER_SIGN_##alg##_##padding##_##kdf:                               \
-        return soter_sign_init_##alg##_##padding##_##kdf(ctx,                \
-                                                         private_key,        \
-                                                         private_key_length, \
-                                                         public_key,         \
-                                                         public_key_length);
 SOTER_PRIVATE_API
 soter_status_t soter_sign_init(soter_sign_ctx_t* ctx,
                                soter_sign_alg_t algId,
@@ -50,23 +39,21 @@ soter_status_t soter_sign_init(soter_sign_ctx_t* ctx,
         return SOTER_INVALID_PARAMETER;
     }
     ctx->alg = algId;
-    switch (algId) {
-
-        SOTER_SIGN_ALGS
+    switch (ctx->alg) {
+    case SOTER_SIGN_rsa_pss_pkcs8:
+        return soter_sign_init_rsa_pss_pkcs8(ctx, private_key, private_key_length, public_key, public_key_length);
+    case SOTER_SIGN_ecdsa_none_pkcs8:
+        return soter_sign_init_ecdsa_none_pkcs8(ctx,
+                                                private_key,
+                                                private_key_length,
+                                                public_key,
+                                                public_key_length);
     default:
         return SOTER_INVALID_PARAMETER;
-    };
+    }
     return SOTER_INVALID_PARAMETER;
 }
-#undef SOTER_SIGN_ALG
 
-#define SOTER_SIGN_ALG(alg, padding, kdf)                                      \
-    case SOTER_SIGN_##alg##_##padding##_##kdf:                                 \
-        return soter_verify_init_##alg##_##padding##_##kdf(ctx,                \
-                                                           private_key,        \
-                                                           private_key_length, \
-                                                           public_key,         \
-                                                           public_key_length);
 SOTER_PRIVATE_API
 soter_status_t soter_verify_init(soter_sign_ctx_t* ctx,
                                  soter_sign_alg_t algId,
@@ -79,133 +66,136 @@ soter_status_t soter_verify_init(soter_sign_ctx_t* ctx,
         return SOTER_INVALID_PARAMETER;
     }
     ctx->alg = algId;
-    switch (algId) {
-        SOTER_SIGN_ALGS
+    switch (ctx->alg) {
+    case SOTER_SIGN_rsa_pss_pkcs8:
+        return soter_verify_init_rsa_pss_pkcs8(ctx,
+                                               private_key,
+                                               private_key_length,
+                                               public_key,
+                                               public_key_length);
+    case SOTER_SIGN_ecdsa_none_pkcs8:
+        return soter_verify_init_ecdsa_none_pkcs8(ctx,
+                                                  private_key,
+                                                  private_key_length,
+                                                  public_key,
+                                                  public_key_length);
     default:
         return SOTER_INVALID_PARAMETER;
-    };
+    }
     return SOTER_INVALID_PARAMETER;
 }
-#undef SOTER_SIGN_ALG
 
-#define SOTER_SIGN_ALG(alg, padding, kdf)      \
-    case SOTER_SIGN_##alg##_##padding##_##kdf: \
-        return soter_sign_export_key_##alg##_##padding##_##kdf(ctx, key, key_length, isprivate);
 soter_status_t soter_sign_export_key(soter_sign_ctx_t* ctx, void* key, size_t* key_length, bool isprivate)
 {
     if (!ctx) {
         return SOTER_INVALID_PARAMETER;
     }
     switch (ctx->alg) {
-        SOTER_SIGN_ALGS
+    case SOTER_SIGN_rsa_pss_pkcs8:
+        return soter_sign_export_key_rsa_pss_pkcs8(ctx, key, key_length, isprivate);
+    case SOTER_SIGN_ecdsa_none_pkcs8:
+        return soter_sign_export_key_ecdsa_none_pkcs8(ctx, key, key_length, isprivate);
     default:
         return SOTER_INVALID_PARAMETER;
-    };
+    }
     return SOTER_INVALID_PARAMETER;
 }
-#undef SOTER_SIGN_ALG
 
-#define SOTER_SIGN_ALG(alg, padding, kdf)      \
-    case SOTER_SIGN_##alg##_##padding##_##kdf: \
-        return soter_sign_update_##alg##_##padding##_##kdf(ctx, data, data_length);
 soter_status_t soter_sign_update(soter_sign_ctx_t* ctx, const void* data, const size_t data_length)
 {
     if (!ctx || !data || !data_length) {
         return SOTER_INVALID_PARAMETER;
     }
     switch (ctx->alg) {
-        SOTER_SIGN_ALGS
+    case SOTER_SIGN_rsa_pss_pkcs8:
+        return soter_sign_update_rsa_pss_pkcs8(ctx, data, data_length);
+    case SOTER_SIGN_ecdsa_none_pkcs8:
+        return soter_sign_update_ecdsa_none_pkcs8(ctx, data, data_length);
     default:
         return SOTER_INVALID_PARAMETER;
-    };
+    }
     return SOTER_INVALID_PARAMETER;
 }
-#undef SOTER_SIGN_ALG
 
-#define SOTER_SIGN_ALG(alg, padding, kdf)      \
-    case SOTER_SIGN_##alg##_##padding##_##kdf: \
-        return soter_verify_update_##alg##_##padding##_##kdf(ctx, data, data_length);
 soter_status_t soter_verify_update(soter_sign_ctx_t* ctx, const void* data, const size_t data_length)
 {
     if (!ctx || !data || !data_length) {
         return SOTER_INVALID_PARAMETER;
     }
     switch (ctx->alg) {
-        SOTER_SIGN_ALGS
+    case SOTER_SIGN_rsa_pss_pkcs8:
+        return soter_verify_update_rsa_pss_pkcs8(ctx, data, data_length);
+    case SOTER_SIGN_ecdsa_none_pkcs8:
+        return soter_verify_update_ecdsa_none_pkcs8(ctx, data, data_length);
     default:
         return SOTER_INVALID_PARAMETER;
-    };
+    }
     return SOTER_INVALID_PARAMETER;
 }
-#undef SOTER_SIGN_ALG
 
-#define SOTER_SIGN_ALG(alg, padding, kdf)      \
-    case SOTER_SIGN_##alg##_##padding##_##kdf: \
-        return soter_sign_final_##alg##_##padding##_##kdf(ctx, signature, signature_length);
 soter_status_t soter_sign_final(soter_sign_ctx_t* ctx, void* signature, size_t* signature_length)
 {
     if (!ctx) {
         return SOTER_INVALID_PARAMETER;
     }
     switch (ctx->alg) {
-        SOTER_SIGN_ALGS
+    case SOTER_SIGN_rsa_pss_pkcs8:
+        return soter_sign_final_rsa_pss_pkcs8(ctx, signature, signature_length);
+    case SOTER_SIGN_ecdsa_none_pkcs8:
+        return soter_sign_final_ecdsa_none_pkcs8(ctx, signature, signature_length);
     default:
         return SOTER_INVALID_PARAMETER;
-    };
+    }
     return SOTER_INVALID_PARAMETER;
 }
-#undef SOTER_SIGN_ALG
 
-#define SOTER_SIGN_ALG(alg, padding, kdf)      \
-    case SOTER_SIGN_##alg##_##padding##_##kdf: \
-        return soter_verify_final_##alg##_##padding##_##kdf(ctx, signature, signature_length);
 soter_status_t soter_verify_final(soter_sign_ctx_t* ctx, const void* signature, const size_t signature_length)
 {
     if (!ctx || !signature || !signature_length) {
         return SOTER_INVALID_PARAMETER;
     }
     switch (ctx->alg) {
-        SOTER_SIGN_ALGS
+    case SOTER_SIGN_rsa_pss_pkcs8:
+        return soter_verify_final_rsa_pss_pkcs8(ctx, signature, signature_length);
+    case SOTER_SIGN_ecdsa_none_pkcs8:
+        return soter_verify_final_ecdsa_none_pkcs8(ctx, signature, signature_length);
     default:
         return SOTER_INVALID_PARAMETER;
-    };
+    }
     return SOTER_INVALID_PARAMETER;
 }
-#undef SOTER_SIGN_ALG
 
-#define SOTER_SIGN_ALG(alg, padding, kdf)      \
-    case SOTER_SIGN_##alg##_##padding##_##kdf: \
-        return soter_sign_cleanup_##alg##_##padding##_##kdf(ctx);
 soter_status_t soter_sign_cleanup(soter_sign_ctx_t* ctx)
 {
     if (!ctx) {
         return SOTER_INVALID_PARAMETER;
     }
     switch (ctx->alg) {
-        SOTER_SIGN_ALGS
+    case SOTER_SIGN_rsa_pss_pkcs8:
+        return soter_sign_cleanup_rsa_pss_pkcs8(ctx);
+    case SOTER_SIGN_ecdsa_none_pkcs8:
+        return soter_sign_cleanup_ecdsa_none_pkcs8(ctx);
     default:
         return SOTER_INVALID_PARAMETER;
-    };
+    }
     return SOTER_INVALID_PARAMETER;
 }
-#undef SOTER_SIGN_ALG
 
-#define SOTER_SIGN_ALG(alg, padding, kdf)      \
-    case SOTER_SIGN_##alg##_##padding##_##kdf: \
-        return soter_verify_cleanup_##alg##_##padding##_##kdf(ctx);
 soter_status_t soter_verify_cleanup(soter_sign_ctx_t* ctx)
 {
     if (!ctx) {
         return SOTER_INVALID_PARAMETER;
     }
     switch (ctx->alg) {
-        SOTER_SIGN_ALGS
+    case SOTER_SIGN_rsa_pss_pkcs8:
+        return soter_verify_cleanup_rsa_pss_pkcs8(ctx);
+    case SOTER_SIGN_ecdsa_none_pkcs8:
+        return soter_verify_cleanup_ecdsa_none_pkcs8(ctx);
     default:
         return SOTER_INVALID_PARAMETER;
-    };
+    }
     return SOTER_INVALID_PARAMETER;
 }
-#undef SOTER_SIGN_ALG
 
 soter_sign_ctx_t* soter_sign_create(soter_sign_alg_t alg,
                                     const void* private_key,

--- a/src/themis/secure_keygen.c
+++ b/src/themis/secure_keygen.c
@@ -119,11 +119,14 @@ themis_key_kind_t themis_get_asym_key_kind(const uint8_t* key, size_t length)
 themis_status_t themis_is_valid_asym_key(const uint8_t* key, size_t length)
 {
     const soter_container_hdr_t* container = (const void*)key;
+    themis_key_kind_t kind = THEMIS_KEY_INVALID;
 
     if (!key || (length < sizeof(soter_container_hdr_t))) {
         return THEMIS_INVALID_PARAMETER;
     }
-    if (THEMIS_KEY_INVALID == themis_get_asym_key_kind(key, length)) {
+
+    kind = themis_get_asym_key_kind(key, length);
+    if (kind == THEMIS_KEY_INVALID) {
         return THEMIS_INVALID_PARAMETER;
     }
     if (length != be32toh(container->size)) {
@@ -133,5 +136,18 @@ themis_status_t themis_is_valid_asym_key(const uint8_t* key, size_t length)
         return THEMIS_DATA_CORRUPT;
     }
 
-    return THEMIS_SUCCESS;
+    switch (kind) {
+    case THEMIS_KEY_RSA_PRIVATE:
+        return soter_rsa_priv_key_check_length(container, length);
+    case THEMIS_KEY_RSA_PUBLIC:
+        return soter_rsa_pub_key_check_length(container, length);
+    case THEMIS_KEY_EC_PRIVATE:
+        return soter_ec_priv_key_check_length(container, length);
+    case THEMIS_KEY_EC_PUBLIC:
+        return soter_ec_pub_key_check_length(container, length);
+    default:
+        return THEMIS_INVALID_PARAMETER;
+    }
+
+    return THEMIS_INVALID_PARAMETER;
 }

--- a/tests/soter/soter_asym_ka_test.c
+++ b/tests/soter/soter_asym_ka_test.c
@@ -267,6 +267,63 @@ static void test_api(void)
                           "soter_asym_ka_destroy: invalid context");
 }
 
+static void test_ec_key_size_quirk(void)
+{
+    soter_status_t res;
+    soter_asym_ka_t ctx;
+
+    uint8_t public_key_buffer[KEY_BUFFER_SIZE];
+    uint8_t private_key_buffer[KEY_BUFFER_SIZE];
+    size_t public_key_buffer_length = sizeof(public_key_buffer);
+    size_t private_key_buffer_length = sizeof(private_key_buffer);
+
+    memset(&ctx, 0, sizeof(soter_asym_ka_t));
+    memset(&public_key_buffer, 0xFF, sizeof(public_key_buffer));
+    memset(&private_key_buffer, 0xFF, sizeof(private_key_buffer));
+
+    res = soter_asym_ka_init(&ctx, SOTER_ASYM_KA_EC_P256);
+    if (res != SOTER_SUCCESS) {
+        testsuite_fail_unless(false, "soter_asym_ka_init failed");
+        return;
+    }
+
+    res = soter_asym_ka_gen_key(&ctx);
+    if (res != SOTER_SUCCESS) {
+        testsuite_fail_unless(false, "soter_asym_ka_gen_key failed");
+        return;
+    }
+
+    res = soter_asym_ka_export_key(&ctx, public_key_buffer, &public_key_buffer_length, false);
+    if (res != SOTER_SUCCESS) {
+        testsuite_fail_unless(false, "soter_asym_ka_export_key failed");
+        return;
+    }
+
+    res = soter_asym_ka_export_key(&ctx, private_key_buffer, &private_key_buffer_length, true);
+    if (res != SOTER_SUCCESS) {
+        testsuite_fail_unless(false, "soter_asym_ka_export_key failed");
+        return;
+    }
+
+    res = soter_asym_ka_cleanup(&ctx);
+    if (res != SOTER_SUCCESS) {
+        testsuite_fail_unless(false, "soter_asym_ka_cleanup failed");
+        return;
+    }
+
+    /*
+     * Due to historical reasons, private keys have the same length as public
+     * ones, with the most significant byte (the first one in network order)
+     * always being set to zero. We have to maintain this format to preserve
+     * backwards compatibility.
+     */
+    testsuite_fail_unless(private_key_buffer_length == public_key_buffer_length,
+                          "private key has the same length as public key");
+
+    testsuite_fail_unless(soter_container_const_data((const void*) private_key_buffer)[0] == 0,
+                          "first byte of private key is zero");
+}
+
 void run_soter_asym_ka_tests(void)
 {
     testsuite_enter_suite("soter asym ka: basic flow");
@@ -274,4 +331,7 @@ void run_soter_asym_ka_tests(void)
 
     testsuite_enter_suite("soter asym ka: api");
     testsuite_run_test(test_api);
+
+    testsuite_enter_suite("soter asym ka: EC key quirks");
+    testsuite_run_test(test_ec_key_size_quirk);
 }

--- a/tests/soter/soter_asym_ka_test.c
+++ b/tests/soter/soter_asym_ka_test.c
@@ -320,7 +320,7 @@ static void test_ec_key_size_quirk(void)
     testsuite_fail_unless(private_key_buffer_length == public_key_buffer_length,
                           "private key has the same length as public key");
 
-    testsuite_fail_unless(soter_container_const_data((const void*) private_key_buffer)[0] == 0,
+    testsuite_fail_unless(soter_container_const_data((const void*)private_key_buffer)[0] == 0,
                           "first byte of private key is zero");
 }
 
@@ -332,6 +332,6 @@ void run_soter_asym_ka_tests(void)
     testsuite_enter_suite("soter asym ka: api");
     testsuite_run_test(test_api);
 
-    testsuite_enter_suite("soter asym ka: EC key quirks");
+    testsuite_enter_suite("soter asym ka: EC key size quirks");
     testsuite_run_test(test_ec_key_size_quirk);
 }

--- a/tests/themis/themis_seccure_message.c
+++ b/tests/themis/themis_seccure_message.c
@@ -1506,8 +1506,17 @@ static void key_validation_test(void)
     testsuite_fail_unless(THEMIS_INVALID_PARAMETER == themis_is_valid_asym_key(NULL, 0),
                           "themis_is_valid_asym_key: invalid arguments");
     testsuite_fail_unless(THEMIS_INVALID_PARAMETER
+                              == themis_is_valid_asym_key(rsa_public_key, rsa_public_key_length - 1),
+                          "themis_is_valid_asym_key: truncated RSA buffer");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER
                               == themis_is_valid_asym_key(ec_private_key, ec_private_key_length - 1),
-                          "themis_is_valid_asym_key: truncated buffer");
+                          "themis_is_valid_asym_key: truncated EC buffer");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER
+                              == themis_is_valid_asym_key(rsa_private_key, rsa_private_key_length + 1),
+                          "themis_is_valid_asym_key: extended RSA buffer");
+    testsuite_fail_unless(THEMIS_INVALID_PARAMETER
+                              == themis_is_valid_asym_key(ec_public_key, ec_public_key_length + 1),
+                          "themis_is_valid_asym_key: extended EC buffer");
 
     testsuite_fail_unless(THEMIS_KEY_INVALID == themis_get_asym_key_kind(NULL, 0),
                           "themis_get_asym_key_kind: invalid arguments");


### PR DESCRIPTION
I only wanted to add some extra length checks to `themis_is_valid_asym_key()` suggested by @veorq, but this delivered way more 🔥**fun**🔥 that expected...

The issue with `themis_is_valid_asym_key()` is that it effectively validates that the provided key buffer is a valid Soter container with expected size. This includes containers that do not actually contain keys (e.g., empty containers, or unrelated Secure Messages). We would like to filter these out earlier, before we actually try to use them as keys. For this we ask Soter to provide us with expected length of the key buffer and compare that against the actual length. (We do not check the content, though. It's not that trivial to do.)

...Or that's what I planned to do. Actually implementing these checks uncovered a couple of nasty idiosyncrasies with the way we export and store keys. You can read the details in commit messages. The lesson remains the same: do not use C structs for data serialization, it's a minefield.

Furthermore, this uncovered a (minor) bug in key exporting implementation where we used incorrect buffer size for private keys, padding them with an additional byte. It kinda worked before and nobody noticed because that's one byte more, not less, and we allowed the buffers to be bigger than they should be.

Strictly speaking, a fix for this bug breaks forward compatibility of previously generated keys because now we enforce length checks and do not allow any extra garbage bytes. This breakage is unacceptable so the code now contains a compatibility branch which will let such keys through.

Alternatively, we may simply accept the mistake and continue using incorrect size of buffer for exported private keys, with an extra byte in the end. Thoughts?

Pre-merge check list:

- [x] verify the build on internal BuildBot
  - [x] [integration build](https://buildbot.cossacklabs.com/#/builders/90/builds/97) — ongoing, with 'usual' failures
  - [x] [crossover build](https://buildbot.cossacklabs.com/#/builders/86/builds/2) — completed, seems to be okay (yay!)
- [x] sign-off by @vixentael on breaking changes