### PR TITLE
Run CircleCI builds every day

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -465,3 +465,23 @@ workflows:
       - php70
       - php71
       - integration_tests
+  nightly:
+    # Apparently CircleCI does not have a "push" or "pull request" trigger
+    # so we have to have a separate workflow with the same job list.
+    triggers:
+      - schedule:
+          cron: "0 5 * * *"
+          filters:
+            branches:
+              only:
+                - master
+                - stable
+    jobs:
+      - analyze
+      - android
+      - x86_64
+      - jsthemis
+      - php5
+      - php70
+      - php71
+      - integration_tests


### PR DESCRIPTION
Modern ecosystem needs to go fast, die young, break early, and ship often. Therefore we can never be sure that if a commit was successfully built today then the same code can be built tomorrow. Transitive dependencies come and go, new toolchain versions get released, etc. We do not have every dependency pinned, so we should be testing regularly to see if anything breaks.

Let's run CircleCI test suite every day at 5:00 to make sure that we see the scheduled breakage early in the morning, not when some poor soul submits a pull request and *then* learns that something does not work.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md