### PR TITLE
Fix and enable Android tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,24 +2,53 @@ version: 2
 jobs:
   android:
     docker:
-      - image: cossacklabs/android-build:2019.01
+      - image: cossacklabs/android-build:2019.11
     steps:
       - checkout
-      - run: git reset HEAD && git submodule sync && git submodule update --init
-      # limit CMake/Ninja build concurrency when building BoringSSL
-      # otherwise we hit the 4GB memory limit for the build container
-      - run: echo 'set_property(GLOBAL APPEND PROPERTY JOB_POOLS circleci_job_pool=4)' >> third_party/boringssl/src/CMakeLists.txt
-      - run: sed -i 's/"-GNinja"/"-DCMAKE_JOB_POOL_COMPILE=circleci_job_pool", "-GNinja"/g' third_party/boringssl/build.gradle
-      - run: ./gradlew --no-daemon --no-parallel --max-workers=2 assembleDebug
-      # install emulator image and create a device
-      - run: $ANDROID_HOME/tools/bin/sdkmanager 'emulator' 'system-images;android-22;default;armeabi-v7a'
-      - run: $ANDROID_HOME/tools/bin/avdmanager create avd --name nexus --device "Nexus 5" --package 'system-images;android-22;default;armeabi-v7a'
       - run:
-          command: $ANDROID_HOME/emulator/emulator -avd nexus -noaudio -no-window -gpu off -verbose -qemu
+          name: Initialize submodules
+          command: |
+            git reset --hard HEAD
+            git submodule sync
+            git submodule update --init
+      - run:
+          name: Build Themis
+          command: |
+            ./gradlew --no-daemon assembleDebug
+      - run:
+          name: Prepare Android emulator
+          command: |
+            # Unfortunately, x86 and x86_64 emulators require KVM support which
+            # is not enabled on CircleCI runners. That's why we have to go with
+            # extremely slow ARM emulation. Recent system images do not even
+            # support it (only x86 and x86_64), so we have to go with API 24.
+            avdmanager create avd \
+              --name nexus --device "Nexus 5" \
+              --package 'system-images;android-24;default;armeabi-v7a'
+      - run:
+          name: Launch Android emulator
           background: true
-      # wait for emulator to fully boot before running tests
-      - run: timeout 10m /bin/bash -c 'while true; do $ANDROID_HOME/platform-tools/adb wait-for-device logcat -b events -d | grep -i boot_progress_enable_screen && break; date; sleep 3; done'
-      - run: ./gradlew --no-daemon --no-parallel --max-workers=2 connectedAndroidTest
+          command: |
+            # Do not disable GPU (-gpu off) since that upsets the emulator and
+            # it gets stuck in an infinite loop during the boot process. However,
+            # we don't have X11 available so we don't need to see the window.
+            emulator -avd nexus -no-window -verbose -qemu
+      - run:
+          name: Wait for Android emulator to boot
+          command: |
+            # Normally this takes about 5 minutes.
+            timeout 15m /bin/bash -c \
+             'while true
+              do
+                  adb wait-for-device logcat -b events -d \
+                  | grep -i boot_progress_enable_screen && break
+                  date
+                  sleep 3
+              done'
+      - run:
+          name: Run test suite
+          command: |
+            ./gradlew --no-daemon connectedAndroidTest
 
   analyze:
     docker:
@@ -431,8 +460,7 @@ workflows:
   tests:
     jobs:
       - analyze
-      # Broken build temporarily disabled (see T1133, 2019-07-03)
-      # - android
+      - android
       - x86_64
       - jsthemis
       - php5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ _Code:_
 
   - JDK location is now detected automatically in most cases, you should not need to set JAVA_HOME or JDK_INCLUDE_PATH manually ([#551](https://github.com/cossacklabs/themis/pull/551)).
   - JNI libraries are now available as `libthemis-jni` packages for supported Linux systems ([#552](https://github.com/cossacklabs/themis/pull/552), [#553](https://github.com/cossacklabs/themis/pull/553)).
+  - Fixed a NullPointerException bug in `SecureSocket` initialisation ([#557](https://github.com/cossacklabs/themis/pull/557)).
 
 - **Python**
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.2.1'
 
         // Two necessary plugins for uploading .aar to bintray
         // from: https://android.jlelse.eu/how-to-distribute-android-library-in-a-convenient-way-d43fb68304a7
@@ -16,17 +16,29 @@ buildscript {
     }
 }
 
+repositories {
+    google()
+    jcenter()
+}
+
 dependencies {
     implementation project(":boringssl")
+    // Instrumentation tests
+    androidTestImplementation 'androidx.test:runner:1.1.0'
+    androidTestImplementation 'androidx.test:rules:1.1.0'
 }
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion "27.0.3"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
+    // BoringSSL requires at least API 21. Google Play as of August 2019 requires
+    // to target at least API 28 (but we can still support lower versions).
     defaultConfig {
-    	minSdkVersion 16
-        targetSdkVersion 16
+        minSdkVersion 21
+        targetSdkVersion 28
+        // Our tests are written in JUnit, set default runner appropriately
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     sourceSets {
@@ -40,6 +52,11 @@ android {
         androidTest.manifest.srcFile 'tests/themis/wrappers/android/AndroidManifest.xml'
 
 	}
+
+    // Dependencies for instrumentation tests
+    useLibrary 'android.test.runner'
+    useLibrary 'android.test.base'
+    useLibrary 'android.test.mock'
 
     // ensure we execute boringssl tasks first
     // tasks.whenTaskAdded({Task task -> task.dependsOn('boringssl:' + task.name)})

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-bin.zip

--- a/src/wrappers/themis/java/com/cossacklabs/themis/SecureSocket.java
+++ b/src/wrappers/themis/java/com/cossacklabs/themis/SecureSocket.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
@@ -51,13 +52,13 @@ public class SecureSocket extends Socket {
 	}
 	
 	public SecureSocket(InetAddress dstAddress, int dstPort, byte[] id, PrivateKey signPrivateKey, ISessionCallbacks callbacks) throws IOException {
-		super(dstAddress, dstPort);
-		
+		super();
+
 		this.id = id;
 		this.signPrivateKey = signPrivateKey;
 		this.callbacks = callbacks;
-		
-		runClientProtocol();
+
+		connect(new InetSocketAddress(dstAddress, dstPort));
 	}
 	
 	static final byte[] HDR_TAG = {0x54, 0x53, 0x50, 0x4d}; // TSPM

--- a/tests/themis/wrappers/android/com/cossacklabs/themis/test/KeypairGeneratorTest.java
+++ b/tests/themis/wrappers/android/com/cossacklabs/themis/test/KeypairGeneratorTest.java
@@ -20,11 +20,12 @@ import com.cossacklabs.themis.Keypair;
 import com.cossacklabs.themis.KeypairGenerator;
 import com.cossacklabs.themis.KeyGenerationException;
 
-import android.test.AndroidTestCase;
+import static org.junit.Assert.*;
+import org.junit.Test;
 
-public class KeypairGeneratorTest extends AndroidTestCase {
+public class KeypairGeneratorTest {
 	
-	@Override
+	@Test
 	public void runTest() {
 		
 		Keypair pair = null;

--- a/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellTest.java
+++ b/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellTest.java
@@ -22,9 +22,10 @@ import java.util.Random;
 import com.cossacklabs.themis.SecureCell;
 import com.cossacklabs.themis.SecureCellData;
 
-import android.test.AndroidTestCase;
+import static org.junit.Assert.*;
+import org.junit.Test;
 
-public class SecureCellTest extends AndroidTestCase {
+public class SecureCellTest {
 	
 	static final int MAX_TEST_DATA = 1024;
 	Random rand = new Random();
@@ -42,7 +43,7 @@ public class SecureCellTest extends AndroidTestCase {
 		return data;
 	}
 
-	@Override
+	@Test
 	public void runTest() {
 		try {
 			testSeal();

--- a/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCompareTest.java
+++ b/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCompareTest.java
@@ -5,9 +5,10 @@ import java.util.Random;
 import com.cossacklabs.themis.SecureCompare;
 import com.cossacklabs.themis.SecureCompareException;
 
-import android.test.AndroidTestCase;
+import static org.junit.Assert.*;
+import org.junit.Test;
 
-public class SecureCompareTest extends AndroidTestCase {
+public class SecureCompareTest {
 	
 	static final int MAX_TEST_DATA = 1024;
 	Random rand = new Random();
@@ -84,7 +85,7 @@ public class SecureCompareTest extends AndroidTestCase {
 		assertTrue(expectedResult == bob.getResult());
 	}
 	
-	@Override
+	@Test
 	public void runTest() {
 				
 		try {

--- a/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureMessageTest.java
+++ b/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureMessageTest.java
@@ -26,11 +26,12 @@ import com.cossacklabs.themis.NullArgumentException;
 import com.cossacklabs.themis.SecureMessage;
 import com.cossacklabs.themis.SecureMessageWrapException;
 
-import android.test.AndroidTestCase;
+import static org.junit.Assert.*;
+import org.junit.Test;
 
-public class SecureMessageTest extends AndroidTestCase {
+public class SecureMessageTest {
 	
-	@Override
+	@Test
 	public void runTest() {
 		
 		Keypair aPair = null;

--- a/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureSessionTest.java
+++ b/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureSessionTest.java
@@ -28,9 +28,11 @@ import com.cossacklabs.themis.SecureSession;
 import com.cossacklabs.themis.SecureSession.SessionDataType;
 import com.cossacklabs.themis.SecureSession.UnwrapResult;
 
-import android.test.AndroidTestCase;
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
 
-public class SecureSessionTest extends AndroidTestCase {
+public class SecureSessionTest {
 	
 	ISessionCallbacks callbacks = new ISessionCallbacks() {
 
@@ -80,7 +82,7 @@ public class SecureSessionTest extends AndroidTestCase {
 	Keypair serverPair;
 	
 	
-	@Override
+	@Before
 	public void setUp() {
 		try {
 			clientPair = KeypairGenerator.generateKeypair();
@@ -106,7 +108,7 @@ public class SecureSessionTest extends AndroidTestCase {
 		return data;
 	}
 	
-	@Override
+	@Test
 	public void runTest() {
 		
 		assertNotNull(clientPair);

--- a/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureSocketTest.java
+++ b/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureSocketTest.java
@@ -37,9 +37,11 @@ import com.cossacklabs.themis.SecureServerSocket;
 import com.cossacklabs.themis.SecureSession;
 import com.cossacklabs.themis.SecureSocket;
 
-import android.test.AndroidTestCase;
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
 
-public class SecureSocketTest extends AndroidTestCase {
+public class SecureSocketTest {
 	
 	ISessionCallbacks callbacks = new ISessionCallbacks() {
 
@@ -88,7 +90,7 @@ public class SecureSocketTest extends AndroidTestCase {
 	Keypair clientPair;
 	Keypair serverPair;
 	
-	@Override
+	@Before
 	public void setUp() {
 		try {
 			clientPair = KeypairGenerator.generateKeypair();
@@ -130,7 +132,7 @@ public class SecureSocketTest extends AndroidTestCase {
 		return false;
 	}
 	
-	@Override
+	@Test
 	public void runTest() {
 		
 		try {

--- a/third_party/boringssl/build.gradle
+++ b/third_party/boringssl/build.gradle
@@ -9,15 +9,23 @@ buildscript {
     }
 }
 
+repositories {
+    google()
+    jcenter()
+}
+
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion "27.0.3"
-    
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
+
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 16
+        // BoringSSL requires at least API 21 to target AArch64. Google Play
+        // as of August 2019 requires to target at least API 28 (but we can
+        // still support lower versions).
+        minSdkVersion 21
+        targetSdkVersion 28
         externalNativeBuild {
 		    cmake {
 		        arguments "-DCMAKE_TOOLCHAIN_FILE=" + android.ndkDirectory + "/build/cmake/android.toolchain.cmake",
@@ -28,13 +36,13 @@ android {
 		    }
 	    }
     }
-    
+
     externalNativeBuild {
         cmake {
             path "src/CMakeLists.txt"
         }
     }
-	
+
 	sourceSets {
         main {
             manifest.srcFile 'AndroidManifest.xml'


### PR DESCRIPTION
**Rejoice, Android, because your name is written in config.yml!**

Ahem... I mean, let’s bring Android build on CircleCI back to life and deliver on [that promise that I made in July](https://github.com/cossacklabs/themis/pull/487). And we’re not moving to Bitrise.

There are quite a few changes in here. More details can be found in commit messages. A short summary is:

- Update Docker image, Gradle, and build tools used for Android
- Update target Android API to 28, minimum required by Google Play
- Update tests to use JUnit4 API instead of deprecated AndoidTestCase
- Fix a bug\* in `SecureSocket` implementation that was breaking the tests

<sup>
__________<br/>
* I have absolutely no idea how it survived given that the tests were working in the past. I strongly suspect now that they were not actually running, or the failure was ignored.
</sup>

## Checklist

- [X] Change is covered by automated tests (duh...)
- [X] Benchmark results are attached (see CircleCI timing, I guess)
- [X] The [coding guidelines] are followed
- [X] ~~Public API has proper documentation~~ (no changes)
- [X] ~~Example projects and code samples are updated~~ (not affected)
- [X] Changelog is updated if needed (bug fixes)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
