### PR TITLE
Prepare for Go 1.11 modules

### DIFF
--- a/gothemis/go.mod
+++ b/gothemis/go.mod
@@ -1,0 +1,3 @@
+module github.com/cossacklabs/themis/gothemis
+
+go 1.12

--- a/gothemis/go.mod
+++ b/gothemis/go.mod
@@ -1,3 +1,1 @@
 module github.com/cossacklabs/themis/gothemis
-
-go 1.12


### PR DESCRIPTION
Initialize go.mod file to support Go 1.11 modules. We don't have any non-standard dependencies so our go.mod and go.sum are mostly empty.

Having this file in the repository will allow users to fetch GoThemis using module system, pin versions, etc.

Since GoThemis and Themis core are still v0.XX, we can ignore all "v2+ modules" thingies in Golang. From semver point of view Themis has major version v0 and there are no compatibility guarantees between versions.

Note that modules are not immediately available with versioning. We still need to release v0.12 and tag it in a proper way.