### PR TITLE
Fetch Composer SHA sum from GitHub

### DIFF
--- a/tests/phpthemis/composer-setup.sh
+++ b/tests/phpthemis/composer-setup.sh
@@ -1,15 +1,19 @@
 #!/bin/bash -e
 
+EXPECTED_SIGNATURE="$(wget -q -O - https://composer.github.io/installer.sig)"
 php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-php -r "echo 'Installed hash = '; echo hash_file('SHA384', 'composer-setup.php');"
+ACTUAL_SIGNATURE="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
 
-php -r "if (hash_file('SHA384', 'composer-setup.php') === '106d3d32cc30011325228b9272424c1941ad75207cb5244bee161e5f9906b0edf07ab2a733e8a1c945173eb9b1966197')
-  { echo 'Valid signature, continue installation'; } 
-else 
-  { echo '\nERROR: Invalid installer signature, probably installer was updated, fix in /tests/phpthemis/composer-setup.sh'; unlink('composer-setup.php'); exit(1); } 
-echo PHP_EOL;"
+if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]
+then
+    echo 2>&1 "Invalid installer signature"
+    echo 2>&1 "expected: $EXPECTED_SIGNATURE"
+    echo 2>&1 "actual:   $ACTUAL_SIGNATURE"
+    php -r "unlink('composer-setup.php');"
+    exit 1
+fi
 
-echo "If installation fails, means installer signature is invalid"
 php composer-setup.php
 RESULT=$?
 php -r "unlink('composer-setup.php');"
+exit $RESULT


### PR DESCRIPTION
PHP Composer installer changes with every release and has a different hash sum. Currently we hardwire the expected value in our installation scripts. This leads to our CI builds breaking with every release of Composer. While it's a nice way to get heads up about updates, it is also somewhat stressful for the maintainers to be notified about that with a broken build.

Instead of relying on a fixed hash sum, fetch it from GitHub Pages site maintained by Composer. This is [recommended way](https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md) to install Composer automatically.

This approach is arguably less secure because the attackers can compromise GitHub Pages site to feed us the SHA value they need, but given that Themis source code is also hosted on GitHub, a joint attack on PHP infrastructure like that would probably be the least of our concerns.

Moreover, Composer is used only when running PHPThemis unit tests. It is not used during package building process, so it's currently not possible to exploit the attack on Composer installer in order to, say, steal our signing keys when building PHPThemis package.

Overall, I'd trade the possible risk for fewer randomly red builds and not having to update a magical check sum every now and then.

## Checklist

- [X] Change is covered by automated tests
- [X] ~~Benchmark results are attached~~
- [X] The [coding guidelines] are followed
- [X] ~~Public API has proper documentation~~
- [X] ~~Example projects and code samples are updated~~
- [X] ~~Changelog is updated~~ (not interesting)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md

## Sign-offs

Required approvals before merge:

- [x] @vixentael 
- [ ] @shadinua 