### PR TITLE
Public PBKDF2 API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,7 @@ jobs:
       # NIST STS tests tend to fail in Docker environment
       NO_NIST_STS: 1
       WITH_FATAL_WARNINGS: yes
+      SOTER_KDF_RUN_LONG_TESTS: yes
     steps:
       - run: sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get -y install libssl-dev python python-setuptools python3 python3-setuptools ruby-dev lcov libc6-dbg rsync software-properties-common pkg-config clang afl
       - run: sudo ln -sf /usr/bin/gcov-5 /usr/bin/gcov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ _Code:_
 
 - **Core**
 
+  - **Soter** (low-level security core used by Themis)
+
+    - New function `soter_pbkdf2_sha256()` can be used to derive encryption keys from passphrases with PBKDF2 algorithm ([#574](https://github.com/cossacklabs/themis/pull/574)).
+
   - **Key generation**
 
     - New function `themis_gen_sym_key()` can be used to securely generate symmetric keys for Secure Cell ([#560](https://github.com/cossacklabs/themis/pull/560)).

--- a/Themis.xcodeproj/project.pbxproj
+++ b/Themis.xcodeproj/project.pbxproj
@@ -103,6 +103,8 @@
 		9F00E93E223C1AE600EC1EF3 /* secure_session.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2438223A74AF005CB63A /* secure_session.c */; };
 		9F00E93F223C1AE600EC1EF3 /* sym_enc_message.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2431223A74AF005CB63A /* sym_enc_message.c */; };
 		9F00E941223C1AFA00EC1EF3 /* openssl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E940223C1AFA00EC1EF3 /* openssl.framework */; };
+		9F33485823B38D9B00368291 /* soter_kdf.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F33485723B38D9B00368291 /* soter_kdf.c */; };
+		9F33485923B38D9B00368291 /* soter_kdf.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F33485723B38D9B00368291 /* soter_kdf.c */; };
 		9F4A24C4223A8FA9005CB63A /* scell_seal.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24B0223A8FA7005CB63A /* scell_seal.m */; };
 		9F4A24C6223A8FA9005CB63A /* ssession_transport_interface.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24B2223A8FA7005CB63A /* ssession_transport_interface.m */; };
 		9F4A24C8223A8FA9005CB63A /* scell_context_imprint.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24B4223A8FA8005CB63A /* scell_context_imprint.m */; };
@@ -253,6 +255,7 @@
 /* Begin PBXFileReference section */
 		9F00E8D7223C197900EC1EF3 /* themis.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = themis.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9F00E940223C1AFA00EC1EF3 /* openssl.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = openssl.framework; path = Carthage/Build/Mac/openssl.framework; sourceTree = "<group>"; };
+		9F33485723B38D9B00368291 /* soter_kdf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = soter_kdf.c; path = src/soter/openssl/soter_kdf.c; sourceTree = "<group>"; };
 		9F4A2342223A73B0005CB63A /* soter_hash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = soter_hash.h; path = src/soter/soter_hash.h; sourceTree = "<group>"; };
 		9F4A2343223A73B0005CB63A /* soter_asym_cipher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = soter_asym_cipher.h; path = src/soter/soter_asym_cipher.h; sourceTree = "<group>"; };
 		9F4A2344223A73B0005CB63A /* soter_sign_rsa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = soter_sign_rsa.h; path = src/soter/soter_sign_rsa.h; sourceTree = "<group>"; };
@@ -498,6 +501,7 @@
 				9F4A2384223A7425005CB63A /* soter_ecdsa_common.h */,
 				9F4A238B223A7425005CB63A /* soter_engine.h */,
 				9F4A2390223A7426005CB63A /* soter_hash.c */,
+				9F33485723B38D9B00368291 /* soter_kdf.c */,
 				9F4A238E223A7426005CB63A /* soter_rand.c */,
 				9F4A2386223A7425005CB63A /* soter_rsa_common.c */,
 				9F4A2391223A7426005CB63A /* soter_rsa_common.h */,
@@ -807,6 +811,7 @@
 				9F00E927223C1AC000EC1EF3 /* soter_rsa_common.c in Sources */,
 				9F00E928223C1AC000EC1EF3 /* soter_rsa_key_pair_gen.c in Sources */,
 				9F00E929223C1AC000EC1EF3 /* soter_rsa_key.c in Sources */,
+				9F33485923B38D9B00368291 /* soter_kdf.c in Sources */,
 				9F98F32922CCEB0E008E14E6 /* soter_wipe.c in Sources */,
 				9F00E92A223C1AC000EC1EF3 /* soter_sign_ecdsa.c in Sources */,
 				9F00E92B223C1AC000EC1EF3 /* soter_sign_rsa.c in Sources */,
@@ -899,6 +904,7 @@
 				9F4A260A223ABECC005CB63A /* soter_rsa_common.c in Sources */,
 				9F4A260B223ABECC005CB63A /* soter_rsa_key_pair_gen.c in Sources */,
 				9F4A260C223ABECC005CB63A /* soter_rsa_key.c in Sources */,
+				9F33485823B38D9B00368291 /* soter_kdf.c in Sources */,
 				9F98F32822CCEB0E008E14E6 /* soter_wipe.c in Sources */,
 				9F4A260D223ABECC005CB63A /* soter_sign_ecdsa.c in Sources */,
 				9F4A260E223ABECC005CB63A /* soter_sign_rsa.c in Sources */,

--- a/src/soter/boringssl/soter_kdf.c
+++ b/src/soter/boringssl/soter_kdf.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2019 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "soter/soter_kdf.h"
+
+#include <limits.h>
+
+#include <openssl/evp.h>
+
+soter_status_t soter_pbkdf2_sha256(const uint8_t* passphrase,
+                                   size_t passphrase_length,
+                                   const uint8_t* salt,
+                                   size_t salt_length,
+                                   size_t iterations,
+                                   uint8_t* key,
+                                   size_t key_length)
+{
+    int res;
+
+    if (!passphrase) {
+        SOTER_CHECK_PARAM(passphrase_length == 0);
+    }
+    if (!salt) {
+        SOTER_CHECK_PARAM(salt_length == 0);
+    }
+    SOTER_CHECK_PARAM(iterations > 0);
+    SOTER_CHECK_PARAM(iterations <= UINT_MAX);
+    SOTER_CHECK_PARAM(key != NULL);
+    SOTER_CHECK_PARAM(key_length > 0);
+
+    res = PKCS5_PBKDF2_HMAC((const char*)passphrase,
+                            passphrase_length,
+                            salt,
+                            salt_length,
+                            (unsigned int)iterations,
+                            EVP_sha256(),
+                            key_length,
+                            key);
+
+    return (res == 1) ? SOTER_SUCCESS : SOTER_FAIL;
+}

--- a/src/soter/boringssl/soter_kdf.c
+++ b/src/soter/boringssl/soter_kdf.c
@@ -30,9 +30,8 @@ soter_status_t soter_pbkdf2_sha256(const uint8_t* passphrase,
 {
     int res;
 
-    if (!passphrase) {
-        SOTER_CHECK_PARAM(passphrase_length == 0);
-    }
+    SOTER_CHECK_PARAM(passphrase != NULL);
+    SOTER_CHECK_PARAM(passphrase_length > 0);
     if (!salt) {
         SOTER_CHECK_PARAM(salt_length == 0);
     }

--- a/src/soter/openssl/soter_kdf.c
+++ b/src/soter/openssl/soter_kdf.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2019 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "soter/soter_kdf.h"
+
+#include <limits.h>
+
+#include <openssl/evp.h>
+
+soter_status_t soter_pbkdf2_sha256(const uint8_t* passphrase,
+                                   size_t passphrase_length,
+                                   const uint8_t* salt,
+                                   size_t salt_length,
+                                   size_t iterations,
+                                   uint8_t* key,
+                                   size_t key_length)
+{
+    int res;
+
+    if (!passphrase) {
+        SOTER_CHECK_PARAM(passphrase_length == 0);
+    }
+    SOTER_CHECK_PARAM(passphrase_length <= INT_MAX);
+    if (!salt) {
+        SOTER_CHECK_PARAM(salt_length == 0);
+    }
+    SOTER_CHECK_PARAM(salt_length <= INT_MAX);
+    SOTER_CHECK_PARAM(iterations > 0);
+    SOTER_CHECK_PARAM(iterations <= INT_MAX);
+    SOTER_CHECK_PARAM(key != NULL);
+    SOTER_CHECK_PARAM(key_length > 0);
+    SOTER_CHECK_PARAM(key_length <= INT_MAX);
+
+    res = PKCS5_PBKDF2_HMAC((const char*)passphrase,
+                            (int)passphrase_length,
+                            salt,
+                            (int)salt_length,
+                            (int)iterations,
+                            EVP_sha256(),
+                            (int)key_length,
+                            key);
+
+    return (res == 1) ? SOTER_SUCCESS : SOTER_FAIL;
+}

--- a/src/soter/openssl/soter_kdf.c
+++ b/src/soter/openssl/soter_kdf.c
@@ -30,9 +30,8 @@ soter_status_t soter_pbkdf2_sha256(const uint8_t* passphrase,
 {
     int res;
 
-    if (!passphrase) {
-        SOTER_CHECK_PARAM(passphrase_length == 0);
-    }
+    SOTER_CHECK_PARAM(passphrase != NULL);
+    SOTER_CHECK_PARAM(passphrase_length > 0);
     SOTER_CHECK_PARAM(passphrase_length <= INT_MAX);
     if (!salt) {
         SOTER_CHECK_PARAM(salt_length == 0);

--- a/src/soter/soter_kdf.h
+++ b/src/soter/soter_kdf.h
@@ -57,6 +57,49 @@ soter_status_t soter_kdf(const void* key,
                          size_t context_count,
                          void* output,
                          size_t output_length);
+
+/**
+ * Computes PKCS#5 PBKDF2 HMAC-SHA-256 for a passphrase.
+ *
+ * @param [in]  passphrase          passphrase used for derivation, may be NULL
+ * @param [in]  passphrase_length   length of `passphrase` in bytes
+ * @param [in]  salt                additional salt for derivation, may be NULL
+ * @param [in]  salt_length         length of `salt` in bytes
+ * @param [in]  iterations          PBKDF2 iteration count
+ * @param [out] key                 output key buffer
+ * @param [in]  key_length          length of `key` in bytes
+ *
+ * This function derives a key from a passphrase using a salt and iteration
+ * count as specified in RFC 8018. It uses HMAC-SHA-256 as the hash function.
+ *
+ * The iteration count must be a positive number. The bigger it is, the slower
+ * the derivation, and the harder it gets for an attacker to perform a brute
+ * force attack with candidate passphrases. RFC 8018 suggests at least 1000.
+ * We suggest using at least 100,000. Generally, you experiment with values,
+ * use the biggest one that you can tolerate at the moment, and periodically
+ * reevaluate your decision and increase the count as machines get faster.
+ *
+ * Note that input parameters are optional, but usually you do not want to have
+ * both passphrase and salt set to NULL.
+ *
+ * @returns SOTER_SUCCESS on successful key derivation.
+ *
+ * @exception SOTER_FAIL on critical backend failure.
+ *
+ * @exception SOTER_INVALID_PARAM if `passphrase` is NULL but `passphrase_length` is not zero.
+ * @exception SOTER_INVALID_PARAM if `salt` is NULL but `salt_length` is not zero.
+ * @exception SOTER_INVALID_PARAM if `iterations` count is zero.
+ * @exception SOTER_INVALID_PARAM if `key` is NULL or `key_length` is zero.
+ */
+SOTER_API
+soter_status_t soter_pbkdf2_sha256(const uint8_t* passphrase,
+                                   size_t passphrase_length,
+                                   const uint8_t* salt,
+                                   size_t salt_length,
+                                   size_t iterations,
+                                   uint8_t* key,
+                                   size_t key_length);
+
 /** @} */
 /** @} */
 

--- a/src/soter/soter_kdf.h
+++ b/src/soter/soter_kdf.h
@@ -61,7 +61,7 @@ soter_status_t soter_kdf(const void* key,
 /**
  * Computes PKCS#5 PBKDF2 HMAC-SHA-256 for a passphrase.
  *
- * @param [in]  passphrase          passphrase used for derivation, may be NULL
+ * @param [in]  passphrase          passphrase used for derivation
  * @param [in]  passphrase_length   length of `passphrase` in bytes
  * @param [in]  salt                additional salt for derivation, may be NULL
  * @param [in]  salt_length         length of `salt` in bytes
@@ -79,14 +79,11 @@ soter_status_t soter_kdf(const void* key,
  * use the biggest one that you can tolerate at the moment, and periodically
  * reevaluate your decision and increase the count as machines get faster.
  *
- * Note that input parameters are optional, but usually you do not want to have
- * both passphrase and salt set to NULL.
- *
  * @returns SOTER_SUCCESS on successful key derivation.
  *
  * @exception SOTER_FAIL on critical backend failure.
  *
- * @exception SOTER_INVALID_PARAM if `passphrase` is NULL but `passphrase_length` is not zero.
+ * @exception SOTER_INVALID_PARAM if `passphrase` is NULL or `passphrase_length` is zero.
  * @exception SOTER_INVALID_PARAM if `salt` is NULL but `salt_length` is not zero.
  * @exception SOTER_INVALID_PARAM if `iterations` count is zero.
  * @exception SOTER_INVALID_PARAM if `key` is NULL or `key_length` is zero.

--- a/src/soter/soter_kdf.h
+++ b/src/soter/soter_kdf.h
@@ -76,8 +76,12 @@ soter_status_t soter_kdf(const void* key,
  * the derivation, and the harder it gets for an attacker to perform a brute
  * force attack with candidate passphrases. RFC 8018 suggests at least 1000.
  * We suggest using at least 100,000. Generally, you experiment with values,
- * use the biggest one that you can tolerate at the moment, and periodically
- * reevaluate your decision and increase the count as machines get faster.
+ * use the biggest one that you can tolerate.
+ *
+ * It is a good idea to periodically reevaluate your decision and increase
+ * the iteration count as machines get faster. However, doing this results
+ * in a different key being derived so you'd need to reencrypt data protected
+ * by the previous key.
  *
  * @returns SOTER_SUCCESS on successful key derivation.
  *

--- a/tests/soter/soter.mk
+++ b/tests/soter/soter.mk
@@ -47,6 +47,10 @@ $(OBJ_PATH)/tests/soter/%: CFLAGS += -DNIST_STS_EXE_PATH=$(realpath $(NIST_STS_D
 $(SOTER_TEST_BIN): nist_rng_test_suite
 endif
 
+ifeq ($(SOTER_KDF_RUN_LONG_TESTS),yes)
+$(OBJ_PATH)/tests/soter/%: CFLAGS += -DSOTER_KDF_RUN_LONG_TESTS=1
+endif
+
 ifdef IS_EMSCRIPTEN
 # Emscripten does not support dynamic linkage, do a static build for it.
 SOTER_TEST_LDFLAGS += -s SINGLE_FILE=1

--- a/tests/soter/soter_kdf_test.c
+++ b/tests/soter/soter_kdf_test.c
@@ -76,6 +76,12 @@ static const struct kdf_test_vector pbkdf2_sha256_test_vectors[] = {
     {"pass\0word", 9, "sa\0lt", 5, 4096, "\x89\xb6\x9d\x05\x16\xf8\x29\x89\x3c\x69\x62\x26\x65\x0a\x86\x87", 16},
 };
 
+#if SOTER_KDF_RUN_LONG_TESTS
+static const size_t pbkdf2_iteration_limit = SIZE_MAX;
+#else
+static const size_t pbkdf2_iteration_limit = 2000000;
+#endif
+
 static void test_pbkdf2_sha256(void)
 {
     soter_status_t res;
@@ -85,6 +91,12 @@ static void test_pbkdf2_sha256(void)
 
     for (i = 0; i < ARRAY_SIZE(pbkdf2_sha256_test_vectors); i++) {
         const struct kdf_test_vector* v = &pbkdf2_sha256_test_vectors[i];
+
+        if (v->iterations >= pbkdf2_iteration_limit) {
+            snprintf(name_buffer, sizeof(name_buffer), "test vector #%zu (skipped)", i + 1);
+            testsuite_fail_unless(true, name_buffer);
+            continue;
+        }
 
         snprintf(name_buffer, sizeof(name_buffer), "test vector #%zu", i + 1);
 

--- a/tests/soter/soter_kdf_test.c
+++ b/tests/soter/soter_kdf_test.c
@@ -117,23 +117,28 @@ static void test_pbkdf2_sha256_api(void)
 {
     soter_status_t res;
     uint8_t key_buffer[256];
+    uint8_t passphrase[] = {'p', 'a', 's', 's', 'w', 'o', 'r', 'd'};
+    uint8_t salt[] = {'s', 'a', 'l', 't'};
 
-    res = soter_pbkdf2_sha256(NULL, 0, NULL, 0, 1, key_buffer, 1);
-    testsuite_fail_unless(res == SOTER_SUCCESS, "null params, zero length");
+    res = soter_pbkdf2_sha256(NULL, 0, salt, sizeof(salt), 1, key_buffer, 1);
+    testsuite_fail_unless(res == SOTER_INVALID_PARAMETER, "null passphrase, zero length");
 
-    res = soter_pbkdf2_sha256(NULL, 1, NULL, 0, 1, key_buffer, 1);
+    res = soter_pbkdf2_sha256(NULL, 1, salt, sizeof(salt), 1, key_buffer, 1);
     testsuite_fail_unless(res == SOTER_INVALID_PARAMETER, "null passphrase, non-zero length");
 
-    res = soter_pbkdf2_sha256(NULL, 0, NULL, 1, 1, key_buffer, 1);
+    res = soter_pbkdf2_sha256(passphrase, sizeof(passphrase), NULL, 0, 1, key_buffer, 1);
+    testsuite_fail_unless(res == SOTER_SUCCESS, "null salt, zero length");
+
+    res = soter_pbkdf2_sha256(passphrase, sizeof(passphrase), NULL, 1, 1, key_buffer, 1);
     testsuite_fail_unless(res == SOTER_INVALID_PARAMETER, "null salt, non-zero length");
 
-    res = soter_pbkdf2_sha256(NULL, 0, NULL, 0, 0, key_buffer, 1);
+    res = soter_pbkdf2_sha256(passphrase, sizeof(passphrase), salt, sizeof(salt), 0, key_buffer, 1);
     testsuite_fail_unless(res == SOTER_INVALID_PARAMETER, "zero iterations");
 
-    res = soter_pbkdf2_sha256(NULL, 0, NULL, 0, 1, NULL, 0);
+    res = soter_pbkdf2_sha256(passphrase, sizeof(passphrase), salt, sizeof(salt), 1, NULL, 0);
     testsuite_fail_unless(res == SOTER_INVALID_PARAMETER, "null key");
 
-    res = soter_pbkdf2_sha256(NULL, 0, NULL, 0, 1, key_buffer, 0);
+    res = soter_pbkdf2_sha256(passphrase, sizeof(passphrase), salt, sizeof(salt), 1, key_buffer, 0);
     testsuite_fail_unless(res == SOTER_INVALID_PARAMETER, "zero key length");
 }
 

--- a/tests/soter/soter_kdf_test.c
+++ b/tests/soter/soter_kdf_test.c
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2019 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "soter/soter_test.h"
+
+#include <stdio.h>
+#include <string.h>
+
+struct kdf_test_vector {
+    const char* passphrase;
+    size_t passphrase_length;
+    const char* salt;
+    size_t salt_length;
+    size_t iterations;
+    const char* key;
+    size_t key_length;
+};
+
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
+
+/*
+ * Unfortunately, there is no RFC with test vectors for PBKDF2 with HMAC-SHA2
+ * family, so here's the best substitute available.
+ *
+ * https://stackoverflow.com/questions/5130513/pbkdf2-hmac-sha2-test-vectors
+ */
+static const struct kdf_test_vector pbkdf2_sha256_test_vectors[] = {
+    {"password",
+     8,
+     "salt",
+     4,
+     1,
+     "\x12\x0f\xb6\xcf\xfc\xf8\xb3\x2c\x43\xe7\x22\x52\x56\xc4\xf8\x37\xa8\x65\x48\xc9\x2c\xcc\x35\x48\x08\x05\x98\x7c\xb7\x0b\xe1\x7b",
+     32},
+    {"password",
+     8,
+     "salt",
+     4,
+     2,
+     "\xae\x4d\x0c\x95\xaf\x6b\x46\xd3\x2d\x0a\xdf\xf9\x28\xf0\x6d\xd0\x2a\x30\x3f\x8e\xf3\xc2\x51\xdf\xd6\xe2\xd8\x5a\x95\x47\x4c\x43",
+     32},
+    {"password",
+     8,
+     "salt",
+     4,
+     4096,
+     "\xc5\xe4\x78\xd5\x92\x88\xc8\x41\xaa\x53\x0d\xb6\x84\x5c\x4c\x8d\x96\x28\x93\xa0\x01\xce\x4e\x11\xa4\x96\x38\x73\xaa\x98\x13\x4a",
+     32},
+    {"password",
+     8,
+     "salt",
+     4,
+     16777216,
+     "\xcf\x81\xc6\x6f\xe8\xcf\xc0\x4d\x1f\x31\xec\xb6\x5d\xab\x40\x89\xf7\xf1\x79\xe8\x9b\x3b\x0b\xcb\x17\xad\x10\xe3\xac\x6e\xba\x46",
+     32},
+    {"passwordPASSWORDpassword",
+     24,
+     "saltSALTsaltSALTsaltSALTsaltSALTsalt",
+     36,
+     4096,
+     "\x34\x8c\x89\xdb\xcb\xd3\x2b\x2f\x32\xd8\x14\xb8\x11\x6e\x84\xcf\x2b\x17\x34\x7e\xbc\x18\x00\x18\x1c\x4e\x2a\x1f\xb8\xdd\x53\xe1\xc6\x35\x51\x8c\x7d\xac\x47\xe9",
+     40},
+    {"pass\0word", 9, "sa\0lt", 5, 4096, "\x89\xb6\x9d\x05\x16\xf8\x29\x89\x3c\x69\x62\x26\x65\x0a\x86\x87", 16},
+};
+
+static void test_pbkdf2_sha256(void)
+{
+    soter_status_t res;
+    uint8_t key_buffer[256];
+    char name_buffer[256];
+    size_t i;
+
+    for (i = 0; i < ARRAY_SIZE(pbkdf2_sha256_test_vectors); i++) {
+        const struct kdf_test_vector* v = &pbkdf2_sha256_test_vectors[i];
+
+        snprintf(name_buffer, sizeof(name_buffer), "test vector #%zu", i + 1);
+
+        res = soter_pbkdf2_sha256((const uint8_t*)v->passphrase,
+                                  v->passphrase_length,
+                                  (const uint8_t*)v->salt,
+                                  v->salt_length,
+                                  v->iterations,
+                                  key_buffer,
+                                  v->key_length);
+
+        testsuite_fail_unless(res == SOTER_SUCCESS && memcmp(key_buffer, v->key, v->key_length) == 0,
+                              name_buffer);
+    }
+}
+
+static void test_pbkdf2_sha256_api(void)
+{
+    soter_status_t res;
+    uint8_t key_buffer[256];
+
+    res = soter_pbkdf2_sha256(NULL, 0, NULL, 0, 1, key_buffer, 1);
+    testsuite_fail_unless(res == SOTER_SUCCESS, "null params, zero length");
+
+    res = soter_pbkdf2_sha256(NULL, 1, NULL, 0, 1, key_buffer, 1);
+    testsuite_fail_unless(res == SOTER_INVALID_PARAMETER, "null passphrase, non-zero length");
+
+    res = soter_pbkdf2_sha256(NULL, 0, NULL, 1, 1, key_buffer, 1);
+    testsuite_fail_unless(res == SOTER_INVALID_PARAMETER, "null salt, non-zero length");
+
+    res = soter_pbkdf2_sha256(NULL, 0, NULL, 0, 0, key_buffer, 1);
+    testsuite_fail_unless(res == SOTER_INVALID_PARAMETER, "zero iterations");
+
+    res = soter_pbkdf2_sha256(NULL, 0, NULL, 0, 1, NULL, 0);
+    testsuite_fail_unless(res == SOTER_INVALID_PARAMETER, "null key");
+
+    res = soter_pbkdf2_sha256(NULL, 0, NULL, 0, 1, key_buffer, 0);
+    testsuite_fail_unless(res == SOTER_INVALID_PARAMETER, "zero key length");
+}
+
+void run_soter_kdf_tests(void)
+{
+    testsuite_enter_suite("Soter KDF: PBKDF2 HMAC-SHA-256");
+    testsuite_run_test(test_pbkdf2_sha256);
+    testsuite_run_test(test_pbkdf2_sha256_api);
+}

--- a/tests/soter/soter_test.c
+++ b/tests/soter/soter_test.c
@@ -31,6 +31,7 @@ int main(int argc, char* argv[])
     run_soter_sym_test();
     run_soter_sign_test();
     run_soter_rand_tests();
+    run_soter_kdf_tests();
 
     testsuite_finish_testing();
 

--- a/tests/soter/soter_test.h
+++ b/tests/soter/soter_test.h
@@ -29,5 +29,6 @@ void run_soter_sym_test(void);
 void run_soter_sign_test(void);
 void run_soter_rand_tests(void);
 void run_soter_hmac_tests(void);
+void run_soter_kdf_tests(void);
 
 #endif /* SOTER_TEST_H */


### PR DESCRIPTION
We were naughty kids all these previous years with Secure Cell passphrase API. So here's your PBKDF2 for Christmas 🎄 🎅 🎁 (_It's better than coal, anyhow..._)

This is a part of new passphrase-based API described in RFC 2 (not available publicly at the moment). It will be used in Secure Cell implementation for proper processing of passphrases.

New public function `soter_pbkdf2_sha256()` computes PBKDF2 with HMAC-SHA-256 as described in [RFC 8081](https://tools.ietf.org/html/rfc8018). Test vectors come from an honest aaz (we trust pervects, right?) because no one else bothered to produce them. We skip the longest one with 16 million iterations by default because it's tad too expensive right now, but the main test job verifies it.

## Checklist

- [X] Change is covered by automated tests
- [X] ~~Benchmark results are attached~~ (uh...)
- [X] The [coding guidelines] are followed
- [X] Public API has proper documentation
- [X] ~~Example projects and code samples are updated~~
- [X] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
