### PR TITLE
Roll back to Emscripten 1.38.48

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,8 +185,9 @@ jobs:
             cd $HOME/emsdk
             git reset --hard
             git pull
-            ./emsdk install latest
-            ./emsdk activate latest
+            # TODO (T1373): roll back to using "latest" when Emscripten regression is resolved
+            ./emsdk install 1.38.48
+            ./emsdk activate 1.38.48
       - checkout
       - run:
           name: Sync submodules
@@ -335,8 +336,9 @@ jobs:
             cd $HOME/emsdk
             git reset --hard
             git pull
-            ./emsdk install latest
-            ./emsdk activate latest
+            # TODO (T1373): roll back to using "latest" when Emscripten regression is resolved
+            ./emsdk install 1.38.48
+            ./emsdk activate 1.38.48
 
       # themis
       - checkout


### PR DESCRIPTION
Recently released 1.39.0 seems to have a regression than [breaks our build](https://circleci.com/gh/cossacklabs/themis/6289?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) for WasmThemis. Let's roll back to the previous version until the issue is examined and resolved.