### PR TITLE
Package libraries to arch-specific directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -575,9 +575,11 @@ ifeq ($(shell lsb_release -is 2> /dev/null),Debian)
 #0.9.4-153-g9915004+jessie_amd64.deb.
 	NAME_SUFFIX = $(VERSION)+$(DEB_CODENAME)_$(DEB_ARCHITECTURE).deb
 	OS_CODENAME = $(shell lsb_release -cs)
+	DEB_LIBDIR := /lib/$(shell $(CC) -dumpmachine)
 else ifeq ($(shell lsb_release -is 2> /dev/null),Ubuntu)
 	NAME_SUFFIX = $(VERSION)+$(DEB_CODENAME)_$(DEB_ARCHITECTURE).deb
 	OS_CODENAME = $(shell lsb_release -cs)
+	DEB_LIBDIR := /lib/$(shell $(CC) -dumpmachine)
 else
 # centos/rpm
 	OS_NAME = $(shell cat /etc/os-release | grep -e "^ID=\".*\"" | cut -d'"' -f2)
@@ -585,6 +587,7 @@ else
 	ARCHITECTURE = $(shell arch)
 	RPM_VERSION = $(shell echo -n "$(VERSION)"|sed s/-/_/g)
 	NAME_SUFFIX = $(RPM_VERSION).$(OS_NAME)$(OS_VERSION).$(ARCHITECTURE).rpm
+	RPM_LIBDIR := $(shell [ $$(arch) == "x86_64" ] && echo "/lib64" || echo "/lib")
 endif
 
 PACKAGE_NAME = libthemis
@@ -620,6 +623,7 @@ THEMISPP_PACKAGE_FILES += $(includedir)/themispp/
 
 deb: DESTDIR = $(BIN_PATH)/deb/root
 deb: PREFIX = /usr
+deb: libdir = $(PREFIX)/$(DEB_LIBDIR)
 
 deb: install themispp_install
 	@printf "ldconfig" > $(POST_INSTALL_SCRIPT)
@@ -682,6 +686,7 @@ deb: install themispp_install
 
 rpm: DESTDIR = $(BIN_PATH)/rpm/root
 rpm: PREFIX = /usr
+rpm: libdir = $(PREFIX)/$(RPM_LIBDIR)
 
 rpm: install themispp_install
 	@printf "ldconfig" > $(POST_INSTALL_SCRIPT)

--- a/src/soter/libsoter.pc.in
+++ b/src/soter/libsoter.pc.in
@@ -1,7 +1,5 @@
-prefix=%prefix%
-exec_prefix=${prefix}
-includedir=${prefix}/include
-libdir=${exec_prefix}/lib
+includedir=%includedir%
+libdir=%libdir%
 
 Name: Soter
 Description: Cryptographic primitives for Themis

--- a/src/soter/soter.mk
+++ b/src/soter/soter.mk
@@ -78,7 +78,8 @@ endif
 
 $(BIN_PATH)/libsoter.pc:
 	@mkdir -p $(BIN_PATH)
-	@sed -e "s!%prefix%!$(PREFIX)!" \
+	@sed -e "s!%libdir%!$(libdir)!" \
+	     -e "s!%includedir%!$(includedir)!" \
 	     -e "s!%version%!$(VERSION)!" \
 	     -e "s!%crypto-libs%!$(CRYPTO_ENGINE_LDFLAGS)!" \
 	    $(SRC_PATH)/soter/libsoter.pc.in > $(BIN_PATH)/libsoter.pc

--- a/src/themis/libthemis.pc.in
+++ b/src/themis/libthemis.pc.in
@@ -1,7 +1,5 @@
-prefix=%prefix%
-exec_prefix=${prefix}
-includedir=${prefix}/include
-libdir=${exec_prefix}/lib
+includedir=%includedir%
+libdir=%libdir%
 
 Name: Themis
 Description: High-level cryptographic services

--- a/src/themis/themis.mk
+++ b/src/themis/themis.mk
@@ -69,7 +69,8 @@ endif
 
 $(BIN_PATH)/libthemis.pc:
 	@mkdir -p $(BIN_PATH)
-	@sed -e "s!%prefix%!$(PREFIX)!" \
+	@sed -e "s!%libdir%!$(libdir)!" \
+	     -e "s!%includedir%!$(includedir)!" \
 	     -e "s!%version%!$(VERSION)!" \
 	    $(SRC_PATH)/themis/libthemis.pc.in > $(BIN_PATH)/libthemis.pc
 


### PR DESCRIPTION
Let's install libraries into the directories expected by Linux distributions when we prepare packages.

Debian-based systems use _multiarch_ approach with shared libraries installed under `/usr/lib/${compiler-target-triple}`. This allows installation of libraries for multiple architectures simultaneously, hence the name. GCC makes it easy to obtain the target triple.

CentOS uses Filesystem Hierarchy Standard (well, it *is* Red Hat) which tells that packages should install libraries to `/usr/lib64` on 64-bit systems and to `/usr/lib` on 32-bit ones. We support only one 64-bit architecture on Linux machines so we can check for it.

With these changes tools like **pkg-config** should work automatically because all libraries are installed to their expected places.