### PR TITLE
Secure usage of Emscripten heap

### DIFF
--- a/src/wrappers/themis/wasm/src/secure_cell_context_imprint.js
+++ b/src/wrappers/themis/wasm/src/secure_cell_context_imprint.js
@@ -62,16 +62,16 @@ module.exports = class SecureCellContextImprint {
         let result_length_ptr = libthemis.allocate(4, 'i32', libthemis.ALLOC_STACK)
         let master_key_ptr, message_ptr, context_ptr, result_ptr, result_length
         try {
-            master_key_ptr = libthemis._malloc(this.masterKey.length)
-            message_ptr = libthemis._malloc(message.length)
-            context_ptr = libthemis._malloc(context.length)
+            master_key_ptr = utils.heapAlloc(this.masterKey.length)
+            message_ptr = utils.heapAlloc(message.length)
+            context_ptr = utils.heapAlloc(context.length)
             if (!master_key_ptr || !message_ptr || !context_ptr) {
                 throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY)
             }
 
-            libthemis.writeArrayToMemory(this.masterKey, master_key_ptr)
-            libthemis.writeArrayToMemory(message, message_ptr)
-            libthemis.writeArrayToMemory(context, context_ptr)
+            utils.heapPutArray(this.masterKey, master_key_ptr)
+            utils.heapPutArray(message, message_ptr)
+            utils.heapPutArray(context, context_ptr)
 
             status = libthemis._themis_secure_cell_encrypt_context_imprint(
                 master_key_ptr, this.masterKey.length,
@@ -84,7 +84,7 @@ module.exports = class SecureCellContextImprint {
             }
 
             result_length = libthemis.getValue(result_length_ptr, 'i32')
-            result_ptr = libthemis._malloc(result_length)
+            result_ptr = utils.heapAlloc(result_length)
             if (!result_ptr) {
                 throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY)
             }
@@ -101,14 +101,13 @@ module.exports = class SecureCellContextImprint {
 
             result_length = libthemis.getValue(result_length_ptr, 'i32')
 
-            return libthemis.HEAPU8.slice(result_ptr, result_ptr + result_length)
+            return utils.heapGetArray(result_ptr, result_length)
         }
         finally {
-            libthemis._memset(master_key_ptr, 0, this.masterKey.length)
-            libthemis._free(master_key_ptr)
-            libthemis._free(message_ptr)
-            libthemis._free(context_ptr)
-            libthemis._free(result_ptr)
+            utils.heapFree(master_key_ptr, this.masterKey.length)
+            utils.heapFree(message_ptr, message.length)
+            utils.heapFree(context_ptr, context.length)
+            utils.heapFree(result_ptr, result_length)
         }
     }
 
@@ -138,16 +137,16 @@ module.exports = class SecureCellContextImprint {
         let result_length_ptr = libthemis.allocate(4, 'i32', libthemis.ALLOC_STACK)
         let master_key_ptr, message_ptr, context_ptr, result_ptr, result_length
         try {
-            master_key_ptr = libthemis._malloc(this.masterKey.length)
-            message_ptr = libthemis._malloc(message.length)
-            context_ptr = libthemis._malloc(context.length)
+            master_key_ptr = utils.heapAlloc(this.masterKey.length)
+            message_ptr = utils.heapAlloc(message.length)
+            context_ptr = utils.heapAlloc(context.length)
             if (!master_key_ptr || !message_ptr || !context_ptr) {
                 throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY)
             }
 
-            libthemis.writeArrayToMemory(this.masterKey, master_key_ptr)
-            libthemis.writeArrayToMemory(message, message_ptr)
-            libthemis.writeArrayToMemory(context, context_ptr)
+            utils.heapPutArray(this.masterKey, master_key_ptr)
+            utils.heapPutArray(message, message_ptr)
+            utils.heapPutArray(context, context_ptr)
 
             status = libthemis._themis_secure_cell_decrypt_context_imprint(
                 master_key_ptr, this.masterKey.length,
@@ -160,7 +159,7 @@ module.exports = class SecureCellContextImprint {
             }
 
             result_length = libthemis.getValue(result_length_ptr, 'i32')
-            result_ptr = libthemis._malloc(result_length)
+            result_ptr = utils.heapAlloc(result_length)
             if (!result_ptr) {
                 throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY)
             }
@@ -177,14 +176,13 @@ module.exports = class SecureCellContextImprint {
 
             result_length = libthemis.getValue(result_length_ptr, 'i32')
 
-            return libthemis.HEAPU8.slice(result_ptr, result_ptr + result_length)
+            return utils.heapGetArray(result_ptr, result_length)
         }
         finally {
-            libthemis._memset(master_key_ptr, 0, this.masterKey.length)
-            libthemis._free(master_key_ptr)
-            libthemis._free(message_ptr)
-            libthemis._free(context_ptr)
-            libthemis._free(result_ptr)
+            utils.heapFree(master_key_ptr, this.masterKey.length)
+            utils.heapFree(message_ptr, message.length)
+            utils.heapFree(context_ptr, context.length)
+            utils.heapFree(result_ptr, result_length)
         }
     }
 }

--- a/src/wrappers/themis/wasm/src/secure_cell_seal.js
+++ b/src/wrappers/themis/wasm/src/secure_cell_seal.js
@@ -55,16 +55,16 @@ module.exports = class SecureCellSeal {
         let result_length_ptr = libthemis.allocate(4, 'i32', libthemis.ALLOC_STACK)
         let master_key_ptr, message_ptr, context_ptr, result_ptr, result_length
         try {
-            master_key_ptr = libthemis._malloc(this.masterKey.length)
-            message_ptr = libthemis._malloc(message.length)
-            context_ptr = libthemis._malloc(context.length)
+            master_key_ptr = utils.heapAlloc(this.masterKey.length)
+            message_ptr = utils.heapAlloc(message.length)
+            context_ptr = utils.heapAlloc(context.length)
             if (!master_key_ptr || !message_ptr || !context_ptr) {
                 throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY)
             }
 
-            libthemis.writeArrayToMemory(this.masterKey, master_key_ptr)
-            libthemis.writeArrayToMemory(message, message_ptr)
-            libthemis.writeArrayToMemory(context, context_ptr)
+            utils.heapPutArray(this.masterKey, master_key_ptr)
+            utils.heapPutArray(message, message_ptr)
+            utils.heapPutArray(context, context_ptr)
 
             status = libthemis._themis_secure_cell_encrypt_seal(
                 master_key_ptr, this.masterKey.length,
@@ -77,7 +77,7 @@ module.exports = class SecureCellSeal {
             }
 
             result_length = libthemis.getValue(result_length_ptr, 'i32')
-            result_ptr = libthemis._malloc(result_length)
+            result_ptr = utils.heapAlloc(result_length)
             if (!result_ptr) {
                 throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY)
             }
@@ -94,14 +94,13 @@ module.exports = class SecureCellSeal {
 
             result_length = libthemis.getValue(result_length_ptr, 'i32')
 
-            return libthemis.HEAPU8.slice(result_ptr, result_ptr + result_length)
+            return utils.heapGetArray(result_ptr, result_length)
         }
         finally {
-            libthemis._memset(master_key_ptr, 0, this.masterKey.length)
-            libthemis._free(master_key_ptr)
-            libthemis._free(message_ptr)
-            libthemis._free(context_ptr)
-            libthemis._free(result_ptr)
+            utils.heapFree(master_key_ptr, this.masterKey.length)
+            utils.heapFree(message_ptr, message.length)
+            utils.heapFree(context_ptr, context.length)
+            utils.heapFree(result_ptr, result_length)
         }
     }
 
@@ -124,16 +123,16 @@ module.exports = class SecureCellSeal {
         let result_length_ptr = libthemis.allocate(4, 'i32', libthemis.ALLOC_STACK)
         let master_key_ptr, message_ptr, context_ptr, result_ptr, result_length
         try {
-            master_key_ptr = libthemis._malloc(this.masterKey.length)
-            message_ptr = libthemis._malloc(message.length)
-            context_ptr = libthemis._malloc(context.length)
+            master_key_ptr = utils.heapAlloc(this.masterKey.length)
+            message_ptr = utils.heapAlloc(message.length)
+            context_ptr = utils.heapAlloc(context.length)
             if (!master_key_ptr || !message_ptr || !context_ptr) {
                 throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY)
             }
 
-            libthemis.writeArrayToMemory(this.masterKey, master_key_ptr)
-            libthemis.writeArrayToMemory(message, message_ptr)
-            libthemis.writeArrayToMemory(context, context_ptr)
+            utils.heapPutArray(this.masterKey, master_key_ptr)
+            utils.heapPutArray(message, message_ptr)
+            utils.heapPutArray(context, context_ptr)
 
             status = libthemis._themis_secure_cell_decrypt_seal(
                 master_key_ptr, this.masterKey.length,
@@ -146,7 +145,7 @@ module.exports = class SecureCellSeal {
             }
 
             result_length = libthemis.getValue(result_length_ptr, 'i32')
-            result_ptr = libthemis._malloc(result_length)
+            result_ptr = utils.heapAlloc(result_length)
             if (!result_ptr) {
                 throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY)
             }
@@ -163,14 +162,13 @@ module.exports = class SecureCellSeal {
 
             result_length = libthemis.getValue(result_length_ptr, 'i32')
 
-            return libthemis.HEAPU8.slice(result_ptr, result_ptr + result_length)
+            return utils.heapGetArray(result_ptr, result_length)
         }
         finally {
-            libthemis._memset(master_key_ptr, 0, this.masterKey.length)
-            libthemis._free(master_key_ptr)
-            libthemis._free(message_ptr)
-            libthemis._free(context_ptr)
-            libthemis._free(result_ptr)
+            utils.heapFree(master_key_ptr, this.masterKey.length)
+            utils.heapFree(message_ptr, message.length)
+            utils.heapFree(context_ptr, context.length)
+            utils.heapFree(result_ptr, result_length)
         }
     }
 }

--- a/src/wrappers/themis/wasm/src/secure_cell_token_protect.js
+++ b/src/wrappers/themis/wasm/src/secure_cell_token_protect.js
@@ -56,16 +56,16 @@ module.exports = class SecureCellTokenProtect {
         let token_length_ptr = libthemis.allocate(4, 'i32', libthemis.ALLOC_STACK)
         let master_key_ptr, message_ptr, context_ptr, result_ptr, result_length, token_ptr, token_length
         try {
-            master_key_ptr = libthemis._malloc(this.masterKey.length)
-            message_ptr = libthemis._malloc(message.length)
-            context_ptr = libthemis._malloc(context.length)
+            master_key_ptr = utils.heapAlloc(this.masterKey.length)
+            message_ptr = utils.heapAlloc(message.length)
+            context_ptr = utils.heapAlloc(context.length)
             if (!master_key_ptr || !message_ptr || !context_ptr) {
                 throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY)
             }
 
-            libthemis.writeArrayToMemory(this.masterKey, master_key_ptr)
-            libthemis.writeArrayToMemory(message, message_ptr)
-            libthemis.writeArrayToMemory(context, context_ptr)
+            utils.heapPutArray(this.masterKey, master_key_ptr)
+            utils.heapPutArray(message, message_ptr)
+            utils.heapPutArray(context, context_ptr)
 
             status = libthemis._themis_secure_cell_encrypt_token_protect(
                 master_key_ptr, this.masterKey.length,
@@ -80,8 +80,8 @@ module.exports = class SecureCellTokenProtect {
 
             result_length = libthemis.getValue(result_length_ptr, 'i32')
             token_length = libthemis.getValue(token_length_ptr, 'i32')
-            result_ptr = libthemis._malloc(result_length)
-            token_ptr = libthemis._malloc(token_length)
+            result_ptr = utils.heapAlloc(result_length)
+            token_ptr = utils.heapAlloc(token_length)
             if (!result_ptr || !token_ptr) {
                 throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY)
             }
@@ -101,17 +101,16 @@ module.exports = class SecureCellTokenProtect {
             token_length = libthemis.getValue(token_length_ptr, 'i32')
 
             return {
-                data: libthemis.HEAPU8.slice(result_ptr, result_ptr + result_length),
-                token: libthemis.HEAPU8.slice(token_ptr, token_ptr + token_length)
+                data: utils.heapGetArray(result_ptr, result_length),
+                token: utils.heapGetArray(token_ptr, token_length)
             }
         }
         finally {
-            libthemis._memset(master_key_ptr, 0, this.masterKey.length)
-            libthemis._free(master_key_ptr)
-            libthemis._free(message_ptr)
-            libthemis._free(context_ptr)
-            libthemis._free(result_ptr)
-            libthemis._free(token_ptr)
+            utils.heapFree(master_key_ptr, this.masterKey.length)
+            utils.heapFree(message_ptr, message.length)
+            utils.heapFree(context_ptr, context.length)
+            utils.heapFree(result_ptr, result_length)
+            utils.heapFree(token_ptr, token_length)
         }
     }
 
@@ -140,18 +139,18 @@ module.exports = class SecureCellTokenProtect {
         let result_length_ptr = libthemis.allocate(4, 'i32', libthemis.ALLOC_STACK)
         let master_key_ptr, message_ptr, context_ptr, token_ptr, result_ptr, result_length
         try {
-            master_key_ptr = libthemis._malloc(this.masterKey.length)
-            message_ptr = libthemis._malloc(message.length)
-            context_ptr = libthemis._malloc(context.length)
-            token_ptr = libthemis._malloc(token.length)
+            master_key_ptr = utils.heapAlloc(this.masterKey.length)
+            message_ptr = utils.heapAlloc(message.length)
+            context_ptr = utils.heapAlloc(context.length)
+            token_ptr = utils.heapAlloc(token.length)
             if (!master_key_ptr || !message_ptr || !context_ptr || !token_ptr) {
                 throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY)
             }
 
-            libthemis.writeArrayToMemory(this.masterKey, master_key_ptr)
-            libthemis.writeArrayToMemory(message, message_ptr)
-            libthemis.writeArrayToMemory(context, context_ptr)
-            libthemis.writeArrayToMemory(token, token_ptr)
+            utils.heapPutArray(this.masterKey, master_key_ptr)
+            utils.heapPutArray(message, message_ptr)
+            utils.heapPutArray(context, context_ptr)
+            utils.heapPutArray(token, token_ptr)
 
             status = libthemis._themis_secure_cell_decrypt_token_protect(
                 master_key_ptr, this.masterKey.length,
@@ -165,7 +164,7 @@ module.exports = class SecureCellTokenProtect {
             }
 
             result_length = libthemis.getValue(result_length_ptr, 'i32')
-            result_ptr = libthemis._malloc(result_length)
+            result_ptr = utils.heapAlloc(result_length)
             if (!result_ptr) {
                 throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY)
             }
@@ -183,15 +182,14 @@ module.exports = class SecureCellTokenProtect {
 
             result_length = libthemis.getValue(result_length_ptr, 'i32')
 
-            return libthemis.HEAPU8.slice(result_ptr, result_ptr + result_length)
+            return utils.heapGetArray(result_ptr, result_length)
         }
         finally {
-            libthemis._memset(master_key_ptr, 0, this.masterKey.length)
-            libthemis._free(master_key_ptr)
-            libthemis._free(message_ptr)
-            libthemis._free(context_ptr)
-            libthemis._free(token_ptr)
-            libthemis._free(result_ptr)
+            utils.heapFree(master_key_ptr, this.masterKey.length)
+            utils.heapFree(message_ptr, message.length)
+            utils.heapFree(context_ptr, context.length)
+            utils.heapFree(result_ptr, result_length)
+            utils.heapFree(token_ptr, token.length)
         }
     }
 }

--- a/src/wrappers/themis/wasm/src/secure_comparator.js
+++ b/src/wrappers/themis/wasm/src/secure_comparator.js
@@ -61,11 +61,12 @@ class SecureComparator {
 
         let secret_ptr
         try {
-            secret_ptr = libthemis._malloc(secret.length)
+            secret_ptr = utils.heapAlloc(secret.length)
             if (!secret_ptr) {
                 throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY)
             }
-            libthemis.writeArrayToMemory(secret, secret_ptr)
+
+            utils.heapPutArray(secret, secret_ptr)
 
             let status = libthemis._secure_comparator_append_secret(
                 this.comparatorPtr, secret_ptr, secret.length
@@ -75,8 +76,7 @@ class SecureComparator {
             }
         }
         finally {
-            libthemis._memset(secret_ptr, 0, secret.length)
-            libthemis._free(secret_ptr)
+            utils.heapFree(secret_ptr, secret.length)
         }
 
         this.haveSecret = true
@@ -117,7 +117,7 @@ class SecureComparator {
             }
 
             message_length = libthemis.getValue(message_length_ptr, 'i32')
-            message_ptr = libthemis._malloc(message_length)
+            message_ptr = utils.heapAlloc(message_length)
             if (!message_ptr) {
                 throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY)
             }
@@ -131,10 +131,10 @@ class SecureComparator {
 
             message_length = libthemis.getValue(message_length_ptr, 'i32')
 
-            return libthemis.HEAPU8.slice(message_ptr, message_ptr + message_length)
+            return utils.heapGetArray(message_ptr, message_length)
         }
         finally {
-            libthemis._free(message_ptr)
+            utils.heapFree(message_ptr, message_length)
         }
     }
 
@@ -146,11 +146,12 @@ class SecureComparator {
         let reply_length_ptr = libthemis.allocate(4, 'i32', libthemis.ALLOC_STACK)
         let request_ptr, reply_ptr, reply_length
         try {
-            request_ptr = libthemis._malloc(request.length)
+            request_ptr = utils.heapAlloc(request.length)
             if (!request_ptr) {
                 throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY)
             }
-            libthemis.writeArrayToMemory(request, request_ptr)
+
+            utils.heapPutArray(request, request_ptr)
 
             status = libthemis._secure_comparator_proceed_compare(this.comparatorPtr,
                 request_ptr, request.length,
@@ -161,7 +162,7 @@ class SecureComparator {
             }
 
             reply_length = libthemis.getValue(reply_length_ptr, 'i32')
-            reply_ptr = libthemis._malloc(reply_length)
+            reply_ptr = utils.heapAlloc(reply_length)
             if (!reply_ptr) {
                 throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY)
             }
@@ -178,11 +179,11 @@ class SecureComparator {
 
             reply_length = libthemis.getValue(reply_length_ptr, 'i32')
 
-            return libthemis.HEAPU8.slice(reply_ptr, reply_ptr + reply_length)
+            return utils.heapGetArray(reply_ptr, reply_length)
         }
         finally {
-            libthemis._free(request_ptr)
-            libthemis._free(reply_ptr)
+            utils.heapFree(request_ptr, request.length)
+            utils.heapFree(reply_ptr, reply_length)
         }
     }
 }

--- a/src/wrappers/themis/wasm/src/secure_keygen.js
+++ b/src/wrappers/themis/wasm/src/secure_keygen.js
@@ -65,14 +65,14 @@ function validateKeyBuffer(buffer, expectedKinds) {
     // so we validate the key and query its kind as a single operation
     // to avoid copying the key twice.
     let buffer_len = buffer.length
-    let buffer_ptr = libthemis._malloc(buffer_len)
+    let buffer_ptr = utils.heapAlloc(buffer_len)
     if (!buffer_ptr) {
         throw new ThemisError(subsystem, ThemisErrorCode.NO_MEMORY)
     }
 
     var kind
     try {
-        libthemis.writeArrayToMemory(buffer, buffer_ptr)
+        utils.heapPutArray(buffer, buffer_ptr)
 
         let err = libthemis._themis_is_valid_asym_key(buffer_ptr, buffer_len)
         if (err != ThemisErrorCode.SUCCESS) {
@@ -82,7 +82,7 @@ function validateKeyBuffer(buffer, expectedKinds) {
         kind = libthemis._themis_get_asym_key_kind(buffer_ptr, buffer_len)
     }
     finally {
-        libthemis._free(buffer_ptr)
+        utils.heapFree(buffer_ptr, buffer_len)
     }
 
     if (!expectedKinds.includes(kind)) {
@@ -133,8 +133,8 @@ function generateECKeyPair() {
     let private_len = libthemis.getValue(private_len_ptr, 'i32')
     let public_len = libthemis.getValue(public_len_ptr, 'i32')
 
-    let private_ptr = libthemis._malloc(private_len)
-    let public_ptr = libthemis._malloc(public_len)
+    let private_ptr = utils.heapAlloc(private_len)
+    let public_ptr = utils.heapAlloc(public_len)
 
     try {
         if (!private_ptr || !public_ptr) {
@@ -150,13 +150,13 @@ function generateECKeyPair() {
         let public_len = libthemis.getValue(public_len_ptr, 'i32')
 
         return {
-            private: libthemis.HEAPU8.slice(private_ptr, private_ptr + private_len),
-            public: libthemis.HEAPU8.slice(public_ptr, public_ptr + public_len),
+            private: utils.heapGetArray(private_ptr, private_len),
+            public: utils.heapGetArray(public_ptr, public_len),
         }
     }
     finally {
-        libthemis._free(private_ptr)
-        libthemis._free(public_ptr)
+        utils.heapFree(private_ptr, private_len)
+        utils.heapFree(public_ptr, public_len)
     }
 }
 

--- a/src/wrappers/themis/wasm/src/secure_message.js
+++ b/src/wrappers/themis/wasm/src/secure_message.js
@@ -76,16 +76,16 @@ class SecureMessage {
         let result_length_ptr = libthemis.allocate(4, 'i32', libthemis.ALLOC_STACK)
         let private_key_ptr, public_key_ptr, message_ptr, result_ptr, result_length
         try {
-            private_key_ptr = libthemis._malloc(this.privateKey.length)
-            public_key_ptr = libthemis._malloc(this.publicKey.length)
-            message_ptr = libthemis._malloc(message.length)
+            private_key_ptr = utils.heapAlloc(this.privateKey.length)
+            public_key_ptr = utils.heapAlloc(this.publicKey.length)
+            message_ptr = utils.heapAlloc(message.length)
             if (!private_key_ptr || !public_key_ptr || !message_ptr) {
                 throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY)
             }
 
-            libthemis.writeArrayToMemory(this.privateKey, private_key_ptr)
-            libthemis.writeArrayToMemory(this.publicKey, public_key_ptr)
-            libthemis.writeArrayToMemory(message, message_ptr)
+            utils.heapPutArray(this.privateKey, private_key_ptr)
+            utils.heapPutArray(this.publicKey, public_key_ptr)
+            utils.heapPutArray(message, message_ptr)
 
             status = libthemis._themis_secure_message_encrypt(
                 private_key_ptr, this.privateKey.length,
@@ -98,7 +98,7 @@ class SecureMessage {
             }
 
             result_length = libthemis.getValue(result_length_ptr, 'i32')
-            result_ptr = libthemis._malloc(result_length)
+            result_ptr = utils.heapAlloc(result_length)
             if (!result_ptr) {
                 throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY)
             }
@@ -115,14 +115,13 @@ class SecureMessage {
 
             result_length = libthemis.getValue(result_length_ptr, 'i32')
 
-            return libthemis.HEAPU8.slice(result_ptr, result_ptr + result_length)
+            return utils.heapGetArray(result_ptr, result_length)
         }
         finally {
-            libthemis._memset(private_key_ptr, 0, this.privateKey.length)
-            libthemis._free(private_key_ptr)
-            libthemis._free(public_key_ptr)
-            libthemis._free(message_ptr)
-            libthemis._free(result_ptr)
+            utils.heapFree(private_key_ptr, this.privateKey.length)
+            utils.heapFree(public_key_ptr, this.publicKey.length)
+            utils.heapFree(message_ptr, message.length)
+            utils.heapFree(result_ptr, result_length)
         }
     }
 
@@ -138,16 +137,16 @@ class SecureMessage {
         let result_length_ptr = libthemis.allocate(4, 'i32', libthemis.ALLOC_STACK)
         let private_key_ptr, public_key_ptr, message_ptr, result_ptr, result_length
         try {
-            private_key_ptr = libthemis._malloc(this.privateKey.length)
-            public_key_ptr = libthemis._malloc(this.publicKey.length)
-            message_ptr = libthemis._malloc(message.length)
+            private_key_ptr = utils.heapAlloc(this.privateKey.length)
+            public_key_ptr = utils.heapAlloc(this.publicKey.length)
+            message_ptr = utils.heapAlloc(message.length)
             if (!private_key_ptr || !public_key_ptr || !message_ptr) {
                 throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY)
             }
 
-            libthemis.writeArrayToMemory(this.privateKey, private_key_ptr)
-            libthemis.writeArrayToMemory(this.publicKey, public_key_ptr)
-            libthemis.writeArrayToMemory(message, message_ptr)
+            utils.heapPutArray(this.privateKey, private_key_ptr)
+            utils.heapPutArray(this.publicKey, public_key_ptr)
+            utils.heapPutArray(message, message_ptr)
 
             status = libthemis._themis_secure_message_decrypt(
                 private_key_ptr, this.privateKey.length,
@@ -160,7 +159,7 @@ class SecureMessage {
             }
 
             result_length = libthemis.getValue(result_length_ptr, 'i32')
-            result_ptr = libthemis._malloc(result_length)
+            result_ptr = utils.heapAlloc(result_length)
             if (!result_ptr) {
                 throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY)
             }
@@ -177,14 +176,13 @@ class SecureMessage {
 
             result_length = libthemis.getValue(result_length_ptr, 'i32')
 
-            return libthemis.HEAPU8.slice(result_ptr, result_ptr + result_length)
+            return utils.heapGetArray(result_ptr, result_length)
         }
         finally {
-            libthemis._memset(private_key_ptr, 0, this.privateKey.length)
-            libthemis._free(private_key_ptr)
-            libthemis._free(public_key_ptr)
-            libthemis._free(message_ptr)
-            libthemis._free(result_ptr)
+            utils.heapFree(private_key_ptr, this.privateKey.length)
+            utils.heapFree(public_key_ptr, this.publicKey.length)
+            utils.heapFree(message_ptr, message.length)
+            utils.heapFree(result_ptr, result_length)
         }
     }
 }
@@ -210,14 +208,14 @@ class SecureMessageSign {
         let result_length_ptr = libthemis.allocate(4, 'i32', libthemis.ALLOC_STACK)
         let private_key_ptr, message_ptr, result_ptr, result_length
         try {
-            private_key_ptr = libthemis._malloc(this.privateKey.length)
-            message_ptr = libthemis._malloc(message.length)
+            private_key_ptr = utils.heapAlloc(this.privateKey.length)
+            message_ptr = utils.heapAlloc(message.length)
             if (!private_key_ptr || !message_ptr) {
                 throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY)
             }
 
-            libthemis.writeArrayToMemory(this.privateKey, private_key_ptr)
-            libthemis.writeArrayToMemory(message, message_ptr)
+            utils.heapPutArray(this.privateKey, private_key_ptr)
+            utils.heapPutArray(message, message_ptr)
 
             status = libthemis._themis_secure_message_sign(
                 private_key_ptr, this.privateKey.length,
@@ -229,7 +227,7 @@ class SecureMessageSign {
             }
 
             result_length = libthemis.getValue(result_length_ptr, 'i32')
-            result_ptr = libthemis._malloc(result_length)
+            result_ptr = utils.heapAlloc(result_length)
             if (!result_ptr) {
                 throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY)
             }
@@ -245,13 +243,12 @@ class SecureMessageSign {
 
             result_length = libthemis.getValue(result_length_ptr, 'i32')
 
-            return libthemis.HEAPU8.slice(result_ptr, result_ptr + result_length)
+            return utils.heapGetArray(result_ptr, result_length)
         }
         finally {
-            libthemis._memset(private_key_ptr, 0, this.privateKey.length)
-            libthemis._free(private_key_ptr)
-            libthemis._free(message_ptr)
-            libthemis._free(result_ptr)
+            utils.heapFree(private_key_ptr, this.privateKey.length)
+            utils.heapFree(message_ptr, message.length)
+            utils.heapFree(result_ptr, result_length)
         }
     }
 }
@@ -277,14 +274,14 @@ class SecureMessageVerify {
         let result_length_ptr = libthemis.allocate(4, 'i32', libthemis.ALLOC_STACK)
         let public_key_ptr, message_ptr, result_ptr, result_length
         try {
-            public_key_ptr = libthemis._malloc(this.publicKey.length)
-            message_ptr = libthemis._malloc(message.length)
+            public_key_ptr = utils.heapAlloc(this.publicKey.length)
+            message_ptr = utils.heapAlloc(message.length)
             if (!public_key_ptr || !message_ptr) {
                 throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY)
             }
 
-            libthemis.writeArrayToMemory(this.publicKey, public_key_ptr)
-            libthemis.writeArrayToMemory(message, message_ptr)
+            utils.heapPutArray(this.publicKey, public_key_ptr)
+            utils.heapPutArray(message, message_ptr)
 
             status = libthemis._themis_secure_message_verify(
                 public_key_ptr, this.publicKey.length,
@@ -296,7 +293,7 @@ class SecureMessageVerify {
             }
 
             result_length = libthemis.getValue(result_length_ptr, 'i32')
-            result_ptr = libthemis._malloc(result_length)
+            result_ptr = utils.heapAlloc(result_length)
             if (!result_ptr) {
                 throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY)
             }
@@ -312,12 +309,12 @@ class SecureMessageVerify {
 
             result_length = libthemis.getValue(result_length_ptr, 'i32')
 
-            return libthemis.HEAPU8.slice(result_ptr, result_ptr + result_length)
+            return utils.heapGetArray(result_ptr, result_length)
         }
         finally {
-            libthemis._free(public_key_ptr)
-            libthemis._free(message_ptr)
-            libthemis._free(result_ptr)
+            utils.heapFree(public_key_ptr, this.publicKey.length)
+            utils.heapFree(message_ptr, message.length)
+            utils.heapFree(result_ptr, result_length)
         }
     }
 }

--- a/src/wrappers/themis/wasm/src/utils.js
+++ b/src/wrappers/themis/wasm/src/utils.js
@@ -17,6 +17,8 @@
  * Miscellaneous utilities.
  */
 
+const libthemis = require('./libthemis.js')
+
 /**
  * Convert an object into a byte buffer.
  *
@@ -30,4 +32,37 @@ module.exports.coerceToBytes = function(buffer) {
         return new Uint8Array(buffer)
     }
     throw new TypeError('type mismatch, expect "Uint8Array" or "ArrayBuffer"')
+}
+
+/**
+ * Allocate a buffer of specified length on Emscripten heap.
+ */
+module.exports.heapAlloc = function(length) {
+	// calloc() in not provided by Emscripten
+	let buffer = libthemis._malloc(length)
+	libthemis._memset(buffer, 0, length)
+	return buffer
+}
+
+/**
+ * Move an array into Emscripten heap from JavaScript heap.
+ */
+module.exports.heapPutArray = function(array, buffer) {
+	libthemis.writeArrayToMemory(array, buffer)
+}
+
+/**
+ * Move an array from Emscripten heap into JavaScript heap.
+ */
+module.exports.heapGetArray = function(buffer, length) {
+	return libthemis.HEAPU8.slice(buffer, buffer + length)
+}
+
+/**
+ * Free a buffer on Emscripten heap.
+ */
+module.exports.heapFree = function(buffer, length) {
+	// Prevent sensitive data leakage througn heap:
+	libthemis._memset(buffer, 0, length)
+	libthemis._free(buffer)
 }

--- a/src/wrappers/themis/wasm/src/utils.js
+++ b/src/wrappers/themis/wasm/src/utils.js
@@ -38,31 +38,35 @@ module.exports.coerceToBytes = function(buffer) {
  * Allocate a buffer of specified length on Emscripten heap.
  */
 module.exports.heapAlloc = function(length) {
-	// calloc() in not provided by Emscripten
-	let buffer = libthemis._malloc(length)
-	libthemis._memset(buffer, 0, length)
-	return buffer
+    // calloc() in not provided by Emscripten
+    let buffer = libthemis._malloc(length)
+    if (!!buffer) {
+        libthemis._memset(buffer, 0, length)
+    }
+    return buffer
 }
 
 /**
  * Move an array into Emscripten heap from JavaScript heap.
  */
 module.exports.heapPutArray = function(array, buffer) {
-	libthemis.writeArrayToMemory(array, buffer)
+    libthemis.writeArrayToMemory(array, buffer)
 }
 
 /**
  * Move an array from Emscripten heap into JavaScript heap.
  */
 module.exports.heapGetArray = function(buffer, length) {
-	return libthemis.HEAPU8.slice(buffer, buffer + length)
+    return libthemis.HEAPU8.slice(buffer, buffer + length)
 }
 
 /**
  * Free a buffer on Emscripten heap.
  */
 module.exports.heapFree = function(buffer, length) {
-	// Prevent sensitive data leakage througn heap:
-	libthemis._memset(buffer, 0, length)
-	libthemis._free(buffer)
+    // Prevent sensitive data leakage througn heap:
+    if (!!buffer) {
+        libthemis._memset(buffer, 0, length)
+    }
+    libthemis._free(buffer)
 }


### PR DESCRIPTION
In order to call Themis Core functions we need to transfer key material and messages from JavaScript memory into Emscripten heap. Operations results are similarly transferred back to JavaScript memory. We do this by explicitly allocating a buffer on Emscripten heap and using Emscripten helpers for transfers.

One important point here is that all data is still retained for some time on Emscripten heap after `free()` is called. This includes sensitive data which theoretically may be accessed by an adversary. Generally it is recommended to wipe the memory that contains sensitive data after use. We can't control JavaScript memory, but we can at least ensure that Emscripten heap does not leave any unwanted traces.

Introduce some functions to help us with data transfer between JavaScript and Emscripten heaps. They are designed to be used together so any new code will naturally use them instead of reaching for C functions and Emscripten runtime directly.

----

- [x] Add common helper functions
- [x] Cover all cryptosystems
  - [x] Key generation (this PR)
  - [x] Secure Cell (#462)
  - [x] Secure Message (#490)
  - [x] Secure Comparator (#491)
  - [x] Secure Session (#492)
