### PR TITLE
Symmetric keygen: Themis Core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,16 @@
 
 Changes that are currently in development and have not been released yet.
 
+**TL;DR:**
+- Added API for generating symmetric keys for use with Secure Cell;
+
 _Code:_
+
+- **Core**
+
+  - **Key generation**
+
+    - New function `themis_gen_sym_key()` can be used to securely generate symmetric keys for Secure Cell ([#560](https://github.com/cossacklabs/themis/pull/560)).
 
 - **Java**
 

--- a/src/themis/secure_keygen.c
+++ b/src/themis/secure_keygen.c
@@ -173,11 +173,8 @@ themis_status_t themis_gen_sym_key(uint8_t* key, size_t* key_length)
     if (key_length == NULL) {
         return THEMIS_INVALID_PARAMETER;
     }
-    if (key != NULL && *key_length == 0) {
-        return THEMIS_INVALID_PARAMETER;
-    }
 
-    if (key == NULL) {
+    if (key == NULL || *key_length == 0) {
         *key_length = THEMIS_SYM_KEY_LENGTH;
         return THEMIS_BUFFER_TOO_SMALL;
     }

--- a/src/themis/secure_keygen.c
+++ b/src/themis/secure_keygen.c
@@ -20,6 +20,7 @@
 
 #include "soter/soter_container.h"
 #include "soter/soter_ec_key.h"
+#include "soter/soter_rand.h"
 #include "soter/soter_rsa_key.h"
 #include "soter/soter_rsa_key_pair_gen.h"
 #include "soter/soter_t.h"
@@ -29,6 +30,14 @@
 #ifndef THEMIS_RSA_KEY_LENGTH
 #define THEMIS_RSA_KEY_LENGTH RSA_KEY_LENGTH_2048
 #endif
+
+/*
+ * This is the default key length recommended for use with Secure Cell.
+ * It will have enough randomness for AES-256 (normally used by Themis)
+ * and is consistent with NIST recommendations for the next ten years,
+ * as of 2020. See: https://www.keylength.com/en/4/
+ */
+#define THEMIS_SYM_KEY_LENGTH 32
 
 themis_status_t themis_gen_key_pair(soter_sign_alg_t alg,
                                     uint8_t* private_key,
@@ -157,4 +166,22 @@ themis_status_t themis_is_valid_asym_key(const uint8_t* key, size_t length)
     }
 
     return THEMIS_INVALID_PARAMETER;
+}
+
+themis_status_t themis_gen_sym_key(uint8_t* key, size_t* key_length)
+{
+    if (key_length == NULL) {
+        return THEMIS_INVALID_PARAMETER;
+    }
+    if (key != NULL && *key_length == 0) {
+        return THEMIS_INVALID_PARAMETER;
+    }
+
+    if (key == NULL) {
+        *key_length = THEMIS_SYM_KEY_LENGTH;
+        return THEMIS_BUFFER_TOO_SMALL;
+    }
+
+    /* Soter error codes have the same value as Themis ones */
+    return soter_rand(key, *key_length);
 }

--- a/src/themis/secure_keygen.h
+++ b/src/themis/secure_keygen.h
@@ -59,14 +59,11 @@ extern "C" {
  *
  * @exception THEMIS_INVALID_PARAM if `key_length` is NULL.
  *
- * @exception THEMIS_INVALID_PARAM if `key` is not NULL,
- * but `key_length` is zero.
- *
  * @exception THEMIS_INVALID_PARAM if `key_length` is too big
  * for cryptographic backend to handle.
  *
- * @exception THEMIS_BUFFER_TOO_SMALL if `key` is not NULL, but
- * `key_length` is not sufficient to hold a generated key.
+ * @exception THEMIS_BUFFER_TOO_SMALL if `key_length` is too small
+ * to hold a generated key.
  *
  * @exception THEMIS_FAIL if cryptographic backend was unable
  * to generate enough randomness to fill the entire buffer.

--- a/src/themis/secure_keygen.h
+++ b/src/themis/secure_keygen.h
@@ -15,8 +15,8 @@
  */
 
 /**
- * @file secure_keygen.h
- * @brief secure key generation
+ * Securely generating random asymmetric key pairs.
+ * @file themis/secure_keygen.h
  */
 
 #ifndef THEMIS_SECURE_KEYGEN_H
@@ -32,24 +32,43 @@ extern "C" {
 /**
  * @addtogroup THEMIS
  * @{
- * @defgroup THEMIS_KEYS secure key generation
- * @brief securely generating random key pairs
+ * @defgroup THEMIS_KEYS Secure key generation
+ * Securely generating random asymmetric key pairs.
  * @{
  */
 
 /**
- * @brief generate RSA key pair
- * @param [out] private_key buffer for private key to store. May be set to NULL for private key
- * length determination
- * @param [in, out] private_key_length length of private_key
- * @param [out] public_key buffer for public key to store. May be set to NULL for public key length
- * determination
- * @param [in, out] public_key_length length of public key
- * @return THEMIS_SUCCESS on success or THEMIS_FAIL on failure
- * @note If private_key==NULL or public_key==NULL or private_key_length is not enought for private
- * key storage or public_key_length is not enought for public key storage then
- * THEMIS_BUFFER_TOO_SMALL will return and private_key_length and public_key_length will store
- * lengths of buffers needed for private key and public key store respectively
+ * Generates an RSA key pair.
+ *
+ * @param [out]     private_key         buffer for private key
+ * @param [in,out]  private_key_length  length of private key in bytes
+ * @param [out]     public_key          buffer for public key
+ * @param [in,out]  public_key_length   length of public key in bytes
+ *
+ * New RSA key pair is generated and written into `private_key` and
+ * `public_key` buffers which must have at least `private_key_length`
+ * and `public_key_length` bytes available respectively. Note that
+ * length parameters are _pointers_ to actual length values.
+ *
+ * You can pass NULL for `private_key` and `public_key` in order to
+ * determine appropriate buffer length. In this case the lengths are
+ * written into provided locations, no key data is generated, and
+ * THEMIS_BUFFER_TOO_SMALL is returned.
+ *
+ * @returns THEMIS_SUCCESS if the keys have been generated successfully
+ * and written to `private_key` and `public_key`.
+ *
+ * @returns THEMIS_BUFFER_TOO_SMALL if the key lengths have been written
+ * to `private_key_length` and `public_key_length`.
+ *
+ * @exception THEMIS_FAIL if key generation has failed.
+ *
+ * @exception THEMIS_INVALID_PARAM if `private_key_length` or
+ * `public_key_length` is NULL.
+ *
+ * @exception THEMIS_BUFFER_TOO_SMALL if `private_key` and `public_key`
+ * are not NULL, but `private_key_length` or `public_key_length` in not
+ * sufficient to hold a generated key.
  */
 THEMIS_API
 themis_status_t themis_gen_rsa_key_pair(uint8_t* private_key,
@@ -58,18 +77,37 @@ themis_status_t themis_gen_rsa_key_pair(uint8_t* private_key,
                                         size_t* public_key_length);
 
 /**
- * @brief generate EC key pair
- * @param [out] private_key buffer for private key to store. May be set to NULL for private key
- * length determination
- * @param [in, out] private_key_length length of private_key
- * @param [out] public_key buffer for public key to store. May be set to NULL for public key length
- * determination
- * @param [in, out] public_key_length length of public key
- * @return THEMIS_SUCCESS on success or THEMIS_FAIL on failure
- * @note If private_key==NULL or public_key==NULL or private_key_length is not enought for private
- * key storage or public_key_length is not enought for public key storage then
- * THEMIS_BUFFER_TOO_SMALL will return and private_key_length and public_key_length will store
- * lengths of buffers needed for private key and public key store respectively
+ * Generates an EC key pair.
+ *
+ * @param [out]     private_key         buffer for private key
+ * @param [in,out]  private_key_length  length of private key in bytes
+ * @param [out]     public_key          buffer for public key
+ * @param [in,out]  public_key_length   length of public key in bytes
+ *
+ * New EC key pair is generated and written into `private_key` and
+ * `public_key` buffers which must have at least `private_key_length`
+ * and `public_key_length` bytes available respectively. Note that
+ * length parameters are _pointers_ to actual length values.
+ *
+ * You can pass NULL for `private_key` and `public_key` in order to
+ * determine appropriate buffer length. In this case the lengths are
+ * written into provided locations, no key data is generated, and
+ * THEMIS_BUFFER_TOO_SMALL is returned.
+ *
+ * @returns THEMIS_SUCCESS if the keys have been generated successfully
+ * and written to `private_key` and `public_key`.
+ *
+ * @returns THEMIS_BUFFER_TOO_SMALL if the key lengths have been written
+ * to `private_key_length` and `public_key_length`.
+ *
+ * @exception THEMIS_FAIL if key generation has failed.
+ *
+ * @exception THEMIS_INVALID_PARAM if `private_key_length` or
+ * `public_key_length` is NULL.
+ *
+ * @exception THEMIS_BUFFER_TOO_SMALL if `private_key` and `public_key`
+ * are not NULL, but `private_key_length` or `public_key_length` in not
+ * sufficient to hold a generated key.
  */
 THEMIS_API
 themis_status_t themis_gen_ec_key_pair(uint8_t* private_key,
@@ -77,30 +115,46 @@ themis_status_t themis_gen_ec_key_pair(uint8_t* private_key,
                                        uint8_t* public_key,
                                        size_t* public_key_length);
 
-enum themis_key_kind {
+/**
+ * Kind of an asymmetric Themis key.
+ */
+typedef enum themis_key_kind {
+    /** Invalid key buffer. */
     THEMIS_KEY_INVALID,
+    /** Private RSA key. */
     THEMIS_KEY_RSA_PRIVATE,
+    /** Public RSA key. */
     THEMIS_KEY_RSA_PUBLIC,
+    /** Private EC key. */
     THEMIS_KEY_EC_PRIVATE,
+    /** Public EC key. */
     THEMIS_KEY_EC_PUBLIC,
-};
-
-typedef enum themis_key_kind themis_key_kind_t;
+} themis_key_kind_t;
 
 /**
- * @brief get Themis key kind
+ * Returns kind of an asymmetric Themis key.
+ *
  * @param [in]  key     key buffer
- * @param [in]  length  length of key
- * @return corresponding key kind if the buffer contains a key, or THEMIS_KEY_INVALID otherwise
+ * @param [in]  length  length of key in bytes
+ *
+ * @return corresponding key kind if the buffer contains a key,
+ * or THEMIS_KEY_INVALID otherwise.
+ *
+ * @exception THEMIS_KEY_INVALID if `key` is NULL.
  */
 THEMIS_API
 themis_key_kind_t themis_get_asym_key_kind(const uint8_t* key, size_t length);
 
 /**
- * @brief validate a Themis key
+ * Validates an asymmetric Themis key.
+ *
  * @param [in]  key     key buffer to validate
- * @param [in]  length  length of key
- * @return THEMIS_SUCCESS if the buffer contains a valid Themis key, or an error code otherwise
+ * @param [in]  length  length of key in bytes
+ *
+ * @return THEMIS_SUCCESS if the buffer contains a valid Themis key,
+ * or THEMIS_INVALID_PARAMETER if it does not.
+ *
+ * @exception THEMIS_INVALID_PARAMETER if `key` is NULL.
  */
 THEMIS_API
 themis_status_t themis_is_valid_asym_key(const uint8_t* key, size_t length);

--- a/src/themis/secure_keygen.h
+++ b/src/themis/secure_keygen.h
@@ -15,7 +15,7 @@
  */
 
 /**
- * Securely generating random asymmetric key pairs.
+ * Securely generating random keys.
  * @file themis/secure_keygen.h
  */
 
@@ -33,9 +33,52 @@ extern "C" {
  * @addtogroup THEMIS
  * @{
  * @defgroup THEMIS_KEYS Secure key generation
- * Securely generating random asymmetric key pairs.
+ * Securely generating random symmetric keys and asymmetric key pairs.
  * @{
  */
+
+/**
+ * Generates a symmetric key.
+ *
+ * @param [out]     key         buffer for generated key
+ * @param [in,out]  key_length  length of generated key in bytes
+ *
+ * New symmetric key is generated and written into `key` buffer which
+ * must have at least `key_length` bytes available. Note that length
+ * parameter is a _pointer_ to actual length value.
+ *
+ * You can pass NULL for `key` in order to determine appropriate buffer
+ * length. In this case the length is written into provided location,
+ * no key data is generated, and THEMIS_BUFFER_TOO_SMALL is returned.
+ *
+ * @returns THEMIS_SUCCESS if the key has been generated successfully
+ * and written into `key`.
+ *
+ * @returns THEMIS_BUFFER_TOO_SMALL if the key length has been written
+ * to `key_length`.
+ *
+ * @exception THEMIS_INVALID_PARAM if `key_length` is NULL.
+ *
+ * @exception THEMIS_INVALID_PARAM if `key` is not NULL,
+ * but `key_length` is zero.
+ *
+ * @exception THEMIS_INVALID_PARAM if `key_length` is too big
+ * for cryptographic backend to handle.
+ *
+ * @exception THEMIS_BUFFER_TOO_SMALL if `key` is not NULL, but
+ * `key_length` is not sufficient to hold a generated key.
+ *
+ * @exception THEMIS_FAIL if cryptographic backend was unable
+ * to generate enough randomness to fill the entire buffer.
+ *
+ * @exception THEMIS_NOT_SUPPORTED if cryptographic backend
+ * does not support strong random number generation.
+ *
+ * @note Some backends might abort the process instead of returning
+ * error codes if they are unable to generate random data.
+ */
+THEMIS_API
+themis_status_t themis_gen_sym_key(uint8_t* key, size_t* key_length);
 
 /**
  * Generates an RSA key pair.

--- a/tests/themis/themis_secure_cell.c
+++ b/tests/themis/themis_secure_cell.c
@@ -68,6 +68,11 @@ static void secure_cell_key_generation(void)
     testsuite_fail_unless(res == THEMIS_BUFFER_TOO_SMALL, "keygen: query key size");
     testsuite_fail_unless(master_key_1_length > 0, "keygen: recommends non-empty key");
 
+    master_key_1_length = 0;
+    res = themis_gen_sym_key(master_key_1, &master_key_1_length);
+    testsuite_fail_unless(res == THEMIS_BUFFER_TOO_SMALL, "keygen: query key size (with buffer)");
+    testsuite_fail_unless(master_key_1_length > 0, "keygen: recommends non-empty key");
+
     size_t old_value = master_key_1_length;
     res = themis_gen_sym_key(master_key_1, &master_key_1_length);
     testsuite_fail_unless(res == THEMIS_SUCCESS, "keygen: generate recommended key");
@@ -115,10 +120,6 @@ static void secure_cell_key_generation(void)
 
     res = themis_gen_sym_key(master_key_1, NULL);
     testsuite_fail_unless(res == THEMIS_INVALID_PARAMETER, "keygen: missing key length");
-
-    master_key_1_length = 0;
-    res = themis_gen_sym_key(master_key_1, &master_key_1_length);
-    testsuite_fail_unless(res == THEMIS_INVALID_PARAMETER, "keygen: invalid key length");
 }
 
 static int secure_cell_seal(void)

--- a/tests/themis/themis_secure_cell.c
+++ b/tests/themis/themis_secure_cell.c
@@ -32,6 +32,35 @@ static char passwd[] = "password";
 static char message[] = "secure cell test message by Mnatsakanov Andrey from Cossack Labs";
 static char user_context[] = "secure cell user context";
 
+static void secure_cell_key_generation(void)
+{
+    themis_status_t res;
+    uint8_t master_key[MAX_KEY_SIZE];
+    size_t master_key_length = 0;
+
+    res = themis_gen_sym_key(NULL, &master_key_length);
+    testsuite_fail_unless(res == THEMIS_BUFFER_TOO_SMALL, "keygen: query key size");
+
+    res = themis_gen_sym_key(master_key, &master_key_length);
+    testsuite_fail_unless(res == THEMIS_SUCCESS, "keygen: generate new key");
+    testsuite_fail_unless(master_key_length > 0, "keygen: key length returned");
+
+    res = themis_gen_sym_key(NULL, NULL);
+    testsuite_fail_unless(res == THEMIS_INVALID_PARAMETER, "keygen: missing key length");
+
+    res = themis_gen_sym_key(master_key, NULL);
+    testsuite_fail_unless(res == THEMIS_INVALID_PARAMETER, "keygen: missing key length");
+
+    master_key_length = 0;
+    res = themis_gen_sym_key(master_key, &master_key_length);
+    testsuite_fail_unless(res == THEMIS_INVALID_PARAMETER, "keygen: invalid key length");
+
+    master_key_length = 8;
+    res = themis_gen_sym_key(master_key, &master_key_length);
+    testsuite_fail_unless(res == THEMIS_SUCCESS, "keygen: custom key length");
+    testsuite_fail_unless(master_key_length == 8, "keygen: key length unchanged");
+}
+
 static int secure_cell_seal(void)
 {
     uint8_t* encrypted_message;
@@ -1363,6 +1392,9 @@ static void secure_cell_context_corruption(void)
 
 void run_secure_cell_test(void)
 {
+    testsuite_enter_suite("secure cell: key generation");
+    testsuite_run_test(secure_cell_key_generation);
+
     testsuite_enter_suite("secure cell: basic flow");
     testsuite_run_test(secure_cell_test);
     testsuite_run_test(secure_cell_test_lengths);

--- a/tests/themis/themis_secure_cell.c
+++ b/tests/themis/themis_secure_cell.c
@@ -29,6 +29,8 @@
 /* Keep it under 2^31 to support 32-bit systems. */
 #define CORRUPTED_LENGTH 0x5AFE
 
+#define DEFAULT_SYM_KEY_LENGTH 32
+
 static char passwd[] = "password";
 static char message[] = "secure cell test message by Mnatsakanov Andrey from Cossack Labs";
 static char user_context[] = "secure cell user context";
@@ -66,12 +68,14 @@ static void secure_cell_key_generation(void)
 
     res = themis_gen_sym_key(NULL, &master_key_1_length);
     testsuite_fail_unless(res == THEMIS_BUFFER_TOO_SMALL, "keygen: query key size");
-    testsuite_fail_unless(master_key_1_length > 0, "keygen: recommends non-empty key");
+    testsuite_fail_unless(master_key_1_length == DEFAULT_SYM_KEY_LENGTH,
+                          "keygen: recommends default key size");
 
     master_key_1_length = 0;
     res = themis_gen_sym_key(master_key_1, &master_key_1_length);
     testsuite_fail_unless(res == THEMIS_BUFFER_TOO_SMALL, "keygen: query key size (with buffer)");
-    testsuite_fail_unless(master_key_1_length > 0, "keygen: recommends non-empty key");
+    testsuite_fail_unless(master_key_1_length == DEFAULT_SYM_KEY_LENGTH,
+                          "keygen: recommends default key size");
 
     size_t old_value = master_key_1_length;
     res = themis_gen_sym_key(master_key_1, &master_key_1_length);


### PR DESCRIPTION
Implement symmetric key generation utilities described in RFC 1 (not available publicly at the moment). This is new API.

We are going to need a way to let our users generate strong symmetric keys for use with Secure Cell. This core function is _the_ implementation of key generation. High-level wrappers will be using it to implement key generation.

The API has the usual “check – allocate – output” style found in other places in Themis:

```c
themis_status_t themis_gen_sym_key(uint8_t* key, size_t* key_length);
```

The users are expected to first pass NULL for key to learn the default length, then allocate a suitable buffer and call the function again to receive key bytes. After that the key can be immediately used with Secure Cell. (Tests and examples for Secure Cell will be updated in next pull requests.)

## Checklist

- [x] Change is covered by automated tests
- [x] ~~Benchmark results are attached~~ (not interesting)
- [x] The [coding guidelines] are followed
- [x] Public API has proper documentation (hell yeah)
- [x] ~~Example projects and code samples are updated~~ (will do later)
- [x] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
