### PR TITLE
Hardening compiler flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,23 @@ endif
 endif
 endif
 
-CFLAGS += -O2 -fno-omit-frame-pointer -g
+CFLAGS += -O2 -g
+# Get better runtime backtraces by preserving the frame pointer. This eats
+# one of seven precious registers on x86, but our functions are quite large
+# so they almost always use stack and need the frame pointer anyway.
+CFLAGS += -fno-omit-frame-pointer
+# Enable runtime stack canaries for functions to guard for buffer overflows.
+ifeq (yes,$(call supported,-fstack-protector-strong))
+CFLAGS += -fstack-protector-strong
+else
+CFLAGS += -fstack-protector
+endif
+# Enable miscellaneous compile-time checks in standard library usage.
+CFLAGS += -D_FORTIFY_SOURCE=2
+# Prevent global offset table overwrite attacks.
+ifdef IS_LINUX
+LDFLAGS += -Wl,-z,relro -Wl,-z,now
+endif
 
 ifdef COVERAGE
 	CFLAGS += -O0 --coverage


### PR DESCRIPTION
Enable more compile-time and run-time protections which are recommended and used by [Debian][1] and [Red Hat][2] when building their package bases.

[1]: https://wiki.debian.org/Hardening
[2]: https://developers.redhat.com/blog/2018/03/21/compiler-and-linker-flags-gcc/

These are quite old compilation flags, only `-fstack-protector-strong` is supported since GCC 4.9. We might need to support earlier versions for distros like RHEL and CentOS so replace it with `-fstack-protector` when unavailable. They are usually even enabled by default, but let’s make sure that the compiler uses them. Stack canaries are run-time checks for buffer overflows in local variables which are the main source of ROP attacks.

> By the way, you saw that PR with passphrase API for Secure Cell (#577)? It introduces a textbook example of a buffer overflow bug which is caught by a stack canary like this. Can you spot the bug? Because I certainly could not – not without a dead canary in my face.

FORTIFY_SOURCE is not enabled by default usually. It replaces various standard library functions (strcpy(), memcpy(), etc.) with their buffer-length-aware alternatives where possible. They will abort the program (or compilation) if they detect an obvious buffer overflow for arrays of statically-known size.

Immediate binding and read-only relocations prevent some exploits which may redirect functions imported by Themis somewhere different. They also somewhat limit possible effects of accidental memory corruption.

macOS/iOS uses different linker flags for relro (`-read_only_relocs`) but relocations have to be writeable on some platforms (e.g., ARM64) therefore we limit it to Linux only.

Another recommended option is using position-independent executable code but since we're a shared library we already build with `-fPIC`.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] Public API has proper documentation
- [X] ~~Changelog is updated~~ (maybe later)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
