### PR TITLE
Redundant key server pools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,17 @@ jobs:
       - run:
           name: Install RVM
           command: |
-            gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+            for key in 409B6B1796C275462A1703113804BB82D39DC0E3 \
+                       7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+            do
+                for server in pgp.mit.edu keyserver.pgp.com ha.pool.sks-keyservers.net
+                do
+                    if gpg --keyserver $server --recv-keys $key
+                    then
+                        break
+                    fi
+                done
+            done
             curl -sSL https://get.rvm.io | bash -s stable
             source ~/.rvm/scripts/rvm
             rvm use system
@@ -184,7 +194,17 @@ jobs:
       - run:
           name: Install RVM
           command: |
-            gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+            for key in 409B6B1796C275462A1703113804BB82D39DC0E3 \
+                       7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+            do
+                for server in pgp.mit.edu keyserver.pgp.com ha.pool.sks-keyservers.net
+                do
+                    if gpg --keyserver $server --recv-keys $key
+                    then
+                        break
+                    fi
+                done
+            done
             curl -sSL https://get.rvm.io | bash -s stable
             source ~/.rvm/scripts/rvm
             rvm use system

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,8 @@ jobs:
       - run:
           name: Install RVM
           command: |
+            # Import keys used by RVM maintainers from recommended key server pools
+            # See https://rvm.io/rvm/security
             for key in 409B6B1796C275462A1703113804BB82D39DC0E3 \
                        7D2BAF1CF37B13E2069D6956105BD0E739499BDB
             do
@@ -194,6 +196,8 @@ jobs:
       - run:
           name: Install RVM
           command: |
+            # Import keys used by RVM maintainers from recommended key server pools
+            # See https://rvm.io/rvm/security
             for key in 409B6B1796C275462A1703113804BB82D39DC0E3 \
                        7D2BAF1CF37B13E2069D6956105BD0E739499BDB
             do


### PR DESCRIPTION
RVM installation added in PR #503 requires PGP keys used by RVM to be available. We pull those from a public key server pool. However, using just "pool.sks-keyservers.net" as recommended by RVM documentation seems to be too unreliable for CI setup. It works fine for singular installations, but when deployed to CircleCI pool-selected servers are often unavailable, time out, and break our builds. Instead of using a single server try multiple ones for each key that we wish to request.