### PR TITLE
Use emcmake when building BoringSSL with Emscripten

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,13 @@ SHARED_EXT = dll
 endif
 
 ifdef IS_EMSCRIPTEN
+# Recent versions of Emscripten toolchain provide new "emcmake" utility
+# specifically for CMake. Older versions rely on generic "emconfigure".
+ifeq ($(shell which emcmake >/dev/null 2>&1 && echo yes),yes)
+CMAKE = emcmake cmake
+else
 CMAKE = emconfigure cmake
+endif
 endif
 
 # Not all platforms include /usr/local into default search path


### PR DESCRIPTION
Emscripten toolchain includes **emconfigure** tool which sets various standard variables to setup crosscompilation. Since v1.14.1 Emscripten includes **emcmake** tool which is effectively emconfigure for CMake.

Themis can build embedded BoringSSL when it is selected as cryptographic backend. With Emscripten we always use (and build) embedded BoringSSL. For that we use `emconfigure cmake` to configure the build.

Since Emscripten v1.39.9 (released 3 days ago) it is now mandatory to use **emcmake** for CMake configuration, as evident from the following error message:

    $ emmake make wasmthemis
    make: make wasmthemis
    building embedded BoringSSL...
    error: use `emcmake` rather then `emconfigure` for cmake projects
    make: *** [build/boringssl/crypto/libcrypto.a] Error 1

Use emmake if it is available, otherwise fall back to emconfigure when building embedded BoringSSL with Emscripten.

Interface for Themis users does not change: it's still simply `emmake make wasmthemis` and we take care of all compatibility details.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] Public API has proper documentation

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
