### PR TITLE
Improved type safety tests

### DIFF
--- a/src/wrappers/themis/wasm/test/test.js
+++ b/src/wrappers/themis/wasm/test/test.js
@@ -74,6 +74,12 @@ describe('wasm-themis', function() {
             ])
         })
     })
+    let generallyInvalidArguments = [
+        null, undefined, 'string',
+        new Int16Array([1, 2, 3]), [4, 5, 6],
+        () => new Uint8Array([27, 18, 28, 18, 28]),
+        { value: [3, 14, 15, 92, 6] }
+    ]
     describe('KeyPair', function() {
         it('generates EC key pairs', function() {
             let pair = new themis.KeyPair()
@@ -95,6 +101,13 @@ describe('wasm-themis', function() {
                     new themis.KeyPair(thatPair.publicKey, thatPair.privateKey)
                 },
                 expectError(ThemisErrorCode.INVALID_PARAMETER)
+            )
+        })
+        it('handles type mismatches', function() {
+            forEachCombination(function(private, public) {
+                    assert.throws(() => new themis.KeyPair(private, public), TypeError)
+                },
+                generallyInvalidArguments, generallyInvalidArguments
             )
         })
         describe('invididual keys', function() {
@@ -121,6 +134,14 @@ describe('wasm-themis', function() {
                 let key = new themis.KeyPair().privateKey
                 key[20] = 256 - key[20]
                 assert.throws(() => new themis.PrivateKey(key))
+            })
+            it('handles type mismatches', function() {
+                forEachCombination(function(key) {
+                        assert.throws(() => new themis.PrivateKey(key), TypeError)
+                        assert.throws(() => new themis.PublicKey(key), TypeError)
+                    },
+                    generallyInvalidArguments
+                )
             })
         })
     })

--- a/src/wrappers/themis/wasm/test/test.js
+++ b/src/wrappers/themis/wasm/test/test.js
@@ -681,6 +681,21 @@ describe('wasm-themis', function() {
             assert.throws(() => comparison.append(new Uint8Array()))
             comparison.destroy()
         })
+        it('handles type mismatches', function() {
+            let comparison = new themis.SecureComparator()
+            forEachCombination(function(invalid) {
+                    assert.throws(() => comparison.append(invalid), TypeError)
+                },
+                generallyInvalidArguments
+            )
+            comparison.append(secretBytes)
+            forEachCombination(function(invalid) {
+                    assert.throws(() => comparison.proceed(invalid), TypeError)
+                },
+                generallyInvalidArguments
+            )
+            comparison.destroy()
+        })
     })
     describe('Secure Session', function() {
         let emptyArray = new Uint8Array()

--- a/src/wrappers/themis/wasm/test/test.js
+++ b/src/wrappers/themis/wasm/test/test.js
@@ -473,6 +473,23 @@ describe('wasm-themis', function() {
                     expectError(ThemisErrorCode.FAIL)
                 )
             })
+            it('handles type mismatches', function() {
+                let keyPair = new themis.KeyPair()
+                let secureMessage = new themis.SecureMessage(keyPair)
+                forEachCombination(function(invalid) {
+                        assert.throws(() => new themis.SecureMessage(invalid),
+                                      expectError(ThemisErrorCode.INVALID_PARAMETER))
+                        assert.throws(() => new themis.SecureMessage(keyPair.publicKey, invalid),
+                                      expectError(ThemisErrorCode.INVALID_PARAMETER))
+                        assert.throws(() => new themis.SecureMessage(invalid, keyPair.privateKey),
+                                      expectError(ThemisErrorCode.INVALID_PARAMETER))
+
+                        assert.throws(() => secureMessage.encrypt(invalid), TypeError)
+                        assert.throws(() => secureMessage.decrypt(invalid), TypeError)
+                    },
+                    generallyInvalidArguments
+                )
+            })
         })
         describe('sign/verify mode', function() {
             it('requires valid keys', function() {
@@ -542,6 +559,22 @@ describe('wasm-themis', function() {
                 signed[12] = 256 - signed[12]
                 assert.throws(() => verifier.verify(signed),
                     expectError(ThemisErrorCode.FAIL)
+                )
+            })
+            it('handles type mismatches', function() {
+                let keyPair = new themis.KeyPair()
+                let signer = new themis.SecureMessageSign(keyPair.privateKey)
+                let verifier = new themis.SecureMessageVerify(keyPair.publicKey)
+                forEachCombination(function(invalid) {
+                        assert.throws(() => new themis.SecureMessageSign(invalid),
+                                      expectError(ThemisErrorCode.INVALID_PARAMETER))
+                        assert.throws(() => new themis.SecureMessageVerify(invalid),
+                                      expectError(ThemisErrorCode.INVALID_PARAMETER))
+
+                        assert.throws(() => signer.sign(invalid), TypeError)
+                        assert.throws(() => verifier.verify(invalid), TypeError)
+                    },
+                    generallyInvalidArguments
                 )
             })
         })

--- a/src/wrappers/themis/wasm/test/test.js
+++ b/src/wrappers/themis/wasm/test/test.js
@@ -119,6 +119,8 @@ describe('wasm-themis', function() {
             it('do not allow empty keys', function() {
                 assert.throws(() => new themis.PrivateKey(new Uint8Array()))
                 assert.throws(() => new themis.PublicKey(new Uint8Array()))
+                assert.throws(() => new themis.PrivateKey(''))
+                assert.throws(() => new themis.PublicKey(''))
             })
             it('check strict types', function() {
                 let key = new themis.KeyPair().publicKey

--- a/src/wrappers/themis/wasm/test/test.js
+++ b/src/wrappers/themis/wasm/test/test.js
@@ -26,7 +26,54 @@ function expectError(errorCode) {
     }
 }
 
+function forEachCombination(closure) {
+    if (arguments.length <= 1) {
+        return
+    }
+    let args = new Array(arguments.length - 1)
+    let indices = new Array(arguments.length - 1)
+    for (var i = 0; i < indices.length; i++) {
+        indices[i] = 0
+    }
+    // So that we get all-zeros values on the first entry into the loop:
+    indices[indices.length - 1] = -1
+    // For each iteration increase the last index and propagate carry-over,
+    // continue until we iterate through all possible index combinations.
+    while (true) {
+        indices[indices.length - 1]++
+        for (var i = indices.length - 1; i >=0; i--) {
+            // If there is no carry-over then we're done
+            if (indices[i] < arguments[i + 1].length) {
+                break
+            }
+            // If we overflow then there are no more combinations to try
+            if (i == 0) {
+                return
+            }
+            indices[i] = 0
+            indices[i - 1]++
+        }
+        // Construct argument array with actual values and pass it to the closure
+        for (var i = 0; i < indices.length; i++) {
+            args[i] = arguments[i + 1][indices[i]]
+        }
+        closure.apply(null, args)
+    }
+}
+
 describe('wasm-themis', function() {
+    describe('test utilities', function() {
+        it('enumerates all combinations', function() {
+            var combinations = []
+            forEachCombination(function(n1, n2, n3) {
+                combinations.push([n1, n2, n3])
+            }, [1, 2], [3, 4, 5], [6, 7])
+            assert.deepStrictEqual(combinations, [
+                [1, 3, 6], [1, 3, 7], [1, 4, 6], [1, 4, 7], [1, 5, 6], [1, 5, 7],
+                [2, 3, 6], [2, 3, 7], [2, 4, 6], [2, 4, 7], [2, 5, 6], [2, 5, 7]
+            ])
+        })
+    })
     describe('KeyPair', function() {
         it('generates EC key pairs', function() {
             let pair = new themis.KeyPair()


### PR DESCRIPTION
JavaScript is dynamically typed, therefore it is highly likely that at some point one of our users will try using something that's not supposed to be used with Themis functions. Add some more tests to ensure that we do cover all the bases and do not accept invalid arguments when we do not support them.

There are quite a few cases that we need to cover:

- `null` & `undefined` (but sometimes `null` is allowed)
- strings (that's debatable, but most API should not accept them directly)
- untyped JavaScript arrays as well as all typed arrays that are not byte arrays
- promises which could come from other async API in JavaScript
- random objects should not be implicitly casted into arrays (one never knows...)

I don't want to miss any of these by chance, and it will be nice to be able to add or remove exceptions for all tests simultaneously. I have added a helper functions to enumerate all possible combinations for arguments. Hopefully it should make it easier to write combinatorial tests.

---

- [x] Add a common helper function
- [x] Cover all cryptosystems
   - [x] Key generation (this PR)
   - [x] Secure Cell (#462)
   - [x] Secure Message (#490)
   - [x] Secure Comparator (#491)
   - [x] Secure Session (#492)