### PR TITLE
Use correct Secure Cell API in PHPThemis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,7 @@ _Code:_
 - **PHP**
 
   - New function `phpthemis_gen_sym_key()` can be used to generate symmetric keys for Secure Cell ([#561](https://github.com/cossacklabs/themis/pull/561)).
-  - PHPThemis now supports _passphrase API_ of Secure Cell in Seal mode ([#594](https://github.com/cossacklabs/themis/pull/594)).
+  - PHPThemis now supports _passphrase API_ of Secure Cell in Seal mode ([#594](https://github.com/cossacklabs/themis/pull/594), [#601](https://github.com/cossacklabs/themis/pull/601)).
 
     ```php
     $encrypted = phpthemis_scell_seal_encrypt_with_passphrase('passphrase', 'message');

--- a/src/wrappers/themis/php7/php_cell.c
+++ b/src/wrappers/themis/php7/php_cell.c
@@ -95,7 +95,7 @@ ZEND_FUNCTION(phpthemis_scell_seal_encrypt_with_passphrase){
         return;
     }
     size_t encrypted_message_length=0;
-    if(themis_secure_cell_encrypt_seal((uint8_t*)passphrase, passphrase_length, (uint8_t*)context, context_length, (uint8_t*)message, message_length, NULL, &encrypted_message_length)!=THEMIS_BUFFER_TOO_SMALL){
+    if(themis_secure_cell_encrypt_seal_with_passphrase((uint8_t*)passphrase, passphrase_length, (uint8_t*)context, context_length, (uint8_t*)message, message_length, NULL, &encrypted_message_length)!=THEMIS_BUFFER_TOO_SMALL){
         zend_throw_exception(zend_exception_get_default(TSRMLS_C), "Error: phpthemis_scell_seal_encrypt_with_passphrase: encrypted message length determination failed.", 0 TSRMLS_CC);
         RETURN_NULL();
     }
@@ -104,7 +104,7 @@ ZEND_FUNCTION(phpthemis_scell_seal_encrypt_with_passphrase){
         zend_throw_exception(zend_exception_get_default(TSRMLS_C), "Error: phpthemis_scell_seal_encrypt_with_passphrase: not enough memory.", 0 TSRMLS_CC);
         RETURN_NULL();
     }
-    if(themis_secure_cell_encrypt_seal((uint8_t*)passphrase, passphrase_length, (uint8_t*)context, context_length, (uint8_t*)message, message_length, (uint8_t*)encrypted_message, &encrypted_message_length)!=THEMIS_SUCCESS){
+    if(themis_secure_cell_encrypt_seal_with_passphrase((uint8_t*)passphrase, passphrase_length, (uint8_t*)context, context_length, (uint8_t*)message, message_length, (uint8_t*)encrypted_message, &encrypted_message_length)!=THEMIS_SUCCESS){
         zend_throw_exception(zend_exception_get_default(TSRMLS_C), "Error: phpthemis_scell_seal_encrypt_with_passphrase: encryption failed.", 0 TSRMLS_CC);
         RETURN_NULL();
     }
@@ -124,7 +124,7 @@ ZEND_FUNCTION(phpthemis_scell_seal_decrypt_with_passphrase){
         RETURN_NULL();
     }
     size_t decrypted_message_length=0;
-    if(themis_secure_cell_decrypt_seal((uint8_t*)passphrase, passphrase_length, (uint8_t*)context, context_length, (uint8_t*)message, message_length, NULL, &decrypted_message_length)!=THEMIS_BUFFER_TOO_SMALL){
+    if(themis_secure_cell_decrypt_seal_with_passphrase((uint8_t*)passphrase, passphrase_length, (uint8_t*)context, context_length, (uint8_t*)message, message_length, NULL, &decrypted_message_length)!=THEMIS_BUFFER_TOO_SMALL){
         zend_throw_exception(zend_exception_get_default(TSRMLS_C), "Error: phpthemis_scell_seal_decrypt_with_passphrase: decrypted message length determination failed.", 0 TSRMLS_CC);
         RETURN_NULL();
     }
@@ -133,7 +133,7 @@ ZEND_FUNCTION(phpthemis_scell_seal_decrypt_with_passphrase){
         zend_throw_exception(zend_exception_get_default(TSRMLS_C), "Error: phpthemis_scell_seal_decrypt_with_passphrase: not enough memory.", 0 TSRMLS_CC);
         RETURN_NULL();
     }
-    if(themis_secure_cell_decrypt_seal((uint8_t*)passphrase, passphrase_length, (uint8_t*)context, context_length, (uint8_t*)message, message_length, (uint8_t*)decrypted_message, &decrypted_message_length)!=THEMIS_SUCCESS){
+    if(themis_secure_cell_decrypt_seal_with_passphrase((uint8_t*)passphrase, passphrase_length, (uint8_t*)context, context_length, (uint8_t*)message, message_length, (uint8_t*)decrypted_message, &decrypted_message_length)!=THEMIS_SUCCESS){
         zend_throw_exception(zend_exception_get_default(TSRMLS_C), "Error: phpthemis_scell_seal_decrypt_with_passphrase: decription failed.", 0 TSRMLS_CC);
         RETURN_NULL();
     }

--- a/tests/phpthemis/scell_test.php
+++ b/tests/phpthemis/scell_test.php
@@ -106,6 +106,15 @@ class ScellTest extends TestCase {
         $this->assertEquals($decrypted2, $message);
     }
 
+    public function testSealMasterKeyIsNotPassphrase() {
+        $master_key = phpthemis_gen_sym_key();
+        $message = 'precious message';
+
+        $encrypted = phpthemis_scell_seal_encrypt($master_key, $message);
+        $this->expectException(Exception::class);
+        $decrypted = phpthemis_scell_seal_decrypt_with_passphrase($master_key, $encrypted);
+    }
+
     /** @dataProvider InvalidValues */
     public function testSealMasterKeyNoKeyEncrypt($empty) {
         $this->expectException(Exception::class);
@@ -192,6 +201,15 @@ class ScellTest extends TestCase {
 
         $this->assertEquals($decrypted1, $message);
         $this->assertEquals($decrypted2, $message);
+    }
+
+    public function testSealPassphraseIsNotMasterKey() {
+        $passphrase = 'my secret key';
+        $message = 'precious message';
+
+        $encrypted = phpthemis_scell_seal_encrypt_with_passphrase($passphrase, $message);
+        $this->expectException(Exception::class);
+        $decrypted = phpthemis_scell_seal_decrypt($passphrase, $encrypted);
     }
 
     /** @dataProvider InvalidValues */


### PR DESCRIPTION
Hey, #594, it's not enough to name the function `with_passphrase` and accept `passphrase` arguments. You also need to call Themis Core API that uses passphrases.

PHP 5 calls the correct API but PHP 7 fell prey to a copy-paste mistake.

Moral of the story: copy-paste is bad 🤦‍♂

(Caught by integration tests with Python in #596, they’re good. I wonder if we need PHP 5 ⟺ PHP 7 integration tests now. Since our current tests use whatever PHP is installed in the system.)

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
