### PR TITLE
Correct recursive make invocation

### DIFF
--- a/tools/afl/fuzzy.mk
+++ b/tools/afl/fuzzy.mk
@@ -76,7 +76,7 @@ $(FUZZ_BIN_PATH)/%: $(FUZZ_BIN_PATH)/%.o $(FUZZ_UTILS) $(FUZZ_THEMIS_LIB)
 	@$(PRINT_OK)
 
 $(FUZZ_THEMIS_LIB):
-	@AFL_QUIET=1 make themis_static soter_static CC=$(AFL_CC) BUILD_PATH=$(FUZZ_THEMIS_PATH)
+	@AFL_QUIET=1 $(MAKE) themis_static soter_static CC=$(AFL_CC) BUILD_PATH=$(FUZZ_THEMIS_PATH)
 
 FMT_FIXUP += $(patsubst $(FUZZ_SRC_PATH)/%,$(FUZZ_BIN_PATH)/%.fmt_fixup,$(FUZZ_SOURCES) $(FUZZ_HEADERS))
 FMT_CHECK += $(patsubst $(FUZZ_SRC_PATH)/%,$(FUZZ_BIN_PATH)/%.fmt_check,$(FUZZ_SOURCES) $(FUZZ_HEADERS))


### PR DESCRIPTION
We use make recursively during AFL fuzzer builds.

Avoid invoking `make` directly as the executable may be called differently (e.g., on macOS running updated make from Homebrew it's typically called `gmake`). Use the standard MAKE variable instead.