### PR TITLE
WasmThemis: Secure Session support

### DIFF
--- a/src/wrappers/themis/wasm/runtime_exports.json
+++ b/src/wrappers/themis/wasm/runtime_exports.json
@@ -3,4 +3,5 @@
 , "allocate"
 , "ALLOC_STACK"
 , "writeArrayToMemory"
+, "addFunction"
 ]

--- a/src/wrappers/themis/wasm/src/index.js
+++ b/src/wrappers/themis/wasm/src/index.js
@@ -19,5 +19,6 @@
 
 Object.assign(module.exports
   , require('./secure_keygen.js')
+  , require('./secure_session.js')
   , require('./themis_error.js')
 )

--- a/src/wrappers/themis/wasm/src/secure_session.js
+++ b/src/wrappers/themis/wasm/src/secure_session.js
@@ -55,8 +55,8 @@ function isFunction(obj) {
 // Hence the following sizes and offsets:
 
 const sizeof_secure_session_user_callbacks_t = 20
-const offsetof_get_public_key_for_id         = 12
 const offsetof_user_data                     = 16
+const offsetof_get_public_key_for_id         = 12
 
 // One does not simply pass JavaScript function into Emscripten memory. We need to use
 // the "addFunction" API which registers a limited number of JavaScript functions and

--- a/src/wrappers/themis/wasm/src/secure_session.js
+++ b/src/wrappers/themis/wasm/src/secure_session.js
@@ -92,7 +92,7 @@ function registerSecureSession(callbacksPtr, session) {
     SecureSessionCallbackRegistry[callbacksPtr] = session
 }
 
-function unregisterSecureSssion(callbacksPtr) {
+function unregisterSecureSession(callbacksPtr) {
     delete SecureSessionCallbackRegistry[callbacksPtr]
 }
 
@@ -203,7 +203,7 @@ class SecureSession {
         }
         this.sessionPtr = null
 
-        unregisterSecureSssion(this.callbacksPtr)
+        unregisterSecureSession(this.callbacksPtr)
         libthemis._free(this.callbacksPtr)
         this.callbacksPtr = null
     }

--- a/src/wrappers/themis/wasm/src/secure_session.js
+++ b/src/wrappers/themis/wasm/src/secure_session.js
@@ -1,0 +1,413 @@
+// Copyright (c) 2019 Cossack Labs Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file
+ * Themis Secure Session.
+ */
+
+const libthemis = require('./libthemis.js')
+const keygen = require('./secure_keygen.js')
+const errors = require('./themis_error.js')
+const utils = require('./utils.js')
+
+const subsystem = 'SecureSession'
+
+const ThemisError = errors.ThemisError
+const ThemisErrorCode = errors.ThemisErrorCode
+
+function isFunction(obj) {
+    return !!(obj && obj.constructor && obj.call && obj.apply)
+}
+
+// Secure Session C API operatates with "secure_session_user_callbacks_t" context structure
+// defined in <themis/secure_session.h>. It must be filled in with C function pointers and
+// an arbitrary C context pointer. Associated C functions are called by Secure Session
+// at appropriate moments. They receive the C context pointer as their last argument which
+// allows to restore context.
+//
+// First, we need to be able to allocate and free "secure_session_user_callbacks_t", and to
+// initialize it before passing them to Secure Session constructor.
+//
+// Here's how it looks in C:
+//
+//     struct secure_session_user_callbacks_type {
+//          send_protocol_data_callback     send_data;
+//          receive_protocol_data_callback  receive_data;
+//          protocol_state_changed_callback state_changed;
+//          get_public_key_for_id_callback  get_public_key_for_id;
+//
+//          void *user_data;
+//     };
+//
+// On Emscripten target all pointers take up 4 bytes and are aligned at 4-byte boundary.
+// Hence the following sizes and offsets:
+
+const sizeof_secure_session_user_callbacks_t = 20
+const offsetof_get_public_key_for_id         = 12
+const offsetof_user_data                     = 16
+
+// One does not simply pass JavaScript function into Emscripten memory. We need to use
+// the "addFunction" API which registers a limited number of JavaScript functions and
+// provides corresponding C function pointers to thunks. We need only one callback so
+// it's relatively easy for us. We just need to ensure that the function is registered
+// only once.
+//
+// As for the context, we'll save a pointer to "secure_session_user_callbacks_t" itself
+// in its "user_data" field.
+
+var getPublicKeyForIdThunkPtr = 0
+
+function initUserCallbacks(callbacksPtr) {
+    if (getPublicKeyForIdThunkPtr == 0) {
+        // LLVM needs to know the prototype of the corresponding C function.
+        // See comment for "getPublicKeyForIdThunk" below.
+        getPublicKeyForIdThunkPtr = libthemis.addFunction(getPublicKeyForIdThunk, 'iiiiii')
+    }
+    libthemis._memset(callbacksPtr, 0, sizeof_secure_session_user_callbacks_t)
+    // We're writing LLVM pointers into memory, hence the '*' type specifier
+    libthemis.setValue(callbacksPtr + offsetof_get_public_key_for_id, getPublicKeyForIdThunkPtr, '*')
+    libthemis.setValue(callbacksPtr + offsetof_user_data, callbacksPtr, '*')
+}
+
+// Now we need to be able to identify JavaScript Secure Session object associated with
+// a particular "secure_session_user_callbacks_t" instance. Unfortunately, keeping another
+// global registry in JavaScript is the only feasible choice because JavaScript object
+// memory is managed completely opaquely.
+
+var SecureSessionCallbackRegistry = {}
+
+function registerSecureSession(callbacksPtr, session) {
+    SecureSessionCallbackRegistry[callbacksPtr] = session
+}
+
+function unregisterSecureSssion(callbacksPtr) {
+    delete SecureSessionCallbackRegistry[callbacksPtr]
+}
+
+function getSecureSession(callbacksPtr) {
+    return SecureSessionCallbackRegistry[callbacksPtr]
+}
+
+// Finally, here's our JavaScript implementation of the C function callback.
+// It has the following prototype:
+//
+//     int get_public_key_for_id_callback(
+//         const void* id,   size_t id_length,
+//         void* key_buffer, size_t key_buffer_length,
+//         void* user_data
+//     );
+//
+// It is expected to look up a public key corresponding to the provided session ID,
+// write the key into provided buffer, and return zero on success. Non-zero return
+// values are considered errors.
+//
+// The function accepts five integer argumentes and returns an integer. Hence its
+// LLVM signature is "iiiiii".
+//
+// We can throw JavaScript exceptions from inside the function, thanks to Emscripten.
+
+const GetPublicKeySuccess = 0
+const GetPublicKeyFailure = -1
+
+function getPublicKeyForIdThunk(idPtr, idLen, keyPtr, keyLen, userData) {
+    let id = libthemis.HEAPU8.slice(idPtr, idPtr + idLen)
+    let session = getSecureSession(userData)
+
+    let publicKey = session.keyCallback(id)
+    if (publicKey == null) {
+        return GetPublicKeyFailure
+    }
+
+    if (!(publicKey instanceof keygen.PublicKey)) {
+        throw new ThemisError(subsystem, ThemisErrorCode.INVALID_PARAMETER,
+            'Secure Session callback must return PublicKey or null')
+    }
+    if (publicKey.length > keyLen) {
+        throw new ThemisError(subsystem, ThemisErrorCode.BUFFER_TOO_SMALL,
+            'public key cannot fit into provided buffer')
+    }
+    libthemis.writeArrayToMemory(publicKey, keyPtr)
+
+    return GetPublicKeySuccess
+}
+
+class SecureSession {
+    constructor(sessionID, privateKey, keyCallback) {
+        sessionID = utils.coerceToBytes(sessionID)
+        if (sessionID.length == 0) {
+            throw new ThemisError(subsystem, ThemisErrorCode.INVALID_PARAMETER,
+                'session ID must be not empty')
+        }
+        if (!(privateKey instanceof keygen.PrivateKey)) {
+            throw new ThemisError(subsystem, ThemisErrorCode.INVALID_PARAMETER,
+                'expected PrivateKey as second argument')
+        }
+        if (!isFunction(keyCallback)) {
+            throw new ThemisError(subsystem, ThemisErrorCode.INVALID_PARAMETER,
+                'expected callback as third argument')
+        }
+
+        let session_id_ptr, private_key_ptr, callbacks_ptr
+        try {
+            session_id_ptr = libthemis._malloc(sessionID.length)
+            private_key_ptr = libthemis._malloc(privateKey.length)
+            callbacks_ptr = libthemis._malloc(sizeof_secure_session_user_callbacks_t)
+            if (!session_id_ptr || !private_key_ptr || !callbacks_ptr) {
+                throw new ThemisError(subsystem, ThemisErrorCode.NO_MEMORY)
+            }
+            libthemis.writeArrayToMemory(sessionID, session_id_ptr)
+            libthemis.writeArrayToMemory(privateKey, private_key_ptr)
+
+            this.keyCallback = keyCallback
+            initUserCallbacks(callbacks_ptr)
+
+            this.sessionPtr = libthemis._secure_session_create(
+                session_id_ptr, sessionID.length,
+                private_key_ptr, privateKey.length,
+                callbacks_ptr
+            )
+            if (!this.sessionPtr) {
+                throw new ThemisError(subsystem, ThemisErrorCode.NO_MEMORY,
+                    'failed to allocate Secure Session')
+            }
+
+            registerSecureSession(callbacks_ptr, this)
+            this.callbacksPtr = callbacks_ptr
+            callbacks_ptr = null
+        }
+        finally {
+            libthemis._memset(private_key_ptr, 0, privateKey.length)
+            libthemis._free(private_key_ptr)
+            libthemis._free(session_id_ptr)
+            libthemis._free(callbacks_ptr)
+        }
+    }
+
+    destroy() {
+        let status = libthemis._secure_session_destroy(this.sessionPtr)
+        if (status != ThemisErrorCode.SUCCESS) {
+            throw new ThemisError(subsystem, status,
+                'failed to destroy Secure Session')
+        }
+        this.sessionPtr = null
+
+        unregisterSecureSssion(this.callbacksPtr)
+        libthemis._free(this.callbacksPtr)
+        this.callbacksPtr = null
+    }
+
+    established() {
+        let value = libthemis._secure_session_is_established(this.sessionPtr)
+        return !(value == 0)
+    }
+
+    connectionRequest() {
+        let status
+        /// C API uses "size_t" for lengths, it's defined as "i32" in Emscripten
+        let request_length_ptr = libthemis.allocate(4, 'i32', libthemis.ALLOC_STACK)
+        let request_ptr, request_length
+        try {
+            status = libthemis._secure_session_generate_connect_request(
+                this.sessionPtr,
+                null, request_length_ptr
+            )
+            if (status != ThemisErrorCode.BUFFER_TOO_SMALL) {
+                throw new ThemisError(subsystem, status)
+            }
+
+            request_length = libthemis.getValue(request_length_ptr, 'i32')
+            request_ptr = libthemis._malloc(request_length)
+            if (!request_ptr) {
+                throw new ThemisError(subsystem, ThemisErrorCode.NO_MEMORY)
+            }
+
+            status = libthemis._secure_session_generate_connect_request(
+                this.sessionPtr,
+                request_ptr, request_length_ptr
+            )
+            if (status != ThemisErrorCode.SUCCESS) {
+                throw new ThemisError(subsystem, status)
+            }
+
+            request_length = libthemis.getValue(request_length_ptr, 'i32')
+
+            return libthemis.HEAPU8.slice(request_ptr, request_ptr + request_length)
+        }
+        finally {
+            libthemis._free(request_ptr)
+        }
+    }
+
+    negotiateReply(message) {
+        message = utils.coerceToBytes(message)
+        if (message.length == 0) {
+            throw new ThemisError(subsystem, ThemisErrorCode.INVALID_PARAMETER,
+                'message must be not empty')
+        }
+
+        let status
+        /// C API uses "size_t" for lengths, it's defined as "i32" in Emscripten
+        let reply_length_ptr = libthemis.allocate(4, 'i32', libthemis.ALLOC_STACK)
+        let message_ptr, reply_ptr, reply_length
+        try {
+            message_ptr = libthemis._malloc(message.length)
+            if (!message_ptr) {
+                throw new ThemisError(subsystem, ThemisErrorCode.NO_MEMORY)
+            }
+            libthemis.writeArrayToMemory(message, message_ptr)
+
+            status = libthemis._secure_session_unwrap(
+                this.sessionPtr,
+                message_ptr, message.length,
+                null, reply_length_ptr
+            )
+            if (status == ThemisErrorCode.SUCCESS) {
+                return new Uint8Array()
+            }
+            if (status != ThemisErrorCode.BUFFER_TOO_SMALL) {
+                throw new ThemisError(subsystem, status)
+            }
+
+            reply_length = libthemis.getValue(reply_length_ptr, 'i32')
+            reply_ptr = libthemis._malloc(reply_length)
+            if (!reply_ptr) {
+                throw new ThemisError(subsystem, ThemisErrorCode.NO_MEMORY)
+            }
+
+            status = libthemis._secure_session_unwrap(
+                this.sessionPtr,
+                message_ptr, message.length,
+                reply_ptr, reply_length_ptr
+            )
+            if (status != ThemisErrorCode.SSESSION_SEND_OUTPUT_TO_PEER) {
+                throw new ThemisError(subsystem, status)
+            }
+
+            reply_length = libthemis.getValue(reply_length_ptr, 'i32')
+
+            return libthemis.HEAPU8.slice(reply_ptr, reply_ptr + reply_length)
+        }
+        finally {
+            libthemis._free(message_ptr)
+            libthemis._free(reply_ptr)
+        }
+    }
+
+    wrap(message) {
+        message = utils.coerceToBytes(message)
+        if (message.length == 0) {
+            throw new ThemisError(subsystem, ThemisErrorCode.INVALID_PARAMETER,
+                'message must be not empty')
+        }
+
+        let status
+        /// C API uses "size_t" for lengths, it's defined as "i32" in Emscripten
+        let wrapped_length_ptr = libthemis.allocate(4, 'i32', libthemis.ALLOC_STACK)
+        let message_ptr, wrapped_ptr, wrapped_length
+        try {
+            message_ptr = libthemis._malloc(message.length)
+            if (!message_ptr) {
+                throw new ThemisError(subsystem, ThemisErrorCode.NO_MEMORY)
+            }
+            libthemis.writeArrayToMemory(message, message_ptr)
+
+            status = libthemis._secure_session_wrap(
+                this.sessionPtr,
+                message_ptr, message.length,
+                null, wrapped_length_ptr
+            )
+            if (status != ThemisErrorCode.BUFFER_TOO_SMALL) {
+                throw new ThemisError(subsystem, status)
+            }
+
+            wrapped_length = libthemis.getValue(wrapped_length_ptr, 'i32')
+            wrapped_ptr = libthemis._malloc(wrapped_length)
+            if (!wrapped_ptr) {
+                throw new ThemisError(subsystem, ThemisErrorCode.NO_MEMORY)
+            }
+
+            status = libthemis._secure_session_wrap(
+                this.sessionPtr,
+                message_ptr, message.length,
+                wrapped_ptr, wrapped_length_ptr
+            )
+            if (status != ThemisErrorCode.SUCCESS) {
+                throw new ThemisError(subsystem, status)
+            }
+
+            wrapped_length = libthemis.getValue(wrapped_length_ptr, 'i32')
+
+            return libthemis.HEAPU8.slice(wrapped_ptr, wrapped_ptr + wrapped_length)
+        }
+        finally {
+            libthemis._free(message_ptr)
+            libthemis._free(wrapped_ptr)
+        }
+    }
+
+    unwrap(message) {
+        message = utils.coerceToBytes(message)
+        if (message.length == 0) {
+            throw new ThemisError(subsystem, ThemisErrorCode.INVALID_PARAMETER,
+                'message must be not empty')
+        }
+
+        let status
+        /// C API uses "size_t" for lengths, it's defined as "i32" in Emscripten
+        let unwrapped_length_ptr = libthemis.allocate(4, 'i32', libthemis.ALLOC_STACK)
+        let message_ptr, unwrapped_ptr, unwrapped_length
+        try {
+            message_ptr = libthemis._malloc(message.length)
+            if (!message_ptr) {
+                throw new ThemisError(subsystem, ThemisErrorCode.NO_MEMORY)
+            }
+            libthemis.writeArrayToMemory(message, message_ptr)
+
+            status = libthemis._secure_session_unwrap(
+                this.sessionPtr,
+                message_ptr, message.length,
+                null, unwrapped_length_ptr
+            )
+            if (status != ThemisErrorCode.BUFFER_TOO_SMALL) {
+                throw new ThemisError(subsystem, status)
+            }
+
+            unwrapped_length = libthemis.getValue(unwrapped_length_ptr, 'i32')
+            unwrapped_ptr = libthemis._malloc(unwrapped_length)
+            if (!unwrapped_ptr) {
+                throw new ThemisError(subsystem, ThemisErrorCode.NO_MEMORY)
+            }
+
+            status = libthemis._secure_session_unwrap(
+                this.sessionPtr,
+                message_ptr, message.length,
+                unwrapped_ptr, unwrapped_length_ptr
+            )
+            if (status != ThemisErrorCode.SUCCESS) {
+                throw new ThemisError(subsystem, status)
+            }
+
+            unwrapped_length = libthemis.getValue(unwrapped_length_ptr, 'i32')
+
+            return libthemis.HEAPU8.slice(unwrapped_ptr, unwrapped_ptr + unwrapped_length)
+        }
+        finally {
+            libthemis._free(message_ptr)
+            libthemis._free(unwrapped_ptr)
+        }
+    }
+}
+
+module.exports.SecureSession = SecureSession

--- a/src/wrappers/themis/wasm/test/test.js
+++ b/src/wrappers/themis/wasm/test/test.js
@@ -77,4 +77,161 @@ describe('wasm-themis', function() {
             })
         })
     })
+    describe('Secure Session', function() {
+        let emptyArray = new Uint8Array()
+        let randomID = new Uint8Array([0x72, 0x61, 0x6E, 0x64, 0x6F, 0x6D])
+        let clientID = new Uint8Array([0x63, 0x6C, 0x69, 0x65, 0x6E, 0x74])
+        let serverID = new Uint8Array([0x73, 0x65, 0x72, 0x76, 0x65, 0x72])
+        let messageA = new Uint8Array([0x6D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65])
+        let messageB = new Uint8Array([0x73, 0x65, 0x63, 0x72, 0x65, 0x74, 0x73])
+        // Really nice of JavaScript to not have a standard library...
+        function arraysEqual(a, b) {
+            if (a === b) return true;
+            if (a == null || b == null) return false;
+            if (a.length != b.length) return false;
+            for (var i = 0; i < a.length; ++i) {
+                if (a[i] !== b[i]) return false;
+            }
+            return true;
+        }
+        function makeKeyMaterial() {
+            let keys = {}
+            keys.client = new themis.KeyPair()
+            keys.server = new themis.KeyPair()
+            keys.clientCallback = function(id) {
+                if (arraysEqual(id, serverID)) {
+                    return keys.server.publicKey
+                }
+                return null
+            }
+            keys.serverCallback = function(id) {
+                if (arraysEqual(id, clientID)) {
+                    return keys.client.publicKey
+                }
+                return null
+            }
+            return keys
+        }
+        it('establishes communication', function() {
+            let keys = makeKeyMaterial()
+            let client = new themis.SecureSession(clientID, keys.client.privateKey, keys.clientCallback)
+            let server = new themis.SecureSession(serverID, keys.server.privateKey, keys.serverCallback)
+
+            let data = client.connectionRequest()
+            let peer = server
+            while (!(client.established() && server.established())) {
+                data = peer.negotiateReply(data)
+                if (peer == server) {
+                    peer = client
+                } else {
+                    peer = server
+                }
+            }
+
+            let wrappedMessageA = client.wrap(messageA)
+            let unwrappedMessageA = server.unwrap(wrappedMessageA)
+            assert.deepStrictEqual(unwrappedMessageA, messageA)
+
+            let wrappedMessageB = server.wrap(messageB)
+            let unwrappedMessageB = client.unwrap(wrappedMessageB)
+            assert.deepStrictEqual(unwrappedMessageB, messageB)
+
+            client.destroy()
+            server.destroy()
+        })
+        it('handles unknown clients', function() {
+            let keys = makeKeyMaterial()
+            let client = new themis.SecureSession(randomID, keys.client.privateKey, keys.clientCallback)
+            let server = new themis.SecureSession(serverID, keys.server.privateKey, keys.serverCallback)
+
+            let request = client.connectionRequest()
+            assert.throws(() => server.negotiateReply(request),
+                expectError(ThemisErrorCode.SSESSION_GET_PUB_FOR_ID_CALLBACK_ERROR)
+            )
+
+            client.destroy()
+            server.destroy()
+        })
+        it('handles unknown servers', function() {
+            let keys = makeKeyMaterial()
+            let client = new themis.SecureSession(clientID, keys.client.privateKey, keys.clientCallback)
+            let server = new themis.SecureSession(randomID, keys.server.privateKey, keys.serverCallback)
+
+            let request = client.connectionRequest()
+            let reply = server.negotiateReply(request)
+            assert.throws(() => client.negotiateReply(reply),
+                expectError(ThemisErrorCode.SSESSION_GET_PUB_FOR_ID_CALLBACK_ERROR)
+            )
+
+            client.destroy()
+            server.destroy()
+        })
+        it('does not allow empty client ID', function() {
+            let keyPair = new themis.KeyPair()
+            assert.throws(() => new themis.SecureSession(emptyArray, keyPair.privateKey, function(){}),
+                expectError(ThemisErrorCode.INVALID_PARAMETER)
+            )
+        })
+        it('does not allow empty message', function() {
+            let keys = makeKeyMaterial()
+            let client = new themis.SecureSession(clientID, keys.client.privateKey, keys.clientCallback)
+            let server = new themis.SecureSession(serverID, keys.server.privateKey, keys.serverCallback)
+
+            let data = client.connectionRequest()
+            let peer = server
+            while (!(client.established() && server.established())) {
+                data = peer.negotiateReply(data)
+                if (peer == server) {
+                    peer = client
+                } else {
+                    peer = server
+                }
+            }
+
+            assert.throws(() => server.wrap(emptyArray),
+                expectError(ThemisErrorCode.INVALID_PARAMETER)
+            )
+
+            client.destroy()
+            server.destroy()
+        })
+        it('does not allow public keys in constructor', function() {
+            let keyPair = new themis.KeyPair()
+            assert.throws(() => new themis.SecureSession(clientID, keyPair.publicKey, function(){}),
+                expectError(ThemisErrorCode.INVALID_PARAMETER)
+            )
+        })
+        it('does not allow private keys in callback', function() {
+            let keys = makeKeyMaterial()
+            let client = new themis.SecureSession(clientID, keys.client.privateKey, function(id) {
+                if (arraysEqual(id, serverID)) {
+                    return keys.server.privateKey
+                }
+            })
+            let server = new themis.SecureSession(serverID, keys.server.privateKey, keys.serverCallback)
+
+            let request = client.connectionRequest()
+            let reply = server.negotiateReply(request)
+            assert.throws(() => client.negotiateReply(reply),
+                expectError(ThemisErrorCode.INVALID_PARAMETER)
+            )
+
+            client.destroy()
+            server.destroy()
+
+        })
+        it('handles exception in callback', function() {
+            let keys = makeKeyMaterial()
+            let client = new themis.SecureSession(randomID, keys.client.privateKey, keys.clientCallback)
+            let server = new themis.SecureSession(serverID, keys.server.privateKey, function(id) {
+                throw "a ball"
+            })
+
+            let request = client.connectionRequest()
+            assert.throws(() => server.negotiateReply(request), "a ball")
+
+            client.destroy()
+            server.destroy()
+        })
+    })
 })

--- a/src/wrappers/themis/wasm/wasmthemis.mk
+++ b/src/wrappers/themis/wasm/wasmthemis.mk
@@ -21,7 +21,7 @@ WASM_SRC += $(wildcard $(WASM_PATH)/src/*.js)
 
 WASM_RUNTIME = $(abspath $(WASM_PATH)/runtime_exports.json)
 
-$(BIN_PATH)/libthemis.js: LDFLAGS += -s EXTRA_EXPORTED_RUNTIME_METHODS=@$(WASM_RUNTIME)
+$(BIN_PATH)/libthemis.js: LDFLAGS += -s EXTRA_EXPORTED_RUNTIME_METHODS=@$(WASM_RUNTIME) -s RESERVED_FUNCTION_POINTERS=1
 
 $(BIN_PATH)/libthemis.js: CMD = $(CC) -o $@ $(filter %.o %a, $^) $(LDFLAGS)
 


### PR DESCRIPTION
Initial implementation of **Secure Session** wrapper. It is exported as `SecureSession` object.

This is the most complex API of Themis both in implementation and usage. It stems from the fact that it use C callbacks, which do not map onto other languages directly. Our approach for Secure Session is described in code comments as it relies on a number of assumptions. Ultimately, we use Emscripten's `addFunction` API to bridge JavaScript callbacks provided by WasmThemis users into Emscripten world.

Just like Secure Comparator, Secure Session also requires manual resource management from the users. That's unfortunate but unavoidable. Similarly, we provide some additional error checks and reporting to prevent common mistakes in Secure Session usage.

Note that we provide only buffer-oriented API of Secure Session. The only callback that the user can register is the required one for obtaining public key by session ID. Using transport-oriented API in JavaScript it hard because it assumes synchronous IO while normally JavaScript uses asynchronous network transfers.