### PR TITLE
WasmThemis: Secure Message support

### DIFF
--- a/src/wrappers/themis/wasm/src/index.js
+++ b/src/wrappers/themis/wasm/src/index.js
@@ -19,5 +19,6 @@
 
 Object.assign(module.exports
   , require('./secure_keygen.js')
+  , require('./secure_message.js')
   , require('./themis_error.js')
 )

--- a/src/wrappers/themis/wasm/src/secure_message.js
+++ b/src/wrappers/themis/wasm/src/secure_message.js
@@ -1,0 +1,327 @@
+// Copyright (c) 2019 Cossack Labs Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file
+ * Themis Secure Message.
+ */
+
+const libthemis = require('./libthemis.js')
+const keygen = require('./secure_keygen.js')
+const errors = require('./themis_error.js')
+const utils = require('./utils.js')
+
+const subsystem = 'SecureMessage'
+
+const ThemisError = errors.ThemisError
+const ThemisErrorCode = errors.ThemisErrorCode
+
+class SecureMessage {
+    constructor(keyPair) {
+        if (arguments.length == 1) {
+            if (!(keyPair instanceof keygen.KeyPair)) {
+                throw new ThemisError(subsystem, ThemisErrorCode.INVALID_PARAMETER,
+                    'invalid argument: must be KeyPair')
+            }
+            this.privateKey = keyPair.privateKey
+            this.publicKey = keyPair.publicKey
+            return
+        }
+
+        if (arguments.length == 2) {
+            let arg0isPrivateKey = arguments[0] instanceof keygen.PrivateKey
+            let arg0isPublicKey  = arguments[0] instanceof keygen.PublicKey
+            let arg1isPrivateKey = arguments[1] instanceof keygen.PrivateKey
+            let arg1isPublicKey  = arguments[1] instanceof keygen.PublicKey
+
+            if (arg0isPublicKey && arg1isPrivateKey) {
+                this.publicKey = arguments[0]
+                this.privateKey = arguments[1]
+                return
+            }
+            if (arg0isPrivateKey && arg1isPublicKey) {
+                this.privateKey = arguments[0]
+                this.publicKey = arguments[1]
+                return
+            }
+
+            throw new ThemisError(subsystem, ThemisErrorCode.INVALID_PARAMETER,
+                'invalid arguments: expected PrivateKey and PublicKey')
+        }
+
+        throw new ThemisError(subsystem, ThemisErrorCode.INVALID_PARAMETER,
+            'invalid argument count: expected either one KeyPair, or PrivateKey and PublicKey')
+    }
+
+    encrypt(message) {
+        message = utils.coerceToBytes(message)
+        if (message.length == 0) {
+            throw new ThemisError(subsystem, ThemisErrorCode.INVALID_PARAMETER,
+                'message must be not empty')
+        }
+
+        let status
+        /// C API uses "size_t" for lengths, it's defined as "i32" in Emscripten
+        let result_length_ptr = libthemis.allocate(4, 'i32', libthemis.ALLOC_STACK)
+        let private_key_ptr, public_key_ptr, message_ptr, result_ptr, result_length
+        try {
+            private_key_ptr = libthemis._malloc(this.privateKey.length)
+            public_key_ptr = libthemis._malloc(this.publicKey.length)
+            message_ptr = libthemis._malloc(message.length)
+            if (!private_key_ptr || !public_key_ptr || !message_ptr) {
+                throw new ThemisError(subsystem, ThemisErrorCode.NO_MEMORY)
+            }
+
+            libthemis.writeArrayToMemory(this.privateKey, private_key_ptr)
+            libthemis.writeArrayToMemory(this.publicKey, public_key_ptr)
+            libthemis.writeArrayToMemory(message, message_ptr)
+
+            status = libthemis._themis_secure_message_encrypt(
+                private_key_ptr, this.privateKey.length,
+                public_key_ptr, this.publicKey.length,
+                message_ptr, message.length,
+                null, result_length_ptr
+            )
+            if (status != ThemisErrorCode.BUFFER_TOO_SMALL) {
+                throw new ThemisError(subsystem, status)
+            }
+
+            result_length = libthemis.getValue(result_length_ptr, 'i32')
+            result_ptr = libthemis._malloc(result_length)
+            if (!result_ptr) {
+                throw new ThemisError(subsystem, ThemisErrorCode.NO_MEMORY)
+            }
+
+            status = libthemis._themis_secure_message_encrypt(
+                private_key_ptr, this.privateKey.length,
+                public_key_ptr, this.publicKey.length,
+                message_ptr, message.length,
+                result_ptr, result_length_ptr
+            )
+            if (status != ThemisErrorCode.SUCCESS) {
+                throw new ThemisError(subsystem, status)
+            }
+
+            result_length = libthemis.getValue(result_length_ptr, 'i32')
+
+            return libthemis.HEAPU8.slice(result_ptr, result_ptr + result_length)
+        }
+        finally {
+            libthemis._memset(private_key_ptr, 0, this.privateKey.length)
+            libthemis._free(private_key_ptr)
+            libthemis._free(public_key_ptr)
+            libthemis._free(message_ptr)
+            libthemis._free(result_ptr)
+        }
+    }
+
+    decrypt(message) {
+        message = utils.coerceToBytes(message)
+        if (message.length == 0) {
+            throw new ThemisError(subsystem, ThemisErrorCode.INVALID_PARAMETER,
+                'message must be not empty')
+        }
+
+        let status
+        /// C API uses "size_t" for lengths, it's defined as "i32" in Emscripten
+        let result_length_ptr = libthemis.allocate(4, 'i32', libthemis.ALLOC_STACK)
+        let private_key_ptr, public_key_ptr, message_ptr, result_ptr, result_length
+        try {
+            private_key_ptr = libthemis._malloc(this.privateKey.length)
+            public_key_ptr = libthemis._malloc(this.publicKey.length)
+            message_ptr = libthemis._malloc(message.length)
+            if (!private_key_ptr || !public_key_ptr || !message_ptr) {
+                throw new ThemisError(subsystem, ThemisErrorCode.NO_MEMORY)
+            }
+
+            libthemis.writeArrayToMemory(this.privateKey, private_key_ptr)
+            libthemis.writeArrayToMemory(this.publicKey, public_key_ptr)
+            libthemis.writeArrayToMemory(message, message_ptr)
+
+            status = libthemis._themis_secure_message_decrypt(
+                private_key_ptr, this.privateKey.length,
+                public_key_ptr, this.publicKey.length,
+                message_ptr, message.length,
+                null, result_length_ptr
+            )
+            if (status != ThemisErrorCode.BUFFER_TOO_SMALL) {
+                throw new ThemisError(subsystem, status)
+            }
+
+            result_length = libthemis.getValue(result_length_ptr, 'i32')
+            result_ptr = libthemis._malloc(result_length)
+            if (!result_ptr) {
+                throw new ThemisError(subsystem, ThemisErrorCode.NO_MEMORY)
+            }
+
+            status = libthemis._themis_secure_message_decrypt(
+                private_key_ptr, this.privateKey.length,
+                public_key_ptr, this.publicKey.length,
+                message_ptr, message.length,
+                result_ptr, result_length_ptr
+            )
+            if (status != ThemisErrorCode.SUCCESS) {
+                throw new ThemisError(subsystem, status)
+            }
+
+            result_length = libthemis.getValue(result_length_ptr, 'i32')
+
+            return libthemis.HEAPU8.slice(result_ptr, result_ptr + result_length)
+        }
+        finally {
+            libthemis._memset(private_key_ptr, 0, this.privateKey.length)
+            libthemis._free(private_key_ptr)
+            libthemis._free(public_key_ptr)
+            libthemis._free(message_ptr)
+            libthemis._free(result_ptr)
+        }
+    }
+}
+
+class SecureMessageSign {
+    constructor(privateKey) {
+        if (!(privateKey instanceof keygen.PrivateKey)) {
+            throw new ThemisError(subsystem, ThemisErrorCode.INVALID_PARAMETER,
+                'invalid argument: expected PrivateKey')
+        }
+        this.privateKey = privateKey
+    }
+
+    sign(message) {
+        message = utils.coerceToBytes(message)
+        if (message.length == 0) {
+            throw new ThemisError(subsystem, ThemisErrorCode.INVALID_PARAMETER,
+                'message must be not empty')
+        }
+
+        let status
+        /// C API uses "size_t" for lengths, it's defined as "i32" in Emscripten
+        let result_length_ptr = libthemis.allocate(4, 'i32', libthemis.ALLOC_STACK)
+        let private_key_ptr, message_ptr, result_ptr, result_length
+        try {
+            private_key_ptr = libthemis._malloc(this.privateKey.length)
+            message_ptr = libthemis._malloc(message.length)
+            if (!private_key_ptr || !message_ptr) {
+                throw new ThemisError(subsystem, ThemisErrorCode.NO_MEMORY)
+            }
+
+            libthemis.writeArrayToMemory(this.privateKey, private_key_ptr)
+            libthemis.writeArrayToMemory(message, message_ptr)
+
+            status = libthemis._themis_secure_message_sign(
+                private_key_ptr, this.privateKey.length,
+                message_ptr, message.length,
+                null, result_length_ptr
+            )
+            if (status != ThemisErrorCode.BUFFER_TOO_SMALL) {
+                throw new ThemisError(subsystem, status)
+            }
+
+            result_length = libthemis.getValue(result_length_ptr, 'i32')
+            result_ptr = libthemis._malloc(result_length)
+            if (!result_ptr) {
+                throw new ThemisError(subsystem, ThemisErrorCode.NO_MEMORY)
+            }
+
+            status = libthemis._themis_secure_message_sign(
+                private_key_ptr, this.privateKey.length,
+                message_ptr, message.length,
+                result_ptr, result_length_ptr
+            )
+            if (status != ThemisErrorCode.SUCCESS) {
+                throw new ThemisError(subsystem, status)
+            }
+
+            result_length = libthemis.getValue(result_length_ptr, 'i32')
+
+            return libthemis.HEAPU8.slice(result_ptr, result_ptr + result_length)
+        }
+        finally {
+            libthemis._memset(private_key_ptr, 0, this.privateKey.length)
+            libthemis._free(private_key_ptr)
+            libthemis._free(message_ptr)
+            libthemis._free(result_ptr)
+        }
+    }
+}
+
+class SecureMessageVerify {
+    constructor(publicKey) {
+        if (!(publicKey instanceof keygen.PublicKey)) {
+            throw new ThemisError(subsystem, ThemisErrorCode.INVALID_PARAMETER,
+                'invalid argument: expected PublicKey')
+        }
+        this.publicKey = publicKey
+    }
+
+    verify(message) {
+        message = utils.coerceToBytes(message)
+        if (message.length == 0) {
+            throw new ThemisError(subsystem, ThemisErrorCode.INVALID_PARAMETER,
+                'message must be not empty')
+        }
+
+        let status
+        /// C API uses "size_t" for lengths, it's defined as "i32" in Emscripten
+        let result_length_ptr = libthemis.allocate(4, 'i32', libthemis.ALLOC_STACK)
+        let public_key_ptr, message_ptr, result_ptr, result_length
+        try {
+            public_key_ptr = libthemis._malloc(this.publicKey.length)
+            message_ptr = libthemis._malloc(message.length)
+            if (!public_key_ptr || !message_ptr) {
+                throw new ThemisError(subsystem, ThemisErrorCode.NO_MEMORY)
+            }
+
+            libthemis.writeArrayToMemory(this.publicKey, public_key_ptr)
+            libthemis.writeArrayToMemory(message, message_ptr)
+
+            status = libthemis._themis_secure_message_verify(
+                public_key_ptr, this.publicKey.length,
+                message_ptr, message.length,
+                null, result_length_ptr
+            )
+            if (status != ThemisErrorCode.BUFFER_TOO_SMALL) {
+                throw new ThemisError(subsystem, status)
+            }
+
+            result_length = libthemis.getValue(result_length_ptr, 'i32')
+            result_ptr = libthemis._malloc(result_length)
+            if (!result_ptr) {
+                throw new ThemisError(subsystem, ThemisErrorCode.NO_MEMORY)
+            }
+
+            status = libthemis._themis_secure_message_verify(
+                public_key_ptr, this.publicKey.length,
+                message_ptr, message.length,
+                result_ptr, result_length_ptr
+            )
+            if (status != ThemisErrorCode.SUCCESS) {
+                throw new ThemisError(subsystem, status)
+            }
+
+            result_length = libthemis.getValue(result_length_ptr, 'i32')
+
+            return libthemis.HEAPU8.slice(result_ptr, result_ptr + result_length)
+        }
+        finally {
+            libthemis._free(public_key_ptr)
+            libthemis._free(message_ptr)
+            libthemis._free(result_ptr)
+        }
+    }
+}
+
+module.exports.SecureMessage = SecureMessage
+module.exports.SecureMessageSign = SecureMessageSign
+module.exports.SecureMessageVerify = SecureMessageVerify

--- a/src/wrappers/themis/wasm/src/secure_message.js
+++ b/src/wrappers/themis/wasm/src/secure_message.js
@@ -22,7 +22,7 @@ const keygen = require('./secure_keygen.js')
 const errors = require('./themis_error.js')
 const utils = require('./utils.js')
 
-const subsystem = 'SecureMessage'
+const cryptosystem_name = 'SecureMessage'
 
 const ThemisError = errors.ThemisError
 const ThemisErrorCode = errors.ThemisErrorCode
@@ -31,7 +31,7 @@ class SecureMessage {
     constructor(keyPair) {
         if (arguments.length == 1) {
             if (!(keyPair instanceof keygen.KeyPair)) {
-                throw new ThemisError(subsystem, ThemisErrorCode.INVALID_PARAMETER,
+                throw new ThemisError(cryptosystem_name, ThemisErrorCode.INVALID_PARAMETER,
                     'invalid argument: must be KeyPair')
             }
             this.privateKey = keyPair.privateKey
@@ -56,18 +56,18 @@ class SecureMessage {
                 return
             }
 
-            throw new ThemisError(subsystem, ThemisErrorCode.INVALID_PARAMETER,
+            throw new ThemisError(cryptosystem_name, ThemisErrorCode.INVALID_PARAMETER,
                 'invalid arguments: expected PrivateKey and PublicKey')
         }
 
-        throw new ThemisError(subsystem, ThemisErrorCode.INVALID_PARAMETER,
+        throw new ThemisError(cryptosystem_name, ThemisErrorCode.INVALID_PARAMETER,
             'invalid argument count: expected either one KeyPair, or PrivateKey and PublicKey')
     }
 
     encrypt(message) {
         message = utils.coerceToBytes(message)
         if (message.length == 0) {
-            throw new ThemisError(subsystem, ThemisErrorCode.INVALID_PARAMETER,
+            throw new ThemisError(cryptosystem_name, ThemisErrorCode.INVALID_PARAMETER,
                 'message must be not empty')
         }
 
@@ -80,7 +80,7 @@ class SecureMessage {
             public_key_ptr = libthemis._malloc(this.publicKey.length)
             message_ptr = libthemis._malloc(message.length)
             if (!private_key_ptr || !public_key_ptr || !message_ptr) {
-                throw new ThemisError(subsystem, ThemisErrorCode.NO_MEMORY)
+                throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY)
             }
 
             libthemis.writeArrayToMemory(this.privateKey, private_key_ptr)
@@ -94,13 +94,13 @@ class SecureMessage {
                 null, result_length_ptr
             )
             if (status != ThemisErrorCode.BUFFER_TOO_SMALL) {
-                throw new ThemisError(subsystem, status)
+                throw new ThemisError(cryptosystem_name, status)
             }
 
             result_length = libthemis.getValue(result_length_ptr, 'i32')
             result_ptr = libthemis._malloc(result_length)
             if (!result_ptr) {
-                throw new ThemisError(subsystem, ThemisErrorCode.NO_MEMORY)
+                throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY)
             }
 
             status = libthemis._themis_secure_message_encrypt(
@@ -110,7 +110,7 @@ class SecureMessage {
                 result_ptr, result_length_ptr
             )
             if (status != ThemisErrorCode.SUCCESS) {
-                throw new ThemisError(subsystem, status)
+                throw new ThemisError(cryptosystem_name, status)
             }
 
             result_length = libthemis.getValue(result_length_ptr, 'i32')
@@ -129,7 +129,7 @@ class SecureMessage {
     decrypt(message) {
         message = utils.coerceToBytes(message)
         if (message.length == 0) {
-            throw new ThemisError(subsystem, ThemisErrorCode.INVALID_PARAMETER,
+            throw new ThemisError(cryptosystem_name, ThemisErrorCode.INVALID_PARAMETER,
                 'message must be not empty')
         }
 
@@ -142,7 +142,7 @@ class SecureMessage {
             public_key_ptr = libthemis._malloc(this.publicKey.length)
             message_ptr = libthemis._malloc(message.length)
             if (!private_key_ptr || !public_key_ptr || !message_ptr) {
-                throw new ThemisError(subsystem, ThemisErrorCode.NO_MEMORY)
+                throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY)
             }
 
             libthemis.writeArrayToMemory(this.privateKey, private_key_ptr)
@@ -156,13 +156,13 @@ class SecureMessage {
                 null, result_length_ptr
             )
             if (status != ThemisErrorCode.BUFFER_TOO_SMALL) {
-                throw new ThemisError(subsystem, status)
+                throw new ThemisError(cryptosystem_name, status)
             }
 
             result_length = libthemis.getValue(result_length_ptr, 'i32')
             result_ptr = libthemis._malloc(result_length)
             if (!result_ptr) {
-                throw new ThemisError(subsystem, ThemisErrorCode.NO_MEMORY)
+                throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY)
             }
 
             status = libthemis._themis_secure_message_decrypt(
@@ -172,7 +172,7 @@ class SecureMessage {
                 result_ptr, result_length_ptr
             )
             if (status != ThemisErrorCode.SUCCESS) {
-                throw new ThemisError(subsystem, status)
+                throw new ThemisError(cryptosystem_name, status)
             }
 
             result_length = libthemis.getValue(result_length_ptr, 'i32')
@@ -192,7 +192,7 @@ class SecureMessage {
 class SecureMessageSign {
     constructor(privateKey) {
         if (!(privateKey instanceof keygen.PrivateKey)) {
-            throw new ThemisError(subsystem, ThemisErrorCode.INVALID_PARAMETER,
+            throw new ThemisError(cryptosystem_name, ThemisErrorCode.INVALID_PARAMETER,
                 'invalid argument: expected PrivateKey')
         }
         this.privateKey = privateKey
@@ -201,7 +201,7 @@ class SecureMessageSign {
     sign(message) {
         message = utils.coerceToBytes(message)
         if (message.length == 0) {
-            throw new ThemisError(subsystem, ThemisErrorCode.INVALID_PARAMETER,
+            throw new ThemisError(cryptosystem_name, ThemisErrorCode.INVALID_PARAMETER,
                 'message must be not empty')
         }
 
@@ -213,7 +213,7 @@ class SecureMessageSign {
             private_key_ptr = libthemis._malloc(this.privateKey.length)
             message_ptr = libthemis._malloc(message.length)
             if (!private_key_ptr || !message_ptr) {
-                throw new ThemisError(subsystem, ThemisErrorCode.NO_MEMORY)
+                throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY)
             }
 
             libthemis.writeArrayToMemory(this.privateKey, private_key_ptr)
@@ -225,13 +225,13 @@ class SecureMessageSign {
                 null, result_length_ptr
             )
             if (status != ThemisErrorCode.BUFFER_TOO_SMALL) {
-                throw new ThemisError(subsystem, status)
+                throw new ThemisError(cryptosystem_name, status)
             }
 
             result_length = libthemis.getValue(result_length_ptr, 'i32')
             result_ptr = libthemis._malloc(result_length)
             if (!result_ptr) {
-                throw new ThemisError(subsystem, ThemisErrorCode.NO_MEMORY)
+                throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY)
             }
 
             status = libthemis._themis_secure_message_sign(
@@ -240,7 +240,7 @@ class SecureMessageSign {
                 result_ptr, result_length_ptr
             )
             if (status != ThemisErrorCode.SUCCESS) {
-                throw new ThemisError(subsystem, status)
+                throw new ThemisError(cryptosystem_name, status)
             }
 
             result_length = libthemis.getValue(result_length_ptr, 'i32')
@@ -259,7 +259,7 @@ class SecureMessageSign {
 class SecureMessageVerify {
     constructor(publicKey) {
         if (!(publicKey instanceof keygen.PublicKey)) {
-            throw new ThemisError(subsystem, ThemisErrorCode.INVALID_PARAMETER,
+            throw new ThemisError(cryptosystem_name, ThemisErrorCode.INVALID_PARAMETER,
                 'invalid argument: expected PublicKey')
         }
         this.publicKey = publicKey
@@ -268,7 +268,7 @@ class SecureMessageVerify {
     verify(message) {
         message = utils.coerceToBytes(message)
         if (message.length == 0) {
-            throw new ThemisError(subsystem, ThemisErrorCode.INVALID_PARAMETER,
+            throw new ThemisError(cryptosystem_name, ThemisErrorCode.INVALID_PARAMETER,
                 'message must be not empty')
         }
 
@@ -280,7 +280,7 @@ class SecureMessageVerify {
             public_key_ptr = libthemis._malloc(this.publicKey.length)
             message_ptr = libthemis._malloc(message.length)
             if (!public_key_ptr || !message_ptr) {
-                throw new ThemisError(subsystem, ThemisErrorCode.NO_MEMORY)
+                throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY)
             }
 
             libthemis.writeArrayToMemory(this.publicKey, public_key_ptr)
@@ -292,13 +292,13 @@ class SecureMessageVerify {
                 null, result_length_ptr
             )
             if (status != ThemisErrorCode.BUFFER_TOO_SMALL) {
-                throw new ThemisError(subsystem, status)
+                throw new ThemisError(cryptosystem_name, status)
             }
 
             result_length = libthemis.getValue(result_length_ptr, 'i32')
             result_ptr = libthemis._malloc(result_length)
             if (!result_ptr) {
-                throw new ThemisError(subsystem, ThemisErrorCode.NO_MEMORY)
+                throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY)
             }
 
             status = libthemis._themis_secure_message_verify(
@@ -307,7 +307,7 @@ class SecureMessageVerify {
                 result_ptr, result_length_ptr
             )
             if (status != ThemisErrorCode.SUCCESS) {
-                throw new ThemisError(subsystem, status)
+                throw new ThemisError(cryptosystem_name, status)
             }
 
             result_length = libthemis.getValue(result_length_ptr, 'i32')


### PR DESCRIPTION
Initial implementation of **Secure Message** wrapper. We export it as three objects:

  - `SecureMessage` providing encrypt/decrypt mode

  - `SecureMessageSign` and `SecureMessageVerify` providing sign/verify mode

The reason for the split is to minimize possibility of API misuse. Encryption and decryption is likely to be bidirectional, therefore we require the users to specify both private and public keys. (Though it might make sense to allow specifying `null` for either of the keys in order to allow unidirectional message flow.) Signing and verifying signatures requires only one part of the key pair, so these object accept a corresponding key.

Note that we allow *only* PrivateKey or PublicKey instances. This ensures that we operate on valid keys every time.

As JavaScript is dynamically typed, we allow several constructor syntax for SecureMessage. We can accept either a KeyPair (a single entity), or two arguments with keys (in any order, so that devs don't have to remember the correct one in absence of static typing and helpful IDE hints).