### PR TITLE
Wipe output on failure: key generation

### DIFF
--- a/src/soter/openssl/soter_rsa_key_pair_gen.c
+++ b/src/soter/openssl/soter_rsa_key_pair_gen.c
@@ -23,7 +23,7 @@
 
 #include "soter/openssl/soter_engine.h"
 
-static unsigned rsa_key_length(const int size)
+static int rsa_key_length(unsigned size)
 {
     switch (size) {
     case RSA_KEY_LENGTH_1024:
@@ -72,7 +72,7 @@ static soter_status_t soter_set_default_rsa_pub_exp(EVP_PKEY_CTX* pkey_ctx)
     return SOTER_SUCCESS;
 }
 
-static soter_status_t soter_set_rsa_key_length(EVP_PKEY_CTX* pkey_ctx, unsigned length)
+static soter_status_t soter_set_rsa_key_length(EVP_PKEY_CTX* pkey_ctx, int length)
 {
     if (EVP_PKEY_CTX_ctrl(pkey_ctx, -1, -1, EVP_PKEY_CTRL_RSA_KEYGEN_BITS, length, NULL) != 1) {
         return SOTER_FAIL;

--- a/src/themis/secure_keygen.c
+++ b/src/themis/secure_keygen.c
@@ -24,6 +24,7 @@
 #include "soter/soter_rsa_key.h"
 #include "soter/soter_rsa_key_pair_gen.h"
 #include "soter/soter_t.h"
+#include "soter/soter_wipe.h"
 
 #include "themis/themis_portable_endian.h"
 
@@ -48,6 +49,13 @@ static themis_status_t combine_key_generation_results(uint8_t* private_key,
 {
     if (private_result == THEMIS_SUCCESS && public_result == THEMIS_SUCCESS) {
         return THEMIS_SUCCESS;
+    }
+
+    if (private_result != THEMIS_BUFFER_TOO_SMALL) {
+        soter_wipe(private_key, *private_key_length);
+    }
+    if (public_result != THEMIS_BUFFER_TOO_SMALL) {
+        soter_wipe(public_key, *public_key_length);
     }
 
     if (private_result == THEMIS_BUFFER_TOO_SMALL || public_result == THEMIS_BUFFER_TOO_SMALL) {
@@ -203,6 +211,6 @@ themis_status_t themis_gen_sym_key(uint8_t* key, size_t* key_length)
         return THEMIS_BUFFER_TOO_SMALL;
     }
 
-    /* Soter error codes have the same value as Themis ones */
+    /* soter_rand() wipes the key on failure, soter_wipe() not needed */
     return soter_rand(key, *key_length);
 }


### PR DESCRIPTION
More wiping 🧹

Refactor high-level EC/RSA key generation functions in Themis so that they are easier to follow and it is easier to insert additional actions into the error path. Then insert soter_wipe() for already exported public key if private key export fails or vice versa.

While we're here, I've noticed and fixed clang-tidy complaints about mismatched integer types in OpenSSL code for RSA key generation. (BoringSSL code is fine, it already uses correct types.)

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
