### PR TITLE
Cleanup Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,17 @@
 # Make sure that "all" is the default target no matter what
 all:
 
+########################################################################
+
+# Increment VERSION when making a new release of Themis.
+#
+# If you make breaking (backwards-incompatible) changes to API or ABI
+# then increment LIBRARY_SO_VERSION as well, and update package names.
+VERSION := $(shell test -d .git && git describe --tags || cat VERSION)
+LIBRARY_SO_VERSION = 0
+
+########################################################################
+
 #CC = clang
 
 CMAKE = cmake
@@ -185,13 +196,6 @@ endif
 ifeq ($(RSA_KEY_LENGTH),8192)
 	CFLAGS += -DTHEMIS_RSA_KEY_LENGTH=RSA_KEY_LENGTH_8192
 endif
-
-# Increment VERSION when making a new release of Themis.
-#
-# If you make breaking (backwards-incompatible) changes to API or ABI
-# then increment LIBRARY_SO_VERSION as well, and update package names.
-VERSION := $(shell test -d .git && git describe --tags || cat VERSION)
-LIBRARY_SO_VERSION = 0
 
 PHP_VERSION := $(shell php -r "echo PHP_MAJOR_VERSION;" 2>/dev/null)
 RUBY_GEM_VERSION := $(shell gem --version 2>/dev/null)

--- a/Makefile
+++ b/Makefile
@@ -430,27 +430,6 @@ uninstall: uninstall_themis uninstall_soter
 	@echo -n "Themis uninstalled from $(PREFIX) "
 	@$(PRINT_OK_)
 
-nsis_installer: $(BIN_PATH)/InstallThemis.exe
-
-$(BIN_PATH)/InstallThemis.exe: FORCE
-ifdef IS_MSYS
-	@$(MAKE) install PREFIX=/ DESTDIR="$(BIN_PATH)/install"
-	@ldd "$(BIN_PATH)/install/bin"/*.dll | \
-	 awk '$$3 ~ "^/usr/bin" { print $$3}' | sort --uniq | \
-	 xargs -I % cp % "$(BIN_PATH)/install/bin"
-	@makensis Themis.nsi
-	@rm -r "$(BIN_PATH)/install"
-else
-	@echo "NSIS installers can only be build in MSYS environment on Windows."
-	@echo
-	@echo "Please make sure that you are using MSYS terminal session which"
-	@echo "is usually available as 'MSYS2 MSYS' shortcut in the MSYS group"
-	@echo "of the Start menu."
-	@exit 1
-endif
-
-FORCE:
-
 ########################################################################
 #
 # Themis distribution tarball
@@ -580,6 +559,11 @@ ifeq ($(or $(PYTHON2_VERSION),$(PYTHON3_VERSION)),)
 endif
 	@echo -n "pythemis install "
 	@$(BUILD_CMD_)
+
+########################################################################
+#
+# Packaging Themis Core: Linux distributions
+#
 
 COSSACKLABS_URL = https://www.cossacklabs.com
 MAINTAINER = "Cossack Labs Limited <dev@cossacklabs.com>"
@@ -770,6 +754,37 @@ rpm: install themispp_install
          $(foreach file,$(THEMISPP_PACKAGE_FILES),$(DESTDIR)/$(file)=$(file))
 
 	@find $(BIN_PATH) -name \*.rpm
+
+########################################################################
+#
+# Packaging Themis Core: Windows (NSIS)
+#
+
+nsis_installer: $(BIN_PATH)/InstallThemis.exe
+
+$(BIN_PATH)/InstallThemis.exe: FORCE
+ifdef IS_MSYS
+	@$(MAKE) install PREFIX=/ DESTDIR="$(BIN_PATH)/install"
+	@ldd "$(BIN_PATH)/install/bin"/*.dll | \
+	 awk '$$3 ~ "^/usr/bin" { print $$3}' | sort --uniq | \
+	 xargs -I % cp % "$(BIN_PATH)/install/bin"
+	@makensis Themis.nsi
+	@rm -r "$(BIN_PATH)/install"
+else
+	@echo "NSIS installers can only be build in MSYS environment on Windows."
+	@echo
+	@echo "Please make sure that you are using MSYS terminal session which"
+	@echo "is usually available as 'MSYS2 MSYS' shortcut in the MSYS group"
+	@echo "of the Start menu."
+	@exit 1
+endif
+
+FORCE:
+
+########################################################################
+#
+# Packaging PHP Themis: Linux distributions
+#
 
 define PKGINFO
 PACKAGE=$(PACKAGE_NAME)

--- a/src/soter/soter.mk
+++ b/src/soter/soter.mk
@@ -84,7 +84,7 @@ $(BIN_PATH)/libsoter.pc:
 	     -e "s!%crypto-libs%!$(CRYPTO_ENGINE_LDFLAGS)!" \
 	    $(SRC_PATH)/soter/libsoter.pc.in > $(BIN_PATH)/libsoter.pc
 
-install_soter: err $(BIN_PATH)/$(LIBSOTER_A) $(BIN_PATH)/$(LIBSOTER_SO) $(BIN_PATH)/libsoter.pc
+install_soter: $(BIN_PATH)/$(LIBSOTER_A) $(BIN_PATH)/$(LIBSOTER_SO) $(BIN_PATH)/libsoter.pc
 	@echo -n "install Soter "
 	@mkdir -p $(DESTDIR)$(includedir)/soter
 	@mkdir -p $(DESTDIR)$(pkgconfigdir)

--- a/src/themis/themis.mk
+++ b/src/themis/themis.mk
@@ -74,7 +74,7 @@ $(BIN_PATH)/libthemis.pc:
 	     -e "s!%version%!$(VERSION)!" \
 	    $(SRC_PATH)/themis/libthemis.pc.in > $(BIN_PATH)/libthemis.pc
 
-install_themis: err $(BIN_PATH)/$(LIBTHEMIS_A) $(BIN_PATH)/$(LIBTHEMIS_SO) $(BIN_PATH)/libthemis.pc
+install_themis: $(BIN_PATH)/$(LIBTHEMIS_A) $(BIN_PATH)/$(LIBTHEMIS_SO) $(BIN_PATH)/libthemis.pc
 	@echo -n "install Themis "
 	@mkdir -p $(DESTDIR)$(includedir)/themis
 	@mkdir -p $(DESTDIR)$(pkgconfigdir)

--- a/src/wrappers/themis/themispp/themispp.mk
+++ b/src/wrappers/themis/themispp/themispp.mk
@@ -29,3 +29,5 @@ themispp_uninstall:
 	@echo -n "uninstall ThemisPP "
 	@rm -rf $(DESTDIR)/$(includedir)/themispp
 	@$(PRINT_OK_)
+
+uninstall: themispp_uninstall

--- a/src/wrappers/themis/wasm/wasmthemis.mk
+++ b/src/wrappers/themis/wasm/wasmthemis.mk
@@ -93,3 +93,5 @@ ifdef NPM_VERSION
 	@echo -n "wasm-themis uninstall "
 	@$(BUILD_CMD_)
 endif
+
+uninstall: wasmthemis_uninstall

--- a/tests/test.mk
+++ b/tests/test.mk
@@ -42,7 +42,7 @@ rustthemis_integration_tools:
 
 prepare_tests_basic: soter_test themis_test
 
-prepare_tests_all: err prepare_tests_basic themispp_test
+prepare_tests_all: prepare_tests_basic themispp_test
 ifdef PHP_VERSION
 	@echo -n "make tests for phpthemis "
 	@echo "#!/bin/bash -e" > ./$(BIN_PATH)/tests/phpthemis_test.sh


### PR DESCRIPTION
tl;dr:

```console
make readable
```

Shuffle around various bits of the Makefile and group them up. This makes our 800-line Makefile a bit easier to navigate. This PR mostly moves stuff around and improves comments, but there are a couple of minor non-trivial changes:

- `err` target is now gone. If the user specifies invalid crypto engine then make fails immediately
- `all` target is now set as default in a different way
- Correctly set `CFLAGS` when building on macOS (matters only for cross-compilation)