### PR TITLE
Fix Node.js 12 support

### DIFF
--- a/src/wrappers/themis/jsthemis/addon.cpp
+++ b/src/wrappers/themis/jsthemis/addon.cpp
@@ -25,7 +25,7 @@
 #include "secure_message.hpp"
 #include "secure_session.hpp"
 
-void InitAll(v8::Handle<v8::Object> exports)
+void InitAll(v8::Local<v8::Object> exports)
 {
     jsthemis::Errors::Init(exports);
     jsthemis::SecureMessage::Init(exports);

--- a/src/wrappers/themis/jsthemis/common.hpp
+++ b/src/wrappers/themis/jsthemis/common.hpp
@@ -21,9 +21,9 @@
     v8::Local<v8::Object> globalObj = v8::Context::GetCurrent()->Global();                   \
     v8::Local<v8::Function> bufferConstructor = v8::Local<v8::Function>::Cast(               \
         globalObj->Get(v8::String::New("Buffer")));                                          \
-    v8::Handle<v8::Value> constructorArgs[3] = {buf->handle_,                                \
-                                                v8::Integer::New(length),                    \
-                                                v8::Integer::New(0)};                        \
+    v8::Local<v8::Value> constructorArgs[3] = {buf->handle_,                                 \
+                                               v8::Integer::New(length),                     \
+                                               v8::Integer::New(0)};                         \
     v8::Local<v8::Object> actualBuffer = bufferConstructor->NewInstance(3, constructorArgs); \
     return scope.Close(actualBuffer)
 

--- a/src/wrappers/themis/jsthemis/errors.cpp
+++ b/src/wrappers/themis/jsthemis/errors.cpp
@@ -26,7 +26,7 @@ namespace jsthemis
 
 static inline void ExportStatusCode(v8::Local<v8::Object>& exports, const char* name, themis_status_t status)
 {
-    exports->Set(Nan::New(name).ToLocalChecked(), Nan::New(status));
+    Nan::Set(exports, Nan::New(name).ToLocalChecked(), Nan::New(status));
 }
 
 void Errors::Init(v8::Local<v8::Object> exports)
@@ -106,7 +106,7 @@ static const char* ErrorDescriptionSecureComparator(themis_status_t status)
 static v8::Local<v8::Value> WithStatus(v8::Local<v8::Value> error, themis_status_t status)
 {
     v8::Local<v8::Object> object = error.As<v8::Object>();
-    object->Set(Nan::New("code").ToLocalChecked(), Nan::New(status));
+    Nan::Set(object, Nan::New("code").ToLocalChecked(), Nan::New(status));
     return error;
 }
 

--- a/src/wrappers/themis/jsthemis/errors.cpp
+++ b/src/wrappers/themis/jsthemis/errors.cpp
@@ -24,12 +24,12 @@
 namespace jsthemis
 {
 
-static inline void ExportStatusCode(v8::Handle<v8::Object>& exports, const char* name, themis_status_t status)
+static inline void ExportStatusCode(v8::Local<v8::Object>& exports, const char* name, themis_status_t status)
 {
     exports->Set(Nan::New(name).ToLocalChecked(), Nan::New(status));
 }
 
-void Errors::Init(v8::Handle<v8::Object> exports)
+void Errors::Init(v8::Local<v8::Object> exports)
 {
     ExportStatusCode(exports, "SUCCESS", THEMIS_SUCCESS);
     ExportStatusCode(exports, "FAIL", THEMIS_FAIL);

--- a/src/wrappers/themis/jsthemis/errors.hpp
+++ b/src/wrappers/themis/jsthemis/errors.hpp
@@ -27,7 +27,7 @@ namespace jsthemis
 namespace Errors
 {
 
-void Init(v8::Handle<v8::Object> exports);
+void Init(v8::Local<v8::Object> exports);
 
 } // namespace Errors
 

--- a/src/wrappers/themis/jsthemis/secure_cell_context_imprint.cpp
+++ b/src/wrappers/themis/jsthemis/secure_cell_context_imprint.cpp
@@ -36,7 +36,7 @@ SecureCellContextImprint::~SecureCellContextImprint()
 {
 }
 
-void SecureCellContextImprint::Init(v8::Handle<v8::Object> exports)
+void SecureCellContextImprint::Init(v8::Local<v8::Object> exports)
 {
     // Prepare constructor template
     v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(SecureCellContextImprint::New);

--- a/src/wrappers/themis/jsthemis/secure_cell_context_imprint.cpp
+++ b/src/wrappers/themis/jsthemis/secure_cell_context_imprint.cpp
@@ -38,15 +38,18 @@ SecureCellContextImprint::~SecureCellContextImprint()
 
 void SecureCellContextImprint::Init(v8::Local<v8::Object> exports)
 {
+    v8::Local<v8::String> className = Nan::New("SecureCellContextImprint").ToLocalChecked();
     // Prepare constructor template
     v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(SecureCellContextImprint::New);
-    tpl->SetClassName(Nan::New("SecureCellContextImprint").ToLocalChecked());
+    tpl->SetClassName(className);
     tpl->InstanceTemplate()->SetInternalFieldCount(1);
     // Prototype
     Nan::SetPrototypeMethod(tpl, "encrypt", encrypt);
     Nan::SetPrototypeMethod(tpl, "decrypt", decrypt);
-    constructor.Reset(tpl->GetFunction());
-    exports->Set(Nan::New("SecureCellContextImprint").ToLocalChecked(), tpl->GetFunction());
+    // Export constructor
+    v8::Local<v8::Function> function = Nan::GetFunction(tpl).ToLocalChecked();
+    constructor.Reset(function);
+    Nan::Set(exports, className, function);
 }
 
 void SecureCellContextImprint::New(const Nan::FunctionCallbackInfo<v8::Value>& args)

--- a/src/wrappers/themis/jsthemis/secure_cell_context_imprint.hpp
+++ b/src/wrappers/themis/jsthemis/secure_cell_context_imprint.hpp
@@ -27,7 +27,7 @@ namespace jsthemis
 class SecureCellContextImprint : public Nan::ObjectWrap
 {
 public:
-    static void Init(v8::Handle<v8::Object> exports);
+    static void Init(v8::Local<v8::Object> exports);
 
 private:
     explicit SecureCellContextImprint(const std::vector<uint8_t>& key);

--- a/src/wrappers/themis/jsthemis/secure_cell_seal.cpp
+++ b/src/wrappers/themis/jsthemis/secure_cell_seal.cpp
@@ -38,15 +38,18 @@ SecureCellSeal::~SecureCellSeal()
 
 void SecureCellSeal::Init(v8::Local<v8::Object> exports)
 {
+    v8::Local<v8::String> className = Nan::New("SecureCellSeal").ToLocalChecked();
     // Prepare constructor template
     v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(New);
-    tpl->SetClassName(Nan::New("SecureCellSeal").ToLocalChecked());
+    tpl->SetClassName(className);
     tpl->InstanceTemplate()->SetInternalFieldCount(1);
     // Prototype
     Nan::SetPrototypeMethod(tpl, "encrypt", encrypt);
     Nan::SetPrototypeMethod(tpl, "decrypt", decrypt);
-    constructor.Reset(tpl->GetFunction());
-    exports->Set(Nan::New("SecureCellSeal").ToLocalChecked(), tpl->GetFunction());
+    // Export constructor
+    v8::Local<v8::Function> function = Nan::GetFunction(tpl).ToLocalChecked();
+    constructor.Reset(function);
+    Nan::Set(exports, className, function);
 }
 
 void SecureCellSeal::New(const Nan::FunctionCallbackInfo<v8::Value>& args)

--- a/src/wrappers/themis/jsthemis/secure_cell_seal.cpp
+++ b/src/wrappers/themis/jsthemis/secure_cell_seal.cpp
@@ -36,7 +36,7 @@ SecureCellSeal::~SecureCellSeal()
 {
 }
 
-void SecureCellSeal::Init(v8::Handle<v8::Object> exports)
+void SecureCellSeal::Init(v8::Local<v8::Object> exports)
 {
     // Prepare constructor template
     v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(New);

--- a/src/wrappers/themis/jsthemis/secure_cell_seal.hpp
+++ b/src/wrappers/themis/jsthemis/secure_cell_seal.hpp
@@ -27,7 +27,7 @@ namespace jsthemis
 class SecureCellSeal : public Nan::ObjectWrap
 {
 public:
-    static void Init(v8::Handle<v8::Object> exports);
+    static void Init(v8::Local<v8::Object> exports);
 
 private:
     explicit SecureCellSeal(const std::vector<uint8_t>& key);

--- a/src/wrappers/themis/jsthemis/secure_cell_token_protect.cpp
+++ b/src/wrappers/themis/jsthemis/secure_cell_token_protect.cpp
@@ -36,7 +36,7 @@ SecureCellTokenProtect::~SecureCellTokenProtect()
 {
 }
 
-void SecureCellTokenProtect::Init(v8::Handle<v8::Object> exports)
+void SecureCellTokenProtect::Init(v8::Local<v8::Object> exports)
 {
     // Prepare constructor template
     v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(SecureCellTokenProtect::New);

--- a/src/wrappers/themis/jsthemis/secure_cell_token_protect.cpp
+++ b/src/wrappers/themis/jsthemis/secure_cell_token_protect.cpp
@@ -38,15 +38,18 @@ SecureCellTokenProtect::~SecureCellTokenProtect()
 
 void SecureCellTokenProtect::Init(v8::Local<v8::Object> exports)
 {
+    v8::Local<v8::String> className = Nan::New("SecureCellTokenProtect").ToLocalChecked();
     // Prepare constructor template
     v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(SecureCellTokenProtect::New);
-    tpl->SetClassName(Nan::New("SecureCellTokenProtect").ToLocalChecked());
+    tpl->SetClassName(className);
     tpl->InstanceTemplate()->SetInternalFieldCount(1);
     // Prototype
     Nan::SetPrototypeMethod(tpl, "encrypt", encrypt);
     Nan::SetPrototypeMethod(tpl, "decrypt", decrypt);
-    constructor.Reset(tpl->GetFunction());
-    exports->Set(Nan::New("SecureCellTokenProtect").ToLocalChecked(), tpl->GetFunction());
+    // Export constructor
+    v8::Local<v8::Function> function = Nan::GetFunction(tpl).ToLocalChecked();
+    constructor.Reset(function);
+    Nan::Set(exports, className, function);
 }
 
 void SecureCellTokenProtect::New(const Nan::FunctionCallbackInfo<v8::Value>& args)

--- a/src/wrappers/themis/jsthemis/secure_cell_token_protect.hpp
+++ b/src/wrappers/themis/jsthemis/secure_cell_token_protect.hpp
@@ -27,7 +27,7 @@ namespace jsthemis
 class SecureCellTokenProtect : public Nan::ObjectWrap
 {
 public:
-    static void Init(v8::Handle<v8::Object> exports);
+    static void Init(v8::Local<v8::Object> exports);
 
 private:
     explicit SecureCellTokenProtect(const std::vector<uint8_t>& key);

--- a/src/wrappers/themis/jsthemis/secure_comparator.cpp
+++ b/src/wrappers/themis/jsthemis/secure_comparator.cpp
@@ -54,17 +54,20 @@ SecureComparator::~SecureComparator()
 
 void SecureComparator::Init(v8::Local<v8::Object> exports)
 {
+    v8::Local<v8::String> className = Nan::New("SecureComparator").ToLocalChecked();
     // Prepare constructor template
     v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(New);
-    tpl->SetClassName(Nan::New("SecureComparator").ToLocalChecked());
+    tpl->SetClassName(className);
     tpl->InstanceTemplate()->SetInternalFieldCount(1);
     // Prototype
     Nan::SetPrototypeMethod(tpl, "beginCompare", beginCompare);
     Nan::SetPrototypeMethod(tpl, "proceedCompare", proceedCompare);
     Nan::SetPrototypeMethod(tpl, "isMatch", isMatch);
     Nan::SetPrototypeMethod(tpl, "isCompareComplete", isCompareComplete);
-    constructor.Reset(tpl->GetFunction());
-    exports->Set(Nan::New("SecureComparator").ToLocalChecked(), tpl->GetFunction());
+    // Export constructor
+    v8::Local<v8::Function> function = Nan::GetFunction(tpl).ToLocalChecked();
+    constructor.Reset(function);
+    Nan::Set(exports, className, function);
 }
 
 void SecureComparator::New(const Nan::FunctionCallbackInfo<v8::Value>& args)

--- a/src/wrappers/themis/jsthemis/secure_comparator.cpp
+++ b/src/wrappers/themis/jsthemis/secure_comparator.cpp
@@ -52,7 +52,7 @@ SecureComparator::~SecureComparator()
     }
 }
 
-void SecureComparator::Init(v8::Handle<v8::Object> exports)
+void SecureComparator::Init(v8::Local<v8::Object> exports)
 {
     // Prepare constructor template
     v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(New);

--- a/src/wrappers/themis/jsthemis/secure_comparator.hpp
+++ b/src/wrappers/themis/jsthemis/secure_comparator.hpp
@@ -29,7 +29,7 @@ namespace jsthemis
 class SecureComparator : public Nan::ObjectWrap
 {
 public:
-    static void Init(v8::Handle<v8::Object> exports);
+    static void Init(v8::Local<v8::Object> exports);
 
 private:
     explicit SecureComparator(const std::vector<uint8_t>& secret);

--- a/src/wrappers/themis/jsthemis/secure_keygen.cpp
+++ b/src/wrappers/themis/jsthemis/secure_keygen.cpp
@@ -40,15 +40,18 @@ KeyPair::~KeyPair()
 
 void KeyPair::Init(v8::Local<v8::Object> exports)
 {
+    v8::Local<v8::String> className = Nan::New("KeyPair").ToLocalChecked();
     // Prepare constructor template
     v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(KeyPair::New);
-    tpl->SetClassName(Nan::New("KeyPair").ToLocalChecked());
+    tpl->SetClassName(className);
     tpl->InstanceTemplate()->SetInternalFieldCount(1);
     // Prototype
     Nan::SetPrototypeMethod(tpl, "private", private_key);
     Nan::SetPrototypeMethod(tpl, "public", public_key);
-    constructor.Reset(tpl->GetFunction());
-    exports->Set(Nan::New("KeyPair").ToLocalChecked(), tpl->GetFunction());
+    // Export constructor
+    v8::Local<v8::Function> function = Nan::GetFunction(tpl).ToLocalChecked();
+    constructor.Reset(function);
+    Nan::Set(exports, className, function);
 }
 
 void KeyPair::New(const Nan::FunctionCallbackInfo<v8::Value>& args)

--- a/src/wrappers/themis/jsthemis/secure_keygen.cpp
+++ b/src/wrappers/themis/jsthemis/secure_keygen.cpp
@@ -38,7 +38,7 @@ KeyPair::~KeyPair()
 {
 }
 
-void KeyPair::Init(v8::Handle<v8::Object> exports)
+void KeyPair::Init(v8::Local<v8::Object> exports)
 {
     // Prepare constructor template
     v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(KeyPair::New);

--- a/src/wrappers/themis/jsthemis/secure_keygen.hpp
+++ b/src/wrappers/themis/jsthemis/secure_keygen.hpp
@@ -29,7 +29,7 @@ namespace jsthemis
 class KeyPair : public Nan::ObjectWrap
 {
 public:
-    static void Init(v8::Handle<v8::Object> exports);
+    static void Init(v8::Local<v8::Object> exports);
 
 private:
     explicit KeyPair(const std::vector<uint8_t>& private_key, const std::vector<uint8_t>& public_key);

--- a/src/wrappers/themis/jsthemis/secure_message.cpp
+++ b/src/wrappers/themis/jsthemis/secure_message.cpp
@@ -41,17 +41,20 @@ SecureMessage::~SecureMessage()
 
 void SecureMessage::Init(v8::Local<v8::Object> exports)
 {
+    v8::Local<v8::String> className = Nan::New("SecureMessage").ToLocalChecked();
     // Prepare constructor template
     v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(SecureMessage::New);
-    tpl->SetClassName(Nan::New("SecureMessage").ToLocalChecked());
+    tpl->SetClassName(className);
     tpl->InstanceTemplate()->SetInternalFieldCount(1);
     // Prototype
     Nan::SetPrototypeMethod(tpl, "encrypt", SecureMessage::encrypt);
     Nan::SetPrototypeMethod(tpl, "decrypt", SecureMessage::decrypt);
     Nan::SetPrototypeMethod(tpl, "sign", SecureMessage::sign);
     Nan::SetPrototypeMethod(tpl, "verify", SecureMessage::verify);
-    constructor.Reset(tpl->GetFunction());
-    exports->Set(Nan::New("SecureMessage").ToLocalChecked(), tpl->GetFunction());
+    // Export constructor
+    v8::Local<v8::Function> function = Nan::GetFunction(tpl).ToLocalChecked();
+    constructor.Reset(function);
+    Nan::Set(exports, className, function);
 }
 
 void SecureMessage::New(const Nan::FunctionCallbackInfo<v8::Value>& args)

--- a/src/wrappers/themis/jsthemis/secure_message.cpp
+++ b/src/wrappers/themis/jsthemis/secure_message.cpp
@@ -39,7 +39,7 @@ SecureMessage::~SecureMessage()
 {
 }
 
-void SecureMessage::Init(v8::Handle<v8::Object> exports)
+void SecureMessage::Init(v8::Local<v8::Object> exports)
 {
     // Prepare constructor template
     v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(SecureMessage::New);

--- a/src/wrappers/themis/jsthemis/secure_message.hpp
+++ b/src/wrappers/themis/jsthemis/secure_message.hpp
@@ -27,7 +27,7 @@ namespace jsthemis
 class SecureMessage : public Nan::ObjectWrap
 {
 public:
-    static void Init(v8::Handle<v8::Object> exports);
+    static void Init(v8::Local<v8::Object> exports);
 
 private:
     explicit SecureMessage(const std::vector<uint8_t>& private_key,

--- a/src/wrappers/themis/jsthemis/secure_session.cpp
+++ b/src/wrappers/themis/jsthemis/secure_session.cpp
@@ -78,17 +78,20 @@ SecureSession::~SecureSession()
 
 void SecureSession::Init(v8::Local<v8::Object> exports)
 {
+    v8::Local<v8::String> className = Nan::New("SecureSession").ToLocalChecked();
     // Prepare constructor template
     v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(New);
-    tpl->SetClassName(Nan::New("SecureSession").ToLocalChecked());
+    tpl->SetClassName(className);
     tpl->InstanceTemplate()->SetInternalFieldCount(1);
     // Prototype
     Nan::SetPrototypeMethod(tpl, "connectRequest", connectRequest);
     Nan::SetPrototypeMethod(tpl, "wrap", wrap);
     Nan::SetPrototypeMethod(tpl, "unwrap", unwrap);
     Nan::SetPrototypeMethod(tpl, "isEstablished", isEstablished);
-    constructor.Reset(tpl->GetFunction());
-    exports->Set(Nan::New("SecureSession").ToLocalChecked(), tpl->GetFunction());
+    // Export constructor
+    v8::Local<v8::Function> function = Nan::GetFunction(tpl).ToLocalChecked();
+    constructor.Reset(function);
+    Nan::Set(exports, className, function);
 }
 
 void SecureSession::New(const Nan::FunctionCallbackInfo<v8::Value>& args)

--- a/src/wrappers/themis/jsthemis/secure_session.cpp
+++ b/src/wrappers/themis/jsthemis/secure_session.cpp
@@ -76,7 +76,7 @@ SecureSession::~SecureSession()
     }
 }
 
-void SecureSession::Init(v8::Handle<v8::Object> exports)
+void SecureSession::Init(v8::Local<v8::Object> exports)
 {
     // Prepare constructor template
     v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(New);

--- a/src/wrappers/themis/jsthemis/secure_session.hpp
+++ b/src/wrappers/themis/jsthemis/secure_session.hpp
@@ -29,7 +29,7 @@ namespace jsthemis
 class SecureSession : public Nan::ObjectWrap
 {
 public:
-    static void Init(v8::Handle<v8::Object> exports);
+    static void Init(v8::Local<v8::Object> exports);
 
 private:
     explicit SecureSession(const std::vector<uint8_t>& id,


### PR DESCRIPTION
Latest stable release of Node.js 12 includes updated V8 engine which has finally removed some of the deprecated API that we are using. JavaScript ecosystem has relatively low half-life periods for versions so we need to upgrade.

* **Use v8::Local instead of v8::Handle**

`v8::Handle` has been deprecated in favor of `v8::Local` since V8 4.5 and has been removed somewhere after V8 7.0. Node.js 12 (current stable) is upgrading V8 engine to 7.4+ which does not support v8::Handle.

Mass-replace v8::Handle → v8::Local to avoid that issue. It's supported even by the ancient Node versions packaged in older Ubuntu releases.

* **Use NAN helpers**

`v8::Object::Set()` and `v8::FunctionTemplate::GetFunction()` have had their API changed between V8 versions. Upgrading Node.js to 12 breaks them completely.

Instead of using this API directly we should be using NAN helpers that encapsulate the changes and provide common API for Maybe types.

----

I have manually verified these changes with the following Node.js versions:

- Node.js v4.2.6 — packaged with Ubuntu 16 LTS (Xenial Xerus), checked by CircleCI
- Node.js v8.16 — current maintenance LTS version of Node.js, still somewhat supported
- Node.js v10.16 — current active LTS version of Node.js, recommended for current users
- Node.js v12.6 — latest stable version of Node.js, in development

Currently CircleCI checks only Node.js v4. This PR does not update the build system so you'll have to trust me that it actually builds, for now.