### PR TITLE
Wipe partial PRNG output

### DIFF
--- a/src/soter/openssl/soter_rand.c
+++ b/src/soter/openssl/soter_rand.c
@@ -20,6 +20,8 @@
 
 #include <openssl/rand.h>
 
+#include "soter/soter_wipe.h"
+
 soter_status_t soter_rand(uint8_t* buffer, size_t length)
 {
     int result;
@@ -30,9 +32,15 @@ soter_status_t soter_rand(uint8_t* buffer, size_t length)
 
     result = RAND_bytes(buffer, (int)length);
 
-    if (result < 0) {
-        return SOTER_NOT_SUPPORTED;
+    if (result == 1) {
+        return SOTER_SUCCESS;
     }
 
-    return (result == 1) ? SOTER_SUCCESS : SOTER_FAIL;
+    /*
+     * Make sure we don't leak PRNG state in case the buffer has been
+     * partially filled and we have to return an error.
+     */
+    soter_wipe(buffer, length);
+
+    return (result < 0) ? SOTER_NOT_SUPPORTED : SOTER_FAIL;
 }


### PR DESCRIPTION
While this is only a theoretically possible attack vector, let's make sure that we are not susceptible to it if it ever becomes practical.

If RAND_bytes() returns an error, wipe the output buffer clean so that none of the partial output is available to the caller, thus avoiding any possible PRNG state leaks *and* leaving highly conspicuous zeros if the caller does not check for soter_rand() success.

For BoringSSL this is excessive because BoringSSL aborts the process on PRNG failures. However, OpenSSL's built-in PRNG can make partial writes into the buffer in case of failure.

Note that normally PRNG should not fail mid-flight. It's either completely unusable because your system and/or OpenSSL is broken, or it is able to produce arbitrary number of pseudorandom bytes. There are special cases like very early boot stages on Linux, but that behavior depends on whatever OpenSSL does in RAND_bytes(), and that's... complicated. Just know that it *may* fail on some systems.

(_I'm cleaning up some old branches of mine. This paranoia fit was inspired by [this thread](https://github.com/cossacklabs/themis/pull/565#discussion_r354419921)._)

## Checklist

- [X] Change is covered by automated tests
- [X] ~~Benchmark results are attached~~ (error path, don't care)
- [X] The [coding guidelines] are followed

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md