### PR TITLE
Avoid overflows in left shifts

### DIFF
--- a/src/soter/soter_crc32.c
+++ b/src/soter/soter_crc32.c
@@ -79,7 +79,7 @@ void soter_crc32_update(soter_crc32_t* crc, const void* buf, size_t len)
 uint32_t soter_crc32_final(soter_crc32_t* crc)
 {
     uint32_t result = ~(*crc);
-    uint8_t byte0, byte1, byte2, byte3;
+    uint32_t byte0, byte1, byte2, byte3;
 
     /*  result  now holds the negated polynomial remainder;
      *  since the table and algorithm is "reflected" [williams95].


### PR DESCRIPTION
Left-shifting uint8_t types kinda works because of integer promotion rules. However, this is incorrect on platforms with 16-bit int types. We should explicitly use 32-bit unsigned integers to get the correct behavior on all platforms (and avoid warnings by undefined behavior sanitizer).