### PR TITLE
Always check soter_rand() for success

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,6 +2,6 @@
 Checks: 'bugprone-*,cppcoreguidelines-*,clang-analyzer-*,misc-*,performance-*,portability-*,readability-*,-readability-implicit-bool-conversion,-readability-isolate-declaration,-*-magic-numbers,-cppcoreguidelines-pro-type-vararg'
 FormatStyle: none
 CheckOptions:
-  - key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor:
+  - key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor
     value: 1
 ...

--- a/src/soter/soter_error.h
+++ b/src/soter/soter_error.h
@@ -79,6 +79,14 @@ typedef int32_t soter_status_t;
 #endif
 #endif
 
+#if __cplusplus >= 201402L
+#define SOTER_MUST_USE [[nodiscard]]
+#elif defined(__GNUC__) || defined(__clang__)
+#define SOTER_MUST_USE __attribute__((warn_unused_result))
+#else
+#define SOTER_MUST_USE
+#endif
+
 /**@}*/
 
 /**

--- a/src/soter/soter_rand.h
+++ b/src/soter/soter_rand.h
@@ -50,6 +50,7 @@ extern "C" {
  * to fill the entire buffer. Please try again later.
  */
 SOTER_API
+SOTER_MUST_USE
 soter_status_t soter_rand(uint8_t* buffer, size_t length);
 
 #ifdef __cplusplus

--- a/src/soter/soter_rand.h
+++ b/src/soter/soter_rand.h
@@ -49,8 +49,8 @@ extern "C" {
  * SOTER_FAIL indicates that there is not enough entropy available
  * to fill the entire buffer. Please try again later.
  */
-SOTER_API
 SOTER_MUST_USE
+SOTER_API
 soter_status_t soter_rand(uint8_t* buffer, size_t length);
 
 #ifdef __cplusplus

--- a/src/wrappers/themis/themispp/secure_rand.hpp
+++ b/src/wrappers/themis/themispp/secure_rand.hpp
@@ -37,7 +37,10 @@ public:
 
     std::vector<uint8_t>& get()
     {
-        soter_rand(&n_[0], block_length_t_p);
+        soter_status_t res = soter_rand(&n_[0], block_length_t_p);
+        if (res != SOTER_SUCCESS) {
+            throw exception_t("failed to generate random bytes", res);
+        }
         return n_;
     }
 

--- a/tests/common/test_utils.c
+++ b/tests/common/test_utils.c
@@ -67,7 +67,10 @@ size_t rand_int(size_t max_val)
 
 	do
 	{
-		soter_rand((uint8_t*)(&res), sizeof(size_t));
+		if (soter_rand((uint8_t*)(&res), sizeof(res)) != SOTER_SUCCESS)
+		{
+			exit(1);
+		}
 		res %= max_val;
 	} while (!res);
 

--- a/tests/themispp/main.cpp
+++ b/tests/themispp/main.cpp
@@ -19,6 +19,7 @@
 #include "secure_cell_test.hpp"
 #include "secure_comparator_test.hpp"
 #include "secure_message_test.hpp"
+#include "secure_rand_test.hpp"
 #include "secure_session_test.hpp"
 
 int main()
@@ -29,6 +30,7 @@ int main()
         themispp::secure_message_test::run_secure_message_test();
         themispp::secure_session_test::run_secure_session_test();
         themispp::secure_session_test::run_secure_comparator_test();
+        themispp::secure_rand_test::run_secure_rand_test();
         sput_finish_testing();
         return sput_get_return_value();
     } catch (const std::exception& e) {

--- a/tests/themispp/secure_rand_test.hpp
+++ b/tests/themispp/secure_rand_test.hpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2019 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef THEMISPP_RAND_TEST
+#define THEMISPP_RAND_TEST
+
+#include <vector>
+
+#include <common/sput.h>
+
+#include <themispp/secure_rand.hpp>
+
+namespace themispp
+{
+namespace secure_rand_test
+{
+
+static bool not_all_zeros(const std::vector<uint8_t>& data)
+{
+    for (size_t i = 0; i < data.size(); i++) {
+        if (data[i] != 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static void secure_rand_test()
+{
+    themispp::secure_rand_t<32> random_32_bytes;
+
+    std::vector<uint8_t> result = random_32_bytes.get();
+    sput_fail_unless(result.size() == 32, "return 32 random bytes", __LINE__);
+    sput_fail_unless(not_all_zeros(result), "they are actually random", __LINE__);
+
+    std::vector<uint8_t> another = random_32_bytes.get();
+    sput_fail_unless(another != result, "random bytes do not repeat", __LINE__);
+
+    try {
+        themispp::secure_rand_t<0> no_random_bytes;
+        no_random_bytes.get();
+        sput_fail_unless(false, "throws on zero size", __LINE__);
+    } catch (themispp::exception_t& e) {
+        sput_fail_unless(true, "throws on zero size", __LINE__);
+    }
+}
+
+inline void run_secure_rand_test()
+{
+    sput_enter_suite("ThemisPP secure rand test:");
+    sput_run_test(secure_rand_test, "secure_rand_test", __FILE__);
+}
+
+} // namespace secure_rand_test
+} // namespace themispp
+
+#endif /* THEMISPP_RAND_TEST */


### PR DESCRIPTION
[As previously discussed](https://github.com/cossacklabs/themis/pull/565#discussion_r354419921), let's make sure that return value of `soter_rand()` is always checked. I have added these failsafes, manually reviewed all existing callsites, and ensured that we abort processing if we fail to generate random data.

#### Warn about unused result of soter_rand()

Checking random number generation for failures is pretty important [[1]](https://github.com/veorq/cryptocoding#use-strong-randomness) [[2]](http://jbp.io/2014/01/16/openssl-rand-api) so let's make it easier for users to track such issues. Introduce a **SOTER_MUST_USE** macro that adds an attribute to the function which will cause a compiler warning if the return value is not used (or not explicitly ignored by casting to void). See [Clang docs](http://releases.llvm.org/9.0.0/tools/clang/docs/AttributeReference.html#nodiscard-warn-unused-result).

Since we treat warnings as errors, CI compilation will fail like this:

    compile build/obj/tests/common/test_utils.c.o
    tests/common/test_utils.c:70:3: warning: ignoring return value of function declared with 'warn_unused_result' attribute [-Wunused-result]
                    soter_rand((uint8_t*)(&res), sizeof(size_t));
                    ^~~~~~~~~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    1 warning generated.

if anyone adds a soter_rand() call without checking the return value.

#### Add missing tests for themispp::secure_rand_t

We have this API, but it's not tested (or documented either). However, it's there and we should at least exercise it in the test suite. Turns out that it was not checking return value of soter_rand() and it's not visible if there are no tests.

#### Handle soter_rand() failures

Add missing error handling. For ThemisPP throw an exception. For tests just abort with non-zero exit code as the API does not allow for returning an error. That's actually the case for [ed25519 code](https://github.com/cossacklabs/themis/blob/5f886e1fa1742beb2070da93a2036ad79030dac5/src/soter/ed25519/gen_rand_32.c#L31-L35) too.

## Checklist

- [X] Change is covered by automated tests
- [X] ~~Benchmark results are attached~~ (N/A)
- [X] The [coding guidelines] are followed
- [X] Public API has proper documentation
- [X] ~~Example projects and code samples are updated~~ (N/A)
- [X] ~~Changelog is updated if needed~~ (internal change, no need to mention it right now)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
