### PR TITLE
Symmetric keygen: JavaThemis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ _Code:_
   - Fixed a NullPointerException bug in `SecureSocket` initialisation ([#557](https://github.com/cossacklabs/themis/pull/557)).
   - Some Themis exceptions have been converted from checked `Exception` to _unchecked_ `RuntimeException`, relaxing requirements for `throws` specifiers ([#563](https://github.com/cossacklabs/themis/pull/563)).
   - Introduced `IKey` interface with accessors to raw key data ([#564](https://github.com/cossacklabs/themis/pull/564)).
+  - New class `SymmetricKey` can be used to generate symmetric keys for Secure Cell ([#565](https://github.com/cossacklabs/themis/pull/565)).
 
 - **Node.js**
 

--- a/jni/themis_keygen.c
+++ b/jni/themis_keygen.c
@@ -113,3 +113,44 @@ JNIEXPORT jobjectArray JNICALL Java_com_cossacklabs_themis_KeypairGenerator_gene
 
     return keys;
 }
+
+JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SymmetricKey_generateSymmetricKey(JNIEnv* env,
+                                                                                           jobject thiz)
+{
+    themis_status_t res;
+    jbyteArray key = NULL;
+    jbyte* key_buffer = NULL;
+    size_t key_length = 0;
+
+    UNUSED(thiz);
+
+    res = themis_gen_sym_key(NULL, &key_length);
+    if (res != THEMIS_BUFFER_TOO_SMALL) {
+        goto error;
+    }
+
+    key = (*env)->NewByteArray(env, key_length);
+    if (!key) {
+        goto error;
+    }
+
+    key_buffer = (*env)->GetByteArrayElements(env, key, NULL);
+    if (!key_buffer) {
+        goto error;
+    }
+
+    res = themis_gen_sym_key((uint8_t*)key_buffer, &key_length);
+    if (res != THEMIS_SUCCESS) {
+        goto error_release_key;
+    }
+
+    (*env)->ReleaseByteArrayElements(env, key, key_buffer, 0);
+
+    return key;
+
+error_release_key:
+    (*env)->ReleaseByteArrayElements(env, key, key_buffer, JNI_ABORT);
+
+error:
+    return NULL;
+}

--- a/src/wrappers/themis/java/com/cossacklabs/themis/KeyGenerationException.java
+++ b/src/wrappers/themis/java/com/cossacklabs/themis/KeyGenerationException.java
@@ -18,4 +18,12 @@ package com.cossacklabs.themis;
 
 public class KeyGenerationException extends RuntimeException {
 
+    KeyGenerationException(String message) {
+        super(message);
+    }
+
+    KeyGenerationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
 }

--- a/src/wrappers/themis/java/com/cossacklabs/themis/KeypairGenerator.java
+++ b/src/wrappers/themis/java/com/cossacklabs/themis/KeypairGenerator.java
@@ -40,7 +40,7 @@ public abstract class KeypairGenerator {
 		try {
 			return generateKeypair(AsymmetricKey.KEYTYPE_EC);
 		} catch (InvalidArgumentException e) {
-			throw new KeyGenerationException();
+			throw new KeyGenerationException("failed to generate keypair", e);
 		}
 	}
 	
@@ -60,7 +60,7 @@ public abstract class KeypairGenerator {
 		byte[][] keys = generateKeys(keyType);
 		
 		if (null == keys) {
-			throw new KeyGenerationException();
+			throw new KeyGenerationException("failed to generate keypair");
 		}
 		
 		return new Keypair(new PrivateKey(keys[0]), new PublicKey(keys[1]));

--- a/src/wrappers/themis/java/com/cossacklabs/themis/SymmetricKey.java
+++ b/src/wrappers/themis/java/com/cossacklabs/themis/SymmetricKey.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2019 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cossacklabs.themis;
+
+/**
+ * Symmetric encryption key.
+ *
+ * These keys are used with Secure Cell cryptosystem.
+ */
+public class SymmetricKey extends KeyBytes {
+
+    /**
+     * Generates a new symmetric key.
+     */
+    public SymmetricKey() {
+        super(newSymmetricKey());
+    }
+
+    /**
+     * Creates a symmetric key from byte array.
+     *
+     * @param key byte array
+     *
+     * @throws NullArgumentException if `key` is null.
+     * @throws InvalidArgumentException if `key` is empty.
+     */
+    public SymmetricKey(byte[] key) {
+        super(key);
+    }
+
+    private static native byte[] generateSymmetricKey();
+
+    private static byte[] newSymmetricKey() {
+        byte[] key = generateSymmetricKey();
+        if (key == null || key.length == 0) {
+            throw new KeyGenerationException("failed to generate symmetric key");
+        }
+        return key;
+    }
+}

--- a/tests/themis/wrappers/android/com/cossacklabs/themis/test/SymmetricKeyTest.java
+++ b/tests/themis/wrappers/android/com/cossacklabs/themis/test/SymmetricKeyTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2019 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cossacklabs.themis.test;
+
+import com.cossacklabs.themis.SymmetricKey;
+import com.cossacklabs.themis.InvalidArgumentException;
+import com.cossacklabs.themis.NullArgumentException;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+public class SymmetricKeyTest {
+
+    private static final int defaultLength = 32;
+
+    @Test
+    public void generateNewKey() {
+        SymmetricKey key = new SymmetricKey();
+
+        byte[] keyBytes = key.toByteArray();
+        assertNotNull(keyBytes);
+        assertEquals(keyBytes.length, defaultLength);
+    }
+
+    @Test
+    public void restoreKeyFromBytes() {
+        byte[] buffer = { 3, 14, 15, 92, 6 };
+        SymmetricKey key = new SymmetricKey(buffer);
+        assertArrayEquals(buffer, key.toByteArray());
+    }
+
+    @Test(expected = NullArgumentException.class)
+    public void restoreKeyFromNull() {
+        SymmetricKey key = new SymmetricKey(null);
+    }
+
+    @Test(expected = InvalidArgumentException.class)
+    public void restoreKeyFromEmpty() {
+        SymmetricKey key = new SymmetricKey(new byte[0]);
+    }
+}


### PR DESCRIPTION
Implement symmetric key generation utilities described in RFC 1 (not available publicly at the moment). This is new API introduced in #560, now distributed to JavaThemis wrapper.

Now that #563 and #564 are merged we can finally do it.

## Language API

### Java

Here's how it can be used:

```java
import com.cossacklabs.themis.SymmetricKey;

SymmetricKey key = new SymmetricKey();

// Use IKey interface to access bytes:
byte[] keyBytes = key.toByteArray();

// Can also wrap existing buffers
SymmetricKey sameKey = new SymmetricKey(keyBytes);
```

## Checklist

- [x] Change is covered by automated tests
- [x] ~~Benchmark results are attached~~ (not interesting)
- [x] The [coding guidelines] are followed
- [x] Public API has proper documentation
- [x] ~~Example projects and code samples are updated~~ (later)
- [x] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
