### PR TITLE
bump themis iOS to 0.12.2, update podspec, update examples

### DIFF
--- a/docs/examples/Themis-server/Obj-C/Podfile
+++ b/docs/examples/Themis-server/Obj-C/Podfile
@@ -23,6 +23,6 @@ use_frameworks!
 
 target :"WorkingWithThemisServer" do
 
-  pod 'themis', '0.12.1'
+  pod 'themis', '0.12.2'
 
 end

--- a/docs/examples/Themis-server/Obj-C/Podfile.lock
+++ b/docs/examples/Themis-server/Obj-C/Podfile.lock
@@ -1,19 +1,19 @@
 PODS:
-  - GRKOpenSSLFramework (1.0.2.19)
-  - themis (0.12.1):
-    - themis/themis-openssl (= 0.12.1)
-  - themis/themis-openssl (0.12.1):
-    - GRKOpenSSLFramework (~> 1.0.1)
-    - themis/themis-openssl/core (= 0.12.1)
-    - themis/themis-openssl/objcwrapper (= 0.12.1)
-  - themis/themis-openssl/core (0.12.1):
-    - GRKOpenSSLFramework (~> 1.0.1)
-  - themis/themis-openssl/objcwrapper (0.12.1):
-    - GRKOpenSSLFramework (~> 1.0.1)
+  - GRKOpenSSLFramework (1.0.2.18)
+  - themis (0.12.2):
+    - themis/themis-openssl (= 0.12.2)
+  - themis/themis-openssl (0.12.2):
+    - GRKOpenSSLFramework (= 1.0.2.18)
+    - themis/themis-openssl/core (= 0.12.2)
+    - themis/themis-openssl/objcwrapper (= 0.12.2)
+  - themis/themis-openssl/core (0.12.2):
+    - GRKOpenSSLFramework (= 1.0.2.18)
+  - themis/themis-openssl/objcwrapper (0.12.2):
+    - GRKOpenSSLFramework (= 1.0.2.18)
     - themis/themis-openssl/core
 
 DEPENDENCIES:
-  - themis (= 0.12.1)
+  - themis (= 0.12.2)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
@@ -21,9 +21,9 @@ SPEC REPOS:
     - themis
 
 SPEC CHECKSUMS:
-  GRKOpenSSLFramework: 4abc733a8fcbc37060619a86a54202d2938dd70e
-  themis: 703d33444f3ecfd0b922a0a2ca3dcbea2046d80d
+  GRKOpenSSLFramework: 1d65e55d569af7b23074373041a92cc8bc768a92
+  themis: f4ef6d942670146ad08dca8cc99a34ae040878c0
 
-PODFILE CHECKSUM: 523ad87c704d144da2b18fbff05166651f850967
+PODFILE CHECKSUM: 0a484fd4a2a45b6c10bd42ee2fabc1b848bf01e4
 
 COCOAPODS: 1.8.0

--- a/docs/examples/Themis-server/Obj-C/WorkingWithThemisServer/WorkingWithThemisServer.xcodeproj/project.pbxproj
+++ b/docs/examples/Themis-server/Obj-C/WorkingWithThemisServer/WorkingWithThemisServer.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		07D532CC346E0B14B4065C30 /* Pods_WorkingWithThemisServer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65A98E649DF5797B62EB85FC /* Pods_WorkingWithThemisServer.framework */; };
 		733BD9BC1BDBF58500C6DA2F /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 733BD9BB1BDBF58500C6DA2F /* main.m */; };
 		733BD9BF1BDBF58600C6DA2F /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 733BD9BE1BDBF58600C6DA2F /* AppDelegate.m */; };
 		733BD9C21BDBF58600C6DA2F /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 733BD9C11BDBF58600C6DA2F /* ViewController.m */; };
@@ -18,6 +17,7 @@
 		733BD9E01BDBF58600C6DA2F /* WorkingWithThemisServerUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = 733BD9DF1BDBF58600C6DA2F /* WorkingWithThemisServerUITests.m */; };
 		733BD9F11BDBF77700C6DA2F /* SMessageClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 733BD9EE1BDBF77700C6DA2F /* SMessageClient.m */; };
 		733BD9F21BDBF77700C6DA2F /* SSessionClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 733BD9F01BDBF77700C6DA2F /* SSessionClient.m */; };
+		7998249C920B85674F0E45A1 /* Pods_WorkingWithThemisServer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3BD9C37918C5180D2FE1C214 /* Pods_WorkingWithThemisServer.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -38,9 +38,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		2D48D85E6AB3EEEC756A7FFD /* Pods-WorkingWithThemisServer.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WorkingWithThemisServer.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WorkingWithThemisServer/Pods-WorkingWithThemisServer.debug.xcconfig"; sourceTree = "<group>"; };
-		3AF51B8253F0D19EE58D064B /* Pods-WorkingWithThemisServer.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WorkingWithThemisServer.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WorkingWithThemisServer/Pods-WorkingWithThemisServer.release.xcconfig"; sourceTree = "<group>"; };
-		65A98E649DF5797B62EB85FC /* Pods_WorkingWithThemisServer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WorkingWithThemisServer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3BD9C37918C5180D2FE1C214 /* Pods_WorkingWithThemisServer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WorkingWithThemisServer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		637B5EF9224970C82C7F3374 /* Pods-WorkingWithThemisServer.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WorkingWithThemisServer.release.xcconfig"; path = "Target Support Files/Pods-WorkingWithThemisServer/Pods-WorkingWithThemisServer.release.xcconfig"; sourceTree = "<group>"; };
 		733BD9B71BDBF58500C6DA2F /* WorkingWithThemisServer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WorkingWithThemisServer.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		733BD9BB1BDBF58500C6DA2F /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		733BD9BD1BDBF58500C6DA2F /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -61,6 +60,7 @@
 		733BD9EE1BDBF77700C6DA2F /* SMessageClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SMessageClient.m; sourceTree = "<group>"; };
 		733BD9EF1BDBF77700C6DA2F /* SSessionClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SSessionClient.h; sourceTree = "<group>"; };
 		733BD9F01BDBF77700C6DA2F /* SSessionClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SSessionClient.m; sourceTree = "<group>"; };
+		ECA699EAF10A7BD78E4A632F /* Pods-WorkingWithThemisServer.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WorkingWithThemisServer.debug.xcconfig"; path = "Target Support Files/Pods-WorkingWithThemisServer/Pods-WorkingWithThemisServer.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -68,7 +68,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				07D532CC346E0B14B4065C30 /* Pods_WorkingWithThemisServer.framework in Frameworks */,
+				7998249C920B85674F0E45A1 /* Pods_WorkingWithThemisServer.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -89,21 +89,12 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		3E6B84F1B30DD14444ADF575 /* Frameworks */ = {
+		151F262E3786B50F4687253C /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				65A98E649DF5797B62EB85FC /* Pods_WorkingWithThemisServer.framework */,
+				3BD9C37918C5180D2FE1C214 /* Pods_WorkingWithThemisServer.framework */,
 			);
 			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		5B4EAB849BFA9ADC914D265A /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				2D48D85E6AB3EEEC756A7FFD /* Pods-WorkingWithThemisServer.debug.xcconfig */,
-				3AF51B8253F0D19EE58D064B /* Pods-WorkingWithThemisServer.release.xcconfig */,
-			);
-			name = Pods;
 			sourceTree = "<group>";
 		};
 		733BD9AE1BDBF58500C6DA2F = {
@@ -113,8 +104,8 @@
 				733BD9D31BDBF58600C6DA2F /* WorkingWithThemisServerTests */,
 				733BD9DE1BDBF58600C6DA2F /* WorkingWithThemisServerUITests */,
 				733BD9B81BDBF58500C6DA2F /* Products */,
-				5B4EAB849BFA9ADC914D265A /* Pods */,
-				3E6B84F1B30DD14444ADF575 /* Frameworks */,
+				EA3E136DA0759FB8D7EC2D56 /* Pods */,
+				151F262E3786B50F4687253C /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -174,6 +165,16 @@
 			path = WorkingWithThemisServerUITests;
 			sourceTree = "<group>";
 		};
+		EA3E136DA0759FB8D7EC2D56 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				ECA699EAF10A7BD78E4A632F /* Pods-WorkingWithThemisServer.debug.xcconfig */,
+				637B5EF9224970C82C7F3374 /* Pods-WorkingWithThemisServer.release.xcconfig */,
+			);
+			name = Pods;
+			path = ../Pods;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -181,11 +182,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 733BD9E41BDBF58600C6DA2F /* Build configuration list for PBXNativeTarget "WorkingWithThemisServer" */;
 			buildPhases = (
-				A6B983AC75AC02909E5FDEF7 /* [CP] Check Pods Manifest.lock */,
+				DA2836CA6159D28F16C1F8E5 /* [CP] Check Pods Manifest.lock */,
 				733BD9B31BDBF58500C6DA2F /* Sources */,
 				733BD9B41BDBF58500C6DA2F /* Frameworks */,
 				733BD9B51BDBF58500C6DA2F /* Resources */,
-				D38B884232238A14E74428AF /* [CP] Embed Pods Frameworks */,
+				9A2445949129AD9A4B1A8A0B /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -243,6 +244,7 @@
 				TargetAttributes = {
 					733BD9B61BDBF58500C6DA2F = {
 						CreatedOnToolsVersion = 7.1;
+						DevelopmentTeam = X6X7AHQ2D4;
 					};
 					733BD9CF1BDBF58600C6DA2F = {
 						CreatedOnToolsVersion = 7.1;
@@ -302,7 +304,27 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		A6B983AC75AC02909E5FDEF7 /* [CP] Check Pods Manifest.lock */ = {
+		9A2445949129AD9A4B1A8A0B /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-WorkingWithThemisServer/Pods-WorkingWithThemisServer-frameworks.sh",
+				"${PODS_ROOT}/GRKOpenSSLFramework/OpenSSL-iOS/bin/openssl.framework",
+				"${BUILT_PRODUCTS_DIR}/themis/themis.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/openssl.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/themis.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-WorkingWithThemisServer/Pods-WorkingWithThemisServer-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		DA2836CA6159D28F16C1F8E5 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -322,26 +344,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		D38B884232238A14E74428AF /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-WorkingWithThemisServer/Pods-WorkingWithThemisServer-frameworks.sh",
-				"${PODS_ROOT}/GRKOpenSSLFramework/OpenSSL-iOS/bin/openssl.framework",
-				"${BUILT_PRODUCTS_DIR}/themis/themis.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/openssl.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/themis.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-WorkingWithThemisServer/Pods-WorkingWithThemisServer-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -514,9 +516,10 @@
 		};
 		733BD9E51BDBF58600C6DA2F /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2D48D85E6AB3EEEC756A7FFD /* Pods-WorkingWithThemisServer.debug.xcconfig */;
+			baseConfigurationReference = ECA699EAF10A7BD78E4A632F /* Pods-WorkingWithThemisServer.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = X6X7AHQ2D4;
 				INFOPLIST_FILE = WorkingWithThemisServer/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.stanfy.WorkingWithThemisServer;
@@ -526,9 +529,10 @@
 		};
 		733BD9E61BDBF58600C6DA2F /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3AF51B8253F0D19EE58D064B /* Pods-WorkingWithThemisServer.release.xcconfig */;
+			baseConfigurationReference = 637B5EF9224970C82C7F3374 /* Pods-WorkingWithThemisServer.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = X6X7AHQ2D4;
 				INFOPLIST_FILE = WorkingWithThemisServer/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.stanfy.WorkingWithThemisServer;

--- a/docs/examples/Themis-server/swift/Podfile
+++ b/docs/examples/Themis-server/swift/Podfile
@@ -23,6 +23,6 @@ use_frameworks!
 
 target :"SwiftThemisServerExample" do
 
-  pod 'themis', '0.12.1'
+  pod 'themis', '0.12.2'
 
 end

--- a/docs/examples/Themis-server/swift/Podfile.lock
+++ b/docs/examples/Themis-server/swift/Podfile.lock
@@ -1,19 +1,19 @@
 PODS:
-  - GRKOpenSSLFramework (1.0.2.19)
-  - themis (0.12.1):
-    - themis/themis-openssl (= 0.12.1)
-  - themis/themis-openssl (0.12.1):
-    - GRKOpenSSLFramework (~> 1.0.1)
-    - themis/themis-openssl/core (= 0.12.1)
-    - themis/themis-openssl/objcwrapper (= 0.12.1)
-  - themis/themis-openssl/core (0.12.1):
-    - GRKOpenSSLFramework (~> 1.0.1)
-  - themis/themis-openssl/objcwrapper (0.12.1):
-    - GRKOpenSSLFramework (~> 1.0.1)
+  - GRKOpenSSLFramework (1.0.2.18)
+  - themis (0.12.2):
+    - themis/themis-openssl (= 0.12.2)
+  - themis/themis-openssl (0.12.2):
+    - GRKOpenSSLFramework (= 1.0.2.18)
+    - themis/themis-openssl/core (= 0.12.2)
+    - themis/themis-openssl/objcwrapper (= 0.12.2)
+  - themis/themis-openssl/core (0.12.2):
+    - GRKOpenSSLFramework (= 1.0.2.18)
+  - themis/themis-openssl/objcwrapper (0.12.2):
+    - GRKOpenSSLFramework (= 1.0.2.18)
     - themis/themis-openssl/core
 
 DEPENDENCIES:
-  - themis (= 0.12.1)
+  - themis (= 0.12.2)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
@@ -21,9 +21,9 @@ SPEC REPOS:
     - themis
 
 SPEC CHECKSUMS:
-  GRKOpenSSLFramework: 4abc733a8fcbc37060619a86a54202d2938dd70e
-  themis: 703d33444f3ecfd0b922a0a2ca3dcbea2046d80d
+  GRKOpenSSLFramework: 1d65e55d569af7b23074373041a92cc8bc768a92
+  themis: f4ef6d942670146ad08dca8cc99a34ae040878c0
 
-PODFILE CHECKSUM: 6e6a11a8765645dd4f930f2908d139bd8afe682f
+PODFILE CHECKSUM: d7dae54b949059d61e288647dc393da42fb7eeec
 
 COCOAPODS: 1.8.0

--- a/docs/examples/Themis-server/swift/SwiftThemisServerExample/SwiftThemisServerExample.xcodeproj/project.pbxproj
+++ b/docs/examples/Themis-server/swift/SwiftThemisServerExample/SwiftThemisServerExample.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		2FC21F8198CD38C3731B8EC6 /* Pods_SwiftThemisServerExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BA738A3EB8F2F86047D8CEC2 /* Pods_SwiftThemisServerExample.framework */; };
 		736DDB661CC5990900CD0C31 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736DDB651CC5990900CD0C31 /* AppDelegate.swift */; };
 		736DDB681CC5990900CD0C31 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736DDB671CC5990900CD0C31 /* ViewController.swift */; };
 		736DDB6B1CC5990900CD0C31 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 736DDB691CC5990900CD0C31 /* Main.storyboard */; };
@@ -15,9 +14,12 @@
 		736DDB701CC5990900CD0C31 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 736DDB6E1CC5990900CD0C31 /* LaunchScreen.storyboard */; };
 		736DDB781CC5A24A00CD0C31 /* SMessageClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736DDB771CC5A24A00CD0C31 /* SMessageClient.swift */; };
 		736DDB7A1CC5A25200CD0C31 /* SSessionClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736DDB791CC5A25200CD0C31 /* SSessionClient.swift */; };
+		F973E8993F5264676E4CE2C6 /* Pods_SwiftThemisServerExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 75BDE3490661708E5D830773 /* Pods_SwiftThemisServerExample.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		13B806E9EA467D91E43D2542 /* Pods-SwiftThemisServerExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftThemisServerExample.release.xcconfig"; path = "Target Support Files/Pods-SwiftThemisServerExample/Pods-SwiftThemisServerExample.release.xcconfig"; sourceTree = "<group>"; };
+		21E6EE97700292F20D15A723 /* Pods-SwiftThemisServerExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftThemisServerExample.debug.xcconfig"; path = "Target Support Files/Pods-SwiftThemisServerExample/Pods-SwiftThemisServerExample.debug.xcconfig"; sourceTree = "<group>"; };
 		736DDB621CC5990900CD0C31 /* SwiftThemisServerExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftThemisServerExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		736DDB651CC5990900CD0C31 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		736DDB671CC5990900CD0C31 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -28,9 +30,7 @@
 		736DDB771CC5A24A00CD0C31 /* SMessageClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SMessageClient.swift; sourceTree = "<group>"; };
 		736DDB791CC5A25200CD0C31 /* SSessionClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SSessionClient.swift; sourceTree = "<group>"; };
 		736DDB7B1CC5A32400CD0C31 /* SwiftThemisServerExample-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SwiftThemisServerExample-Bridging-Header.h"; sourceTree = "<group>"; };
-		75D29D72035E4F884E78B8AC /* Pods-SwiftThemisServerExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftThemisServerExample.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-SwiftThemisServerExample/Pods-SwiftThemisServerExample.debug.xcconfig"; sourceTree = "<group>"; };
-		8C836590FDA85CE009B30B63 /* Pods-SwiftThemisServerExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftThemisServerExample.release.xcconfig"; path = "../Pods/Target Support Files/Pods-SwiftThemisServerExample/Pods-SwiftThemisServerExample.release.xcconfig"; sourceTree = "<group>"; };
-		BA738A3EB8F2F86047D8CEC2 /* Pods_SwiftThemisServerExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SwiftThemisServerExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		75BDE3490661708E5D830773 /* Pods_SwiftThemisServerExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SwiftThemisServerExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -38,29 +38,20 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2FC21F8198CD38C3731B8EC6 /* Pods_SwiftThemisServerExample.framework in Frameworks */,
+				F973E8993F5264676E4CE2C6 /* Pods_SwiftThemisServerExample.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		2DB412AE9BE13C498B985683 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				75D29D72035E4F884E78B8AC /* Pods-SwiftThemisServerExample.debug.xcconfig */,
-				8C836590FDA85CE009B30B63 /* Pods-SwiftThemisServerExample.release.xcconfig */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
 		736DDB591CC5990900CD0C31 = {
 			isa = PBXGroup;
 			children = (
 				736DDB641CC5990900CD0C31 /* SwiftThemisServerExample */,
 				736DDB631CC5990900CD0C31 /* Products */,
-				2DB412AE9BE13C498B985683 /* Pods */,
-				9FA633501B35B3593C90DB2F /* Frameworks */,
+				BEF09F8CC4689F72A489DEC6 /* Pods */,
+				ECD66815BA6F894F2EBB2D5D /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -88,10 +79,20 @@
 			path = SwiftThemisServerExample;
 			sourceTree = "<group>";
 		};
-		9FA633501B35B3593C90DB2F /* Frameworks */ = {
+		BEF09F8CC4689F72A489DEC6 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				BA738A3EB8F2F86047D8CEC2 /* Pods_SwiftThemisServerExample.framework */,
+				21E6EE97700292F20D15A723 /* Pods-SwiftThemisServerExample.debug.xcconfig */,
+				13B806E9EA467D91E43D2542 /* Pods-SwiftThemisServerExample.release.xcconfig */,
+			);
+			name = Pods;
+			path = ../Pods;
+			sourceTree = "<group>";
+		};
+		ECD66815BA6F894F2EBB2D5D /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				75BDE3490661708E5D830773 /* Pods_SwiftThemisServerExample.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -103,11 +104,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 736DDB741CC5990900CD0C31 /* Build configuration list for PBXNativeTarget "SwiftThemisServerExample" */;
 			buildPhases = (
-				B2A939CE985F6D823C4C9843 /* [CP] Check Pods Manifest.lock */,
+				BF6A07720F1D59E3BC580E82 /* [CP] Check Pods Manifest.lock */,
 				736DDB5E1CC5990900CD0C31 /* Sources */,
 				736DDB5F1CC5990900CD0C31 /* Frameworks */,
 				736DDB601CC5990900CD0C31 /* Resources */,
-				B8305360BEEC905C3995033E /* [CP] Embed Pods Frameworks */,
+				6A572032B57C45CD50BEE743 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -130,6 +131,7 @@
 				TargetAttributes = {
 					736DDB611CC5990900CD0C31 = {
 						CreatedOnToolsVersion = 7.3;
+						DevelopmentTeam = X6X7AHQ2D4;
 						LastSwiftMigration = 0910;
 					};
 				};
@@ -167,7 +169,27 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		B2A939CE985F6D823C4C9843 /* [CP] Check Pods Manifest.lock */ = {
+		6A572032B57C45CD50BEE743 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-SwiftThemisServerExample/Pods-SwiftThemisServerExample-frameworks.sh",
+				"${PODS_ROOT}/GRKOpenSSLFramework/OpenSSL-iOS/bin/openssl.framework",
+				"${BUILT_PRODUCTS_DIR}/themis/themis.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/openssl.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/themis.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-SwiftThemisServerExample/Pods-SwiftThemisServerExample-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		BF6A07720F1D59E3BC580E82 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -187,26 +209,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		B8305360BEEC905C3995033E /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-SwiftThemisServerExample/Pods-SwiftThemisServerExample-frameworks.sh",
-				"${PODS_ROOT}/GRKOpenSSLFramework/OpenSSL-iOS/bin/openssl.framework",
-				"${BUILT_PRODUCTS_DIR}/themis/themis.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/openssl.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/themis.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-SwiftThemisServerExample/Pods-SwiftThemisServerExample-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -347,9 +349,10 @@
 		};
 		736DDB751CC5990900CD0C31 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 75D29D72035E4F884E78B8AC /* Pods-SwiftThemisServerExample.debug.xcconfig */;
+			baseConfigurationReference = 21E6EE97700292F20D15A723 /* Pods-SwiftThemisServerExample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = X6X7AHQ2D4;
 				INFOPLIST_FILE = SwiftThemisServerExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.SwiftThemisServerExample;
@@ -362,9 +365,10 @@
 		};
 		736DDB761CC5990900CD0C31 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8C836590FDA85CE009B30B63 /* Pods-SwiftThemisServerExample.release.xcconfig */;
+			baseConfigurationReference = 13B806E9EA467D91E43D2542 /* Pods-SwiftThemisServerExample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = X6X7AHQ2D4;
 				INFOPLIST_FILE = SwiftThemisServerExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.SwiftThemisServerExample;

--- a/docs/examples/objc/iOS-CocoaPods/Podfile
+++ b/docs/examples/objc/iOS-CocoaPods/Podfile
@@ -23,6 +23,6 @@ use_frameworks!
 
 target :"ThemisTest" do
 
-  pod 'themis', '0.12.1'
+  pod 'themis', '0.12.2'
 
 end

--- a/docs/examples/objc/iOS-CocoaPods/Podfile.lock
+++ b/docs/examples/objc/iOS-CocoaPods/Podfile.lock
@@ -1,19 +1,19 @@
 PODS:
-  - GRKOpenSSLFramework (1.0.2.19)
-  - themis (0.12.1):
-    - themis/themis-openssl (= 0.12.1)
-  - themis/themis-openssl (0.12.1):
-    - GRKOpenSSLFramework (~> 1.0.1)
-    - themis/themis-openssl/core (= 0.12.1)
-    - themis/themis-openssl/objcwrapper (= 0.12.1)
-  - themis/themis-openssl/core (0.12.1):
-    - GRKOpenSSLFramework (~> 1.0.1)
-  - themis/themis-openssl/objcwrapper (0.12.1):
-    - GRKOpenSSLFramework (~> 1.0.1)
+  - GRKOpenSSLFramework (1.0.2.18)
+  - themis (0.12.2):
+    - themis/themis-openssl (= 0.12.2)
+  - themis/themis-openssl (0.12.2):
+    - GRKOpenSSLFramework (= 1.0.2.18)
+    - themis/themis-openssl/core (= 0.12.2)
+    - themis/themis-openssl/objcwrapper (= 0.12.2)
+  - themis/themis-openssl/core (0.12.2):
+    - GRKOpenSSLFramework (= 1.0.2.18)
+  - themis/themis-openssl/objcwrapper (0.12.2):
+    - GRKOpenSSLFramework (= 1.0.2.18)
     - themis/themis-openssl/core
 
 DEPENDENCIES:
-  - themis (= 0.12.1)
+  - themis (= 0.12.2)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
@@ -21,9 +21,9 @@ SPEC REPOS:
     - themis
 
 SPEC CHECKSUMS:
-  GRKOpenSSLFramework: 4abc733a8fcbc37060619a86a54202d2938dd70e
-  themis: 703d33444f3ecfd0b922a0a2ca3dcbea2046d80d
+  GRKOpenSSLFramework: 1d65e55d569af7b23074373041a92cc8bc768a92
+  themis: f4ef6d942670146ad08dca8cc99a34ae040878c0
 
-PODFILE CHECKSUM: 99233cd2b9e36fe386da3dd7f7fc64fec3b69573
+PODFILE CHECKSUM: fed7ab7061ee5b8f0c8cd13d6f59c51828473cac
 
 COCOAPODS: 1.8.0

--- a/docs/examples/objc/iOS-CocoaPods/ThemisTest/ThemisTest.xcodeproj/project.pbxproj
+++ b/docs/examples/objc/iOS-CocoaPods/ThemisTest/ThemisTest.xcodeproj/project.pbxproj
@@ -18,7 +18,7 @@
 		73156E171ADBDF0F00E3E520 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 73156E161ADBDF0F00E3E520 /* Images.xcassets */; };
 		731624981ADB174200972A7A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 731624971ADB174200972A7A /* main.m */; };
 		731624B21ADB174200972A7A /* ThemisTestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 731624B11ADB174200972A7A /* ThemisTestTests.m */; };
-		908D32BCD083D36F705191DE /* Pods_ThemisTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71CD1FB56D5C44A118475EED /* Pods_ThemisTest.framework */; };
+		B35ED97225A7E4197A0AA0AE /* Pods_ThemisTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93A7B8C89ACDDE5EB678CD95 /* Pods_ThemisTest.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -36,8 +36,7 @@
 		192EA533E67AA52864927032 /* server.pub */ = {isa = PBXFileReference; lastKnownFileType = file.pub; path = server.pub; sourceTree = "<group>"; };
 		192EA61539E5DA001A808B56 /* client.pub */ = {isa = PBXFileReference; lastKnownFileType = file.pub; path = client.pub; sourceTree = "<group>"; };
 		192EAEE7A8A8277025A0F60C /* client.priv */ = {isa = PBXFileReference; lastKnownFileType = file.priv; path = client.priv; sourceTree = "<group>"; };
-		5A91618204D2056C8B82B2E5 /* Pods-ThemisTest.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ThemisTest.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-ThemisTest/Pods-ThemisTest.debug.xcconfig"; sourceTree = "<group>"; };
-		71CD1FB56D5C44A118475EED /* Pods_ThemisTest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ThemisTest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		205BAE6C0A797582A1BADD50 /* Pods-ThemisTest.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ThemisTest.release.xcconfig"; path = "Target Support Files/Pods-ThemisTest/Pods-ThemisTest.release.xcconfig"; sourceTree = "<group>"; };
 		73156E031ADBDE7900E3E520 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = LaunchScreen.xib; sourceTree = "<group>"; };
 		73156E051ADBDE7900E3E520 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Main.storyboard; sourceTree = "<group>"; };
 		73156E0D1ADBDF0800E3E520 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -52,7 +51,8 @@
 		731624B01ADB174200972A7A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		731624B11ADB174200972A7A /* ThemisTestTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ThemisTestTests.m; sourceTree = "<group>"; };
 		738D1E7F1ADBBEBB00661F4A /* libobjcthemis.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libobjcthemis.a; path = ../themis/objcthemis/ios/lib/libobjcthemis.a; sourceTree = "<group>"; };
-		E24A7AF50B289BEC524C95B5 /* Pods-ThemisTest.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ThemisTest.release.xcconfig"; path = "../Pods/Target Support Files/Pods-ThemisTest/Pods-ThemisTest.release.xcconfig"; sourceTree = "<group>"; };
+		93A7B8C89ACDDE5EB678CD95 /* Pods_ThemisTest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ThemisTest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FFE61BEB81FB4FF4AC421B37 /* Pods-ThemisTest.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ThemisTest.debug.xcconfig"; path = "Target Support Files/Pods-ThemisTest/Pods-ThemisTest.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -60,7 +60,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				908D32BCD083D36F705191DE /* Pods_ThemisTest.framework in Frameworks */,
+				B35ED97225A7E4197A0AA0AE /* Pods_ThemisTest.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -100,18 +100,9 @@
 			isa = PBXGroup;
 			children = (
 				738D1E7F1ADBBEBB00661F4A /* libobjcthemis.a */,
-				71CD1FB56D5C44A118475EED /* Pods_ThemisTest.framework */,
+				93A7B8C89ACDDE5EB678CD95 /* Pods_ThemisTest.framework */,
 			);
 			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		59D5EAEA01F94AEC401245DA /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				5A91618204D2056C8B82B2E5 /* Pods-ThemisTest.debug.xcconfig */,
-				E24A7AF50B289BEC524C95B5 /* Pods-ThemisTest.release.xcconfig */,
-			);
-			name = Pods;
 			sourceTree = "<group>";
 		};
 		73156E0C1ADBDF0800E3E520 /* Classes */ = {
@@ -132,7 +123,7 @@
 				731624AE1ADB174200972A7A /* ThemisTestTests */,
 				731624931ADB174200972A7A /* Products */,
 				1F5F881BD0CD342D1E9B9E25 /* Frameworks */,
-				59D5EAEA01F94AEC401245DA /* Pods */,
+				E2188C81A9E1F264E3C877A3 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -181,6 +172,16 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		E2188C81A9E1F264E3C877A3 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				FFE61BEB81FB4FF4AC421B37 /* Pods-ThemisTest.debug.xcconfig */,
+				205BAE6C0A797582A1BADD50 /* Pods-ThemisTest.release.xcconfig */,
+			);
+			name = Pods;
+			path = ../Pods;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -188,11 +189,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 731624B51ADB174200972A7A /* Build configuration list for PBXNativeTarget "ThemisTest" */;
 			buildPhases = (
-				670C81885F3868F687C60838 /* [CP] Check Pods Manifest.lock */,
+				4897AF4A2FE6CD4DF9EC1B96 /* [CP] Check Pods Manifest.lock */,
 				7316248E1ADB174200972A7A /* Sources */,
 				7316248F1ADB174200972A7A /* Frameworks */,
 				731624901ADB174200972A7A /* Resources */,
-				EBC13B54B183A07A1A55B738 /* [CP] Embed Pods Frameworks */,
+				6FE817FC467FEF1A89661594 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -286,7 +287,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		670C81885F3868F687C60838 /* [CP] Check Pods Manifest.lock */ = {
+		4897AF4A2FE6CD4DF9EC1B96 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -308,7 +309,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		EBC13B54B183A07A1A55B738 /* [CP] Embed Pods Frameworks */ = {
+		6FE817FC467FEF1A89661594 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -486,7 +487,7 @@
 		};
 		731624B61ADB174200972A7A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5A91618204D2056C8B82B2E5 /* Pods-ThemisTest.debug.xcconfig */;
+			baseConfigurationReference = FFE61BEB81FB4FF4AC421B37 /* Pods-ThemisTest.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -505,7 +506,7 @@
 		};
 		731624B71ADB174200972A7A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E24A7AF50B289BEC524C95B5 /* Pods-ThemisTest.release.xcconfig */;
+			baseConfigurationReference = 205BAE6C0A797582A1BADD50 /* Pods-ThemisTest.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";

--- a/docs/examples/swift/iOS-CocoaPods/Podfile
+++ b/docs/examples/swift/iOS-CocoaPods/Podfile
@@ -23,6 +23,6 @@ use_frameworks!
 
 target :"ThemisSwift" do
 
-  pod 'themis', '0.12.1'
+  pod 'themis', '0.12.2'
 
 end

--- a/docs/examples/swift/iOS-CocoaPods/Podfile.lock
+++ b/docs/examples/swift/iOS-CocoaPods/Podfile.lock
@@ -1,19 +1,19 @@
 PODS:
-  - GRKOpenSSLFramework (1.0.2.19)
-  - themis (0.12.1):
-    - themis/themis-openssl (= 0.12.1)
-  - themis/themis-openssl (0.12.1):
-    - GRKOpenSSLFramework (~> 1.0.1)
-    - themis/themis-openssl/core (= 0.12.1)
-    - themis/themis-openssl/objcwrapper (= 0.12.1)
-  - themis/themis-openssl/core (0.12.1):
-    - GRKOpenSSLFramework (~> 1.0.1)
-  - themis/themis-openssl/objcwrapper (0.12.1):
-    - GRKOpenSSLFramework (~> 1.0.1)
+  - GRKOpenSSLFramework (1.0.2.18)
+  - themis (0.12.2):
+    - themis/themis-openssl (= 0.12.2)
+  - themis/themis-openssl (0.12.2):
+    - GRKOpenSSLFramework (= 1.0.2.18)
+    - themis/themis-openssl/core (= 0.12.2)
+    - themis/themis-openssl/objcwrapper (= 0.12.2)
+  - themis/themis-openssl/core (0.12.2):
+    - GRKOpenSSLFramework (= 1.0.2.18)
+  - themis/themis-openssl/objcwrapper (0.12.2):
+    - GRKOpenSSLFramework (= 1.0.2.18)
     - themis/themis-openssl/core
 
 DEPENDENCIES:
-  - themis (= 0.12.1)
+  - themis (= 0.12.2)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
@@ -21,9 +21,9 @@ SPEC REPOS:
     - themis
 
 SPEC CHECKSUMS:
-  GRKOpenSSLFramework: 4abc733a8fcbc37060619a86a54202d2938dd70e
-  themis: 703d33444f3ecfd0b922a0a2ca3dcbea2046d80d
+  GRKOpenSSLFramework: 1d65e55d569af7b23074373041a92cc8bc768a92
+  themis: f4ef6d942670146ad08dca8cc99a34ae040878c0
 
-PODFILE CHECKSUM: 95e33569bed439ebdbd60d58b0b7df9177bc1e45
+PODFILE CHECKSUM: 0ecce665d872eed22efbc79e9784e8813eba3dd8
 
 COCOAPODS: 1.8.0

--- a/docs/examples/swift/iOS-CocoaPods/ThemisSwift/ThemisSwift.xcodeproj/project.pbxproj
+++ b/docs/examples/swift/iOS-CocoaPods/ThemisSwift/ThemisSwift.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		09EB1D806D04A45BCC77A6E2 /* Pods_ThemisSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 31E99AD8AA2678836EC39341 /* Pods_ThemisSwift.framework */; };
+		589E3AB46FEFED757B4131A9 /* Pods_ThemisSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C62EC44DF5B1717D370F9794 /* Pods_ThemisSwift.framework */; };
 		7399813E1CC449010095138F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7399812E1CC449010095138F /* AppDelegate.swift */; };
 		7399813F1CC449010095138F /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7399812F1CC449010095138F /* ViewController.swift */; };
 		739981401CC449010095138F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 739981311CC449010095138F /* Assets.xcassets */; };
@@ -20,9 +20,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		09C7B9BE51E1DCE5F981F9D2 /* Pods-ThemisSwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ThemisSwift.release.xcconfig"; path = "../Pods/Target Support Files/Pods-ThemisSwift/Pods-ThemisSwift.release.xcconfig"; sourceTree = "<group>"; };
-		11111B95879A6FD8BF0EDE42 /* Pods-ThemisSwift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ThemisSwift.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-ThemisSwift/Pods-ThemisSwift.debug.xcconfig"; sourceTree = "<group>"; };
-		31E99AD8AA2678836EC39341 /* Pods_ThemisSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ThemisSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		15D4143D2B7DBBB08E9F6D96 /* Pods-ThemisSwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ThemisSwift.release.xcconfig"; path = "Target Support Files/Pods-ThemisSwift/Pods-ThemisSwift.release.xcconfig"; sourceTree = "<group>"; };
+		267D206279DDBB5EEEAE5D0A /* Pods-ThemisSwift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ThemisSwift.debug.xcconfig"; path = "Target Support Files/Pods-ThemisSwift/Pods-ThemisSwift.debug.xcconfig"; sourceTree = "<group>"; };
 		739981171CC42C880095138F /* ThemisSwift.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ThemisSwift.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7399812E1CC449010095138F /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7399812F1CC449010095138F /* ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -35,6 +34,7 @@
 		7399813A1CC449010095138F /* server.pub */ = {isa = PBXFileReference; lastKnownFileType = file; path = server.pub; sourceTree = "<group>"; };
 		739981491CC44ABA0095138F /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7399814A1CC44ABA0095138F /* ThemisSwift-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ThemisSwift-Bridging-Header.h"; sourceTree = "<group>"; };
+		C62EC44DF5B1717D370F9794 /* Pods_ThemisSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ThemisSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -42,28 +42,20 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				09EB1D806D04A45BCC77A6E2 /* Pods_ThemisSwift.framework in Frameworks */,
+				589E3AB46FEFED757B4131A9 /* Pods_ThemisSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		56F37F1A7038CC2C638C404C /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				31E99AD8AA2678836EC39341 /* Pods_ThemisSwift.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 		7399810E1CC42C880095138F = {
 			isa = PBXGroup;
 			children = (
 				739981191CC42C880095138F /* ThemisSwift */,
 				739981181CC42C880095138F /* Products */,
-				B5D07D12E7B2ACB27146F62C /* Pods */,
-				56F37F1A7038CC2C638C404C /* Frameworks */,
+				9730B30D6BDD6DFEC487F94C /* Pods */,
+				806F350E0AF2ABB0202825C6 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -125,13 +117,22 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
-		B5D07D12E7B2ACB27146F62C /* Pods */ = {
+		806F350E0AF2ABB0202825C6 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				11111B95879A6FD8BF0EDE42 /* Pods-ThemisSwift.debug.xcconfig */,
-				09C7B9BE51E1DCE5F981F9D2 /* Pods-ThemisSwift.release.xcconfig */,
+				C62EC44DF5B1717D370F9794 /* Pods_ThemisSwift.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		9730B30D6BDD6DFEC487F94C /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				267D206279DDBB5EEEAE5D0A /* Pods-ThemisSwift.debug.xcconfig */,
+				15D4143D2B7DBBB08E9F6D96 /* Pods-ThemisSwift.release.xcconfig */,
 			);
 			name = Pods;
+			path = ../Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -141,12 +142,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 739981291CC42C880095138F /* Build configuration list for PBXNativeTarget "ThemisSwift" */;
 			buildPhases = (
-				1DA40E0D7992D14F7A0DC819 /* [CP] Check Pods Manifest.lock */,
+				C88190DDBFC5CE3874543DB5 /* [CP] Check Pods Manifest.lock */,
 				739981131CC42C880095138F /* Sources */,
 				739981141CC42C880095138F /* Frameworks */,
 				739981151CC42C880095138F /* Resources */,
 				73688AFE1CC4504F00D3C430 /* ShellScript */,
-				1FCD953BBC293CBE9279EE20 /* [CP] Embed Pods Frameworks */,
+				CEAB072F8AB94A91A7A953E7 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -211,7 +212,20 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		1DA40E0D7992D14F7A0DC819 /* [CP] Check Pods Manifest.lock */ = {
+		73688AFE1CC4504F00D3C430 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n# uncomment for autocorrection\n# swiftlint autocorrect\n    swiftlint lint --quiet\nelse\n    echo \"SwiftLint does not exist, download from https://github.com/realm/SwiftLint\"\nfi";
+		};
+		C88190DDBFC5CE3874543DB5 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -233,7 +247,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		1FCD953BBC293CBE9279EE20 /* [CP] Embed Pods Frameworks */ = {
+		CEAB072F8AB94A91A7A953E7 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -252,19 +266,6 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ThemisSwift/Pods-ThemisSwift-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
-		};
-		73688AFE1CC4504F00D3C430 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n# uncomment for autocorrection\n# swiftlint autocorrect\n    swiftlint lint --quiet\nelse\n    echo \"SwiftLint does not exist, download from https://github.com/realm/SwiftLint\"\nfi";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -408,7 +409,7 @@
 		};
 		7399812A1CC42C880095138F /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 11111B95879A6FD8BF0EDE42 /* Pods-ThemisSwift.debug.xcconfig */;
+			baseConfigurationReference = 267D206279DDBB5EEEAE5D0A /* Pods-ThemisSwift.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -430,7 +431,7 @@
 		};
 		7399812B1CC42C880095138F /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 09C7B9BE51E1DCE5F981F9D2 /* Pods-ThemisSwift.release.xcconfig */;
+			baseConfigurationReference = 15D4143D2B7DBBB08E9F6D96 /* Pods-ThemisSwift.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";

--- a/src/wrappers/themis/Obj-C/Themis/Info.plist
+++ b/src/wrappers/themis/Obj-C/Themis/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.12.1</string>
+	<string>0.12.2</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/themis.podspec
+++ b/themis.podspec
@@ -1,12 +1,14 @@
 Pod::Spec.new do |s|
     s.name = "themis"
-    s.version = "0.12.1"
+    s.version = "0.12.2"
     s.summary = "Data security library for network communication and data storage for iOS and mac OS"
     s.description = "Themis is a data security library, providing users with high-quality security services for secure messaging of any kinds and flexible data storage. Themis is aimed at modern development practices, with high level OOP wrappers for iOS / macOS, node,js, Go, Ruby, Python, PHP and Java / Android. It is designed with ease of use in mind, high security and cross-platform availability."
     s.homepage = "https://cossacklabs.com"
     s.license = { :type => 'Apache 2.0'}
 
-    s.source = { :git => "https://github.com/cossacklabs/themis.git", :tag => "#{s.version}" }
+    # TODO: use tag version, current update is just a dependency hotfix (26 sept 2019) 
+    #s.source = { :git => "https://github.com/cossacklabs/themis.git", :tag => "#{s.version}" } # <-- this is good
+    s.source = { :git => "https://github.com/cossacklabs/themis.git", :tag => "0.12.1" }        # <-- this is bad and temp
     s.author = {'cossacklabs' => 'info@cossacklabs.com'}
 
     s.module_name = 'themis'
@@ -22,7 +24,15 @@ Pod::Spec.new do |s|
         # Enable bitcode for openssl only, unfortunately boringssl with bitcode not available at the moment
         so.ios.pod_target_xcconfig = {'ENABLE_BITCODE' => 'YES' }
 
-        so.dependency 'GRKOpenSSLFramework', '~> 1.0.1'
+        # TODO: due to error in symbols in GRKOpenSSLFramework 219 release, we've manually switched to 218
+        # which doesn't sound like a good decision, so when GRKOpenSSLFramework will be updated – 
+        # please bring back correct dependency version
+        # https://github.com/cossacklabs/themis/issues/538
+        # 26 sept 2019
+        #so.dependency 'GRKOpenSSLFramework', '~> 1.0.1' # <-- this is good
+
+        so.dependency 'GRKOpenSSLFramework', '1.0.2.18'  # <-- this is bad and temp
+
 
         so.ios.xcconfig = { 'OTHER_CFLAGS' => '-DLIBRESSL', 'USE_HEADERMAP' => 'NO',
         'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/themis/src" "${PODS_ROOT}/themis/src/wrappers/themis/Obj-C"', 'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES' }


### PR DESCRIPTION
(as part of 0.12.0 release flow)

Due to problems with latest [GRKOpenSSLFramework 2.19 release](https://github.com/levigroker/GRKOpenSSLFramework/releases) I've downgraded dependency to `2.18`, pushed new `themis.podspec` and updated examples.

Unfortunately, 2.19 release doesn't have some symbols and causes failure of archiving Xcode app, see #538. 

Good thing:
- it's fixed

Bad thing:
- this fix is temporary until GRKOpenSSLFramework is fixed
- such cruel dependency linking might cause dependency linking failure for projects that use GRKOpenSSLFramework separately.

