### PR TITLE
Fix error handling in key generation

### DIFF
--- a/src/themis/secure_keygen.c
+++ b/src/themis/secure_keygen.c
@@ -29,6 +29,7 @@
 #ifndef THEMIS_RSA_KEY_LENGTH
 #define THEMIS_RSA_KEY_LENGTH RSA_KEY_LENGTH_2048
 #endif
+
 themis_status_t themis_gen_key_pair(soter_sign_alg_t alg,
                                     uint8_t* private_key,
                                     size_t* private_key_length,
@@ -37,18 +38,21 @@ themis_status_t themis_gen_key_pair(soter_sign_alg_t alg,
 {
     soter_sign_ctx_t* ctx = soter_sign_create(alg, NULL, 0, NULL, 0);
     THEMIS_CHECK(ctx != NULL);
-    soter_status_t res = soter_sign_export_key(ctx, private_key, private_key_length, true);
-    if (res != THEMIS_SUCCESS && res != THEMIS_BUFFER_TOO_SMALL) {
+
+    soter_status_t res_private = soter_sign_export_key(ctx, private_key, private_key_length, true);
+    if (res_private != THEMIS_SUCCESS && res_private != THEMIS_BUFFER_TOO_SMALL) {
         soter_sign_destroy(ctx);
-        return res;
+        return res_private;
     }
-    soter_status_t res2 = soter_sign_export_key(ctx, public_key, public_key_length, false);
-    if (res2 != THEMIS_SUCCESS && res2 != THEMIS_BUFFER_TOO_SMALL) {
+
+    soter_status_t res_public = soter_sign_export_key(ctx, public_key, public_key_length, false);
+    if (res_public != THEMIS_SUCCESS && res_public != THEMIS_BUFFER_TOO_SMALL) {
         soter_sign_destroy(ctx);
-        return res;
+        return res_public;
     }
+
     soter_sign_destroy(ctx);
-    if (res == THEMIS_BUFFER_TOO_SMALL || res2 == THEMIS_BUFFER_TOO_SMALL) {
+    if (res_private == THEMIS_BUFFER_TOO_SMALL || res_public == THEMIS_BUFFER_TOO_SMALL) {
         return THEMIS_BUFFER_TOO_SMALL;
     }
     return THEMIS_SUCCESS;
@@ -61,20 +65,23 @@ themis_status_t themis_gen_rsa_key_pair(uint8_t* private_key,
 {
     soter_rsa_key_pair_gen_t* key_pair_ctx = soter_rsa_key_pair_gen_create(THEMIS_RSA_KEY_LENGTH);
     THEMIS_CHECK(key_pair_ctx != NULL);
-    soter_status_t res =
+
+    soter_status_t res_private =
         soter_rsa_key_pair_gen_export_key(key_pair_ctx, private_key, private_key_length, true);
-    if (res != THEMIS_SUCCESS && res != THEMIS_BUFFER_TOO_SMALL) {
+    if (res_private != THEMIS_SUCCESS && res_private != THEMIS_BUFFER_TOO_SMALL) {
         soter_rsa_key_pair_gen_destroy(key_pair_ctx);
-        return res;
+        return res_private;
     }
-    soter_status_t res2 =
+
+    soter_status_t res_public =
         soter_rsa_key_pair_gen_export_key(key_pair_ctx, public_key, public_key_length, false);
-    if (res2 != THEMIS_SUCCESS && res2 != THEMIS_BUFFER_TOO_SMALL) {
+    if (res_public != THEMIS_SUCCESS && res_public != THEMIS_BUFFER_TOO_SMALL) {
         soter_rsa_key_pair_gen_destroy(key_pair_ctx);
-        return res2;
+        return res_public;
     }
+
     soter_rsa_key_pair_gen_destroy(key_pair_ctx);
-    if (res == THEMIS_BUFFER_TOO_SMALL || res2 == THEMIS_BUFFER_TOO_SMALL) {
+    if (res_private == THEMIS_BUFFER_TOO_SMALL || res_public == THEMIS_BUFFER_TOO_SMALL) {
         return THEMIS_BUFFER_TOO_SMALL;
     }
     return THEMIS_SUCCESS;

--- a/tests/themis/themis_seccure_message.c
+++ b/tests/themis/themis_seccure_message.c
@@ -1540,19 +1540,13 @@ static void keygen_parameters_ec(void)
     size_t ec_private_key_length = sizeof(ec_private_key);
     size_t ec_public_key_length = sizeof(ec_public_key);
 
-    status = themis_gen_ec_key_pair(ec_private_key,
-                                    &ec_private_key_length,
-                                    NULL,
-                                    NULL);
+    status = themis_gen_ec_key_pair(ec_private_key, &ec_private_key_length, NULL, NULL);
     testsuite_fail_unless(status == THEMIS_INVALID_PARAMETER,
-                          "themis_gen_ec_key_pair: only private key");
+                          "themis_gen_ec_key_pair: only private key requested");
 
-    status = themis_gen_ec_key_pair(NULL,
-                                    NULL,
-                                    ec_public_key,
-                                    &ec_public_key_length);
+    status = themis_gen_ec_key_pair(NULL, NULL, ec_public_key, &ec_public_key_length);
     testsuite_fail_unless(status == THEMIS_INVALID_PARAMETER,
-                          "themis_gen_ec_key_pair: only public key");
+                          "themis_gen_ec_key_pair: only public key requested");
 }
 
 static void keygen_parameters_rsa(void)
@@ -1563,19 +1557,13 @@ static void keygen_parameters_rsa(void)
     size_t rsa_private_key_length = sizeof(rsa_private_key);
     size_t rsa_public_key_length = sizeof(rsa_public_key);
 
-    status = themis_gen_rsa_key_pair(rsa_private_key,
-                                     &rsa_private_key_length,
-                                     NULL,
-                                     NULL);
+    status = themis_gen_rsa_key_pair(rsa_private_key, &rsa_private_key_length, NULL, NULL);
     testsuite_fail_unless(status == THEMIS_INVALID_PARAMETER,
-                          "themis_gen_rsa_key_pair: only private key");
+                          "themis_gen_rsa_key_pair: only private key requested");
 
-    status = themis_gen_rsa_key_pair(NULL,
-                                     NULL,
-                                     rsa_public_key,
-                                     &rsa_public_key_length);
+    status = themis_gen_rsa_key_pair(NULL, NULL, rsa_public_key, &rsa_public_key_length);
     testsuite_fail_unless(status == THEMIS_INVALID_PARAMETER,
-                          "themis_gen_rsa_key_pair: only public key");
+                          "themis_gen_rsa_key_pair: only public key requested");
 }
 
 void run_secure_message_test(void)

--- a/tests/themis/themis_seccure_message.c
+++ b/tests/themis/themis_seccure_message.c
@@ -1532,6 +1532,52 @@ static void key_validation_test(void)
                           "themis_get_asym_key_kind: garbage input");
 }
 
+static void keygen_parameters_ec(void)
+{
+    themis_status_t status;
+    uint8_t ec_private_key[MAX_KEY_SIZE] = {0};
+    uint8_t ec_public_key[MAX_KEY_SIZE] = {0};
+    size_t ec_private_key_length = sizeof(ec_private_key);
+    size_t ec_public_key_length = sizeof(ec_public_key);
+
+    status = themis_gen_ec_key_pair(ec_private_key,
+                                    &ec_private_key_length,
+                                    NULL,
+                                    NULL);
+    testsuite_fail_unless(status == THEMIS_INVALID_PARAMETER,
+                          "themis_gen_ec_key_pair: only private key");
+
+    status = themis_gen_ec_key_pair(NULL,
+                                    NULL,
+                                    ec_public_key,
+                                    &ec_public_key_length);
+    testsuite_fail_unless(status == THEMIS_INVALID_PARAMETER,
+                          "themis_gen_ec_key_pair: only public key");
+}
+
+static void keygen_parameters_rsa(void)
+{
+    themis_status_t status;
+    uint8_t rsa_private_key[MAX_KEY_SIZE] = {0};
+    uint8_t rsa_public_key[MAX_KEY_SIZE] = {0};
+    size_t rsa_private_key_length = sizeof(rsa_private_key);
+    size_t rsa_public_key_length = sizeof(rsa_public_key);
+
+    status = themis_gen_rsa_key_pair(rsa_private_key,
+                                     &rsa_private_key_length,
+                                     NULL,
+                                     NULL);
+    testsuite_fail_unless(status == THEMIS_INVALID_PARAMETER,
+                          "themis_gen_rsa_key_pair: only private key");
+
+    status = themis_gen_rsa_key_pair(NULL,
+                                     NULL,
+                                     rsa_public_key,
+                                     &rsa_public_key_length);
+    testsuite_fail_unless(status == THEMIS_INVALID_PARAMETER,
+                          "themis_gen_rsa_key_pair: only public key");
+}
+
 void run_secure_message_test(void)
 {
     testsuite_enter_suite("generic secure message");
@@ -1544,4 +1590,6 @@ void run_secure_message_test(void)
 
     testsuite_enter_suite("key generation and validation");
     testsuite_run_test(key_validation_test);
+    testsuite_run_test(keygen_parameters_ec);
+    testsuite_run_test(keygen_parameters_rsa);
 }


### PR DESCRIPTION
Note that EC key generation has incorrect return value when public key export fails (should be `res2` instead of `res`). This may cause key generation function to return success if private key has been exported successfully, but public key has not. The user will then proceed with uninitialized public key buffer and will not be amused afterwards.

Change variable names to be more distinct so that the difference is more obvious and add some empty lines so that the code is easier to read.

Add a test which makes sure we have correct behavior when one of the keys fail. Using NULL values is the easiest way to trigger this behavior.

Thanks to @vixentael for finding this! 🔍 🕵️‍♀️ 