### PR TITLE
Correct EVP_PKEY ownership

### DIFF
--- a/src/soter/boringssl/soter_asym_cipher.c
+++ b/src/soter/boringssl/soter_asym_cipher.c
@@ -77,7 +77,8 @@ soter_status_t soter_asym_cipher_init(soter_asym_cipher_t* asym_cipher,
                                       const size_t key_length,
                                       soter_asym_cipher_padding_t pad)
 {
-    EVP_PKEY* pkey;
+    soter_status_t err = SOTER_FAIL;
+    EVP_PKEY* pkey = NULL;
 
     if ((!asym_cipher) || (SOTER_ASYM_CIPHER_OAEP != pad)) {
         return SOTER_INVALID_PARAMETER;
@@ -90,18 +91,29 @@ soter_status_t soter_asym_cipher_init(soter_asym_cipher_t* asym_cipher,
 
     /* Only RSA supports asymmetric encryption */
     if (!EVP_PKEY_set_type(pkey, EVP_PKEY_RSA)) {
-        EVP_PKEY_free(pkey);
-        return SOTER_FAIL;
+        goto free_pkey;
     }
 
     asym_cipher->pkey_ctx = EVP_PKEY_CTX_new(pkey, NULL);
     if (!(asym_cipher->pkey_ctx)) {
-        EVP_PKEY_free(pkey);
-        return SOTER_FAIL;
+        err = SOTER_NO_MEMORY;
+        goto free_pkey;
     }
-    SOTER_IF_FAIL(soter_asym_cipher_import_key(asym_cipher, key, key_length) == SOTER_SUCCESS,
-                  (EVP_PKEY_free(pkey), EVP_PKEY_CTX_free(asym_cipher->pkey_ctx)));
+
+    err = soter_asym_cipher_import_key(asym_cipher, key, key_length);
+    if (err != SOTER_SUCCESS) {
+        goto free_pkey_ctx;
+    }
+
+    EVP_PKEY_free(pkey);
     return SOTER_SUCCESS;
+
+free_pkey_ctx:
+    EVP_PKEY_CTX_free(asym_cipher->pkey_ctx);
+    asym_cipher->pkey_ctx = NULL;
+free_pkey:
+    EVP_PKEY_free(pkey);
+    return err;
 }
 
 SOTER_PRIVATE_API
@@ -112,11 +124,8 @@ soter_status_t soter_asym_cipher_cleanup(soter_asym_cipher_t* asym_cipher)
     }
 
     if (asym_cipher->pkey_ctx) {
-        EVP_PKEY* pkey = EVP_PKEY_CTX_get0_pkey(asym_cipher->pkey_ctx);
-        if (pkey) {
-            EVP_PKEY_free(pkey);
-        }
         EVP_PKEY_CTX_free(asym_cipher->pkey_ctx);
+        asym_cipher->pkey_ctx = NULL;
     }
 
     return SOTER_SUCCESS;

--- a/src/soter/boringssl/soter_asym_ka.c
+++ b/src/soter/boringssl/soter_asym_ka.c
@@ -64,11 +64,10 @@ soter_status_t soter_asym_ka_init(soter_asym_ka_t* asym_ka_ctx, soter_asym_ka_al
         goto free_pkey_ctx;
     }
 
-    if (1 != EVP_PKEY_set1_EC_KEY(pkey, ec)) {
+    if (EVP_PKEY_assign_EC_KEY(pkey, ec) != 1) {
         goto free_ec_key;
     }
 
-    EC_KEY_free(ec);
     EVP_PKEY_free(pkey);
     return SOTER_SUCCESS;
 

--- a/src/soter/boringssl/soter_ecdsa_common.c
+++ b/src/soter/boringssl/soter_ecdsa_common.c
@@ -36,21 +36,18 @@ soter_status_t soter_ec_gen_key(EVP_PKEY_CTX* pkey_ctx)
     if (EVP_PKEY_EC != EVP_PKEY_id(pkey)) {
         return SOTER_INVALID_PARAMETER;
     }
-    /* ec = EVP_PKEY_get0_EC_KEY(pkey); */
-    /* if (NULL == ec){ */
-    /*   return SOTER_INVALID_PARAMETER; */
-    /* } */
     ec = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
     if (!ec) {
         return SOTER_ENGINE_FAIL;
     }
-    if (!EC_KEY_generate_key(ec)) {
+    if (EC_KEY_generate_key(ec) != 1) {
+        EC_KEY_free(ec);
         return SOTER_ENGINE_FAIL;
     }
-    if (!EVP_PKEY_set1_EC_KEY(pkey, ec)) {
+    if (EVP_PKEY_assign_EC_KEY(pkey, ec) != 1) {
+        EC_KEY_free(ec);
         return SOTER_ENGINE_FAIL;
     }
-    EC_KEY_free(ec);
     return SOTER_SUCCESS;
 }
 

--- a/src/soter/boringssl/soter_sign_ecdsa.c
+++ b/src/soter/boringssl/soter_sign_ecdsa.c
@@ -30,52 +30,66 @@ soter_status_t soter_sign_init_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
                                                 const void* public_key,
                                                 const size_t public_key_length)
 {
-    /* pkey_ctx init */
-    EVP_PKEY* pkey;
+    soter_status_t err = SOTER_FAIL;
+    EVP_PKEY* pkey = NULL;
+
     pkey = EVP_PKEY_new();
     if (!pkey) {
         return SOTER_NO_MEMORY;
     }
+
     if (!EVP_PKEY_set_type(pkey, EVP_PKEY_EC)) {
-        EVP_PKEY_free(pkey);
-        return SOTER_FAIL;
+        goto free_pkey;
     }
+
     ctx->pkey_ctx = EVP_PKEY_CTX_new(pkey, NULL);
     if (!(ctx->pkey_ctx)) {
-        EVP_PKEY_free(pkey);
-        return SOTER_FAIL;
+        err = SOTER_NO_MEMORY;
+        goto free_pkey;
     }
+
     if ((!private_key) && (!public_key)) {
-        if (soter_ec_gen_key(ctx->pkey_ctx) != SOTER_SUCCESS) {
-            soter_sign_cleanup_ecdsa_none_pkcs8(ctx);
-            return SOTER_FAIL;
+        err = soter_ec_gen_key(ctx->pkey_ctx);
+        if (err != SOTER_SUCCESS) {
+            goto free_pkey_ctx;
         }
     } else {
         if (private_key != NULL) {
-            if (soter_ec_import_key(pkey, private_key, private_key_length) != SOTER_SUCCESS) {
-                soter_sign_cleanup_ecdsa_none_pkcs8(ctx);
-                return SOTER_FAIL;
+            err = soter_ec_import_key(pkey, private_key, private_key_length);
+            if (err != SOTER_SUCCESS) {
+                goto free_pkey_ctx;
             }
         }
         if (public_key != NULL) {
-            if (soter_ec_import_key(pkey, public_key, public_key_length) != SOTER_SUCCESS) {
-                soter_sign_cleanup_ecdsa_none_pkcs8(ctx);
-                return SOTER_FAIL;
+            err = soter_ec_import_key(pkey, public_key, public_key_length);
+            if (err != SOTER_SUCCESS) {
+                goto free_pkey_ctx;
             }
         }
     }
 
-    /*md_ctx init*/
     ctx->md_ctx = EVP_MD_CTX_create();
     if (!(ctx->md_ctx)) {
-        soter_sign_cleanup_ecdsa_none_pkcs8(ctx);
-        return SOTER_NO_MEMORY;
+        err = SOTER_NO_MEMORY;
+        goto free_pkey_ctx;
     }
+
     if (EVP_DigestSignInit(ctx->md_ctx, NULL, EVP_sha256(), NULL, pkey) != 1) {
-        soter_sign_cleanup_ecdsa_none_pkcs8(ctx);
-        return SOTER_FAIL;
+        goto free_md_ctx;
     }
+
+    EVP_PKEY_free(pkey);
     return SOTER_SUCCESS;
+
+free_md_ctx:
+    EVP_MD_CTX_destroy(ctx->md_ctx);
+    ctx->md_ctx = NULL;
+free_pkey_ctx:
+    EVP_PKEY_CTX_free(ctx->pkey_ctx);
+    ctx->pkey_ctx = NULL;
+free_pkey:
+    EVP_PKEY_free(pkey);
+    return err;
 }
 
 soter_status_t soter_sign_export_key_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
@@ -129,10 +143,6 @@ soter_status_t soter_sign_cleanup_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx)
         ctx->md_ctx = NULL;
     }
     if (ctx->pkey_ctx) {
-        EVP_PKEY* pkey = EVP_PKEY_CTX_get0_pkey(ctx->pkey_ctx);
-        if (pkey) {
-            EVP_PKEY_free(pkey);
-        }
         EVP_PKEY_CTX_free(ctx->pkey_ctx);
         ctx->pkey_ctx = NULL;
     }

--- a/src/soter/boringssl/soter_verify_ecdsa.c
+++ b/src/soter/boringssl/soter_verify_ecdsa.c
@@ -29,48 +29,60 @@ soter_status_t soter_verify_init_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
                                                   const void* public_key,
                                                   const size_t public_key_length)
 {
-    /* pkey_ctx init */
-    EVP_PKEY* pkey;
+    soter_status_t err = SOTER_FAIL;
+    EVP_PKEY* pkey = NULL;
+
     pkey = EVP_PKEY_new();
     if (!pkey) {
         return SOTER_NO_MEMORY;
     }
+
     if (!EVP_PKEY_set_type(pkey, EVP_PKEY_EC)) {
-        EVP_PKEY_free(pkey);
-        return SOTER_FAIL;
+        goto free_pkey;
     }
+
     ctx->pkey_ctx = EVP_PKEY_CTX_new(pkey, NULL);
     if (!(ctx->pkey_ctx)) {
-        EVP_PKEY_free(pkey);
-        return SOTER_FAIL;
+        err = SOTER_NO_MEMORY;
+        goto free_pkey;
     }
 
     /* TODO: Review needed */
     if ((private_key) && (private_key_length)) {
-        if (soter_ec_import_key(pkey, private_key, private_key_length) != SOTER_SUCCESS) {
-            soter_verify_cleanup_ecdsa_none_pkcs8(ctx);
-            return SOTER_FAIL;
+        err = soter_ec_import_key(pkey, private_key, private_key_length);
+        if (err != SOTER_SUCCESS) {
+            goto free_pkey_ctx;
         }
     }
-
     if ((public_key) && (public_key_length)) {
-        if (soter_ec_import_key(pkey, public_key, public_key_length) != SOTER_SUCCESS) {
-            soter_verify_cleanup_ecdsa_none_pkcs8(ctx);
-            return SOTER_FAIL;
+        err = soter_ec_import_key(pkey, public_key, public_key_length);
+        if (err != SOTER_SUCCESS) {
+            goto free_pkey_ctx;
         }
     }
 
-    /*md_ctx init*/
     ctx->md_ctx = EVP_MD_CTX_create();
     if (!(ctx->md_ctx)) {
-        soter_verify_cleanup_ecdsa_none_pkcs8(ctx);
-        return SOTER_NO_MEMORY;
+        err = SOTER_NO_MEMORY;
+        goto free_pkey_ctx;
     }
+
     if (!EVP_DigestVerifyInit(ctx->md_ctx, NULL, EVP_sha256(), NULL, pkey)) {
-        soter_verify_cleanup_ecdsa_none_pkcs8(ctx);
-        return SOTER_FAIL;
+        goto free_md_ctx;
     }
+
+    EVP_PKEY_free(pkey);
     return SOTER_SUCCESS;
+
+free_md_ctx:
+    EVP_MD_CTX_destroy(ctx->md_ctx);
+    ctx->md_ctx = NULL;
+free_pkey_ctx:
+    EVP_PKEY_CTX_free(ctx->pkey_ctx);
+    ctx->pkey_ctx = NULL;
+free_pkey:
+    EVP_PKEY_free(pkey);
+    return err;
 }
 
 soter_status_t soter_verify_update_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
@@ -112,10 +124,6 @@ soter_status_t soter_verify_cleanup_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx)
         return SOTER_INVALID_PARAMETER;
     }
     if (ctx->pkey_ctx) {
-        EVP_PKEY* pkey = EVP_PKEY_CTX_get0_pkey(ctx->pkey_ctx);
-        if (pkey) {
-            EVP_PKEY_free(pkey);
-        }
         EVP_PKEY_CTX_free(ctx->pkey_ctx);
         ctx->pkey_ctx = NULL;
     }

--- a/src/soter/boringssl/soter_verify_rsa.c
+++ b/src/soter/boringssl/soter_verify_rsa.c
@@ -29,54 +29,67 @@ soter_status_t soter_verify_init_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
                                                const void* public_key,
                                                const size_t public_key_length)
 {
-    /* pkey_ctx init */
-    EVP_PKEY* pkey;
+    soter_status_t err = SOTER_FAIL;
+    EVP_PKEY* pkey = NULL;
+    EVP_PKEY_CTX* md_pkey_ctx = NULL;
+
     pkey = EVP_PKEY_new();
     if (!pkey) {
         return SOTER_NO_MEMORY;
     }
+
     if (!EVP_PKEY_set_type(pkey, EVP_PKEY_RSA)) {
-        EVP_PKEY_free(pkey);
-        return SOTER_FAIL;
+        goto free_pkey;
     }
+
     ctx->pkey_ctx = EVP_PKEY_CTX_new(pkey, NULL);
     if (!(ctx->pkey_ctx)) {
-        EVP_PKEY_free(pkey);
-        return SOTER_FAIL;
+        err = SOTER_NO_MEMORY;
+        goto free_pkey;
     }
+
     if (private_key && private_key_length != 0) {
-        if (soter_rsa_import_key(pkey, private_key, private_key_length) != SOTER_SUCCESS) {
-            soter_verify_cleanup_rsa_pss_pkcs8(ctx);
-            return SOTER_FAIL;
+        err = soter_rsa_import_key(pkey, private_key, private_key_length);
+        if (err != SOTER_SUCCESS) {
+            goto free_pkey_ctx;
         }
     }
     if (public_key && public_key_length != 0) {
-        if (soter_rsa_import_key(pkey, public_key, public_key_length) != SOTER_SUCCESS) {
-            soter_verify_cleanup_rsa_pss_pkcs8(ctx);
-            return SOTER_FAIL;
+        err = soter_rsa_import_key(pkey, public_key, public_key_length);
+        if (err != SOTER_SUCCESS) {
+            goto free_pkey_ctx;
         }
     }
 
-    /*md_ctx init*/
     ctx->md_ctx = EVP_MD_CTX_create();
     if (!(ctx->md_ctx)) {
-        soter_verify_cleanup_rsa_pss_pkcs8(ctx);
-        return SOTER_NO_MEMORY;
+        err = SOTER_NO_MEMORY;
+        goto free_pkey_ctx;
     }
-    EVP_PKEY_CTX* md_pkey_ctx = NULL;
+
+    /* md_pkey_ctx is owned by ctx->md_ctx */
     if (!EVP_DigestVerifyInit(ctx->md_ctx, &md_pkey_ctx, EVP_sha256(), NULL, pkey)) {
-        soter_verify_cleanup_rsa_pss_pkcs8(ctx);
-        return SOTER_FAIL;
+        goto free_md_ctx;
     }
     if (!EVP_PKEY_CTX_set_rsa_padding(md_pkey_ctx, RSA_PKCS1_PSS_PADDING)) {
-        soter_verify_cleanup_rsa_pss_pkcs8(ctx);
-        return SOTER_FAIL;
+        goto free_md_ctx;
     }
     if (!EVP_PKEY_CTX_set_rsa_pss_saltlen(md_pkey_ctx, -2)) {
-        soter_verify_cleanup_rsa_pss_pkcs8(ctx);
-        return SOTER_FAIL;
+        goto free_md_ctx;
     }
+
+    EVP_PKEY_free(pkey);
     return SOTER_SUCCESS;
+
+free_md_ctx:
+    EVP_MD_CTX_destroy(ctx->md_ctx);
+    ctx->md_ctx = NULL;
+free_pkey_ctx:
+    EVP_PKEY_CTX_free(ctx->pkey_ctx);
+    ctx->pkey_ctx = NULL;
+free_pkey:
+    EVP_PKEY_free(pkey);
+    return err;
 }
 
 soter_status_t soter_verify_update_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
@@ -115,12 +128,8 @@ soter_status_t soter_verify_cleanup_rsa_pss_pkcs8(soter_sign_ctx_t* ctx)
         return SOTER_INVALID_PARAMETER;
     }
     if (ctx->pkey_ctx) {
-        EVP_PKEY* pkey = EVP_PKEY_CTX_get0_pkey(ctx->pkey_ctx);
         EVP_PKEY_CTX_free(ctx->pkey_ctx);
         ctx->pkey_ctx = NULL;
-        if (pkey) {
-            EVP_PKEY_free(pkey);
-        }
     }
     if (ctx->md_ctx) {
         EVP_MD_CTX_destroy(ctx->md_ctx);

--- a/src/soter/openssl/soter_asym_cipher.c
+++ b/src/soter/openssl/soter_asym_cipher.c
@@ -78,7 +78,8 @@ soter_status_t soter_asym_cipher_init(soter_asym_cipher_t* asym_cipher,
                                       const size_t key_length,
                                       soter_asym_cipher_padding_t pad)
 {
-    EVP_PKEY* pkey;
+    soter_status_t err = SOTER_FAIL;
+    EVP_PKEY* pkey = NULL;
 
     if ((!asym_cipher) || (SOTER_ASYM_CIPHER_OAEP != pad)) {
         return SOTER_INVALID_PARAMETER;
@@ -91,21 +92,29 @@ soter_status_t soter_asym_cipher_init(soter_asym_cipher_t* asym_cipher,
 
     /* Only RSA supports asymmetric encryption */
     if (!EVP_PKEY_set_type(pkey, EVP_PKEY_RSA)) {
-        EVP_PKEY_free(pkey);
-        return SOTER_FAIL;
+        goto free_pkey;
     }
 
     asym_cipher->pkey_ctx = EVP_PKEY_CTX_new(pkey, NULL);
     if (!(asym_cipher->pkey_ctx)) {
-        EVP_PKEY_free(pkey);
-        return SOTER_FAIL;
+        err = SOTER_NO_MEMORY;
+        goto free_pkey;
     }
-    SOTER_IF_FAIL(soter_asym_cipher_import_key(asym_cipher, key, key_length) == SOTER_SUCCESS,
-                  (EVP_PKEY_free(pkey),
-                   EVP_PKEY_CTX_free(asym_cipher->pkey_ctx),
-                   asym_cipher->pkey_ctx = NULL));
+
+    err = soter_asym_cipher_import_key(asym_cipher, key, key_length);
+    if (err != SOTER_SUCCESS) {
+        goto free_pkey_ctx;
+    }
+
     EVP_PKEY_free(pkey);
     return SOTER_SUCCESS;
+
+free_pkey_ctx:
+    EVP_PKEY_CTX_free(asym_cipher->pkey_ctx);
+    asym_cipher->pkey_ctx = NULL;
+free_pkey:
+    EVP_PKEY_free(pkey);
+    return err;
 }
 
 SOTER_PRIVATE_API

--- a/src/soter/openssl/soter_asym_ka.c
+++ b/src/soter/openssl/soter_asym_ka.c
@@ -35,7 +35,8 @@ static int soter_alg_to_curve_nid(soter_asym_ka_alg_t alg)
 SOTER_PRIVATE_API
 soter_status_t soter_asym_ka_init(soter_asym_ka_t* asym_ka_ctx, soter_asym_ka_alg_t alg)
 {
-    EVP_PKEY* pkey;
+    soter_status_t err = SOTER_FAIL;
+    EVP_PKEY* pkey = NULL;
     int nid = soter_alg_to_curve_nid(alg);
 
     if ((!asym_ka_ctx) || (0 == nid)) {
@@ -48,38 +49,34 @@ soter_status_t soter_asym_ka_init(soter_asym_ka_t* asym_ka_ctx, soter_asym_ka_al
     }
 
     if (!EVP_PKEY_set_type(pkey, EVP_PKEY_EC)) {
-        EVP_PKEY_free(pkey);
-        return SOTER_FAIL;
+        goto free_pkey;
     }
 
     asym_ka_ctx->pkey_ctx = EVP_PKEY_CTX_new(pkey, NULL);
     if (!(asym_ka_ctx->pkey_ctx)) {
-        EVP_PKEY_free(pkey);
-        return SOTER_FAIL;
+        err = SOTER_NO_MEMORY;
+        goto free_pkey;
     }
+
     if (1 != EVP_PKEY_paramgen_init(asym_ka_ctx->pkey_ctx)) {
-        EVP_PKEY_free(pkey);
-        return SOTER_FAIL;
+        goto free_pkey_ctx;
     }
-
     if (1 != EVP_PKEY_CTX_set_ec_paramgen_curve_nid(asym_ka_ctx->pkey_ctx, nid)) {
-        EVP_PKEY_free(pkey);
-        return SOTER_FAIL;
+        goto free_pkey_ctx;
     }
-
     if (1 != EVP_PKEY_paramgen(asym_ka_ctx->pkey_ctx, &pkey)) {
-        EVP_PKEY_free(pkey);
-        return SOTER_FAIL;
+        goto free_pkey_ctx;
     }
 
-    /*if (1 != EVP_PKEY_CTX_ctrl(asym_ka_ctx->pkey_ctx, EVP_PKEY_EC, -1,
-    EVP_PKEY_CTRL_EC_PARAMGEN_CURVE_NID, nid, NULL))
-    {
-            EVP_PKEY_free(pkey);
-            return SOTER_FAIL;
-    }*/
-
+    EVP_PKEY_free(pkey);
     return SOTER_SUCCESS;
+
+free_pkey_ctx:
+    EVP_PKEY_CTX_free(asym_ka_ctx->pkey_ctx);
+    asym_ka_ctx->pkey_ctx = NULL;
+free_pkey:
+    EVP_PKEY_free(pkey);
+    return err;
 }
 
 SOTER_PRIVATE_API
@@ -89,11 +86,8 @@ soter_status_t soter_asym_ka_cleanup(soter_asym_ka_t* asym_ka_ctx)
         return SOTER_INVALID_PARAMETER;
     }
     if (asym_ka_ctx->pkey_ctx) {
-        EVP_PKEY* pkey = EVP_PKEY_CTX_get0_pkey(asym_ka_ctx->pkey_ctx);
         EVP_PKEY_CTX_free(asym_ka_ctx->pkey_ctx);
-        if (pkey) {
-            EVP_PKEY_free(pkey);
-        }
+        asym_ka_ctx->pkey_ctx = NULL;
     }
     return SOTER_SUCCESS;
 }

--- a/src/soter/openssl/soter_sign_ecdsa.c
+++ b/src/soter/openssl/soter_sign_ecdsa.c
@@ -30,64 +30,76 @@ soter_status_t soter_sign_init_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
                                                 const void* public_key,
                                                 const size_t public_key_length)
 {
-    /* pkey_ctx init */
-    EVP_PKEY* pkey;
+    soter_status_t err = SOTER_FAIL;
+    EVP_PKEY* pkey = NULL;
+
     pkey = EVP_PKEY_new();
     if (!pkey) {
         return SOTER_NO_MEMORY;
     }
+
     if (!EVP_PKEY_set_type(pkey, EVP_PKEY_EC)) {
-        EVP_PKEY_free(pkey);
-        return SOTER_FAIL;
+        goto free_pkey;
     }
+
     ctx->pkey_ctx = EVP_PKEY_CTX_new(pkey, NULL);
     if (!(ctx->pkey_ctx)) {
-        EVP_PKEY_free(pkey);
-        return SOTER_FAIL;
+        err = SOTER_NO_MEMORY;
+        goto free_pkey;
     }
+
     if (!EVP_PKEY_paramgen_init(ctx->pkey_ctx)) {
-        soter_sign_cleanup_ecdsa_none_pkcs8(ctx);
-        return SOTER_FAIL;
+        goto free_pkey_ctx;
     }
     if (!EVP_PKEY_CTX_set_ec_paramgen_curve_nid(ctx->pkey_ctx, NID_X9_62_prime256v1)) {
-        soter_sign_cleanup_ecdsa_none_pkcs8(ctx);
-        return SOTER_FAIL;
+        goto free_pkey_ctx;
     }
     if (!EVP_PKEY_paramgen(ctx->pkey_ctx, &pkey)) {
-        soter_sign_cleanup_ecdsa_none_pkcs8(ctx);
-        return SOTER_FAIL;
+        goto free_pkey_ctx;
     }
+
     if ((!private_key) && (!public_key)) {
-        if (soter_ec_gen_key(ctx->pkey_ctx) != SOTER_SUCCESS) {
-            soter_sign_cleanup_ecdsa_none_pkcs8(ctx);
-            return SOTER_FAIL;
+        err = soter_ec_gen_key(ctx->pkey_ctx);
+        if (err != SOTER_SUCCESS) {
+            goto free_pkey_ctx;
         }
     } else {
         if (private_key != NULL) {
-            if (soter_ec_import_key(pkey, private_key, private_key_length) != SOTER_SUCCESS) {
-                soter_sign_cleanup_ecdsa_none_pkcs8(ctx);
-                return SOTER_FAIL;
+            err = soter_ec_import_key(pkey, private_key, private_key_length);
+            if (err != SOTER_SUCCESS) {
+                goto free_pkey_ctx;
             }
         }
         if (public_key != NULL) {
-            if (soter_ec_import_key(pkey, public_key, public_key_length) != SOTER_SUCCESS) {
-                soter_sign_cleanup_ecdsa_none_pkcs8(ctx);
-                return SOTER_FAIL;
+            err = soter_ec_import_key(pkey, public_key, public_key_length);
+            if (err != SOTER_SUCCESS) {
+                goto free_pkey_ctx;
             }
         }
     }
 
-    /*md_ctx init*/
     ctx->md_ctx = EVP_MD_CTX_create();
     if (!(ctx->md_ctx)) {
-        soter_sign_cleanup_ecdsa_none_pkcs8(ctx);
-        return SOTER_NO_MEMORY;
+        err = SOTER_NO_MEMORY;
+        goto free_pkey_ctx;
     }
+
     if (EVP_DigestSignInit(ctx->md_ctx, NULL, EVP_sha256(), NULL, pkey) != 1) {
-        soter_sign_cleanup_ecdsa_none_pkcs8(ctx);
-        return SOTER_FAIL;
+        goto free_md_ctx;
     }
+
+    EVP_PKEY_free(pkey);
     return SOTER_SUCCESS;
+
+free_md_ctx:
+    EVP_MD_CTX_destroy(ctx->md_ctx);
+    ctx->md_ctx = NULL;
+free_pkey_ctx:
+    EVP_PKEY_CTX_free(ctx->pkey_ctx);
+    ctx->pkey_ctx = NULL;
+free_pkey:
+    EVP_PKEY_free(pkey);
+    return err;
 }
 
 soter_status_t soter_sign_export_key_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
@@ -141,10 +153,6 @@ soter_status_t soter_sign_cleanup_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx)
         ctx->md_ctx = NULL;
     }
     if (ctx->pkey_ctx) {
-        EVP_PKEY* pkey = EVP_PKEY_CTX_get0_pkey(ctx->pkey_ctx);
-        if (pkey) {
-            EVP_PKEY_free(pkey);
-        }
         EVP_PKEY_CTX_free(ctx->pkey_ctx);
         ctx->pkey_ctx = NULL;
     }

--- a/src/soter/openssl/soter_sign_rsa.c
+++ b/src/soter/openssl/soter_sign_rsa.c
@@ -29,61 +29,74 @@ soter_status_t soter_sign_init_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
                                              const void* public_key,
                                              const size_t public_key_length)
 {
-    /* pkey_ctx init */
-    EVP_PKEY* pkey;
+    soter_status_t err = SOTER_FAIL;
+    EVP_PKEY* pkey = NULL;
+    EVP_PKEY_CTX* md_pkey_ctx = NULL;
+
     pkey = EVP_PKEY_new();
     if (!pkey) {
         return SOTER_NO_MEMORY;
     }
+
     if (!EVP_PKEY_set_type(pkey, EVP_PKEY_RSA)) {
-        EVP_PKEY_free(pkey);
-        return SOTER_FAIL;
+        goto free_pkey;
     }
+
     ctx->pkey_ctx = EVP_PKEY_CTX_new(pkey, NULL);
     if (!(ctx->pkey_ctx)) {
-        EVP_PKEY_free(pkey);
-        return SOTER_FAIL;
+        err = SOTER_NO_MEMORY;
+        goto free_pkey;
     }
+
     if ((!private_key) && (!public_key)) {
-        if (soter_rsa_gen_key(ctx->pkey_ctx) != SOTER_SUCCESS) {
-            soter_sign_cleanup_rsa_pss_pkcs8(ctx);
-            return SOTER_FAIL;
+        err = soter_rsa_gen_key(ctx->pkey_ctx);
+        if (err != SOTER_SUCCESS) {
+            goto free_pkey_ctx;
         }
     } else {
         if (private_key != NULL) {
-            if (soter_rsa_import_key(pkey, private_key, private_key_length) != SOTER_SUCCESS) {
-                soter_sign_cleanup_rsa_pss_pkcs8(ctx);
-                return SOTER_FAIL;
+            err = soter_rsa_import_key(pkey, private_key, private_key_length);
+            if (err != SOTER_SUCCESS) {
+                goto free_pkey_ctx;
             }
         }
         if (public_key != NULL) {
-            if (soter_rsa_import_key(pkey, public_key, public_key_length) != SOTER_SUCCESS) {
-                soter_sign_cleanup_rsa_pss_pkcs8(ctx);
-                return SOTER_FAIL;
+            err = soter_rsa_import_key(pkey, public_key, public_key_length);
+            if (err != SOTER_SUCCESS) {
+                goto free_pkey_ctx;
             }
         }
     }
 
-    /*md_ctx init*/
     ctx->md_ctx = EVP_MD_CTX_create();
     if (!(ctx->md_ctx)) {
-        soter_sign_cleanup_rsa_pss_pkcs8(ctx);
-        return SOTER_NO_MEMORY;
+        err = SOTER_NO_MEMORY;
+        goto free_pkey_ctx;
     }
-    EVP_PKEY_CTX* md_pkey_ctx = NULL;
+
+    /* md_pkey_ctx is owned by ctx->md_ctx */
     if (!EVP_DigestSignInit(ctx->md_ctx, &md_pkey_ctx, EVP_sha256(), NULL, pkey)) {
-        soter_sign_cleanup_rsa_pss_pkcs8(ctx);
-        return SOTER_FAIL;
+        goto free_md_ctx;
     }
     if (!EVP_PKEY_CTX_set_rsa_padding(md_pkey_ctx, RSA_PKCS1_PSS_PADDING)) {
-        soter_sign_cleanup_rsa_pss_pkcs8(ctx);
-        return SOTER_FAIL;
+        goto free_md_ctx;
     }
     if (!EVP_PKEY_CTX_set_rsa_pss_saltlen(md_pkey_ctx, -2)) {
-        soter_sign_cleanup_rsa_pss_pkcs8(ctx);
-        return SOTER_FAIL;
+        goto free_md_ctx;
     }
+
+    EVP_PKEY_free(pkey);
     return SOTER_SUCCESS;
+
+free_md_ctx:
+    EVP_MD_CTX_destroy(ctx->md_ctx);
+    ctx->md_ctx = NULL;
+free_pkey_ctx:
+    EVP_PKEY_CTX_free(ctx->pkey_ctx);
+    ctx->pkey_ctx = NULL;
+free_pkey:
+    EVP_PKEY_free(pkey);
+    return err;
 }
 
 soter_status_t soter_sign_export_key_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
@@ -130,10 +143,6 @@ soter_status_t soter_sign_cleanup_rsa_pss_pkcs8(soter_sign_ctx_t* ctx)
         return SOTER_INVALID_PARAMETER;
     }
     if (ctx->pkey_ctx) {
-        EVP_PKEY* pkey = EVP_PKEY_CTX_get0_pkey(ctx->pkey_ctx);
-        if (pkey) {
-            EVP_PKEY_free(pkey);
-        }
         EVP_PKEY_CTX_free(ctx->pkey_ctx);
         ctx->pkey_ctx = NULL;
     }

--- a/src/soter/openssl/soter_verify_ecdsa.c
+++ b/src/soter/openssl/soter_verify_ecdsa.c
@@ -29,48 +29,60 @@ soter_status_t soter_verify_init_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
                                                   const void* public_key,
                                                   const size_t public_key_length)
 {
-    /* pkey_ctx init */
-    EVP_PKEY* pkey;
+    soter_status_t err = SOTER_FAIL;
+    EVP_PKEY* pkey = NULL;
+
     pkey = EVP_PKEY_new();
     if (!pkey) {
         return SOTER_NO_MEMORY;
     }
+
     if (!EVP_PKEY_set_type(pkey, EVP_PKEY_EC)) {
-        EVP_PKEY_free(pkey);
-        return SOTER_FAIL;
+        goto free_pkey;
     }
+
     ctx->pkey_ctx = EVP_PKEY_CTX_new(pkey, NULL);
     if (!(ctx->pkey_ctx)) {
-        EVP_PKEY_free(pkey);
-        return SOTER_FAIL;
+        err = SOTER_NO_MEMORY;
+        goto free_pkey;
     }
 
     /* TODO: Review needed */
     if ((private_key) && (private_key_length)) {
-        if (soter_ec_import_key(pkey, private_key, private_key_length) != SOTER_SUCCESS) {
-            soter_verify_cleanup_ecdsa_none_pkcs8(ctx);
-            return SOTER_FAIL;
+        err = soter_ec_import_key(pkey, private_key, private_key_length);
+        if (err != SOTER_SUCCESS) {
+            goto free_pkey_ctx;
         }
     }
-
     if ((public_key) && (public_key_length)) {
-        if (soter_ec_import_key(pkey, public_key, public_key_length) != SOTER_SUCCESS) {
-            soter_verify_cleanup_ecdsa_none_pkcs8(ctx);
-            return SOTER_FAIL;
+        err = soter_ec_import_key(pkey, public_key, public_key_length);
+        if (err != SOTER_SUCCESS) {
+            goto free_pkey_ctx;
         }
     }
 
-    /*md_ctx init*/
     ctx->md_ctx = EVP_MD_CTX_create();
     if (!(ctx->md_ctx)) {
-        soter_verify_cleanup_ecdsa_none_pkcs8(ctx);
-        return SOTER_NO_MEMORY;
+        err = SOTER_NO_MEMORY;
+        goto free_pkey_ctx;
     }
+
     if (!EVP_DigestVerifyInit(ctx->md_ctx, NULL, EVP_sha256(), NULL, pkey)) {
-        soter_verify_cleanup_ecdsa_none_pkcs8(ctx);
-        return SOTER_FAIL;
+        goto free_md_ctx;
     }
+
+    EVP_PKEY_free(pkey);
     return SOTER_SUCCESS;
+
+free_md_ctx:
+    EVP_MD_CTX_destroy(ctx->md_ctx);
+    ctx->md_ctx = NULL;
+free_pkey_ctx:
+    EVP_PKEY_CTX_free(ctx->pkey_ctx);
+    ctx->pkey_ctx = NULL;
+free_pkey:
+    EVP_PKEY_free(pkey);
+    return err;
 }
 
 soter_status_t soter_verify_update_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
@@ -117,10 +129,6 @@ soter_status_t soter_verify_cleanup_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx)
         ctx->md_ctx = NULL;
     }
     if (ctx->pkey_ctx) {
-        EVP_PKEY* pkey = EVP_PKEY_CTX_get0_pkey(ctx->pkey_ctx);
-        if (pkey) {
-            EVP_PKEY_free(pkey);
-        }
         EVP_PKEY_CTX_free(ctx->pkey_ctx);
         ctx->pkey_ctx = NULL;
     }

--- a/src/soter/openssl/soter_verify_rsa.c
+++ b/src/soter/openssl/soter_verify_rsa.c
@@ -29,54 +29,67 @@ soter_status_t soter_verify_init_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
                                                const void* public_key,
                                                const size_t public_key_length)
 {
-    /* pkey_ctx init */
-    EVP_PKEY* pkey;
+    soter_status_t err = SOTER_FAIL;
+    EVP_PKEY* pkey = NULL;
+    EVP_PKEY_CTX* md_pkey_ctx = NULL;
+
     pkey = EVP_PKEY_new();
     if (!pkey) {
         return SOTER_NO_MEMORY;
     }
+
     if (!EVP_PKEY_set_type(pkey, EVP_PKEY_RSA)) {
-        EVP_PKEY_free(pkey);
-        return SOTER_FAIL;
+        goto free_pkey;
     }
+
     ctx->pkey_ctx = EVP_PKEY_CTX_new(pkey, NULL);
     if (!(ctx->pkey_ctx)) {
-        EVP_PKEY_free(pkey);
-        return SOTER_FAIL;
+        err = SOTER_NO_MEMORY;
+        goto free_pkey;
     }
+
     if (private_key && private_key_length != 0) {
-        if (soter_rsa_import_key(pkey, private_key, private_key_length) != SOTER_SUCCESS) {
-            soter_verify_cleanup_rsa_pss_pkcs8(ctx);
-            return SOTER_FAIL;
+        err = soter_rsa_import_key(pkey, private_key, private_key_length);
+        if (err != SOTER_SUCCESS) {
+            goto free_pkey_ctx;
         }
     }
     if (public_key && public_key_length != 0) {
-        if (soter_rsa_import_key(pkey, public_key, public_key_length) != SOTER_SUCCESS) {
-            soter_verify_cleanup_rsa_pss_pkcs8(ctx);
-            return SOTER_FAIL;
+        err = soter_rsa_import_key(pkey, public_key, public_key_length);
+        if (err != SOTER_SUCCESS) {
+            goto free_pkey_ctx;
         }
     }
 
-    /*md_ctx init*/
     ctx->md_ctx = EVP_MD_CTX_create();
     if (!(ctx->md_ctx)) {
-        soter_verify_cleanup_rsa_pss_pkcs8(ctx);
-        return SOTER_NO_MEMORY;
+        err = SOTER_NO_MEMORY;
+        goto free_pkey_ctx;
     }
-    EVP_PKEY_CTX* md_pkey_ctx = NULL;
+
+    /* md_pkey_ctx is owned by ctx->md_ctx */
     if (!EVP_DigestVerifyInit(ctx->md_ctx, &md_pkey_ctx, EVP_sha256(), NULL, pkey)) {
-        soter_verify_cleanup_rsa_pss_pkcs8(ctx);
-        return SOTER_FAIL;
+        goto free_md_ctx;
     }
     if (!EVP_PKEY_CTX_set_rsa_padding(md_pkey_ctx, RSA_PKCS1_PSS_PADDING)) {
-        soter_verify_cleanup_rsa_pss_pkcs8(ctx);
-        return SOTER_FAIL;
+        goto free_md_ctx;
     }
     if (!EVP_PKEY_CTX_set_rsa_pss_saltlen(md_pkey_ctx, -2)) {
-        soter_verify_cleanup_rsa_pss_pkcs8(ctx);
-        return SOTER_FAIL;
+        goto free_md_ctx;
     }
+
+    EVP_PKEY_free(pkey);
     return SOTER_SUCCESS;
+
+free_md_ctx:
+    EVP_MD_CTX_destroy(ctx->md_ctx);
+    ctx->md_ctx = NULL;
+free_pkey_ctx:
+    EVP_PKEY_CTX_free(ctx->pkey_ctx);
+    ctx->pkey_ctx = NULL;
+free_pkey:
+    EVP_PKEY_free(pkey);
+    return err;
 }
 
 soter_status_t soter_verify_update_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
@@ -115,10 +128,6 @@ soter_status_t soter_verify_cleanup_rsa_pss_pkcs8(soter_sign_ctx_t* ctx)
         return SOTER_INVALID_PARAMETER;
     }
     if (ctx->pkey_ctx) {
-        EVP_PKEY* pkey = EVP_PKEY_CTX_get0_pkey(ctx->pkey_ctx);
-        if (pkey) {
-            EVP_PKEY_free(pkey);
-        }
         EVP_PKEY_CTX_free(ctx->pkey_ctx);
         ctx->pkey_ctx = NULL;
     }

--- a/tests/soter/soter_asym_cipher_test.c
+++ b/tests/soter/soter_asym_cipher_test.c
@@ -160,10 +160,11 @@ void test_api(int key_length)
     testsuite_fail_unless(SOTER_INVALID_PARAMETER
                               == soter_asym_cipher_init(NULL, key_data, key_data_length, SOTER_ASYM_CIPHER_OAEP),
                           "soter_asym_cipher_init: invalid context");
-    testsuite_fail_unless(SOTER_FAIL
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER
                               == soter_asym_cipher_init(&ctx, NULL, key_data_length, SOTER_ASYM_CIPHER_OAEP),
                           "soter_asym_cipher_init: invalid key");
-    testsuite_fail_unless(SOTER_FAIL == soter_asym_cipher_init(&ctx, key_data, 0, SOTER_ASYM_CIPHER_OAEP),
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER
+                              == soter_asym_cipher_init(&ctx, key_data, 0, SOTER_ASYM_CIPHER_OAEP),
                           "soter_asym_cipher_init: invalid key length");
     testsuite_fail_unless(SOTER_INVALID_PARAMETER
                               == soter_asym_cipher_init(&ctx,
@@ -237,10 +238,10 @@ void test_api(int key_length)
     testsuite_fail_unless(SOTER_INVALID_PARAMETER
                               == soter_asym_cipher_init(NULL, key_data, key_data_length, SOTER_ASYM_CIPHER_OAEP),
                           "soter_asym_cipher_init: invalid context");
-    testsuite_fail_unless(SOTER_FAIL
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER
                               == soter_asym_cipher_init(&decrypt_ctx, NULL, key_data_length, SOTER_ASYM_CIPHER_OAEP),
                           "soter_asym_cipher_init: invalid key");
-    testsuite_fail_unless(SOTER_FAIL
+    testsuite_fail_unless(SOTER_INVALID_PARAMETER
                               == soter_asym_cipher_init(&decrypt_ctx, key_data, 0, SOTER_ASYM_CIPHER_OAEP),
                           "soter_asym_cipher_init: invalid key length");
     testsuite_fail_unless(SOTER_INVALID_PARAMETER


### PR DESCRIPTION
Memory management is hard, especially in C. Recent code reviews by @outspace have uncovered a bunch of issues with OpenSSL usage, in particular with EVP_PKEY and EVP_PKEY_CTX objects. Here we attempt to fix them. This PR should resolve issues #532, #533, #534.

I have manually reviewed EVP_PKEY and EVP_PKEY_CTX usage in our code and it seems to be okay now. @ignatk, could you please vet these changes?

The key point in most of the cases is that EVP_PKEY_CTX_new() does not _transfer_ ownership over EVP_PKEY – it increments the refcount on it and we still have to free the original reference to avoid memory leaks. Sometimes we did an additional free in the destructor and this balanced all out, but it’s hardly an elegant solution.

---

We've got a bunch of functions which are currently doing tricky things with EVP_PKEY and EVP_PKEY_CTX objects, sometimes incorrectly. Let’s make sure that the code is readable, that we don't leak objects in the failure path, and that we don't free objects twice.

The general rules we follow are:

1. The function allocating the object is the one that frees it.

2. Unless the ownership is *transferred* to some other object, in which case we must not free the transferred object: the new owner is responsible for that. This includes constructors.

3. Set the field to NULL after freeing the object stored there. (It's okay to leave local variables as is.)

They all seem obvious in the hindsight, but the current code contains a number of violations in these rules. Partially, due to magic macros which make it *seem* like the error handling and resource management are correct, while in fact they are not. Therefore we get rid of the macros and replace them with plain old conditions.

We use "goto" pattern in order to make destruction of objects more structured. Yeah, "goto" and "structured" in the same sentence, but this is one of the few cases where using goto makes sense in C. (We'd use proper destructors in modern language, but we aren't.)

Since we use goto, this may have weird effects on variable scoping and initialization. Move all variable declarations to the top of the function and make sure that all local variables are initialized.

Some of these changes make Soter return more accurate error codes: for example, SOTER_INVALID_PARAMETER instead of SOTER_FAIL when the issue is actually in the parameter. Update the test suite to expect the new error codes. Strictly speaking, this *does* break backwards compatibility (or at least, may break someone's weird use case), but I feel that it's acceptable to make this change. Usually, applications don't check concrete error values, and if they do they expect to catch parameter errors that way and we should return appropriate error codes.