### PR TITLE
Prepare for publishing WasmThemis

### DIFF
--- a/src/wrappers/themis/wasm/.npmignore
+++ b/src/wrappers/themis/wasm/.npmignore
@@ -1,5 +1,5 @@
 # Themis build system
-runtime_exports.json
+emscripten/
 wasmthemis.mk
 
 # Results of local "npm pack"

--- a/src/wrappers/themis/wasm/README.md
+++ b/src/wrappers/themis/wasm/README.md
@@ -45,10 +45,6 @@ themis.initialized.then(function() {
 })
 ```
 
-([_Browserify_ your code][browserify] to use WasmThemis in web apps.)
-
-[browserify]: http://browserify.org
-
 ### Documentation
 
 Read the following resources to learn more:

--- a/src/wrappers/themis/wasm/package.json
+++ b/src/wrappers/themis/wasm/package.json
@@ -1,7 +1,6 @@
 {
   "name": "wasm-themis",
   "version": "0.11.1",
-  "private": true,
   "description": "Themis data security library",
   "main": "src/index.js",
   "scripts": {
@@ -22,7 +21,7 @@
   "bugs": {
     "url": "https://github.com/cossacklabs/themis/issues"
   },
-  "homepage": "https://github.com/cossacklabs/themis#readme",
+  "homepage": "https://www.cossacklabs.com/themis/",
   "devDependencies": {
     "mocha": "^6.1.4"
   }


### PR DESCRIPTION
Miscellaneous minor changes to packaging and packaged files.

* Remove Browserify reference from README

   This is not the only bundler in existance. We're going to discuss bundling in the documentation so we don't need this here. Supposedly, Web developers know what to do with npm packages to get them shipped.

* Update package.json for wasm-themis

    Remove `private` option so that the package can be published in public npm repositories.

    Update `homepage` to an actual home page of Themis, not just README which is reachable via the repository link.

* Update .npmignore

    We have moved some of the internal build files but did not update .npmignore so that they won't get packaged in the release build.