### PR TITLE
Don't suppress UBSan unless compiling with UBSan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -314,6 +314,7 @@ CFLAGS += -fvisibility=hidden
 #
 
 ifdef WITH_ASAN
+CFLAGS += -DWITH_ASAN
 ifeq (yes,$(call supported,-fsanitize=address))
 SANITIZERS += -fsanitize=address
 else
@@ -322,6 +323,7 @@ endif
 endif
 
 ifdef WITH_MSAN
+CFLAGS += -DWITH_MSAN
 ifeq (yes,$(call supported,-fsanitize=memory))
 SANITIZERS += -fsanitize=memory -fsanitize-memory-track-origins=2
 else
@@ -330,6 +332,7 @@ endif
 endif
 
 ifdef WITH_TSAN
+CFLAGS += -DWITH_TSAN
 ifeq (yes,$(call supported,-fsanitize=thread))
 SANITIZERS += -fsanitize=thread
 else
@@ -338,6 +341,7 @@ endif
 endif
 
 ifdef WITH_UBSAN
+CFLAGS += -DWITH_UBSAN
 ifeq (yes,$(call supported,-fsanitize=undefined))
 SANITIZERS += -fsanitize=undefined
 else

--- a/src/soter/ed25519/fe.h
+++ b/src/soter/ed25519/fe.h
@@ -13,14 +13,14 @@ typedef uint64_t crypto_uint64;
 
 typedef crypto_int32 fe[10];
 
-#if defined(__clang__)
+#if defined(WITH_UBSAN) && defined(__clang__)
 #define SOTER_ED25519_NO_UBSAN __attribute__((no_sanitize( \
     "shift", \
     "unsigned-integer-overflow", \
     "implicit-integer-sign-change", \
     "implicit-unsigned-integer-truncation", \
     "implicit-signed-integer-truncation")))
-#elif defined(__GNUC__)
+#elif defined(WITH_UBSAN) && defined(__GNUC__)
 #define SOTER_ED25519_NO_UBSAN __attribute__((no_sanitize("undefined")))
 #else
 #define SOTER_ED25519_NO_UBSAN


### PR DESCRIPTION
Recently added SOTER_ED25519_NO_UBSAN macro is expanded into UBSan tweaks even when we do not compile with Undefined Behavior sanitizer enabled. This can produce ugly warnings on systems that do not support all of the sanitizer flags:

<img width="600" alt="compiler warnings" src="https://user-images.githubusercontent.com/1256587/68509866-b68a3d00-027a-11ea-8ede-a6a3e2d4cfea.png">

Let's just expand this macro into a no-op if we are not compiling with sanitizers. That's easier than deducing exactly which sanitizer flags are supported to avoid compiler warnings.

## Checklist

- [X] Change is covered by automated tests
- [X] ~~Benchmark results are attached~~ (not relevant)
- [X] The [coding guidelines] are followed
- [X] ~~Public API has proper documentation~~ (private changes)
- [X] ~~Example projects and code samples are updated~~ (no API changes)
- [X] ~~Changelog is updated if needed~~ (not interesting)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
