### PR TITLE
Update BoringSSL submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "third_party/boringssl/src"]
 	path = third_party/boringssl/src
-	url = https://github.com/cossacklabs/boringssl
+	url = https://boringssl.googlesource.com/boringssl


### PR DESCRIPTION
Our changes for Emscripten support have been merged into upstream. Switch back to Google's repository and update the submodule to use the latest version of BoringSSL.