### PR TITLE
Link libthemis_jni.so dynamically

### DIFF
--- a/jni/themis_jni.mk
+++ b/jni/themis_jni.mk
@@ -35,9 +35,9 @@ endif
 
 $(OBJ_PATH)/jni/%: CFLAGS += $(jvm_includes)
 
-$(BIN_PATH)/$(LIBTHEMISJNI_SO): CMD = $(CC) -shared -o $@ $(filter %.o %.a, $^) $(LDFLAGS) $(CRYPTO_ENGINE_LDFLAGS)
+$(BIN_PATH)/$(LIBTHEMISJNI_SO): CMD = $(CC) -shared -o $@ $(filter %.o %.a, $^) $(LDFLAGS) -lthemis
 
-$(BIN_PATH)/$(LIBTHEMISJNI_SO): $(THEMIS_JNI_OBJ) $(THEMIS_STATIC)
+$(BIN_PATH)/$(LIBTHEMISJNI_SO): $(THEMIS_JNI_OBJ) $(BIN_PATH)/$(LIBTHEMIS_SO)
 	@mkdir -p $(@D)
 	@echo -n "link "
 	@$(BUILD_CMD)

--- a/src/themis/secure_session_t.h
+++ b/src/themis/secure_session_t.h
@@ -42,14 +42,14 @@ struct secure_session_type {
     bool is_client;
 };
 
-THEMIS_API
+THEMIS_PRIVATE_API
 themis_status_t secure_session_init(secure_session_t* session_ctx,
                                     const void* id,
                                     size_t id_length,
                                     const void* sign_key,
                                     size_t sign_key_length,
                                     const secure_session_user_callbacks_t* user_callbacks);
-THEMIS_API
+THEMIS_PRIVATE_API
 themis_status_t secure_session_cleanup(secure_session_t* session_ctx);
 
 #endif /* THEMIS_SECURE_SESSION_T_H */

--- a/src/themis/secure_session_t.h
+++ b/src/themis/secure_session_t.h
@@ -42,12 +42,14 @@ struct secure_session_type {
     bool is_client;
 };
 
+THEMIS_API
 themis_status_t secure_session_init(secure_session_t* session_ctx,
                                     const void* id,
                                     size_t id_length,
                                     const void* sign_key,
                                     size_t sign_key_length,
                                     const secure_session_user_callbacks_t* user_callbacks);
+THEMIS_API
 themis_status_t secure_session_cleanup(secure_session_t* session_ctx);
 
 #endif /* THEMIS_SECURE_SESSION_T_H */

--- a/src/themis/themis_api.h
+++ b/src/themis/themis_api.h
@@ -35,4 +35,10 @@
 #define THEMIS_API EMSCRIPTEN_KEEPALIVE
 #endif
 
+/*
+ * Marks API that needs to be exported for technical reasons, but otherwise
+ * is not intended for user consumption.
+ */
+#define THEMIS_PRIVATE_API THEMIS_API
+
 #endif /* THEMIS_API_H */


### PR DESCRIPTION
Do not embed Themis, Soter, and cryptographic backend (if present) into libthemis_jni shared object. Instead, link it dynamically against Themis like a proper library.

It has been a nice experiment to provide self-contained library for Java. However, we are going to distribute the library as a proper system package and for that we will need to have it properly linked against its dependencies. Themis Core will be installed by the package manager so all dependencies are going to be satisfied.

## Checklist

- [X] Change is covered by automated tests
- [X] ~~Benchmark results are attached (if applicable)~~
- [X] The [coding guidelines] are followed
- [X] Public API has proper documentation
- [X] Example projects and code samples are updated if needed (in case of API changes)
- [X] ~~Changelog is updated if needed~~ minor change, will be included into packaging PR

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
