### PR TITLE
Always fill buffer length in Secure Cell

### DIFF
--- a/src/themis/secure_cell.c
+++ b/src/themis/secure_cell.c
@@ -29,6 +29,9 @@ themis_status_t themis_secure_cell_encrypt_seal(const uint8_t* master_key,
 {
     size_t ctx_length_;
     size_t msg_length_;
+    size_t total_length;
+
+    THEMIS_CHECK_PARAM(encrypted_message_length != NULL);
     THEMIS_STATUS_CHECK(themis_auth_sym_encrypt_message(master_key,
                                                         master_key_length,
                                                         message,
@@ -40,10 +43,14 @@ themis_status_t themis_secure_cell_encrypt_seal(const uint8_t* master_key,
                                                         NULL,
                                                         &msg_length_),
                         THEMIS_BUFFER_TOO_SMALL);
-    if (encrypted_message == NULL || (*encrypted_message_length) < (ctx_length_ + msg_length_)) {
-        (*encrypted_message_length) = (ctx_length_ + msg_length_);
+
+    total_length = ctx_length_ + msg_length_;
+    if (!encrypted_message || *encrypted_message_length < total_length) {
+        *encrypted_message_length = total_length;
         return THEMIS_BUFFER_TOO_SMALL;
     }
+
+    *encrypted_message_length = total_length;
     return themis_auth_sym_encrypt_message(master_key,
                                            master_key_length,
                                            message,


### PR DESCRIPTION
Sealing mode of Secure Cell is a bit special in that its output is a concatenation of encrypted message and authentication context. Other modes return these components separately.

The users need to allocate a suitably big buffer to fit the results of encryption.  Usually they pass NULL for buffer pointer in order to measure the size first, then allocate the buffer and pass the correct buffer pointer and size to Themis.

However, the users might also allocate a big enough buffer right away and do not rely on measurements. Or allocate a buffer with some extra rounding (e.g., to a page size or something). In this case they need to know the resulting length too.

Unfortunately, Secure Cell in sealing mode does not fill in the in-out length parameter if the buffer turns out to be big enough already. This will result in extra unused and uninitialized content at the end of the encrypted message if the user decides to trust the length.

Make sure that we return the length in this case. Add a test to check that resulting length is consistent with prior measurements. Check other modes as well, just in case.