### PR TITLE
Build with optimizations by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,13 +236,15 @@ ifdef IS_LINUX
 LDFLAGS += -Wl,--no-undefined
 endif
 
+CFLAGS += -O2 -fno-omit-frame-pointer -g
+
 ifdef COVERAGE
-	CFLAGS += -g -O0 --coverage
+	CFLAGS += -O0 --coverage
 	LDFLAGS += --coverage
 endif
 
 ifdef DEBUG
-	CFLAGS += -DDEBUG -g
+	CFLAGS += -O0 -DDEBUG
 endif
 
 ifneq ($(GEM_INSTALL_OPTIONS),)


### PR DESCRIPTION
GCC builds without optimizations by default while Clang uses -O2. Use -O2 for GCC by default too, but switch to -O0 when DEBUG is defined. Also make sure to always output debug information, not only in debug builds. Additional sections with it do not impact performance but are very useful in production. And they can be easily stripped out of the binaries if necessary, like we do when building packages.

We disable frame pointer omission optimization to get better stack frames and enable debugging on x86. While it has some impact, I’d rather have working backtraces.