### PR TITLE
Temporarily disable Android build on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,7 +247,8 @@ workflows:
   tests:
     jobs:
       - analyze
-      - android
+      # Broken build temporarily disabled (see T1133, 2019-07-03)
+      # - android
       - x86_64
       - php5
       - php70


### PR DESCRIPTION
This job has been failing for literally *months*, keeping our builds red and preventing PRs from being merged cleanly. It is also quite slow in comparison with other jobs.

Let's disable Android builds for now. The plan is it move Android CI to [Bitrise](https://www.bitrise.io/) in the nearest time. There is no GitHub issue for this, but the progress may be tracked [internally at Cossack Labs][1].

[1]: https://ph.cossacklabs.com/T1133