### PR TITLE
Fix compatibility with Rust 1.40

### DIFF
--- a/src/wrappers/themis/rust/libthemis-src/src/lib.rs
+++ b/src/wrappers/themis/rust/libthemis-src/src/lib.rs
@@ -34,14 +34,12 @@
 //! Typical usage from a `*-sys` crate looks like this:
 //!
 //! ```no_run
-//! fn main() {
-//!     #[cfg(feature = "vendored")]
-//!     libthemis_src::make();
+//! #[cfg(feature = "vendored")]
+//! libthemis_src::make();
 //!
-//!     // Go on with your usual build.rs business, pkg_config crate
-//!     // should be able to locate the local installation of Themis.
-//!     // You'll probably need to use the static library.
-//! }
+//! // Go on with your usual build.rs business, pkg_config crate
+//! // should be able to locate the local installation of Themis.
+//! // You'll probably need to use the static library.
 //! ```
 
 use std::env;

--- a/tests/rust/run_tests.sh
+++ b/tests/rust/run_tests.sh
@@ -31,8 +31,13 @@ cargo test --all -- --test-threads 1
 echo
 echo "Checking documentation..."
 echo
-cargo clean --doc && cargo doc --no-deps
-cargo clean --doc && cargo doc --no-deps --features "vendored"
+# Cargo does not allow "--features" to be used with virtual crate in workspace.
+# Jump into RustThemis subdirectory to make Cargo happy and use "--workspace"
+# to still document all crates in the workspace.
+cd src/wrappers/themis/rust
+cargo clean --doc && cargo doc --workspace --no-deps
+cargo clean --doc && cargo doc --workspace --no-deps --features "vendored"
+cd -
 
 echo
 echo "Rust tests OK!"


### PR DESCRIPTION
Recently released Clippy 1.40 ships with this lint enabled by default. Since we run with "warnings as errors" policy, this lint [causes build failures](https://circleci.com/gh/cossacklabs/themis/7116) which is not nice.

    error: needless `fn main` in doctest
      --> src/wrappers/themis/rust/libthemis-src/src/lib.rs:37:4
       |
    37 | //! fn main() {
       |    ^^^^^^^^^^^^
       |
       = note: `-D clippy::needless-doctest-main` implied by `-D warnings`
       = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_doctest_main

    error: aborting due to previous error

I wouldn't say that explicit main() here is needless and some people [share the same sentiment][1]. However, since this is top-level module docs, we cannot disable this lint for this place specifically without turning it off in the entire module. Okay, Clippy, you win.

[1]: https://github.com/rust-lang/rust-clippy/issues/4858

## Checklist

- [X] Change is covered by automated tests
- [X] ~~Benchmark results are attached~~ (N/A)
- [X] The [coding guidelines] are followed
- [X] Public API has proper documentation
- [X] ~~Example projects and code samples are updated~~ (no API changes)
- [X] ~~Changelog is updated if needed~~ (minor change)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
