### PR TITLE
Unbreak Doxygen configuration

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -32,7 +32,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "THEMIS"
+PROJECT_NAME           = Themis
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version
@@ -44,7 +44,7 @@ PROJECT_NUMBER         =
 # for a project that appears at the top of each page and should give viewer a
 # quick idea about the purpose of the project. Keep the description short.
 
-PROJECT_BRIEF          = "Data security library for network communication and data storage."
+PROJECT_BRIEF          = "Data security library for network communication and data storage"
 
 # With the PROJECT_LOGO tag one can specify an logo or icon that is included in
 # the documentation. The maximum height of the logo should not exceed 55 pixels
@@ -177,7 +177,7 @@ SHORT_NAMES            = NO
 # description.)
 # The default value is: NO.
 
-JAVADOC_AUTOBRIEF      = NO
+JAVADOC_AUTOBRIEF      = YES
 
 # If the QT_AUTOBRIEF tag is set to YES then doxygen will interpret the first
 # line (until the first dot) of a Qt-style comment as the brief description. If
@@ -242,7 +242,7 @@ TCL_SUBST              =
 # members will be omitted, etc.
 # The default value is: NO.
 
-OPTIMIZE_OUTPUT_FOR_C  = NO
+OPTIMIZE_OUTPUT_FOR_C  = YES
 
 # Set the OPTIMIZE_OUTPUT_JAVA tag to YES if your project consists of Java or
 # Python sources only. Doxygen will then generate output that is more tailored
@@ -382,7 +382,7 @@ INLINE_SIMPLE_STRUCTS  = NO
 # types are typedef'ed and only the typedef is referenced, never the tag name.
 # The default value is: NO.
 
-TYPEDEF_HIDES_STRUCT   = NO
+TYPEDEF_HIDES_STRUCT   = YES
 
 # The size of the symbol lookup cache can be set using LOOKUP_CACHE_SIZE. This
 # cache is used to resolve symbols given their name and scope. Since this can be
@@ -753,7 +753,7 @@ WARN_LOGFILE           =
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = src
+INPUT                  = README.md src/soter src/themis
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -773,7 +773,7 @@ INPUT_ENCODING         = UTF-8
 # *.md, *.mm, *.dox, *.py, *.f90, *.f, *.for, *.tcl, *.vhd, *.vhdl, *.ucf,
 # *.qsf, *.as and *.js.
 
-FILE_PATTERNS          =
+FILE_PATTERNS          = *.c *.h
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.
@@ -889,7 +889,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE =
+USE_MDFILE_AS_MAINPAGE = README.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing
@@ -1933,7 +1933,7 @@ ENABLE_PREPROCESSING   = YES
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-MACRO_EXPANSION        = NO
+MACRO_EXPANSION        = YES
 
 # If the EXPAND_ONLY_PREDEF and MACRO_EXPANSION tags are both set to YES then
 # the macro expansion is limited to the macros specified with the PREDEFINED and
@@ -1941,7 +1941,7 @@ MACRO_EXPANSION        = NO
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_ONLY_PREDEF     = NO
+EXPAND_ONLY_PREDEF     = YES
 
 # If the SEARCH_INCLUDES tag is set to YES the includes files in the
 # INCLUDE_PATH will be searched if a #include is found.
@@ -1973,7 +1973,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED             = THEMIS_API SOTER_API
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/src/themis/secure_message.h
+++ b/src/themis/secure_message.h
@@ -154,8 +154,7 @@ themis_status_t themis_secure_message_verify(const uint8_t* public_key,
  * storage then THEMIS_BUFFER_TOO_SMALL will return and wrapped_message_length will store length of
  * buffer needed for wrapped message store
  */
-DEPRECATED("use 'themis_secure_message_encrypt' with private and public keys to encrypt message, "
-           "or 'themis_secure_message_sign' with private key to sign message")
+DEPRECATED("use 'themis_secure_message_encrypt' with private and public keys to encrypt message, or 'themis_secure_message_sign' with private key to sign message")
 THEMIS_API
 themis_status_t themis_secure_message_wrap(const uint8_t* private_key,
                                            size_t private_key_length,
@@ -182,8 +181,7 @@ themis_status_t themis_secure_message_wrap(const uint8_t* private_key,
  * THEMIS_BUFFER_TOO_SMALL will return and message_length will store length of buffer needed for
  * plain message store
  */
-DEPRECATED("use 'themis_secure_message_decrypt' with private and public key to decrypt message or "
-           "'themis_secure_message_verify' with public key to verify signed message")
+DEPRECATED("use 'themis_secure_message_decrypt' with private and public key to decrypt message or 'themis_secure_message_verify' with public key to verify signed message")
 THEMIS_API
 themis_status_t themis_secure_message_unwrap(const uint8_t* private_key,
                                              size_t private_key_length,


### PR DESCRIPTION
We have a Doxyfile and a lot of Doxygen-compatible comments in Themis codebase. However, they are currently broken. Update Doxyfile and unbreak Doxygen configuration.

Now running `doxygen` from the project root is actually useful.

Before:

<img width="934" alt="doxygen before" src="https://user-images.githubusercontent.com/1256587/70031993-2f985e00-15b5-11ea-9d18-1cd7385bd738.png">

After:

<img width="934" alt="doxygen after" src="https://user-images.githubusercontent.com/1256587/70031891-fbbd3880-15b4-11ea-9488-af7ee7bbae94.png">

It does not look as good as it could, there are many missing files, some docs are not pretty, etc. But at least they can be viewed now and we can work on improvements. Some of the most obnoxious ones are fixed right here.

## Checklist

- [x] ~~Change is covered by automated tests~~ (it is not)
- [x] ~~Benchmark results are attached~~ (not applicable)
- [x] The [coding guidelines] are followed
- [x] Public API has proper documentation
- [x] ~~Example projects and code samples are updated if needed~~ (not applicable)
- [x] ~~Changelog is updated if needed~~ (not applicable)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
