### PR TITLE
Fix ODR violation in ThemisPP

### DIFF
--- a/src/wrappers/themis/themispp/secure_keygen.hpp
+++ b/src/wrappers/themis/themispp/secure_keygen.hpp
@@ -140,7 +140,7 @@ inline bool is_public_key(const std::vector<uint8_t>& key)
  * If the vector does not have enough space for a good key then
  * it will be resized. Otherwise no reallocations are performed.
  */
-void gen_sym_key(std::vector<uint8_t>& key)
+inline void gen_sym_key(std::vector<uint8_t>& key)
 {
     if (key.empty()) {
         size_t key_length = 0;
@@ -165,7 +165,7 @@ void gen_sym_key(std::vector<uint8_t>& key)
  *
  * @returns a newly allocated key of default size.
  */
-std::vector<uint8_t> gen_sym_key()
+inline std::vector<uint8_t> gen_sym_key()
 {
     std::vector<uint8_t> key;
     gen_sym_key(key);


### PR DESCRIPTION
All functions defined in header files must be marked `inline` so that the compiler does proper deduplication and does not violate [“one definition rule”](https://en.wikipedia.org/wiki/One_Definition_Rule) (ODR). Otherwise (you guessed it, right?)
undefined behavior happens.

Thanks goes go **clang-analyzer** whose warnings we diligently ignore. We've been burnt by this in the past (see #540, and there were customers with broken builds because of this). I never learn because C++ is such a monster that I easily forget something about it all the time.

This is new symmetric key generation API that is pending for release in Themis 0.13.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] Public API has proper documentation

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md