### PR TITLE
Improve detection of JDK location for JNI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Themis ChangeLog
 
+## Unreleased
+
+Changes that are currently in development and have not been released yet.
+
+_Code:_
+
+- **Java**
+
+  - JDK location is now detected automatically in most cases, you should not need to set JAVA_HOME or JDK_INCLUDE_PATH manually ([#551](https://github.com/cossacklabs/themis/pull/551)).
+
 ## [0.12.0](https://github.com/cossacklabs/themis/releases/tag/0.12.0), September 27th 2019
 
 **TL;DR:**

--- a/jni/themis_jni.mk
+++ b/jni/themis_jni.mk
@@ -28,9 +28,20 @@ JAVA_DEFAULTS=/usr/share/java/java_defaults.mk
 ifeq ($(JDK_INCLUDE_PATH),)
 	ifneq ("$(wildcard $(JAVA_DEFAULTS))","")
 		include $(JAVA_DEFAULTS)
+	else
+		ifndef JAVA_HOME
+			JAVA_HOME := $(shell java -XshowSettings:properties -version 2>&1 | sed -n '/java.home/s/.*java.home = //p')
+		endif
+		jvm_includes += -I$(JAVA_HOME)/include
+		ifdef IS_LINUX
+			jvm_includes += -I$(JAVA_HOME)/include/linux
+		endif
+		ifdef IS_MACOS
+			jvm_includes += -I$(JAVA_HOME)/include/darwin
+		endif
 	endif
 else
-	jvm_includes=$(JAVA_HOME)/include
+	jvm_includes += $(addprefix -I,$(JDK_INCLUDE_PATH))
 endif
 
 $(OBJ_PATH)/jni/%: CFLAGS += $(jvm_includes)


### PR DESCRIPTION
Currently on anything other than Debian it is necessary to manually point the build to the JDK location. There is a rudimentary mechanism for automatic detection, but we can do better. Let’s make sure that running `make themis_jni` ‘just works’ for all operating systems that we support.

We need to have correct include path to be able to access JNI headers. These are installed by JDK somewhere into the system. Normally there are two paths: generic path where "jni.h" is located and a platform-specific directory (usually a subdirectory under the generic path).

First of all, there is user override. If JDK_INCLUDE_PATH contains anything, that’s considered our include path. Prepend `-I` to every directory in that list and use that.

Otherwise we try to detect the paths automatically. Debian and Ubuntu packages distribute a `java_defaults.mk` makefile which conveniently defines C compiler flags in the `jvm_includes` variable. Check if that file exists via Make magic, include it, and use that variable. Note
that this file requires the **dpkg-dev** package to be installed in addition to JDK package (e.g., **openjdk-11-jdk** for Debian 10 Buster).

Other systems are not so nice. JNI headers are usually installed into JAVA_HOME. If JAVA_HOME environment variable is not set then ask Java. The includes are usually located under the `include` directory in the home directory plus there is an platform-specific subdirectory. On macOS it's called `darwin`. Many Linux distributions use `linux` (CentOS certainly does).

If automatic detection does not work, use JDK_INCLUDE_PATH. Typically you’ll need something like this:

    make themis_jni JDK_INCLUDE_PATH="$JAVA_HOME/include $JAVA_HOME/include/plan9"

P.S. Android uses its own magic for building the library correctly, see `jni/Android.mk`.

## Checklist

- [x] Change is covered by automated tests
- [x] ~~Benchmark results are attached~~ (not applicable)
- [x] The [coding guidelines] are followed
- [x] Public API has proper documentation: [external docs](https://docs.cossacklabs.com/pages/documentation-themis/#java-wrapper-installation)
- [x] ~~Example projects and code samples are updated if needed~~ (no API changes)
- [x] Changelog is updated if needed (in case of notable or breaking changes)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md