### PR TITLE
Avoid needless return in libthemis-sys

### DIFF
--- a/src/wrappers/themis/rust/libthemis-sys/build.rs
+++ b/src/wrappers/themis/rust/libthemis-sys/build.rs
@@ -53,12 +53,10 @@ fn get_themis() -> Library {
     pkg_config.statik(true);
 
     match pkg_config.probe("libthemis") {
-        Ok(library) => {
-            return Library {
-                include_paths: library.include_paths,
-                link_paths: library.link_paths,
-            };
-        }
+        Ok(library) => Library {
+            include_paths: library.include_paths,
+            link_paths: library.link_paths,
+        },
         Err(error) => {
             eprintln!(
                 "


### PR DESCRIPTION
With recent updates Clippy got smarter and now sees that we (needlessly) use "return" in a tail position. Remove `return` so that Clippy is happy. I personally find this questionable but Clippy is the authority here.

<details>
<summary>Clippy warning that breaks the build</summary>

```
   Compiling libthemis-sys v0.12.0 (/Users/ilammy/Documents/dev/themis/src/wrappers/themis/rust/libthemis-sys)
error: unneeded return statement
  --> src/wrappers/themis/rust/libthemis-sys/build.rs:57:13
   |
57 | /             return Library {
58 | |                 include_paths: library.include_paths,
59 | |                 link_paths: library.link_paths,
60 | |             };
   | |______________^
   |
   = note: `-D clippy::needless-return` implied by `-D warnings`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return
help: remove `return`
   |
57 |             Library {
58 |                 include_paths: library.include_paths,
59 |                 link_paths: library.link_paths,
60 |             }
   |

error: aborting due to previous error

error: could not compile `libthemis-sys`.
warning: build failed, waiting for other jobs to finish...
error: build failed
make: *** [test_rust] Error 101
```

</details>

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md