### PR TITLE
Run ThemisPP tests with C++14 and C++17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,10 +155,15 @@ jobs:
       - run: '[ -z "$CIRCLE_PR_NUMBER" ] && ! [ -z "$COVERALLS_TOKEN" ] && cd $HOME/go/src/$GOTHEMIS_IMPORT && $HOME/go/bin/goveralls -v -service=circle-ci -repotoken=$COVERALLS_TOKEN || true'
       - run: sudo /sbin/ldconfig
       - run: make test
-      - run: make clean_themispp_test && CFLAGS="-std=c++03" make themispp_test && make test_cpp
-      - run: make clean_themispp_test && CFLAGS="-std=c++11" make themispp_test && make test_cpp
-      - run: make clean_themispp_test && CFLAGS="-std=c++14" make themispp_test && make test_cpp
-      - run: make clean_themispp_test && CFLAGS="-std=c++17" make themispp_test && make test_cpp
+      - run: make clean_themispp_test && CXX="g++"     CFLAGS="-std=c++03" make themispp_test && make test_cpp
+      - run: make clean_themispp_test && CXX="g++"     CFLAGS="-std=c++11" make themispp_test && make test_cpp
+      - run: make clean_themispp_test && CXX="g++"     CFLAGS="-std=c++14" make themispp_test && make test_cpp
+      - run: make clean_themispp_test && CXX="g++"     CFLAGS="-std=c++17" make themispp_test && make test_cpp
+      - run: make clean_themispp_test && CXX="clang++" CFLAGS="-std=c++03" make themispp_test && make test_cpp
+      - run: make clean_themispp_test && CXX="clang++" CFLAGS="-std=c++11" make themispp_test && make test_cpp
+      - run: make clean_themispp_test && CXX="clang++" CFLAGS="-std=c++14" make themispp_test && make test_cpp
+      # Clang 3.8 that we have here does not support C++17 yet
+#     - run: make clean_themispp_test && CXX="clang++" CFLAGS="-std=c++17" make themispp_test && make test_cpp
       - run: make test_python
       - run: make test_ruby
       - run: make test_go

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,6 +157,8 @@ jobs:
       - run: make test
       - run: make clean_themispp_test && CFLAGS="-std=c++03" make themispp_test && make test_cpp
       - run: make clean_themispp_test && CFLAGS="-std=c++11" make themispp_test && make test_cpp
+      - run: make clean_themispp_test && CFLAGS="-std=c++14" make themispp_test && make test_cpp
+      - run: make clean_themispp_test && CFLAGS="-std=c++17" make themispp_test && make test_cpp
       - run: make test_python
       - run: make test_ruby
       - run: make test_go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ _Code:_
 - **C++**
 
   - New function `themispp::gen_sym_key()` can be used to generate symmetric keys for Secure Cell ([#561](https://github.com/cossacklabs/themis/pull/561)).
+  - Updated test suite to test C++14 and C++17 (in addition to C++11 and C++03) ([#572](https://github.com/cossacklabs/themis/pull/572)).
 
 - **Go**
 


### PR DESCRIPTION
We [boast in the docs](https://docs.cossacklabs.com/pages/cpp-howto/#supported-versions) about C++14 being “tested and supported“ so we’d better do that :) Explicitly test compatibility with C++14 and C++17.

C++20 is currently being finalized. It's somewhat supported in the compilers, but not in the versions shipped with Ubuntu 16.04.

## Checklist

- [X] Change is covered by automated tests
- [X] ~~Benchmark results are attached~~
- [X] The [coding guidelines] are followed
- [X] ~~Public API has proper documentation~~
- [X] ~~Example projects and code samples are updated~~
- [X] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
