### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,7 @@
 # Default reviewer set
 *                   @vixentael @Lagovas
-/src/soter/         @vixentael @Lagovas @ilammy @storojs72 @secumod
-/src/themis/        @vixentael @Lagovas @ilammy @storojs72 @secumod
+/src/soter/         @vixentael @Lagovas @ilammy @storojs72 @ignatk
+/src/themis/        @vixentael @Lagovas @ilammy @storojs72 @ignatk
 
 # Build system
 Makefile            @vixentael @Lagovas @shadinua


### PR DESCRIPTION
I was wondering why Ignat is never added as code reviewer automatically. Turns out that the GitHub handle is wrong. Fix it. Now I no longer need to remember to add important people for code review manually.