### PR TITLE
Symmetric keygen: high-level wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ _Code:_
 
   - Fixed compatibility issues on 32-bit platforms ([#555](https://github.com/cossacklabs/themis/pull/555)).
 
+- **WebAssembly**
+
+  - New class `SymmetricKey` can be used to generate symmetric keys for Secure Cell ([#561](https://github.com/cossacklabs/themis/pull/561)).
+
 ## [0.12.0](https://github.com/cossacklabs/themis/releases/tag/0.12.0), September 27th 2019
 
 **TL;DR:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ _Code:_
 - **Python**
 
   - Fixed compatibility issues on 32-bit platforms ([#555](https://github.com/cossacklabs/themis/pull/555)).
+  - New function `skeygen.GenerateSymmetricKey()` can be used to generate symmetric keys for Secure Cell ([#561](https://github.com/cossacklabs/themis/pull/561)).
 
 - **WebAssembly**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ _Code:_
 
     - New function `themis_gen_sym_key()` can be used to securely generate symmetric keys for Secure Cell ([#560](https://github.com/cossacklabs/themis/pull/560)).
 
+- **C++**
+
+  - New function `themispp::gen_sym_key()` can be used to generate symmetric keys for Secure Cell ([#561](https://github.com/cossacklabs/themis/pull/561)).
+
 - **Java**
 
   - JDK location is now detected automatically in most cases, you should not need to set JAVA_HOME or JDK_INCLUDE_PATH manually ([#551](https://github.com/cossacklabs/themis/pull/551)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ _Code:_
 
   - New function `keys.NewSymmetricKey()` can be used to generate symmetric keys for Secure Cell ([#561](https://github.com/cossacklabs/themis/pull/561)).
 
+- **iOS and macOS**
+
+  - New function `TSGenerateSymmetricKey()` (available in Objective-C and Swift) can be used to generate symmetric keys for Secure Cell ([#561](https://github.com/cossacklabs/themis/pull/561)).
+
 - **Java**
 
   - JDK location is now detected automatically in most cases, you should not need to set JAVA_HOME or JDK_INCLUDE_PATH manually ([#551](https://github.com/cossacklabs/themis/pull/551)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ _Code:_
 
   - New function `themispp::gen_sym_key()` can be used to generate symmetric keys for Secure Cell ([#561](https://github.com/cossacklabs/themis/pull/561)).
 
+- **Go**
+
+  - New function `keys.NewSymmetricKey()` can be used to generate symmetric keys for Secure Cell ([#561](https://github.com/cossacklabs/themis/pull/561)).
+
 - **Java**
 
   - JDK location is now detected automatically in most cases, you should not need to set JAVA_HOME or JDK_INCLUDE_PATH manually ([#551](https://github.com/cossacklabs/themis/pull/551)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ _Code:_
 
   - New function `Themis::gen_sym_key()` can be used to generate symmetric keys for Secure Cell ([#561](https://github.com/cossacklabs/themis/pull/561)).
 
+- **Rust**
+
+  - New object `themis::keys::SymmetricKey` can be used to generate symmetric keys for Secure Cell ([#561](https://github.com/cossacklabs/themis/pull/561)).
+
 - **WebAssembly**
 
   - New class `SymmetricKey` can be used to generate symmetric keys for Secure Cell ([#561](https://github.com/cossacklabs/themis/pull/561)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ _Code:_
   - Fixed a NullPointerException bug in `SecureSocket` initialisation ([#557](https://github.com/cossacklabs/themis/pull/557)).
   - Some Themis exceptions have been converted from checked `Exception` to _unchecked_ `RuntimeException`, relaxing requirements for `throws` specifiers ([#563](https://github.com/cossacklabs/themis/pull/563)).
 
+- **PHP**
+
+  - New function `phpthemis_gen_sym_key()` can be used to generate symmetric keys for Secure Cell ([#561](https://github.com/cossacklabs/themis/pull/561)).
+
 - **Python**
 
   - Fixed compatibility issues on 32-bit platforms ([#555](https://github.com/cossacklabs/themis/pull/555)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ _Code:_
   - Fixed compatibility issues on 32-bit platforms ([#555](https://github.com/cossacklabs/themis/pull/555)).
   - New function `skeygen.GenerateSymmetricKey()` can be used to generate symmetric keys for Secure Cell ([#561](https://github.com/cossacklabs/themis/pull/561)).
 
+- **Ruby**
+
+  - New function `Themis::gen_sym_key()` can be used to generate symmetric keys for Secure Cell ([#561](https://github.com/cossacklabs/themis/pull/561)).
+
 - **WebAssembly**
 
   - New class `SymmetricKey` can be used to generate symmetric keys for Secure Cell ([#561](https://github.com/cossacklabs/themis/pull/561)).

--- a/gothemis/keys/symmetric.go
+++ b/gothemis/keys/symmetric.go
@@ -1,0 +1,46 @@
+package keys
+
+/*
+#cgo LDFLAGS: -lthemis
+
+#include <stdbool.h>
+#include <themis/themis.h>
+
+static bool get_sym_key_size(size_t *key_len)
+{
+	return themis_gen_sym_key(NULL, key_len) == THEMIS_BUFFER_TOO_SMALL;
+}
+
+static bool gen_sym_key(void *key, size_t key_len)
+{
+	return themis_gen_sym_key(key, &key_len) == THEMIS_SUCCESS;
+}
+
+*/
+import "C"
+
+import (
+	"unsafe"
+
+	"github.com/cossacklabs/themis/gothemis/errors"
+)
+
+// SymmetricKey stores a master key for Secure Cell.
+type SymmetricKey struct {
+	Value []byte
+}
+
+// NewSymmetricKey generates a new random symmetric key.
+func NewSymmetricKey() (*SymmetricKey, error) {
+	var len C.size_t
+	if !bool(C.get_sym_key_size(&len)) {
+		return nil, errors.New("Failed to get symmetric key size")
+	}
+
+	key := make([]byte, int(len), int(len))
+	if !bool(C.gen_sym_key(unsafe.Pointer(&key[0]), len)) {
+		return nil, errors.New("Failed to generate symmetric key")
+	}
+
+	return &SymmetricKey{Value: key}, nil
+}

--- a/gothemis/keys/symmetric_test.go
+++ b/gothemis/keys/symmetric_test.go
@@ -1,0 +1,15 @@
+package keys
+
+import (
+	"testing"
+)
+
+func TestNewSymmetricKey(t *testing.T) {
+	key, err := NewSymmetricKey()
+	if err != nil {
+		t.Error(err)
+	}
+	if len(key.Value) == 0 {
+		t.Error("empty key.Value")
+	}
+}

--- a/gothemis/keys/symmetric_test.go
+++ b/gothemis/keys/symmetric_test.go
@@ -4,12 +4,14 @@ import (
 	"testing"
 )
 
+const defaultLength = 32
+
 func TestNewSymmetricKey(t *testing.T) {
 	key, err := NewSymmetricKey()
 	if err != nil {
 		t.Error(err)
 	}
-	if len(key.Value) == 0 {
-		t.Error("empty key.Value")
+	if len(key.Value) != defaultLength {
+		t.Error("invalid key.Value")
 	}
 }

--- a/src/wrappers/themis/Obj-C/objcthemis/skeygen.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/skeygen.h
@@ -56,6 +56,15 @@ typedef NS_ENUM(NSInteger, TSKeyGenAsymmetricAlgorithm) {
 
 @end
 
+/**
+ * Generates new symmetric master key.
+ *
+ * Securely generate a new master key suitable for Secure Cell.
+ *
+ * @returns a newly allocated key of default size.
+ */
+NSData* __nullable TSGenerateSymmetricKey();
+
 NS_ASSUME_NONNULL_END
 
 /** @} */

--- a/src/wrappers/themis/Obj-C/objcthemis/skeygen.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/skeygen.h
@@ -63,7 +63,7 @@ typedef NS_ENUM(NSInteger, TSKeyGenAsymmetricAlgorithm) {
  *
  * @returns a newly allocated key of default size.
  */
-NSData* __nullable TSGenerateSymmetricKey();
+NSData* __nullable TSGenerateSymmetricKey(void);
 
 NS_ASSUME_NONNULL_END
 

--- a/src/wrappers/themis/Obj-C/objcthemis/skeygen.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/skeygen.m
@@ -81,7 +81,7 @@
 
 @end
 
-NSData* __nullable TSGenerateSymmetricKey()
+NSData* __nullable TSGenerateSymmetricKey(void)
 {
     TSErrorType result;
     NSMutableData *key;

--- a/src/wrappers/themis/Obj-C/objcthemis/skeygen.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/skeygen.m
@@ -80,3 +80,24 @@
 }
 
 @end
+
+NSData* __nullable TSGenerateSymmetricKey()
+{
+    TSErrorType result;
+    NSMutableData *key;
+    size_t keyLength = 0;
+
+    result = (TSErrorType) themis_gen_sym_key(NULL, &keyLength);
+    if (result != TSErrorTypeBufferTooSmall) {
+        return nil;
+    }
+
+    key = [NSMutableData dataWithLength:keyLength];
+
+    result = (TSErrorType) themis_gen_sym_key(key.mutableBytes, &keyLength);
+    if (result != TSErrorTypeSuccess) {
+        return nil;
+    }
+
+    return key;
+}

--- a/src/wrappers/themis/php/php_themis.c
+++ b/src/wrappers/themis/php/php_themis.c
@@ -240,6 +240,7 @@ static zend_function_entry php_themis_functions[] = {
   PHP_FE(phpthemis_secure_message_unwrap, NULL)
   PHP_FE(phpthemis_gen_rsa_key_pair, NULL)
   PHP_FE(phpthemis_gen_ec_key_pair, NULL)
+  PHP_FE(phpthemis_gen_sym_key, NULL)
   PHP_FE(phpthemis_scell_seal_encrypt, NULL)
   PHP_FE(phpthemis_scell_seal_decrypt, NULL)
   PHP_FE(phpthemis_scell_token_protect_encrypt,NULL)
@@ -395,6 +396,25 @@ PHP_FUNCTION(phpthemis_gen_ec_key_pair){
   array_init(return_value);
   add_assoc_stringl(return_value, "private_key", private_key, private_key_length, 0);
   add_assoc_stringl(return_value, "public_key", public_key, public_key_length, 0);
+}
+
+PHP_FUNCTION(phpthemis_gen_sym_key){
+  size_t key_length;
+  if(themis_gen_sym_key(NULL, &key_length)!=THEMIS_BUFFER_TOO_SMALL){
+    zend_throw_exception(zend_exception_get_default(TSRMLS_C), "Error: themis_gen_sym_key: invalid parameters.", 0 TSRMLS_CC);
+    RETURN_NULL();
+  }
+  uint8_t* key=emalloc(key_length);
+  if(key==NULL){
+    zend_throw_exception(zend_exception_get_default(TSRMLS_C), "Error: themis_gen_sym_key: not enough memory.", 0 TSRMLS_CC);
+    RETURN_NULL();
+  }
+  if(themis_gen_sym_key(key, &key_length)!=THEMIS_SUCCESS){
+    zend_throw_exception(zend_exception_get_default(TSRMLS_C), "Error: themis_gen_sym_key: generation failed.", 0 TSRMLS_CC);
+    RETURN_NULL();
+  }
+  ZVAL_STRINGL(return_value, key, (int)key_length, 0);
+  return;
 }
 
 PHP_FUNCTION(phpthemis_scell_seal_encrypt){

--- a/src/wrappers/themis/php/php_themis.h
+++ b/src/wrappers/themis/php/php_themis.h
@@ -25,6 +25,7 @@ PHP_FUNCTION(phpthemis_secure_message_unwrap);
 PHP_FUNCTION(phpthemis_gen_rsa_key_pair);
 PHP_FUNCTION(phpthemis_gen_ec_key_pair);
 
+PHP_FUNCTION(phpthemis_gen_sym_key);
 PHP_FUNCTION(phpthemis_scell_seal_encrypt);
 PHP_FUNCTION(phpthemis_scell_seal_decrypt);
 PHP_FUNCTION(phpthemis_scell_token_protect_encrypt);

--- a/src/wrappers/themis/php7/php_key_generator.c
+++ b/src/wrappers/themis/php7/php_key_generator.c
@@ -66,3 +66,22 @@ ZEND_FUNCTION(phpthemis_gen_ec_key_pair){
     add_assoc_stringl(return_value, "private_key", private_key, private_key_length);
     add_assoc_stringl(return_value, "public_key", public_key, public_key_length);
 }
+
+ZEND_FUNCTION(phpthemis_gen_sym_key){
+    size_t key_length;
+    if(themis_gen_sym_key(NULL, &key_length)!=THEMIS_BUFFER_TOO_SMALL){
+        zend_throw_exception(zend_exception_get_default(TSRMLS_C), "Error: themis_gen_sym_key: invalid parameters.", 0 TSRMLS_CC);
+        RETURN_NULL();
+    }
+    uint8_t* key=emalloc(key_length);
+    if(key==NULL){
+        zend_throw_exception(zend_exception_get_default(TSRMLS_C), "Error: themis_gen_sym_key: not enough memory.", 0 TSRMLS_CC);
+        RETURN_NULL();
+    }
+    if(themis_gen_sym_key(key, &key_length)!=THEMIS_SUCCESS){
+        zend_throw_exception(zend_exception_get_default(TSRMLS_C), "Error: themis_gen_sym_key: generation failed.", 0 TSRMLS_CC);
+        RETURN_NULL();
+    }
+    ZVAL_STRINGL(return_value, key, (int)key_length);
+    return;
+}

--- a/src/wrappers/themis/php7/php_key_generator.h
+++ b/src/wrappers/themis/php7/php_key_generator.h
@@ -25,4 +25,6 @@
 ZEND_FUNCTION(phpthemis_gen_rsa_key_pair);
 ZEND_FUNCTION(phpthemis_gen_ec_key_pair);
 
+ZEND_FUNCTION(phpthemis_gen_sym_key);
+
 #endif //THEMIS_KEY_GENERATOR_H

--- a/src/wrappers/themis/php7/php_themis.c
+++ b/src/wrappers/themis/php7/php_themis.c
@@ -31,6 +31,7 @@ static zend_function_entry php_themis_functions[] = {
   ZEND_FE(phpthemis_secure_message_unwrap, NULL)
   ZEND_FE(phpthemis_gen_rsa_key_pair, NULL)
   ZEND_FE(phpthemis_gen_ec_key_pair, NULL)
+  ZEND_FE(phpthemis_gen_sym_key, NULL)
   ZEND_FE(phpthemis_scell_seal_encrypt, NULL)
   ZEND_FE(phpthemis_scell_seal_decrypt, NULL)
   ZEND_FE(phpthemis_scell_token_protect_encrypt, NULL)

--- a/src/wrappers/themis/python/pythemis/skeygen.py
+++ b/src/wrappers/themis/python/pythemis/skeygen.py
@@ -63,3 +63,18 @@ class themis_gen_key_pair(GenerateKeyPair):
         warnings.warn("themis_gen_key_pair is deprecated in favor of "
                       "GenerateKeyPair.")
         super(themis_gen_key_pair, self).__init__(*args, **kwargs)
+
+
+def GenerateSymmetricKey():
+    """Returns a byte string with newly generated key."""
+    key_length = c_int(0)
+    res = themis.themis_gen_sym_key(None, byref(key_length))
+    if res != THEMIS_CODES.BUFFER_TOO_SMALL:
+        raise ThemisError(res, "Themis failed to get symmetric key size")
+
+    key = create_string_buffer(key_length.value)
+    res = themis.themis_gen_sym_key(key, byref(key_length))
+    if res != THEMIS_CODES.SUCCESS:
+        raise ThemisError(res, "Themis failed to generate symmetric key")
+
+    return string_at(key, key_length.value)

--- a/src/wrappers/themis/ruby/lib/rbthemis.rb
+++ b/src/wrappers/themis/ruby/lib/rbthemis.rb
@@ -73,6 +73,8 @@ module ThemisImport
                   [:pointer, :pointer, :pointer, :pointer], :int
   attach_function :themis_gen_ec_key_pair,
                   [:pointer, :pointer, :pointer, :pointer], :int
+  attach_function :themis_gen_sym_key,
+                  [:pointer, :pointer], :int
 
   THEMIS_KEY_INVALID = 0
   THEMIS_KEY_RSA_PRIVATE = 1
@@ -476,6 +478,24 @@ module Themis
     unwrapped_message.get_bytes(0, unwrapped_message_length.read_uint)
   end
 
+  def gen_sym_key
+    key_length = FFI::MemoryPointer.new(:uint)
+
+    res = themis_gen_sym_key(nil, key_length)
+    if res != BUFFER_TOO_SMALL
+      raise ThemisError, "failed to get symmetric key size: #{res}"
+    end
+
+    key = FFI::MemoryPointer.new(:char, key_length.read_uint)
+
+    res = themis_gen_sym_key(key, key_length)
+    if res != SUCCESS
+      raise ThemisError, "failed to generate symmetric key: #{res}"
+    end
+
+    return key.get_bytes(0, key_length.read_uint)
+  end
+
   class Scell
     include ThemisCommon
     include ThemisImport
@@ -702,4 +722,5 @@ module Themis
   module_function :Sverify
   module_function :s_sign
   module_function :s_verify
+  module_function :gen_sym_key
 end

--- a/src/wrappers/themis/rust/CHANGELOG.md
+++ b/src/wrappers/themis/rust/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 The version currently in development.
 
+## New features
+
+- New `SymmetricKey` objects can be used as master keys for `SecureCell`. ([#561])
+
+[#561]: https://github.com/cossacklabs/themis/pull/561
+
 Version 0.12.0 - 2019-09-26
 ===========================
 

--- a/src/wrappers/themis/themispp/secure_keygen.hpp
+++ b/src/wrappers/themis/themispp/secure_keygen.hpp
@@ -130,6 +130,48 @@ inline bool is_public_key(const std::vector<uint8_t>& key)
     return false;
 }
 
+/**
+ * Generates new symmetric master key in-place.
+ *
+ * Securely generate a new key suitable for Secure Cell.
+ *
+ * @param [out] key a vector to be filled with the key data
+ *
+ * If the vector does not have enough space for a good key then
+ * it will be resized. Otherwise no reallocations are performed.
+ */
+void gen_sym_key(std::vector<uint8_t>& key)
+{
+    if (key.empty()) {
+        size_t key_length = 0;
+        themis_status_t status = themis_gen_sym_key(NULL, &key_length);
+        if (status != THEMIS_BUFFER_TOO_SMALL) {
+            throw themispp::exception_t("Themis failed to query key size", status);
+        }
+        key.resize(key_length);
+    }
+
+    size_t key_length = key.size();
+    themis_status_t status = themis_gen_sym_key(&key.front(), &key_length);
+    if (status != THEMIS_SUCCESS) {
+        throw themispp::exception_t("Themis failed to generate symmetric key", status);
+    }
+}
+
+/**
+ * Generates new symmetric key.
+ *
+ * Securely generate a new key suitable for Secure Cell.
+ *
+ * @returns a newly allocated key of default size.
+ */
+std::vector<uint8_t> gen_sym_key()
+{
+    std::vector<uint8_t> key;
+    gen_sym_key(key);
+    return key;
+}
+
 } // namespace themispp
 
 #endif

--- a/src/wrappers/themis/wasm/test/test.js
+++ b/src/wrappers/themis/wasm/test/test.js
@@ -122,6 +122,13 @@ describe('wasm-themis', function() {
                     expectError(ThemisErrorCode.INVALID_PARAMETER)
                 )
             })
+            it('fails with invalid types', function() {
+                generallyInvalidArguments.forEach(function(invalid) {
+                    assert.throws(() => new themis.SymmetricKey(invalid),
+                        TypeError
+                    )
+                })
+            })
         })
         let masterKey1 = new Uint8Array([1, 2, 3, 4])
         let masterKey2 = new Uint8Array([5, 6, 7, 8, 9])

--- a/src/wrappers/themis/wasm/test/test.js
+++ b/src/wrappers/themis/wasm/test/test.js
@@ -110,7 +110,7 @@ describe('wasm-themis', function() {
             const defaultLength = 32
             it('generates new keys', function() {
                 let key = new themis.SymmetricKey()
-                assert,equal(key.length, defaultLength)
+                assert.equal(key.length, defaultLength)
             })
             it('wraps existing keys', function() {
                 let buffer = new Uint8Array([1, 2, 3, 4])

--- a/src/wrappers/themis/wasm/test/test.js
+++ b/src/wrappers/themis/wasm/test/test.js
@@ -107,9 +107,10 @@ describe('wasm-themis', function() {
     })
     describe('SecureCell', function() {
         describe('key generation', function() {
+            const defaultLength = 32
             it('generates new keys', function() {
                 let key = new themis.SymmetricKey()
-                assert(key.length > 0)
+                assert,equal(key.length, defaultLength)
             })
             it('wraps existing keys', function() {
                 let buffer = new Uint8Array([1, 2, 3, 4])

--- a/src/wrappers/themis/wasm/test/test.js
+++ b/src/wrappers/themis/wasm/test/test.js
@@ -106,6 +106,22 @@ describe('wasm-themis', function() {
         })
     })
     describe('SecureCell', function() {
+        describe('key generation', function() {
+            it('generates new keys', function() {
+                let key = new themis.SymmetricKey()
+                assert(key.length > 0)
+            })
+            it('wraps existing keys', function() {
+                let buffer = new Uint8Array([1, 2, 3, 4])
+                let key = new themis.SymmetricKey(buffer)
+                assert.deepEqual(key, buffer)
+            })
+            it('fails with empty buffer', function() {
+                assert.throws(() => new themis.SymmetricKey(new Uint8Array()),
+                    expectError(ThemisErrorCode.INVALID_PARAMETER)
+                )
+            })
+        })
         let masterKey1 = new Uint8Array([1, 2, 3, 4])
         let masterKey2 = new Uint8Array([5, 6, 7, 8, 9])
         let emptyArray = new Uint8Array()

--- a/tests/objcthemis/objthemis/SecureCellTests.m
+++ b/tests/objcthemis/objthemis/SecureCellTests.m
@@ -30,6 +30,15 @@
     return masterKeyData;
 }
 
+#pragma mark - Key generation
+
+- (void)testKeyGeneration
+{
+    NSData *masterKey = TSGenerateSymmetricKey();
+
+    XCTAssertNotNil(masterKey, "TSGenerateSymmetricKey() should not fail");
+    XCTAssertGreaterThan(masterKey.length, 0, "generated key must be not empty");
+}
 
 #pragma MARK - Seal Mode -
 

--- a/tests/objcthemis/objthemis/SecureCellTests.m
+++ b/tests/objcthemis/objthemis/SecureCellTests.m
@@ -32,12 +32,14 @@
 
 #pragma mark - Key generation
 
+static const size_t defaultLength = 32;
+
 - (void)testKeyGeneration
 {
     NSData *masterKey = TSGenerateSymmetricKey();
 
     XCTAssertNotNil(masterKey, "TSGenerateSymmetricKey() should not fail");
-    XCTAssertGreaterThan(masterKey.length, 0, "generated key must be not empty");
+    XCTAssertEqual(masterKey.length, defaultLength, "generated key must be not empty");
 }
 
 #pragma MARK - Seal Mode -

--- a/tests/objcthemis/objthemis/SecureCellTestsSwift.swift
+++ b/tests/objcthemis/objthemis/SecureCellTestsSwift.swift
@@ -16,7 +16,18 @@ class SecureCellTestsSwift: XCTestCase {
         
         self.masterKeyData = generateMasterKey()
     }
-    
+
+    // MARK: - Key generation
+
+    func testKeyGeneration() {
+        let masterKey = TSGenerateSymmetricKey()
+
+        XCTAssertNotNil(masterKey, "TSGenerateSymmetricKey() should not fail")
+        XCTAssertFalse(masterKey!.isEmpty, "generated key must be not empty")
+    }
+
+    // MARK: - Seal
+
     func generateMasterKey() -> Data {
         let masterKeyString: String = "UkVDMgAAAC13PCVZAKOczZXUpvkhsC+xvwWnv3CLmlG0Wzy8ZBMnT+2yx/dg"
         let masterKeyData: Data = Data(base64Encoded: masterKeyString, options: .ignoreUnknownCharacters)!

--- a/tests/objcthemis/objthemis/SecureCellTestsSwift.swift
+++ b/tests/objcthemis/objthemis/SecureCellTestsSwift.swift
@@ -19,11 +19,13 @@ class SecureCellTestsSwift: XCTestCase {
 
     // MARK: - Key generation
 
+    let defaultKeyLength = 32
+
     func testKeyGeneration() {
         let masterKey = TSGenerateSymmetricKey()
 
         XCTAssertNotNil(masterKey, "TSGenerateSymmetricKey() should not fail")
-        XCTAssertFalse(masterKey!.isEmpty, "generated key must be not empty")
+        XCTAssertEqual(masterKey!.count, defaultKeyLength, "generated key must be not empty")
     }
 
     // MARK: - Seal

--- a/tests/phpthemis/scell_test.php
+++ b/tests/phpthemis/scell_test.php
@@ -21,6 +21,11 @@ use PHPUnit\Framework\TestCase;
 
 class ScellTest extends TestCase {
 
+    public function testKeyGeneration() {
+        $key = phpthemis_gen_sym_key();
+        $this->assertTrue(strlen($key) > 0, 'generated key must be not empty');
+    }
+
     /**
      * @dataProvider SealWithContextProvider
      */

--- a/tests/phpthemis/scell_test.php
+++ b/tests/phpthemis/scell_test.php
@@ -27,6 +27,16 @@ class ScellTest extends TestCase {
         $this->assertEquals(strlen($key), $defaultLength);
     }
 
+    public function testKeyInstances() {
+        // Make sure that wrapper code generates distinct PHP objects
+        // and does not do anything silly like reusing memory buffers.
+        $key1 = phpthemis_gen_sym_key();
+        $key2 = phpthemis_gen_sym_key();
+        $this->assertNotEquals($key1, $key2);
+        $this->assertNotSame($key1, $key2);
+        $this->assertTrue($key1 !== $key2);
+    }
+
     /**
      * @dataProvider SealWithContextProvider
      */

--- a/tests/phpthemis/scell_test.php
+++ b/tests/phpthemis/scell_test.php
@@ -22,8 +22,9 @@ use PHPUnit\Framework\TestCase;
 class ScellTest extends TestCase {
 
     public function testKeyGeneration() {
+        $defaultLength = 32;
         $key = phpthemis_gen_sym_key();
-        $this->assertTrue(strlen($key) > 0, 'generated key must be not empty');
+        $this->assertEquals(strlen($key), $defaultLength);
     }
 
     /**

--- a/tests/pythemis/test_skeygen.py
+++ b/tests/pythemis/test_skeygen.py
@@ -27,5 +27,6 @@ class GenerateKeyPairTest(unittest.TestCase):
 
 class GenerateSymmetricKeyTest(unittest.TestCase):
     def test_generator(self):
+        default_length = 32
         key = GenerateSymmetricKey()
-        self.assertTrue(len(key) > 0)
+        self.assertEqual(len(key), default_length)

--- a/tests/pythemis/test_skeygen.py
+++ b/tests/pythemis/test_skeygen.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 import unittest
 from pythemis.skeygen import GenerateKeyPair, KEY_PAIR_TYPE
+from pythemis.skeygen import GenerateSymmetricKey
 from pythemis.exception import ThemisError
 
 
@@ -22,3 +23,9 @@ class GenerateKeyPairTest(unittest.TestCase):
 
         with self.assertRaises(ThemisError):
             GenerateKeyPair("incorrect algorithm")
+
+
+class GenerateSymmetricKeyTest(unittest.TestCase):
+    def test_generator(self):
+        key = GenerateSymmetricKey()
+        self.assertTrue(len(key) > 0)

--- a/tests/rbthemis/scell_test.rb
+++ b/tests/rbthemis/scell_test.rb
@@ -28,9 +28,10 @@ class TestScell < Test::Unit::TestCase
   end
 
   def test_keygen
+    default_length = 32
     key = Themis::gen_sym_key()
     assert_not_nil(key)
-    assert(key.length > 0)
+    assert_equal(key.length, default_length)
   end
 
   def test_seal

--- a/tests/rbthemis/scell_test.rb
+++ b/tests/rbthemis/scell_test.rb
@@ -27,6 +27,12 @@ class TestScell < Test::Unit::TestCase
     @message = 'This is test message'
   end
 
+  def test_keygen
+    key = Themis::gen_sym_key()
+    assert_not_nil(key)
+    assert(key.length > 0)
+  end
+
   def test_seal
     assert_raise(NoMethodError) do
       seal = Themis::Scell.new(nil, Themis::Scell::SEAL_MODE)

--- a/tests/rust/keys.rs
+++ b/tests/rust/keys.rs
@@ -87,8 +87,9 @@ fn join_mismatching_keys() {
 
 #[test]
 fn generate_symmetric_keys() {
+    let default_size = 32;
     let key = SymmetricKey::new();
-    assert!(!key.as_ref().is_empty());
+    assert_eq!(key.as_ref().len(), default_size);
 }
 
 #[test]

--- a/tests/rust/keys.rs
+++ b/tests/rust/keys.rs
@@ -15,7 +15,7 @@
 use themis::keygen::{gen_ec_key_pair, gen_rsa_key_pair};
 use themis::keys::{
     EcdsaPrivateKey, EcdsaPublicKey, KeyKind, KeyPair, PrivateKey, PublicKey, RsaPrivateKey,
-    RsaPublicKey,
+    RsaPublicKey, SymmetricKey,
 };
 use themis::ErrorKind;
 
@@ -83,4 +83,25 @@ fn join_mismatching_keys() {
 
     let error = KeyPair::try_join(private_ec, public_rsa).expect_err("kind mismatch");
     assert_eq!(error.kind(), ErrorKind::InvalidParameter);
+}
+
+#[test]
+fn generate_symmetric_keys() {
+    let key = SymmetricKey::new();
+    assert!(!key.as_ref().is_empty());
+}
+
+#[test]
+fn parse_generated_symmetric_keys_back() {
+    let this_key = SymmetricKey::new();
+    let same_key = SymmetricKey::try_from_slice(&this_key);
+    assert!(same_key.is_ok());
+    let same_key = same_key.unwrap();
+    assert_eq!(this_key, same_key);
+}
+
+#[test]
+fn parse_custom_symmetric_keys() {
+    assert!(SymmetricKey::try_from_slice(&[0]).is_ok());
+    assert!(SymmetricKey::try_from_slice(&[]).is_err());
 }

--- a/tests/themispp/secure_cell_test.hpp
+++ b/tests/themispp/secure_cell_test.hpp
@@ -44,9 +44,11 @@ static const std::vector<uint8_t> context2 = as_bytes("secure cell test context2
 
 static void secure_cell_keygen_test()
 {
+    static const size_t default_size = 32;
+
     try {
         std::vector<uint8_t> key = themispp::gen_sym_key();
-        sput_fail_unless(!key.empty(), "key generation (default)", __LINE__);
+        sput_fail_unless(key.size() == default_size, "key generation (default)", __LINE__);
     } catch (const themispp::exception_t&) {
         sput_fail_unless(false, "key generation (default)", __LINE__);
     }
@@ -54,7 +56,7 @@ static void secure_cell_keygen_test()
     try {
         std::vector<uint8_t> key;
         themispp::gen_sym_key(key);
-        sput_fail_unless(!key.empty(), "key generation (in-place)", __LINE__);
+        sput_fail_unless(key.size() == default_size, "key generation (in-place)", __LINE__);
     } catch (const themispp::exception_t&) {
         sput_fail_unless(false, "key generation (in-place)", __LINE__);
     }

--- a/tests/themispp/secure_cell_test.hpp
+++ b/tests/themispp/secure_cell_test.hpp
@@ -24,6 +24,7 @@
 #include <common/sput.h>
 
 #include <themispp/secure_cell.hpp>
+#include <themispp/secure_keygen.hpp>
 
 #include "utils.hpp"
 
@@ -40,6 +41,32 @@ static const std::vector<uint8_t> message2 = as_bytes("secure cell test message2
 
 static const std::vector<uint8_t> context1 = as_bytes("secure cell test context1 message");
 static const std::vector<uint8_t> context2 = as_bytes("secure cell test context2 message");
+
+static void secure_cell_keygen_test()
+{
+    try {
+        std::vector<uint8_t> key = themispp::gen_sym_key();
+        sput_fail_unless(!key.empty(), "key generation (default)", __LINE__);
+    } catch (const themispp::exception_t&) {
+        sput_fail_unless(false, "key generation (default)", __LINE__);
+    }
+
+    try {
+        std::vector<uint8_t> key;
+        themispp::gen_sym_key(key);
+        sput_fail_unless(!key.empty(), "key generation (in-place)", __LINE__);
+    } catch (const themispp::exception_t&) {
+        sput_fail_unless(false, "key generation (in-place)", __LINE__);
+    }
+
+    try {
+        std::vector<uint8_t> key(8);
+        themispp::gen_sym_key(key);
+        sput_fail_unless(key.size() == 8, "key generation (custom)", __LINE__);
+    } catch (const themispp::exception_t&) {
+        sput_fail_unless(false, "key generation (custom)", __LINE__);
+    }
+}
 
 static void secure_cell_construction_test()
 {
@@ -261,6 +288,7 @@ static void secure_cell_context_imprint_test()
 inline void run_secure_cell_test()
 {
     sput_enter_suite("ThemisPP secure cell seal mode test:");
+    sput_run_test(secure_cell_keygen_test, "secure_cell_keygen_test", __FILE__);
     sput_run_test(secure_cell_construction_test, "secure_cell_construction_test", __FILE__);
     sput_run_test(secure_cell_seal_test, "secure_cell_seal_test", __FILE__);
     sput_run_test(secure_cell_seal_context_test, "secure_cell_seal_context_test", __FILE__);


### PR DESCRIPTION
Implement symmetric key generation utilities described in RFC 1 (not available publicly at the moment). This is new API introduced in #560, now distributed to high-level wrappers.

This PR contains ‘easy’ wrappers that do not require anything special and with more or less straightforward and compact implementation. I placed them in one PR in order to have fewer merge conflicts in the changelog later.

Node.js (JsThemis) and Java (Android) are hard. They will be added in their own PRs.

## Language API

With exception of C++ there is only one entry point for key generation. High-level wrappers generally do not allow the user to customize key length and generate default keys (32 bytes). 

Where applicable, new types are introduced along with conversion API.

### C++

```cpp
#include <themispp/secure_keygen.hpp>

std::vector<uint8_t> key = themispp::gen_sym_key();

// Write by reference, mostly for C++03 compatibility:
themispp::gen_sym_key(key);
```

### Go

```go
import "github.com/cossacklabs/themis/gothemis/keys"

key, err := keys.NewSymmetricKey() // returns keys.SymmetricKey

key.Value // access []byte slice
```

### JavaScript (WebAssembly)

```js
const themis = required('wasm-themis')

let key = new themis.SymmetricKey()
// inherits from Uint8Array to access key bytes

// Can also wrap existing buffers
let buffer = new Uint8Array([1, 2, 3, 4, 5, 6])
let anotherKey = new themis.SymmetricKey(buffer)
```

### Objective-C

```objective-c
#import <objcthemis/objcthemis.h>

NSData *key = TSGenerateSymmetricKey();
```

### PHP

```php
// returns string with key bytes
$key = phpthemis_gen_sym_key();
```

### Python

```python
from pythemis.skeygen import GenerateSymmetricKey

# bytes for Python 3, str for Python2
key = GenerateSymmetricKey()
```

### Ruby

```ruby
require 'rbthemis'

# returns byte string
key = Themis::gen_sym_key()
```

### Rust

```rust
use themis::keys::SymmetricKey;

let key = SymmetricKey::new();
// implements AsRef<[u8]> to access key bytes

// Can also wrap existing buffers
let another_key = SymmetricKey::from_slice(&[1, 2, 3, 4])?;
```

### Swift

```swift
import Themis

let key: Data? = TSGenerateSymmetricKey();
```

## Checklist

- [x] Change is covered by automated tests
- [x] ~~Benchmark results are attached~~ (not interesting)
- [x] The [coding guidelines] are followed
- [x] Public API has proper documentation
- [x] ~~Example projects and code samples are updated~~ (later)
- [x] Changelog is updated if needed

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
