### PR TITLE
Search build directory first when linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ TEST_SRC_PATH = tests
 TEST_BIN_PATH = $(BIN_PATH)/tests
 
 CFLAGS += -I$(SRC_PATH) -I$(SRC_PATH)/wrappers/themis/ -I/usr/local/include -fPIC $(CRYPTO_ENGINE_CFLAGS)
-LDFLAGS += -L/usr/local/lib
+LDFLAGS += -L$(BIN_PATH) -L/usr/local/lib
 
 unexport CFLAGS LDFLAGS
 

--- a/src/themis/themis.mk
+++ b/src/themis/themis.mk
@@ -57,7 +57,7 @@ $(BIN_PATH)/$(LIBTHEMIS_A): $(THEMIS_OBJ)
 	@echo -n "link "
 	@$(BUILD_CMD)
 
-$(BIN_PATH)/$(LIBTHEMIS_SO): CMD = $(CC) -shared -o $@ $(filter %.o %.a, $^) $(LDFLAGS) -L$(BIN_PATH) -lsoter $(LIBTHEMIS_SO_LDFLAGS)
+$(BIN_PATH)/$(LIBTHEMIS_SO): CMD = $(CC) -shared -o $@ $(filter %.o %.a, $^) $(LDFLAGS) -lsoter $(LIBTHEMIS_SO_LDFLAGS)
 
 $(BIN_PATH)/$(LIBTHEMIS_SO): $(BIN_PATH)/$(LIBSOTER_SO) $(THEMIS_OBJ)
 	@mkdir -p $(@D)


### PR DESCRIPTION
Make sure that we look into our build directory before `/usr/local/lib` or any other system directories. Developer builds should use newly built libraries even if the system already has Themis installed.

If we look into `/usr/local/lib` first then developer builds may fail on macOS which has Themis installed to `/usr/local/lib` by default. This is important for correct dependency information to be recorded in the libraries (especially if the ABI changes one day).