### PR TITLE
Use "fastcomp" flavor of Emscripten

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,9 +225,8 @@ jobs:
             cd $HOME/emsdk
             git reset --hard
             git pull
-            # TODO (T1373): roll back to using "latest" when Emscripten regression is resolved
-            ./emsdk install 1.38.48
-            ./emsdk activate 1.38.48
+            ./emsdk install  latest-fastcomp
+            ./emsdk activate latest-fastcomp
       - checkout
       - run:
           name: Sync submodules
@@ -376,9 +375,8 @@ jobs:
             cd $HOME/emsdk
             git reset --hard
             git pull
-            # TODO (T1373): roll back to using "latest" when Emscripten regression is resolved
-            ./emsdk install 1.38.48
-            ./emsdk activate 1.38.48
+            ./emsdk install  latest-fastcomp
+            ./emsdk activate latest-fastcomp
 
       # themis
       - checkout


### PR DESCRIPTION
PR #550 rolled back Emscripten from `latest` to `1.38.48` because then-latest `1.39.0` was broken.

We have figured out that it's not the new version that's broken, it's the flavor. WasmThemis does not work well with the `upstream` flavor of Emscripten which is the default for `latest` branch since 1.39.

Instead of pinning an older version, use a suitable flavor. We'll be testing with `upstream` later once we figure out what's wrong with it.

## Checklist

- [X] Change is covered by automated tests
- [X] ~~Benchmark results are attached~~
- [X] The [coding guidelines] are followed
- [X] Public API has proper documentation
- [X] ~~Example projects and code samples are updated~~
- [X] ~~Changelog is updated if needed~~ (will consolidate if we fix upstream)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
