### PR TITLE
ObjCThemis: Secure Cell API update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,88 @@ _Code:_
 
   - New function `TSGenerateSymmetricKey()` (available in Objective-C and Swift) can be used to generate symmetric keys for Secure Cell ([#561](https://github.com/cossacklabs/themis/pull/561)).
 
+  - Secure Cell API updates ([#606](https://github.com/cossacklabs/themis/pull/606)).
+
+    - New encryption/decryption API with consistent naming: `encrypt` and `decrypt`.
+
+    - Improved Token Protect API:
+      - Encryption results use `NSData` now which bridges with Swift `Data` directly.
+      - Decryption no longer requires an intermediate `TSCellTokenEncryptedData` object.
+
+  - **Deprecated API**
+
+    - Secure Cell wrapData/unwrapData renamed into encrypt/decrypt ([#606](https://github.com/cossacklabs/themis/pull/606)).
+
+      As a result, the following methods are deprecated. There are no plans for their removal.
+
+      <details>
+      <summary>Swift</summary>
+      <table>
+        <tr><th>Mode</th><th>Deprecation</th><th>Replacement</th></tr>
+        <tr>
+          <td rowspan=2><code>TSCellSeal</code></td>
+          <td><code>wrap(_:, context:)</code><br/><code>wrap</code></td>
+          <td><code>encrypt(_:, context:)</code><br/><code>encrypt</code></td>
+        </tr>
+        <tr>
+          <td><code>unwrapData(_:, context:)</code><br/><code>unwrapData</code></td>
+          <td><code>decrypt(_:, context:)</code><br/><code>decrypt</code></td>
+        </tr>
+        <tr>
+          <td rowspan=2><code>TSCellToken</code></td>
+          <td><code>wrap(_:, context:)</code><br/><code>wrap</code></td>
+          <td><code>encrypt(_:, context:)</code><br/><code>encrypt</code></td>
+        </tr>
+        <tr>
+          <td><code>unwrapData(_:, context:)</code><br/><code>unwrapData</code></td>
+          <td><code>decrypt(_:, token:, context:)</code><br/><code>decrypt(_:, token:)</code></td>
+        </tr>
+        <tr>
+          <td rowspan=2><code>TSCellContextImprint</code></td>
+          <td><code>wrap(_:, context:)</code><br/><code>wrap</code></td>
+          <td><code>encrypt(_:, context:)</code><br/><code>encrypt</code></td>
+        </tr>
+        <tr>
+          <td><code>unwrapData(_:, context:)</code><br/><code>unwrapData</code></td>
+          <td><code>decrypt(_:, context:)</code><br/><code>decrypt</code></td>
+        </tr>
+      </table>
+      </details>
+
+      <details>
+      <summary>Objective-C</summary>
+      <table>
+        <tr><th>Mode</th><th>Deprecation</th><th>Replacement</th></tr>
+        <tr>
+          <td rowspan=2><code>TSCellSeal</code></td>
+          <td><code>wrapData:context:error:</code><br><code>wrapData:error:</code></td>
+          <td><code>encrypt:context:error:</code><br><code>encrypt:error:</code></td>
+        </tr>
+        <tr>
+          <td><code>unwrapData:context:error:</code><br><code>unwrapData:error:</code></td>
+          <td><code>decrypt:context:error:</code><br><code>decrypt:error:</code></td>
+        </tr>
+        <tr>
+          <td rowspan=2><code>TSCellToken</code></td>
+          <td><code>wrapData:context:error:</code><br><code>wrapData:error:</code></td>
+          <td><code>encrypt:context:error:</code><br><code>encrypt:error:</code></td>
+        </tr>
+        <tr>
+          <td><code>unwrapData:context:error:</code><br><code>unwrapData:error:</code></td>
+          <td><code>decrypt:token:context:error:</code><br><code>decrypt:token:error:</code></td>
+        </tr>
+        <tr>
+          <td rowspan=2><code>TSCellContextImprint</code></td>
+          <td><code>wrapData:context:error:</code><br><code>wrapData:error:</code></td>
+          <td><code>encrypt:context:error:</code><br><code>encrypt:error:</code></td>
+        </tr>
+        <tr>
+          <td><code>unwrapData:context:error:</code><br><code>unwrapData:error:</code></td>
+          <td><code>decrypt:context:error:</code><br><code>decrypt:error:</code></td>
+        </tr>
+      </table>
+      </details>
+
 - **Java**
 
   - JDK location is now detected automatically in most cases, you should not need to set JAVA_HOME or JDK_INCLUDE_PATH manually ([#551](https://github.com/cossacklabs/themis/pull/551)).

--- a/src/wrappers/themis/Obj-C/objcthemis/scell_context_imprint.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_context_imprint.h
@@ -47,28 +47,91 @@ NS_ASSUME_NONNULL_BEGIN
 @interface TSCellContextImprint : TSCell
 
 /**
-* @brief Initialize Secure cell object in context imprint mode
-* @param [in] key master key
-*/
+ * Initialise Secure Cell in Context Imprint mode with a master key.
+ *
+ * @param [in] key  non-empty master key
+ *
+ * @returns @c nil if key is empty.
+ */
 - (nullable instancetype)initWithKey:(NSData *)key;
 
 /**
-* @brief Wrap message with context
-* @param [in] message message to wrap
-* @param [in] context user context
-* @param [in] error pointer to Error on failure
-* @return Wrapped message as NSData object on success or nil on failure
-*/
-- (nullable NSData *)wrapData:(NSData *)message context:(NSData *)context error:(NSError **)error;
+ * Encrypt data.
+ *
+ * @param [in]  message data to encrypt, must not be empty
+ * @param [in]  context associated context, must not be empty
+ * @param [out] error   optional error output
+ *
+ * Data is encrypted and context is cryptographically mixed with the data, but not included
+ * into the resulting encrypted message. You will have to provide the same context again
+ * during decryption. Usually this is some plaintext data associated with encrypted data,
+ * such as database row number, protocol message ID, etc.
+ *
+ * @returns Encrypted data has the same length as input and cannot be authenticated.
+ *
+ * @returns @c nil will be returned on failure, such as if @c message or @c context is empty
+ * or in case of some internal failure in cryptographic backend.
+ *
+ * @returns If @c error is not @c nil, it will describe the reason of failure.
+ */
+- (nullable NSData *)encrypt:(NSData *)message
+                     context:(NSData *)context
+                       error:(NSError **)error;
 
 /**
-* @brief Unwrap message with context
-* @param [in] message message to unwrap
-* @param [in] context user context
-* @param [in] error pointer to Error on failure
-* @return Unwrapped message as NSData object on success or nil on failure
-*/
-- (nullable NSData *)unwrapData:(NSData *)message context:(NSData *)context error:(NSError **)error;
+ * Encrypt data.
+ * @see encrypt:context:error:
+ */
+- (nullable NSData *)encrypt:(NSData *)message context:(NSData *)context
+    NS_SWIFT_UNAVAILABLE("use throwing encrypt(_:,context:)");
+
+/**
+ * Encrypt data.
+ * @deprecated since Themis 0.13
+ * @see encrypt:context:error:
+ */
+- (nullable NSData *)wrapData:(NSData *)message context:(NSData *)context error:(NSError **)error
+    __deprecated_msg("use 'encrypt:context:error:' instead");
+
+/**
+ * Decrypt data.
+ *
+ * @param [in]  message data to decrypt, cannot be empty
+ * @param [in]  context associated context, cannot be empty
+ * @param [out] error   optional error output
+ *
+ * Secure Cell validates association with the context data and decrypts the message.
+ * You need to provide the same context as it was used during encryption.
+ *
+ * @returns Decrypted data is returned if everything goes well.
+ *
+ * @returns Note that data integrity is not verified by Context Imprint mode:
+ * garbage in — garbage out. If data has been corrupted or context is incorrect
+ * then Secure Cell will most likely successfully return corrupted output.
+ *
+ * @returns @c nil will be returned on failure, such as if @c message or @c context
+ * is empty, or in case of some internal failure in cryptographic backend.
+ *
+ * @returns If @c error is not @c nil, it will describe the reason of failure.
+ */
+- (nullable NSData *)decrypt:(NSData *)message
+                     context:(NSData *)context
+                       error:(NSError **)error;
+
+/**
+ * Decrypt data.
+ * @see decrypt:context:error:
+ */
+- (nullable NSData *)decrypt:(NSData *)message context:(NSData *)context
+    NS_SWIFT_UNAVAILABLE("use throwing decrypt(_:,context:)");
+
+/**
+ * Decrypt data.
+ * @deprecated since Themis 0.13
+ * @see decrypt:context:error:
+ */
+- (nullable NSData *)unwrapData:(NSData *)message context:(NSData *)context error:(NSError **)error
+    __deprecated_msg("use 'decrypt:context:error:' instead");
 
 @end
 

--- a/src/wrappers/themis/Obj-C/objcthemis/scell_context_imprint.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_context_imprint.h
@@ -29,21 +29,27 @@
  * @{
  */
 
-/** @brief Secure Cell Context Imprint mode interface
-*
-* This object mode is for environments where storage constraints do not allow the size of the data to grow and
-* there is no auxiliary storage available. Secure Cell context imprint relies on the user to provide the data context
-* along with the secret to protect the information. Also, no authentication tag is computed or verified.
-* This means the integrity of the data is not enforced, so the overall security level is slightly lower than preceding
-* two cases.
-*
-* @image html scell-context_imprint.png Secure Cell Context imprint mode
-* @note To ensure highest security level possible user has to supply different context for each encryption invocation
-* of the object for the same secret.
-*/
-
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ * Secure Cell in Context Imprint mode.
+ *
+ * Context Imprint mode is intended for environments where storage constraints
+ * do not allow the size of the data to grow and there is no auxiliary storage
+ * available. Context Imprint mode requires an additional "associated context"
+ * to be provided along with the secret in order to protect the data.
+ *
+ * In Context Imprint mode no authentication token is computed or verified.
+ * This means the integrity of the data is not enforced, so the overall
+ * security level is slightly lower than in Seal or Token Protect modes.
+ *
+ * @note To ensure highest security level possible, supply a different
+ * associated context for each encryption invocation with the same secret.
+ *
+ * Read more about Context Imprint mode:
+ *
+ * https://docs.cossacklabs.com/pages/secure-cell-cryptosystem/#context-imprint-mode
+ */
 @interface TSCellContextImprint : TSCell
 
 /**

--- a/src/wrappers/themis/Obj-C/objcthemis/scell_context_imprint.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_context_imprint.m
@@ -25,8 +25,12 @@
     return self;
 }
 
+#pragma mark - Encryption
 
-- (nullable NSData *)wrapData:(NSData *)message context:(NSData *)context error:(NSError **)error {
+- (nullable NSData *)encrypt:(NSData *)message
+                     context:(NSData *)context
+                       error:(NSError **)error
+{
     size_t wrappedMessageLength = 0;
 
     TSErrorType encryptionResult = (TSErrorType) themis_secure_cell_encrypt_context_imprint([self.key bytes], [self.key length],
@@ -55,8 +59,22 @@
     return [NSData dataWithBytesNoCopy:wrappedMessage length:wrappedMessageLength];
 }
 
+- (nullable NSData *)encrypt:(NSData *)message context:(NSData *)context
+{
+    return [self encrypt:message context:context error:nil];
+}
 
-- (nullable NSData *)unwrapData:(NSData *)message context:(NSData *)context error:(NSError **)error {
+- (nullable NSData *)wrapData:(NSData *)message context:(NSData *)context error:(NSError **)error
+{
+    return [self encrypt:message context:context error:error];
+}
+
+#pragma mark - Decryption
+
+- (nullable NSData *)decrypt:(NSData *)message
+                     context:(NSData *)context
+                       error:(NSError **)error
+{
     size_t unwrappedMessageLength = 0;
 
     int decryptionResult = themis_secure_cell_decrypt_context_imprint([self.key bytes], [self.key length],
@@ -83,6 +101,16 @@
     }
 
     return [NSData dataWithBytesNoCopy:unwrappedMessage length:unwrappedMessageLength];
+}
+
+- (nullable NSData *)decrypt:(NSData *)message context:(NSData *)context
+{
+    return [self decrypt:message context:context error:nil];
+}
+
+- (nullable NSData *)unwrapData:(NSData *)message context:(NSData *)context error:(NSError **)error
+{
+    return [self decrypt:message context:context error:error];
 }
 
 @end

--- a/src/wrappers/themis/Obj-C/objcthemis/scell_seal.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_seal.h
@@ -47,43 +47,163 @@ NS_ASSUME_NONNULL_BEGIN
 @interface TSCellSeal : TSCell
 
 /**
-* @brief Initialize Secure cell object in seal mode
-* @param [in] key master key
-*/
+ * Initialise Secure Cell in Seal mode with a master key.
+ *
+ * @param [in] key  non-empty master key
+ *
+ * @returns @c nil if key is empty.
+ */
 - (nullable instancetype)initWithKey:(NSData *)key;
 
 /**
-* @brief Wrap message
-* @param [in] message message to wrap
-* @param [in] error pointer to Error on failure
-* @return Wrapped message as NSData object on success or nil on failure
-*/
-- (nullable NSData *)wrapData:(NSData *)message error:(NSError *__autoreleasing *)error;
+ * Encrypt data.
+ *
+ * @param [in]  message data to encrypt, must not be empty
+ * @param [in]  context optional associated context
+ * @param [out] error   optional error output
+ *
+ * Data is encrypted and authentication token is appended to form a single sealed buffer.
+ *
+ * The context, if provided, is cryptographically mixed with the data, but is not included
+ * into the resulting encrypted message. You will have to provide the same context again
+ * during decryption. Usually this is some plaintext data associated with encrypted data,
+ * such as database row number, protocol message ID, etc.
+ *
+ * @returns Encrypted data is returned as a single buffer.
+ *
+ * @returns @c nil will be returned on failure, such as if @c message is empty
+ * or in case of some internal failure in cryptographic backend.
+ *
+ * @returns If @c error is not @c nil, it will describe the reason of failure.
+ */
+- (nullable NSData *)encrypt:(NSData *)message
+                     context:(nullable NSData *)context
+                       error:(NSError **)error;
 
 /**
-* @brief Unwrap message
-* @param [in] message message to unwrap
-* @param [in] error pointer to Error on failure
-* @return Unwrapped message as NSData object on success or nil on failure
-*/
-- (nullable NSData *)unwrapData:(NSData *)message error:(NSError *__autoreleasing *)error;
+ * Encrypt data.
+ *
+ * @param [in]  message data to encrypt, must not be empty
+ * @param [out] error   optional error output
+ *
+ * Data is encrypted and authentication token is appended to form a single sealed buffer.
+ *
+ * This call is equivalent to encryption with @c nil associated context.
+ *
+ * @returns Encrypted data is returned as a single buffer.
+ *
+ * @returns @c nil will be returned on failure, such as if @c message is empty
+ * or in case of some internal failure in cryptographic backend.
+ *
+ * @returns If @c error is not @c nil, it will describe the reason of failure.
+ */
+- (nullable NSData *)encrypt:(NSData *)message error:(NSError **)error;
 
 /**
-* @brief Wrap message with context
-* @param [in] message message to wrap
-* @param [in] context user context
-* @param [in] error pointer to Error on failure
-* @return Wrapped message as NSData object on success or nil on failure
-*/
-- (nullable NSData *)wrapData:(NSData *)message context:(nullable NSData *)context error:(NSError *__autoreleasing *)error;
+ * Encrypt data.
+ * @see encrypt:context:error:
+ */
+- (nullable NSData *)encrypt:(NSData *)message context:(nullable NSData *)context
+    NS_SWIFT_UNAVAILABLE("use throwing encrypt(_:,context:)");
 
 /**
-* @brief Unwrap message
-* @param [in] message message to unwrap
-* @param [in] error pointer to Error on failure
-* @return Unwrapped message as NSData object on success or nil on failure
-*/
-- (nullable NSData *)unwrapData:(NSData *)message context:(nullable NSData *)context error:(NSError *__autoreleasing *)error;
+ * Encrypt data.
+ * @see encrypt:context:error:
+ */
+- (nullable NSData *)encrypt:(NSData *)message
+    NS_SWIFT_UNAVAILABLE("use throwing encrypt");
+
+/**
+ * Encrypt data.
+ * @deprecated since Themis 0.13
+ * @see encrypt:context:error:
+ */
+- (nullable NSData *)wrapData:(NSData *)message context:(nullable NSData *)context error:(NSError **)error
+    __deprecated_msg("use 'encrypt:context:error:' instead");
+
+/**
+ * Encrypt data.
+ * @deprecated since Themis 0.13
+ * @see encrypt:error:
+ */
+- (nullable NSData *)wrapData:(NSData *)message error:(NSError **)error
+    __deprecated_msg("use 'encrypt:error:' instead");
+
+/**
+ * Decrypt data.
+ *
+ * @param [in]  message data to decrypt, cannot be empty
+ * @param [in]  context optional associated context
+ * @param [out] error   optional error output
+ *
+ * Secure Cell validates association with the context data, decrypts the message,
+ * and verifies data integrity using authentication data embedded into the message.
+ *
+ * You need to provide the same context as used during encryption
+ * (or use @c nil or empty context if there was no context).
+ *
+ * @returns Decrypted data is returned if everything goes well.
+ *
+ * @returns @c nil will be returned on failure, such as if @c message is empty,
+ * or if the data has been tampered with, or the secret or associated context
+ * are not the same as were used to encrypt the data.
+ *
+ * @returns If @c error is not @c nil, it will describe the reason of failure.
+ */
+- (nullable NSData *)decrypt:(NSData *)message
+                     context:(nullable NSData *)context
+                       error:(NSError **)error;
+
+/**
+ * Decrypt data.
+ *
+ * @param [in]  message data to decrypt, cannot be empty
+ * @param [out] error   optional error output
+ *
+ * Secure Cell decrypts the message and verifies data integrity using
+ * authentication data embedded into the message.
+ *
+ * This call is equivalent to decryption with @c nil associated context.
+ *
+ * @returns Decrypted data is returned if everything goes well.
+ *
+ * @returns @c nil will be returned on failure, such as if @c message is empty,
+ * or if the data has been tampered with, or the secret or associated context
+ * are not the same as were used to encrypt the data.
+ *
+ * @returns If @c error is not @c nil, it will describe the reason of failure.
+ */
+- (nullable NSData *)decrypt:(NSData *)message error:(NSError **)error;
+
+/**
+ * Decrypt data.
+ * @see decrypt:context:error:
+ */
+- (nullable NSData *)decrypt:(NSData *)message context:(nullable NSData *)context
+    NS_SWIFT_UNAVAILABLE("use throwing decrypt(_:,context:)");
+
+/**
+ * Decrypt data.
+ * @see decrypt:context:error:
+ */
+- (nullable NSData *)decrypt:(NSData *)message
+    NS_SWIFT_UNAVAILABLE("use throwing decrypt");
+
+/**
+ * Decrypt data.
+ * @deprecated since Themis 0.13
+ * @see decrypt:context:error:
+ */
+- (nullable NSData *)unwrapData:(NSData *)message context:(nullable NSData *)context error:(NSError **)error
+    __deprecated_msg("use 'decrypt:context:error:' instead");
+
+/**
+ * Decrypt data.
+ * @deprecated since Themis 0.13
+ * @see decrypt:error:
+ */
+- (nullable NSData *)unwrapData:(NSData *)message error:(NSError **)error
+    __deprecated_msg("use 'decrypt:error:' instead");
 
 @end
 

--- a/src/wrappers/themis/Obj-C/objcthemis/scell_seal.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_seal.h
@@ -29,21 +29,34 @@
 * @{
 */
 
-/** @brief Secure Cell Seal mode interface
-*
-* This is the most secure and easy way to protect stored data. All one have to do is to provide some secret
-* (password, secret key etc) to the API and the data itself.
-* The data will be encrypted and an authentication tag will be appended to the data, so the size of the encrypted data
-* will be larger than original. Also, users of this object mode can bind the data to some context
-* (for example, database row number), so decryption of the data with incorrect context will fail
-* (even if the secret will be correct). This allows establishing cryptographically secure associations between
-* protected data and its context. In example with database row numbers, it will prevent encrypted data from tampering
-* by attacker (for example, forcing the system to accept wrong hash to check credentials by displacing
-* row numbers or primary key values).
-* @image html scell-seal.png "Secure Cell Seal mode"
-*/
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ * Secure Cell in Seal mode.
+ *
+ * This is the most secure and easy way to protect stored data. You provide
+ * some secret (a master key) and the data then receive encrypted data back.
+ *
+ * Secure Cell in Seal mode will encrypt the data and append an "authentication
+ * tag" to it with auxiliary security information. This means that that size
+ * of the encrypted data will be larger than the original input.
+ *
+ * Additionally, it is possible to bind the encrypted data to some "associated
+ * context" (for example, database row number). In this case decryption of the
+ * data with incorrect context will fail (even if the secret is correct and
+ * the data has not been tampered). This establishes cryptographically secure
+ * association between the protected data and the context in which it is used.
+ * With database row numbers, for example, this prevents the attacker from
+ * swapping encrypted password hashes in the database so the system will not
+ * accept credentials of a different user.
+ *
+ * @note Use @c TSGenerateSymmetricKey() to generate master keys suitable
+ * for Secure Cell.
+ *
+ * Read more about Seal mode:
+ *
+ * https://docs.cossacklabs.com/pages/secure-cell-cryptosystem/#seal-mode
+ */
 @interface TSCellSeal : TSCell
 
 /**

--- a/src/wrappers/themis/Obj-C/objcthemis/scell_seal.m
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_seal.m
@@ -25,18 +25,12 @@
     return self;
 }
 
+#pragma mark - Encryption
 
-- (nullable NSData *)wrapData:(NSData *)message error:(NSError *__autoreleasing *)error {
-    return [self wrapData:message context:nil error:error];
-}
-
-
-- (nullable NSData *)unwrapData:(NSData *)message error:(NSError *__autoreleasing *)error {
-    return [self unwrapData:message context:nil error:error];
-}
-
-
-- (nullable NSData *)wrapData:(NSData *)message context:(nullable NSData *)context error:(NSError *__autoreleasing *)error {
+- (nullable NSData *)encrypt:(NSData *)message
+                     context:(nullable NSData *)context
+                       error:(NSError **)error
+{
     size_t wrappedMessageLength = 0;
 
     const void *contextData = [context bytes];
@@ -73,7 +67,37 @@
     return [NSData dataWithBytesNoCopy:wrappedMessage length:wrappedMessageLength];
 }
 
-- (nullable NSData *)unwrapData:(NSData *)message context:(nullable NSData *)context error:(NSError *__autoreleasing *)error {
+- (nullable NSData *)encrypt:(NSData *)message context:(nullable NSData *)context
+{
+    return [self encrypt:message context:context error:nil];
+}
+
+- (nullable NSData *)encrypt:(NSData *)message error:(NSError **)error
+{
+    return [self encrypt:message context:nil error:error];
+}
+
+- (nullable NSData *)encrypt:(NSData *)message
+{
+    return [self encrypt:message context:nil error:nil];
+}
+
+- (nullable NSData *)wrapData:(NSData *)message context:(nullable NSData *)context error:(NSError **) error
+{
+    return [self encrypt:message context:context error:error];
+}
+
+- (nullable NSData *)wrapData:(NSData *)message error:(NSError **)error
+{
+    return [self encrypt:message context:nil error:error];
+}
+
+#pragma mark - Decryption
+
+- (nullable NSData *)decrypt:(NSData *)message
+                     context:(nullable NSData *)context
+                       error:(NSError **)error
+{
     size_t unwrappedMessageLength = 0;
 
     const void *contextData = [context bytes];
@@ -109,6 +133,31 @@
     }
 
     return [NSData dataWithBytesNoCopy:unwrappedMessage length:unwrappedMessageLength];
+}
+
+- (nullable NSData *)decrypt:(NSData *)message context:(nullable NSData *)context
+{
+    return [self decrypt:message context:context error:nil];
+}
+
+- (nullable NSData *)decrypt:(NSData *)message error:(NSError **)error
+{
+    return [self decrypt:message context:nil error:error];
+}
+
+- (nullable NSData *)decrypt:(NSData *)message
+{
+    return [self decrypt:message context:nil error:nil];
+}
+
+- (nullable NSData *)unwrapData:(NSData *)message context:(nullable NSData *)context error:(NSError **)error
+{
+    return [self decrypt:message context:context error:error];
+}
+
+- (nullable NSData *)unwrapData:(NSData *)message error:(NSError **)error
+{
+    return [self decrypt:message context:nil error:error];
 }
 
 @end

--- a/src/wrappers/themis/Obj-C/objcthemis/scell_token.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_token.h
@@ -61,20 +61,32 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-/** @brief Secure Cell Context Token Protect interface
-*
-* This object mode is designed for cases when underlying storage constraints do not allow the size of the data to grow
-* (so @ref TSCellSeal "Secure cell seal" cannot be used), however the user has access to a different storage location
-* (ex. another table in the database) where he can store needed security parameters.
-* The Secure Cell object puts authentication tag and other auxiliary information (aka data token) to a separate buffer,
-* so user can store it elsewhere, while keeping the original encrypted data size.
-* The same token has to be provided along with the correct secret for data to be decrypted successfully.
-* Since the same security parameters are used (just stored in a different location) this object mode has same security
-* level as @ref TSCellSeal "Secure cell seal" but requires slightly more effort from the user.
-* Also, user has the ability to bind the data to its context as before.
-* @image html scell-token_protect.png "Secure Cell Token protect mode"
-*/
 
+/**
+ * Secure Cell in Token Protect mode.
+ *
+ * Token Protect mode is designed for cases when underlying storage constraints
+ * do not allow the size of the data to grow (so @c TSCellSeal cannot be used).
+ * However, if you have access to a different storage location (e.g., another
+ * table in the database) where additional security parameters can be stored
+ * then Token Protect mode can be used instead of Seal mode.
+ *
+ * Token Protect mode produces authentication tag and other auxiliary data
+ * (aka "authentication token") in a detached buffer. This keeps the original
+ * size of the encrypted data while enabling separate storage of security
+ * information. Note that the same token must be provided along with the
+ * correct secret and matching associated context in order for the data
+ * to be decrypted successfully.
+ *
+ * Since @c TSCellToken uses the same security parameters as @c TSCellSeal
+ * (just stored in a different location), these modes have the same highest
+ * security level. Token Protect mode only requires slightly more effort
+ * in exchange for preserving the original data size.
+ *
+ * @note Read more about Token Protect mode:
+ *
+ * https://docs.cossacklabs.com/pages/secure-cell-cryptosystem/#token-protect-mode
+ */
 @interface TSCellToken : TSCell
 
 /**

--- a/src/wrappers/themis/Obj-C/objcthemis/scell_token.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_token.h
@@ -41,6 +41,25 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+/**
+ * Encryption result returned by Secure Cell in Token Protect mode.
+ */
+@interface TSCellTokenEncryptedResult : NSObject
+
+/** Encrypted data. */
+@property (nonatomic, readonly) NSData *encrypted;
+/** Authentication token. */
+@property (nonatomic, readonly) NSData *token;
+
+/**
+ * Encrypted data.
+ * @deprecated since Themis 0.13
+ * @see encrypted
+ */
+@property (nonatomic, readonly) NSData *cipherText
+    __deprecated_msg("use 'encrypted' instead");
+
+@end
 
 /** @brief Secure Cell Context Token Protect interface
 *
@@ -59,44 +78,168 @@ NS_ASSUME_NONNULL_BEGIN
 @interface TSCellToken : TSCell
 
 /**
-* @brief Initialize Secure cell object in context token mode
-* @param [in] key master key
-*/
+ * Initialise Secure Cell in Token Protect mode with a master key.
+ *
+ * @param [in] key  non-empty master key
+ *
+ * @returns @c nil if key is empty.
+ */
 - (nullable instancetype)initWithKey:(NSData *)key;
 
 /**
-* @brief Wrap message
-* @param [in] message message to wrap
-* @param [in] error pointer to Error on failure
-* @return Wrapped message as NSData object on success or nil on failure
-*/
-- (nullable TSCellTokenEncryptedData *)wrapData:(NSData *)message error:(NSError *__autoreleasing *)error;
+ * Encrypt data.
+ *
+ * @param [in]  message data to encrypt, must not be empty
+ * @param [in]  context optional associated context
+ * @param [out] error   optional error output
+ *
+ * Data is encrypted and authentication token is produced separately.
+ *
+ * The context, if provided, is cryptographically mixed with the data, but it not included
+ * into the resulting encrypted message. You will have to provide the same context again
+ * during decryption. Usually this is some plaintext data associated with encrypted data,
+ * such as database row number, protocol message ID, etc.
+ *
+ * @returns Successful encryption returns an object containing encrypted data and
+ * authentication token.
+ *
+ * @returns @c nil will be returned on failure, such as if @c message is empty
+ * or in case of some internal failure in cryptographic backend.
+ *
+ * @returns If @c error is not @c nil, it will describe the reason of failure.
+ */
+- (nullable TSCellTokenEncryptedResult *)encrypt:(NSData *)message
+                                         context:(nullable NSData *)context
+                                           error:(NSError **)error;
 
 /**
-* @brief Unwrap message
-* @param [in] message message to unwrap
-* @param [in] error pointer to Error on failure
-* @return Unwrapped message as NSData object on success or nil on failure
-*/
-- (nullable NSData *)unwrapData:(TSCellTokenEncryptedData *)message error:(NSError *__autoreleasing *)error;
+ * Encrypt data.
+ *
+ * @param [in]  message data to encrypt, must not be empty
+ * @param [out] error   optional error output
+ *
+ * Data is encrypted and authentication token is produced separately.
+ *
+ * This call is equivalent to encryption with @c nil associated context.
+ *
+ * @returns Successful encryption returns an object containing encrypted data and
+ * authentication token.
+ *
+ * @returns @c nil will be returned on failure, such as if @c message is empty
+ * or in case of some internal failure in cryptographic backend.
+ *
+ * @returns If @c error is not @c nil, it will describe the reason of failure.
+ */
+- (nullable TSCellTokenEncryptedResult *)encrypt:(NSData *)message error:(NSError **)error;
 
 /**
-* @brief Wrap message with context
-* @param [in] message message to wrap
-* @param [in] context user context
-* @param [in] error pointer to Error on failure
-* @return Wrapped message as NSData object on success or nil on failure
-*/
-- (nullable TSCellTokenEncryptedData *)wrapData:(NSData *)message context:(nullable NSData *)context error:(NSError *__autoreleasing *)error;
+ * Encrypt data.
+ * @see encrypt:context:error:
+ */
+- (nullable TSCellTokenEncryptedResult *)encrypt:(NSData *)message context:(nullable NSData *)context
+    NS_SWIFT_UNAVAILABLE("use throwing encrypt(_:,context:)");
 
 /**
-* @brief Unwrap message with context
-* @param [in] message message to unwrap
-* @param [in] context user context
-* @param [in] error pointer to Error on failure
-* @return Unwrapped message as NSData object on success or nil on failure
-*/
-- (nullable NSData *)unwrapData:(TSCellTokenEncryptedData *)message context:(nullable NSData *)context error:(NSError *__autoreleasing *)error;
+ * Encrypt data.
+ * @see encrypt:context:error:
+ */
+- (nullable TSCellTokenEncryptedResult *)encrypt:(NSData *)message
+    NS_SWIFT_UNAVAILABLE("use throwing encrypt");
+
+/**
+ * Encrypt data.
+ * @deprecated since Themis 0.13
+ * @see encrypt:context:error:
+ */
+- (nullable TSCellTokenEncryptedData *)wrapData:(NSData *)message context:(nullable NSData *)context error:(NSError **)error
+    __deprecated_msg("use 'encrypt:context:error:' instead");
+
+/**
+ * Encrypt data.
+ * @deprecated since Themis 0.13
+ * @see encrypt:error:
+ */
+- (nullable TSCellTokenEncryptedData *)wrapData:(NSData *)message error:(NSError **)error
+    __deprecated_msg("use 'encrypt:error:' instead");
+
+/**
+ * Decrypt data.
+ *
+ * @param [in]  message data to decrypt, cannot be empty
+ * @param [in]  token   authentication token to verify, cannot be empty
+ * @param [in]  context optional associated context
+ * @param [out] error   optional error output
+ *
+ * Secure Cell validates association with the context data, decrypts the message,
+ * and verifies data integrity using the provided authentication token.
+ *
+ * You need to provide the same context as it was used during encryption
+ * (or use @c nil or empty context if there was no context).
+ *
+ * @returns Decrypted data is returned if everything goes well.
+ *
+ * @returns @c nil will be returned on failure, such as if @c message or @c token
+ * is empty, or if the data has been tampered with, or the secret or associated context
+ * are not the same as were used to encrypt the data.
+ *
+ * @returns If @c error is not @c nil, it will describe the reason of failure.
+ */
+- (nullable NSData *)decrypt:(NSData *)message
+                       token:(NSData *)token
+                     context:(nullable NSData *)context
+                       error:(NSError **)error;
+
+/**
+ * Decrypt data.
+ *
+ * @param [in]  message data to decrypt, cannot be empty
+ * @param [in]  token   authentication token to verify, cannot be empty
+ * @param [out] error   optional error output
+ *
+ * Secure Cell decrypts the message and verifies data integrity using
+ * the provided authentication token.
+ *
+ * This call is equivalent to decryption with @c nil associated context.
+ *
+ * @returns Decrypted data is returned if everything goes well.
+ *
+ * @returns @c nil will be returned on failure, such as if @c message or @c token
+ * is empty, or if the data has been tampered with, or the secret or associated context
+ * are not the same as were used to encrypt the data.
+ *
+ * @returns If @c error is not @c nil, it will describe the reason of failure.
+ */
+- (nullable NSData *)decrypt:(NSData *)message token:(NSData *)token error:(NSError **)error;
+
+/**
+ * Decrypt data.
+ * @see decrypt:token:context:error:
+ */
+- (nullable NSData *)decrypt:(NSData *)message token:(NSData *)token context:(nullable NSData *)context
+    NS_SWIFT_UNAVAILABLE("use throwing decrypt(_:,token:,context:)");
+
+/**
+ * Decrypt data.
+ * @see decrypt:token:context:error:
+ */
+- (nullable NSData *)decrypt:(NSData *)message token:(NSData *)token
+    NS_SWIFT_UNAVAILABLE("use throwing decrypt(_:,context:)");
+
+/**
+ * Decrypt data.
+ * @deprecated since Themis 0.13
+ * @see decrypt:token:context:error:
+ */
+- (nullable NSData *)unwrapData:(TSCellTokenEncryptedData *)message context:(nullable NSData *)context error:(NSError **)error
+    __deprecated_msg("use 'decrypt:token:context:error:' instead");
+
+/**
+ * Decrypt data.
+ * @deprecated since Themis 0.13
+ * @see decrypt:token:error:
+ */
+- (nullable NSData *)unwrapData:(TSCellTokenEncryptedData *)message error:(NSError **)error
+    __deprecated_msg("use 'decrypt:token:error:' instead");
 
 @end
 

--- a/tests/objcthemis/objthemis/SecureCellTestsSwift.swift
+++ b/tests/objcthemis/objthemis/SecureCellTestsSwift.swift
@@ -7,17 +7,9 @@
 
 import XCTest
 
-class SecureCellTestsSwift: XCTestCase {
-    
-    var masterKeyData: Data!
-    
-    override func setUp() {
-        super.setUp()
-        
-        self.masterKeyData = generateMasterKey()
-    }
+// MARK: - Key generation
 
-    // MARK: - Key generation
+class SecureCellKeygenSwift: XCTestCase {
 
     let defaultKeyLength = 32
 
@@ -27,216 +19,649 @@ class SecureCellTestsSwift: XCTestCase {
         XCTAssertNotNil(masterKey, "TSGenerateSymmetricKey() should not fail")
         XCTAssertEqual(masterKey!.count, defaultKeyLength, "generated key must be not empty")
     }
+}
 
-    // MARK: - Seal
+// MARK: - Seal Mode
 
-    func generateMasterKey() -> Data {
-        let masterKeyString: String = "UkVDMgAAAC13PCVZAKOczZXUpvkhsC+xvwWnv3CLmlG0Wzy8ZBMnT+2yx/dg"
-        let masterKeyData: Data = Data(base64Encoded: masterKeyString, options: .ignoreUnknownCharacters)!
-        return masterKeyData
-    }
-    
-    func testSecureCellSealModeInit() {
-        let cellSeal: TSCellSeal = TSCellSeal(key: masterKeyData)!
-        XCTAssertNotNil(cellSeal, "secure cell encrypter (seal mode) should not be created without key")
-        
-        let cellSealWrong = TSCellSeal(key: Data())
-        XCTAssertNil(cellSealWrong, "secure cell encrypter (seal mode) creation error")
-    }
-    
-    func testSecureCellSealModeWithContext() {
-        let cellSeal: TSCellSeal = TSCellSeal(key: masterKeyData)!
-        let message: String = "All your base are belong to us!"
-        let context: String = "For great justice"
-        
-        let encryptedMessage = try? cellSeal.wrap(message.data(using: .utf8)!,
-                                                  context: context.data(using: .utf8)!)
-        XCTAssertNotNil(encryptedMessage, "encryption with data and context should be successful")
-        
-        
-        var decryptedMessage = try? cellSeal.unwrapData(encryptedMessage!,
-                                                  context: nil)
-        XCTAssertNil(decryptedMessage, "decryption without context should return nil data")
-        
-        decryptedMessage = try? cellSeal.unwrapData(encryptedMessage!,
-                                                    context: context.data(using: .utf8))
-        XCTAssertNotNil(decryptedMessage, "decryption with data and context should be successful")
-        
-        let resultString = String(data: decryptedMessage!, encoding: .utf8)
-        XCTAssertTrue((message == resultString), "initial string and decrypted string should be the same")
-    }
-    
-    func testSecureCellSealModeWithoutContext() {
-        let cellSeal: TSCellSeal = TSCellSeal(key: masterKeyData)!
-        let message: String = "All your base are belong to us!"
-        let context: String = "For great justice"
-        
-        let encryptedMessageNoContext = try? cellSeal.wrap(message.data(using: .utf8)!,
-                                                  context: nil)
-        XCTAssertNotNil(encryptedMessageNoContext, "encryption with data and without context should return data")
-        
-        
-        var decryptedMessageNoContext = try? cellSeal.unwrapData(encryptedMessageNoContext!,
-                                                        context: context.data(using: .utf8))
-        XCTAssertNil(decryptedMessageNoContext, "decrypt data with context that was encypted without context should return nil data")
-        
-        decryptedMessageNoContext = try? cellSeal.unwrapData(encryptedMessageNoContext!,
-                                                    context: nil)
-        XCTAssertNotNil(decryptedMessageNoContext, "decryption without context should be successful")
-        
-        let resultString = String(data: decryptedMessageNoContext!, encoding: .utf8)
-        XCTAssertTrue((message == resultString), "initial string and decrypted string should be the same")
-    }
-    
-    func testSecureCellSealModeEncryptionDecryptionMixed() {
-        let cellSeal: TSCellSeal = TSCellSeal(key: masterKeyData)!
-        let message: String = "All your base are belong to us!"
-        let context: String = "For great justice"
-        
-        let encryptedMessage = try? cellSeal.wrap(message.data(using: .utf8)!,
-                                                  context: context.data(using: .utf8)!)
-        let encryptedMessageNoContext = try? cellSeal.wrap(message.data(using: .utf8)!,
-                                                  context: nil)
-        
-        XCTAssertFalse((encryptedMessage == encryptedMessageNoContext), "secure cell encrypter (seal mode) encryption result with and without context can`t be equal")
+class SecureCellSealSwift: XCTestCase {
+
+    func testInitWithGenerated() {
+        let cell = TSCellSeal(key: TSGenerateSymmetricKey()!)
+        XCTAssertNotNil(cell)
     }
 
-    func testSecureCellSealModeWrongContext() {
-        let cellSeal: TSCellSeal = TSCellSeal(key: masterKeyData)!
-        let message: String = "All your base are belong to us!"
-        let context: String = "For great justice"
-        let wrongContext: String = "Or not"
-        
-        let encryptedMessage = try? cellSeal.wrap(message.data(using: .utf8)!,
-                                                  context: context.data(using: .utf8)!)
-        XCTAssertNotNil(encryptedMessage, "encryption with data and without context should return data")
-        
-        
-        let decryptedMessageWrongContext = try? cellSeal.unwrapData(encryptedMessage!,
-                                                                    context: wrongContext.data(using: .utf8)!)
-        XCTAssertNil(decryptedMessageWrongContext, "decrypt data with wrong context should return nil data")
-    }
-    
-    // MARK: - Token Protect
-    
-    func testSecureCellTokenProtectModeInit() {
-        let cellToken: TSCellToken = TSCellToken(key: masterKeyData)!
-        XCTAssertNotNil(cellToken, "secure cell encrypter (token protect mode) creation error")
-        
-        let cellTokenWrong = TSCellToken(key: Data())
-        XCTAssertNil(cellTokenWrong, "secure cell encrypter (token protect mode) should not be created without key")
-    }
-    
-    func testSecureCellTokenProtectModeWithContext() {
-        let cellToken: TSCellToken = TSCellToken(key: masterKeyData)!
-        let message: String = "Roses are grey. Violets are grey."
-        let context: String = "I'm a dog"
-        let messageData: Data = message.data(using: .utf8)!
-    
-        let encryptedMessage = try? cellToken.wrap(messageData,
-                                              context: context.data(using: .utf8)!)
-        XCTAssertNotNil(encryptedMessage, "encryption with data and context should be successful")
-        XCTAssertEqual(encryptedMessage?.cipherText.length, messageData.count)
-        
-        var decryptedMessage = try? cellToken.unwrapData(encryptedMessage!,
-                                                        context: nil)
-        XCTAssertNil(decryptedMessage, "decryption without context should return nil data")
-        
-        decryptedMessage = try? cellToken.unwrapData(encryptedMessage!,
-                                                    context: context.data(using: .utf8)!)
-        XCTAssertNotNil(decryptedMessage, "decryption with data and context should be successful")
-        
-        let resultString = String(data: decryptedMessage!, encoding: .utf8)
-        XCTAssertTrue((message == resultString), "initial string and decrypted string should be the same")
-    }
-    
-    func testSecureCellTokenProtectModeWithoutContext() {
-        let cellToken: TSCellToken = TSCellToken(key: masterKeyData)!
-        let message: String = "Roses are grey. Violets are grey."
-        let context: String = "I'm a dog"
-        let messageData: Data = message.data(using: .utf8)!
-        
-        let encryptedMessageNoContext = try? cellToken.wrap(messageData,
-                                               context: nil)
-        XCTAssertNotNil(encryptedMessageNoContext, "encryption without data-to-encrypt, without context should be successful")
-        XCTAssertEqual(encryptedMessageNoContext?.cipherText.length, messageData.count)
-        
-        var decryptedMessageNoContext = try? cellToken.unwrapData(encryptedMessageNoContext!,
-                                                         context: context.data(using: .utf8))
-        XCTAssertNil(decryptedMessageNoContext, "decrypt data with context that was encypted without context should return nil data")
-        
-        decryptedMessageNoContext = try? cellToken.unwrapData(encryptedMessageNoContext!,
-                                                              context: nil)
-        XCTAssertNotNil(decryptedMessageNoContext, "decryption without context should be successful")
-        
-        let resultString = String(data: decryptedMessageNoContext!, encoding: .utf8)
-        XCTAssertTrue((message == resultString), "initial string and decrypted string should be the same")
-    }
-    
-    func testSecureCellTokenProtectModeIncorrectContext() {
-        let cellToken: TSCellToken = TSCellToken(key: masterKeyData)!
-        let message: String = "Roses are grey. Violets are grey."
-        let context: String = "I'm a dog"
-        let wrongContext: String = "I'm a cat"
-        
-        let encryptedMessage = try? cellToken.wrap(message.data(using: .utf8)!,
-                                                            context: context.data(using: .utf8))
-        
-        let decryptedMessageWrongContext = try? cellToken.unwrapData(encryptedMessage!,
-                                                                  context: wrongContext.data(using: .utf8))
-        XCTAssertNil(decryptedMessageWrongContext, "decrypt data with wrong context should return nil data")
-    }
-    
-    // MARK: - Token Imprint
-    
-    func testSecureCellContextImprintModeInit() {
-        let contextImprint: TSCellContextImprint = TSCellContextImprint(key: masterKeyData)!
-        XCTAssertNotNil(contextImprint, "secure cell encrypter (token imprint mode) creation error")
-        
-        let contextImprintWrong = TSCellContextImprint(key: Data())
-        XCTAssertNil(contextImprintWrong, "secure cell encrypter (token imprint mode) should not be created without key")
-    }
-    
-    func testSecureCellContextImprint() {
-        let contextImprint: TSCellContextImprint = TSCellContextImprint(key: masterKeyData)!
-        let message: String = "Roses are red. My name is Dave. This poem have no sense"
-        let context: String = "Microwave"
-        
-        let encryptedMessageEmptyContext = try? contextImprint.wrap(message.data(using: .utf8)!,
-                                                                    context: Data())
-        XCTAssertNil(encryptedMessageEmptyContext, "encryption with data-to-encrypt, and empty context should return nil data")
-        
-        let encryptedMessageNoContext = try? contextImprint.wrap(message.data(using: .utf8)!,
-                                                                 context: context.data(using: .utf8)!)
-        XCTAssertNotNil(encryptedMessageNoContext, "encryption with data-to-encrypt, and context should be successful")
+    func testInitWithFixed() {
+        let masterKeyString = "UkVDMgAAAC13PCVZAKOczZXUpvkhsC+xvwWnv3CLmlG0Wzy8ZBMnT+2yx/dg"
+        let masterKeyData = Data(base64Encoded: masterKeyString)!
 
-        let decryptedMessageNoContext = try? contextImprint.unwrapData(encryptedMessageNoContext!,
-                                                                       context: context.data(using: .utf8)!)
-        XCTAssertNotNil(decryptedMessageNoContext, "decrypt data with context that was encypted without context should return nil data")
-        
-        let decryptedMessageEmptyContext = try? contextImprint.unwrapData(encryptedMessageNoContext!,
-                                                                          context: Data())
-        XCTAssertNil(decryptedMessageEmptyContext, "decrypt data and empty context should return nil data")
-        
-        let resultString = String(data: decryptedMessageNoContext!, encoding: .utf8)
-        XCTAssertTrue((message == resultString), "initial string and decrypted string should be the same")
+        let cell = TSCellSeal(key: masterKeyData)
+        XCTAssertNotNil(cell)
     }
-    
-    func testSecureCellContextImprintIncorrectContext() {
-        let contextImprint: TSCellContextImprint = TSCellContextImprint(key: masterKeyData)!
-        let message: String = "Roses are red. My name is Dave. This poem have no sense"
-        let context: String = "Microwave"
-        let wrongContext: String = "Oven"
-        
-        let encryptedMessage = try? contextImprint.wrap(message.data(using: .utf8)!,
-                                                        context: context.data(using: .utf8)!)
 
-        let decryptedMessageWrongContext = try? contextImprint.unwrapData(encryptedMessage!,
-                                                                          context: wrongContext.data(using: .utf8)!)
-        XCTAssertNotNil(decryptedMessageWrongContext, "decrypt data with wrong context should ignore context")
-        
-        let decryptedMessageEmptyContext = try? contextImprint.unwrapData(encryptedMessage!,
-                                                                          context: Data())
-        XCTAssertNil(decryptedMessageEmptyContext, "decrypt data with empty context should return nil data")
+    func testInitWithEmpty() {
+        XCTAssertNil(TSCellSeal(key: Data()))
+    }
+
+    func testRoundtrip() {
+        let cell = TSCellSeal(key: TSGenerateSymmetricKey()!)!
+        let message = "All your base are belong to us!"
+        let context = "For great justice"
+
+        let encrypted = try? cell.encrypt(message.data(using: .utf8)!,
+                                          context: context.data(using: .utf8)!)
+        XCTAssertNotNil(encrypted)
+
+        let decrypted = try? cell.decrypt(encrypted!,
+                                          context: context.data(using: .utf8)!)
+        XCTAssertNotNil(decrypted)
+
+        let decryptedMessage = String(data: decrypted!, encoding: .utf8)
+        XCTAssertNotNil(decryptedMessage)
+
+        XCTAssertEqual(decryptedMessage, message)
+    }
+
+    func testDataLengthExtension() {
+        let cell = TSCellSeal(key: TSGenerateSymmetricKey()!)!
+        let message = "All your base are belong to us!".data(using: .utf8)!
+
+        let encrypted = try! cell.encrypt(message)
+
+        XCTAssertGreaterThan(encrypted.count, message.count)
+    }
+
+    func testContextInclusion() {
+        let cell = TSCellSeal(key: TSGenerateSymmetricKey()!)!
+        let message = "All your base are belong to us!".data(using: .utf8)!
+        let shortContext = ".".data(using: .utf8)!
+        let longContext = "You have no chance to survive make your time. Ha ha ha ha ...".data(using: .utf8)!
+
+        let encryptedShort = try! cell.encrypt(message, context: shortContext)
+        let encryptedLong = try! cell.encrypt(message, context: longContext)
+
+        // Context is not (directly) included into encrypted message.
+        XCTAssertEqual(encryptedShort.count, encryptedLong.count)
+    }
+
+    func testWithoutContext() {
+        let cell = TSCellSeal(key: TSGenerateSymmetricKey()!)!
+        let message = "All your base are belong to us!".data(using: .utf8)!
+
+        // Absent, empty, or nil context are all the same.
+        let encrypted1 = try! cell.encrypt(message)
+        let encrypted2 = try! cell.encrypt(message, context: nil)
+        let encrypted3 = try! cell.encrypt(message, context: Data())
+
+        XCTAssertEqual(message, try! cell.decrypt(encrypted1))
+        XCTAssertEqual(message, try! cell.decrypt(encrypted2))
+        XCTAssertEqual(message, try! cell.decrypt(encrypted3))
+
+        XCTAssertEqual(message, try! cell.decrypt(encrypted1, context:nil))
+        XCTAssertEqual(message, try! cell.decrypt(encrypted2, context:nil))
+        XCTAssertEqual(message, try! cell.decrypt(encrypted3, context:nil))
+
+        XCTAssertEqual(message, try! cell.decrypt(encrypted1, context:Data()))
+        XCTAssertEqual(message, try! cell.decrypt(encrypted2, context:Data()))
+        XCTAssertEqual(message, try! cell.decrypt(encrypted3, context:Data()))
+    }
+
+    func testContextSignificance() {
+        let cell = TSCellSeal(key: TSGenerateSymmetricKey()!)!
+        let message = "All your base are belong to us!".data(using: .utf8)!
+        let correctContext = "We are CATS".data(using: .utf8)!
+        let incorrectContext = "Captain !!".data(using: .utf8)!
+
+        let encrypted = try! cell.encrypt(message, context: correctContext)
+
+        // You cannot use a different context to decrypt data.
+        XCTAssertThrowsError(try cell.decrypt(encrypted, context: incorrectContext))
+
+        // Only the original context will work.
+        let decrypted = try! cell.decrypt(encrypted, context: correctContext)
+        XCTAssertEqual(decrypted, message)
+    }
+
+    func testDetectCorruptedData() {
+        let cell = TSCellSeal(key: TSGenerateSymmetricKey()!)!
+        let message = "All your base are belong to us!".data(using: .utf8)!
+
+        let encrypted = try! cell.encrypt(message)
+
+        var corrupted = Data(encrypted)
+        // Invert every odd byte, this will surely break the message.
+        for i in corrupted.indices where i % 2 == 1 {
+            corrupted[i] = ~corrupted[i]
+        }
+
+        XCTAssertThrowsError(try cell.decrypt(corrupted))
+    }
+
+    func testDetectTruncatedData() {
+        let cell = TSCellSeal(key: TSGenerateSymmetricKey()!)!
+        let message = "All your base are belong to us!".data(using: .utf8)!
+
+        let encrypted = try! cell.encrypt(message)
+
+        let truncated = encrypted.dropLast(1)
+
+        XCTAssertThrowsError(try cell.decrypt(truncated))
+    }
+
+    func testDetectExtendedData() {
+        let cell = TSCellSeal(key: TSGenerateSymmetricKey()!)!
+        let message = "All your base are belong to us!".data(using: .utf8)!
+
+        let encrypted = try! cell.encrypt(message)
+
+        var extended = Data(encrypted)
+        extended.append(0)
+
+        XCTAssertThrowsError(try cell.decrypt(extended))
+    }
+
+    func testEmptyMessage() {
+        let cell = TSCellSeal(key: TSGenerateSymmetricKey()!)!
+
+        XCTAssertThrowsError(try cell.encrypt(Data()))
+        XCTAssertThrowsError(try cell.decrypt(Data()))
+    }
+
+    @available(*, deprecated)
+    func testOldAPI() {
+        let cell = TSCellSeal(key: TSGenerateSymmetricKey()!)!
+        let message = "All your base are belong to us!".data(using: .utf8)!
+        let context = "For great justice".data(using: .utf8)!
+        var encrypted, decrypted: Data?
+
+        encrypted = try? cell.wrap(message, context: context)
+        XCTAssertNotNil(encrypted)
+
+        decrypted = try? cell.decrypt(encrypted!, context: context)
+        XCTAssertNotNil(decrypted)
+        XCTAssertEqual(decrypted, message)
+
+        encrypted = try? cell.encrypt(message, context: context)
+        XCTAssertNotNil(encrypted)
+
+        decrypted = try? cell.unwrapData(encrypted!, context: context)
+        XCTAssertNotNil(decrypted)
+        XCTAssertEqual(decrypted, message)
+    }
+
+    @available(*, deprecated)
+    func testOldAPIWithoutContext() {
+        let cell = TSCellSeal(key: TSGenerateSymmetricKey()!)!
+        let message = "All your base are belong to us!".data(using: .utf8)!
+        var encrypted, decrypted: Data?
+
+        encrypted = try? cell.wrap(message)
+        XCTAssertNotNil(encrypted)
+
+        decrypted = try? cell.decrypt(encrypted!)
+        XCTAssertNotNil(decrypted)
+        XCTAssertEqual(decrypted, message)
+
+        encrypted = try? cell.encrypt(message)
+        XCTAssertNotNil(encrypted)
+
+        decrypted = try? cell.unwrapData(encrypted!)
+        XCTAssertNotNil(decrypted)
+        XCTAssertEqual(decrypted, message)
+    }
+}
+
+// MARK: - Token Protect
+
+class SecureCellTokenProtectSwift: XCTestCase {
+
+    func testInitWithGenerated() {
+        let cell = TSCellToken(key: TSGenerateSymmetricKey()!)
+        XCTAssertNotNil(cell)
+    }
+
+    func testInitWithFixed() {
+        let masterKeyString = "UkVDMgAAAC13PCVZAKOczZXUpvkhsC+xvwWnv3CLmlG0Wzy8ZBMnT+2yx/dg"
+        let masterKeyData = Data(base64Encoded: masterKeyString)!
+
+        let cell = TSCellToken(key: masterKeyData)
+        XCTAssertNotNil(cell)
+    }
+
+    func testInitWithEmpty() {
+        XCTAssertNil(TSCellToken(key: Data()))
+    }
+
+    func testRoundtrip() {
+        let cell = TSCellToken(key: TSGenerateSymmetricKey()!)!
+        let message = "Roses are grey. Violets are grey."
+        let context = "I'm a dog"
+
+        let result = try? cell.encrypt(message.data(using: .utf8)!,
+                                       context: context.data(using: .utf8)!)
+        XCTAssertNotNil(result?.encrypted)
+        XCTAssertNotNil(result?.token)
+
+        let decrypted = try? cell.decrypt(result!.encrypted,
+                                          token: result!.token,
+                                          context: context.data(using: .utf8)!)
+        XCTAssertNotNil(decrypted)
+
+        let decryptedMessage = String(data: decrypted!, encoding: .utf8)
+        XCTAssertNotNil(decryptedMessage)
+
+        XCTAssertEqual(decryptedMessage, message)
+    }
+
+    func testDataLengthPreservation() {
+        let cell = TSCellToken(key: TSGenerateSymmetricKey()!)!
+        let message = "Roses are grey. Violets are grey.".data(using: .utf8)!
+
+        let result = try! cell.encrypt(message)
+
+        XCTAssertEqual(result.encrypted.count, message.count)
+        XCTAssertFalse(result.token.isEmpty)
+    }
+
+    func testContextInclusion() {
+        let cell = TSCellToken(key: TSGenerateSymmetricKey()!)!
+        let message = "Roses are grey. Violets are grey.".data(using: .utf8)!
+        let shortContext = "I'm a dog".data(using: .utf8)!
+        let longContext = "This is why cats are ultimately superior creatures.".data(using: .utf8)!
+
+        let resultShort = try! cell.encrypt(message, context: shortContext)
+        let resultLong = try! cell.encrypt(message, context: longContext)
+
+        // Context is not (directly) included into encrypted message.
+        XCTAssertEqual(resultShort.encrypted.count, resultShort.encrypted.count)
+        XCTAssertEqual(resultShort.token.count, resultLong.token.count)
+    }
+
+    func testWithoutContext() {
+        let cell = TSCellToken(key: TSGenerateSymmetricKey()!)!
+        let message = "Roses are grey. Violets are grey.".data(using: .utf8)!
+
+        // Absent, empty, or nil context are all the same.
+        let result1 = try! cell.encrypt(message)
+        let result2 = try! cell.encrypt(message, context: nil)
+        let result3 = try! cell.encrypt(message, context: Data())
+
+        XCTAssertEqual(message, try! cell.decrypt(result1.encrypted, token: result1.token))
+        XCTAssertEqual(message, try! cell.decrypt(result2.encrypted, token: result2.token))
+        XCTAssertEqual(message, try! cell.decrypt(result3.encrypted, token: result3.token))
+
+        XCTAssertEqual(message, try! cell.decrypt(result1.encrypted, token: result1.token, context:nil))
+        XCTAssertEqual(message, try! cell.decrypt(result2.encrypted, token: result2.token, context:nil))
+        XCTAssertEqual(message, try! cell.decrypt(result3.encrypted, token: result3.token, context:nil))
+
+        XCTAssertEqual(message, try! cell.decrypt(result1.encrypted, token: result1.token, context:Data()))
+        XCTAssertEqual(message, try! cell.decrypt(result2.encrypted, token: result2.token, context:Data()))
+        XCTAssertEqual(message, try! cell.decrypt(result3.encrypted, token: result3.token, context:Data()))
+    }
+
+    func testContextSignificance() {
+        let cell = TSCellToken(key: TSGenerateSymmetricKey()!)!
+        let message = "Roses are grey. Violets are grey.".data(using: .utf8)!
+        let correctContext = "I'm a dog".data(using: .utf8)!
+        let incorrectContext = "Volcano eruption".data(using: .utf8)!
+
+        let result = try! cell.encrypt(message, context: correctContext)
+
+        // You cannot use a different context to decrypt data.
+        XCTAssertThrowsError(try cell.decrypt(result.encrypted,
+                                              token: result.token,
+                                              context: incorrectContext))
+
+        // Only the original context will work.
+        let decrypted = try! cell.decrypt(result.encrypted,
+                                          token: result.token,
+                                          context: correctContext)
+        XCTAssertEqual(decrypted, message)
+    }
+
+    func testTokenSignificance() {
+        let cell = TSCellToken(key: TSGenerateSymmetricKey()!)!
+        let message = "Roses are grey. Violets are grey.".data(using: .utf8)!
+
+        let result1 = try! cell.encrypt(message)
+        let result2 = try! cell.encrypt(message)
+
+        // You cannot use a different token to decrypt data.
+        XCTAssertThrowsError(try cell.decrypt(result1.encrypted, token: result2.token))
+        XCTAssertThrowsError(try cell.decrypt(result2.encrypted, token: result1.token))
+
+        // Only the original context will work.
+        XCTAssertNoThrow(try cell.decrypt(result1.encrypted, token: result1.token))
+        XCTAssertNoThrow(try cell.decrypt(result2.encrypted, token: result2.token))
+    }
+
+    func testDetectCorruptedData() {
+        let cell = TSCellToken(key: TSGenerateSymmetricKey()!)!
+        let message = "Roses are grey. Violets are grey.".data(using: .utf8)!
+
+        let result = try! cell.encrypt(message)
+
+        var corrupted = Data(result.encrypted)
+        // Invert every odd byte, this will surely break the message.
+        for i in corrupted.indices where i % 2 == 1 {
+            corrupted[i] = ~corrupted[i]
+        }
+
+        XCTAssertThrowsError(try cell.decrypt(corrupted, token: result.token))
+    }
+
+    func testDetectTruncatedData() {
+        let cell = TSCellToken(key: TSGenerateSymmetricKey()!)!
+        let message = "Roses are grey. Violets are grey.".data(using: .utf8)!
+
+        let result = try! cell.encrypt(message)
+
+        let truncated = result.encrypted.dropLast(1)
+
+        XCTAssertThrowsError(try cell.decrypt(truncated, token: result.token))
+    }
+
+    func testDetectExtendedData() {
+        let cell = TSCellToken(key: TSGenerateSymmetricKey()!)!
+        let message = "Roses are grey. Violets are grey.".data(using: .utf8)!
+
+        let result = try! cell.encrypt(message)
+
+        var extended = Data(result.encrypted)
+        extended.append(0)
+
+        XCTAssertThrowsError(try cell.decrypt(extended, token: result.token))
+    }
+
+    func testDetectCorruptedToken() {
+        let cell = TSCellToken(key: TSGenerateSymmetricKey()!)!
+        let message = "Roses are grey. Violets are grey.".data(using: .utf8)!
+
+        let result = try! cell.encrypt(message)
+
+        var corruptedToken = Data(result.token)
+        // Invert every odd byte, this will surely break the token.
+        for i in corruptedToken.indices where i % 2 == 1 {
+            corruptedToken[i] = ~corruptedToken[i]
+        }
+
+        XCTAssertThrowsError(try cell.decrypt(result.encrypted, token: corruptedToken))
+    }
+
+    func testDetectTruncatedToken() {
+        let cell = TSCellToken(key: TSGenerateSymmetricKey()!)!
+        let message = "Roses are grey. Violets are grey.".data(using: .utf8)!
+
+        let result = try! cell.encrypt(message)
+
+        let truncatedToken = result.token.dropLast(1)
+
+        XCTAssertThrowsError(try cell.decrypt(result.encrypted, token: truncatedToken))
+    }
+
+    func testDetectExtendedToken() {
+        let cell = TSCellToken(key: TSGenerateSymmetricKey()!)!
+        let message = "Roses are grey. Violets are grey.".data(using: .utf8)!
+
+        let result = try! cell.encrypt(message)
+
+        var extendedToken = Data(result.token)
+        extendedToken.append(0)
+
+        // Current implementation of Secure Cell allows the token to be overlong.
+        // Extra data is simply ignored.
+        let decrypted = try! cell.decrypt(result.encrypted, token: extendedToken)
+        XCTAssertEqual(decrypted, message)
+    }
+
+    func testSwapTokenAndData() {
+        let cell = TSCellToken(key: TSGenerateSymmetricKey()!)!
+        let message = "Roses are grey. Violets are grey.".data(using: .utf8)!
+
+        let result = try! cell.encrypt(message)
+
+        XCTAssertThrowsError(try cell.decrypt(result.token, token: result.encrypted))
+    }
+
+    func testEmptyMessageOrToken() {
+        let cell = TSCellToken(key: TSGenerateSymmetricKey()!)!
+
+        XCTAssertThrowsError(try cell.encrypt(Data()))
+
+        let result = try! cell.encrypt(TSGenerateSymmetricKey()!)
+
+        XCTAssertThrowsError(try cell.decrypt(Data(), token: result.token))
+        XCTAssertThrowsError(try cell.decrypt(result.encrypted, token: Data()))
+    }
+
+    @available(*, deprecated)
+    func testOldAPI() {
+        let cell = TSCellToken(key: TSGenerateSymmetricKey()!)!
+        let message = "Roses are grey. Violets are grey.".data(using: .utf8)!
+        let context = "I'm a dog".data(using: .utf8)!
+        var decrypted: Data?
+
+        let encryptedData: TSCellTokenEncryptedData? =
+            try? cell.wrap(message, context: context)
+        XCTAssertNotNil(encryptedData)
+        XCTAssertNotNil(encryptedData?.cipherText)
+        XCTAssertNotNil(encryptedData?.token)
+
+        decrypted = try? cell.decrypt(encryptedData!.cipherText as Data,
+                                      token: encryptedData!.token as Data,
+                                      context: context)
+        XCTAssertNotNil(decrypted)
+        XCTAssertEqual(decrypted, message)
+
+        let result = try? cell.encrypt(message, context: context)
+        XCTAssertNotNil(result)
+        XCTAssertNotNil(result?.cipherText)
+        XCTAssertNotNil(result?.token)
+
+        let data = TSCellTokenEncryptedData()
+        data.cipherText = NSMutableData(data: result!.cipherText)
+        data.token = NSMutableData(data: result!.token)
+        decrypted = try? cell.unwrapData(data, context: context)
+        XCTAssertNotNil(decrypted)
+        XCTAssertEqual(decrypted, message)
+    }
+
+    @available(*, deprecated)
+    func testOldAPIWithoutContext() {
+        let cell = TSCellToken(key: TSGenerateSymmetricKey()!)!
+        let message = "Roses are grey. Violets are grey.".data(using: .utf8)!
+        var decrypted: Data?
+
+        let encryptedData = try? cell.wrap(message)
+        XCTAssertNotNil(encryptedData)
+        XCTAssertNotNil(encryptedData?.cipherText)
+        XCTAssertNotNil(encryptedData?.token)
+
+        decrypted = try? cell.decrypt(encryptedData!.cipherText as Data,
+                                      token: encryptedData!.token as Data)
+        XCTAssertNotNil(decrypted)
+        XCTAssertEqual(decrypted, message)
+
+        let result = try? cell.encrypt(message)
+        XCTAssertNotNil(result)
+        XCTAssertNotNil(result?.cipherText)
+        XCTAssertNotNil(result?.token)
+
+        let data = TSCellTokenEncryptedData()
+        data.cipherText = NSMutableData(data: result!.cipherText)
+        data.token = NSMutableData(data: result!.token)
+        decrypted = try? cell.unwrapData(data)
+        XCTAssertNotNil(decrypted)
+        XCTAssertEqual(decrypted, message)
+    }
+}
+
+// MARK: - Context Imprint
+
+class SecureCellContextImprintSwift: XCTestCase {
+
+    func testInitWithGenerated() {
+        let cell = TSCellContextImprint(key: TSGenerateSymmetricKey()!)
+        XCTAssertNotNil(cell)
+    }
+
+    func testInitWithFixed() {
+        let masterKeyString = "UkVDMgAAAC13PCVZAKOczZXUpvkhsC+xvwWnv3CLmlG0Wzy8ZBMnT+2yx/dg"
+        let masterKeyData = Data(base64Encoded: masterKeyString)!
+
+        let cell = TSCellContextImprint(key: masterKeyData)
+        XCTAssertNotNil(cell)
+    }
+
+    func testInitWithEmpty() {
+        XCTAssertNil(TSCellContextImprint(key: Data()))
+    }
+
+    func testRoundtrip() {
+        let cell = TSCellContextImprint(key: TSGenerateSymmetricKey()!)!
+        let message = "All your base are belong to us!"
+        let context = "For great justice"
+
+        let encrypted = try? cell.encrypt(message.data(using: .utf8)!,
+                                          context: context.data(using: .utf8)!)
+        XCTAssertNotNil(encrypted)
+
+        let decrypted = try? cell.decrypt(encrypted!,
+                                          context: context.data(using: .utf8)!)
+        XCTAssertNotNil(decrypted)
+
+        let decryptedMessage = String(data: decrypted!, encoding: .utf8)
+        XCTAssertNotNil(decryptedMessage)
+
+        XCTAssertEqual(decryptedMessage, message)
+    }
+
+    func testDataLengthPreservation() {
+        let cell = TSCellContextImprint(key: TSGenerateSymmetricKey()!)!
+        let message = "All your base are belong to us!".data(using: .utf8)!
+        let context = "For great justice".data(using: .utf8)!
+
+        let encrypted = try! cell.encrypt(message, context: context)
+
+        XCTAssertEqual(encrypted.count, message.count)
+    }
+
+    func testContextInclusion() {
+        let cell = TSCellContextImprint(key: TSGenerateSymmetricKey()!)!
+        let message = "All your base are belong to us!".data(using: .utf8)!
+        let shortContext = ".".data(using: .utf8)!
+        let longContext = "You have no chance to survive make your time. Ha ha ha ha ...".data(using: .utf8)!
+
+        let encryptedShort = try! cell.encrypt(message, context: shortContext)
+        let encryptedLong = try! cell.encrypt(message, context: longContext)
+
+        // Context is not (directly) included into encrypted message.
+        XCTAssertEqual(encryptedShort.count, encryptedLong.count)
+    }
+
+    func testContextSignificance() {
+        let cell = TSCellContextImprint(key: TSGenerateSymmetricKey()!)!
+        let message = "All your base are belong to us!".data(using: .utf8)!
+        let correctContext = "We are CATS".data(using: .utf8)!
+        let incorrectContext = "Captain !!".data(using: .utf8)!
+
+        let encrypted = try! cell.encrypt(message, context: correctContext)
+
+        // You can use a different context to decrypt data, but you'll get garbage.
+        let decryptedGarbage = try? cell.decrypt(encrypted, context: incorrectContext)
+        XCTAssertNotNil(decryptedGarbage)
+        XCTAssertNotEqual(decryptedGarbage!, message)
+        XCTAssertEqual(decryptedGarbage!.count, message.count)
+
+        // Only the original context will work.
+        let decrypted = try? cell.decrypt(encrypted, context: correctContext)
+        XCTAssertNotNil(decrypted)
+        XCTAssertEqual(decrypted!, message)
+    }
+
+    func testNoDetectCorruptedData() {
+        let cell = TSCellContextImprint(key: TSGenerateSymmetricKey()!)!
+        let message = "All your base are belong to us!".data(using: .utf8)!
+        let context = "For great justice".data(using: .utf8)!
+
+        let encrypted = try! cell.encrypt(message, context: context)
+
+        var corrupted = Data(encrypted)
+        // Invert every odd byte, this will surely break the message.
+        for i in corrupted.indices where i % 2 == 1 {
+            corrupted[i] = ~corrupted[i]
+        }
+
+        // Decrypts successfully but the content is garbage.
+        let decrypted = try? cell.decrypt(corrupted, context: context)
+        XCTAssertNotNil(decrypted)
+        XCTAssertNotEqual(decrypted!, message)
+        XCTAssertEqual(decrypted!.count, message.count)
+    }
+
+    func testNoDetectTruncatedData() {
+        let cell = TSCellContextImprint(key: TSGenerateSymmetricKey()!)!
+        let message = "All your base are belong to us!".data(using: .utf8)!
+        let context = "For great justice".data(using: .utf8)!
+
+        let encrypted = try! cell.encrypt(message, context: context)
+
+        let truncated = encrypted.dropLast(1)
+
+        // Decrypts successfully but the content is garbage.
+        let decrypted = try? cell.decrypt(truncated, context: context)
+        XCTAssertNotNil(decrypted)
+        XCTAssertNotEqual(decrypted!, message)
+        XCTAssertNotEqual(decrypted!.count, message.count)
+    }
+
+    func testDetectExtendedData() {
+        let cell = TSCellContextImprint(key: TSGenerateSymmetricKey()!)!
+        let message = "All your base are belong to us!".data(using: .utf8)!
+        let context = "For great justice".data(using: .utf8)!
+
+        let encrypted = try! cell.encrypt(message, context: context)
+
+        var extended = Data(encrypted)
+        extended.append(0)
+
+        // Decrypts successfully but the content is garbage.
+        let decrypted = try? cell.decrypt(extended, context: context)
+        XCTAssertNotNil(decrypted)
+        XCTAssertNotEqual(decrypted!, message)
+        XCTAssertNotEqual(decrypted!.count, message.count)
+    }
+
+    func testRequiredMessageAndContext() {
+        let cell = TSCellContextImprint(key: TSGenerateSymmetricKey()!)!
+        let message = "All your base are belong to us!".data(using: .utf8)!
+        let context = "For great justice".data(using: .utf8)!
+
+        XCTAssertThrowsError(try cell.encrypt(message, context: Data()))
+        XCTAssertThrowsError(try cell.encrypt(Data(), context: context))
+
+        XCTAssertThrowsError(try cell.decrypt(message, context: Data()))
+        XCTAssertThrowsError(try cell.decrypt(Data(), context: context))
+    }
+
+    @available(*, deprecated)
+    func testOldAPI() {
+        let cell = TSCellContextImprint(key: TSGenerateSymmetricKey()!)!
+        let message = "All your base are belong to us!".data(using: .utf8)!
+        let context = "For great justice".data(using: .utf8)!
+        var encrypted, decrypted: Data?
+
+        encrypted = try? cell.wrap(message, context: context)
+        XCTAssertNotNil(encrypted)
+
+        decrypted = try? cell.decrypt(encrypted!, context: context)
+        XCTAssertNotNil(decrypted)
+        XCTAssertEqual(decrypted, message)
+
+        encrypted = try? cell.encrypt(message, context: context)
+        XCTAssertNotNil(encrypted)
+
+        decrypted = try? cell.unwrapData(encrypted!, context: context)
+        XCTAssertNotNil(decrypted)
+        XCTAssertEqual(decrypted, message)
     }
 }


### PR DESCRIPTION
Update Secure Cell API for Objective-C and Swift as a preparation to passphrase support. This has been described in RFC 3.5.

This is a non-functional change, just making the API more consistent and easy to use, with a straightforward way to add passphrase API soon.

## User notes

### Swift

All modes now use consistent naming of encryption/decryption methods:

```swift
let encrypted = try cell.encrypt(message, context: nil)

let decrypted = try cell.decrypt(encrypted)
```

They accept `Data` as their first unnamed argument, followed an optional `context:` argument (except for Context Imprint mode which requires associated context). Processed data is returned as `Data`. Errors are reported with Swift exceptions.

#### Token Protect mode improvements

Token Protect mode returns a helper object with encrypted message and authentication token:

```swift
let result = try cell.encrypt(message)

print("Encrypted message:    ", result.encrypted)
print("Authentication token: ", result.token)
```

Encrypted message and token are accepted separately for decryption, no longer requiring to fill `TSCellTokenEncryptedData` manually:

```swift
let decrypted = try cell.decrypt(encrypted, token: token)
```

New API is bridged with Swift's `Data` directly, no longer requiring manual conversion from/to `NSMutableData`.

### Objective-C

All modes now use consistent naming of encryption/decryption methods:

```objective-c
NSData *encrypted = [cell encrypt:message];

NSError *error;
NSData *decrypted = [cell decrypt:encrypted
                          context:nil
                            error:&error];
```

They accept `NSData` as their first argument, followed an optional `context:` argument (except for Context Imprint mode which requires associated context), followed by an optional `error:` out-parameter. Processed data is returned as `NSData`. Errors are reported as `NSError` objects, if requested.

There are convenience overloads with omitted `context` parameters if you don't need them, and omitted `error:` parameters if you're not interested in error values (`nil` is returned in case of error).

#### Token Protect mode improvements

Token Protect mode returns a helper result object with encrypted message and authentication token:

```objective-c
TSCellTokenEncryptedResult *result = [cell encrypt:message];

NSLog(@"Encrypted message:    %@", result.encrypted);
NSLog(@"Authentication token: %@", result.token);
```

Encrypted message and token are accepted separately for decryption, no longer requiring to fill `TSCellTokenEncryptedData` manually:

```objective-c
NSData *decrypted = [cell decrypt:encrypted token:token];
```

Note that new helper object `TSCellTokenEncryptedResult` represents only encryption result. It is immutable and uses `NSData` for fields.

### Deprecated API

Old encryption/decryption API is declared deprecated and its use is discouraged. There are no plans to remove this API in the future, it will be retained for compatibility (probably until 1.0).

<details>
<summary>Complete list of deprecated API</summary>

Swift:

<table>
  <tr><th>Mode</th><th>Deprecation</th><th>Replacement</th></tr>
  <tr>
    <td rowspan=2><code>TSCellSeal</code></td>
    <td><code>wrap(_:, context:)</code><br/><code>wrap</code></td>
    <td><code>encrypt(_:, context:)</code><br/><code>encrypt</code></td>
  </tr>
  <tr>
    <td><code>unwrapData(_:, context:)</code><br/><code>unwrapData</code></td>
    <td><code>decrypt(_:, context:)</code><br/><code>decrypt</code></td>
  </tr>
  <tr>
    <td rowspan=2><code>TSCellToken</code></td>
    <td><code>wrap(_:, context:)</code><br/><code>wrap</code></td>
    <td><code>encrypt(_:, context:)</code><br/><code>encrypt</code></td>
  </tr>
  <tr>
    <td><code>unwrapData(_:, context:)</code><br/><code>unwrapData</code></td>
    <td><code>decrypt(_:, token:, context:)</code><br/><code>decrypt(_:, token:)</code></td>
  </tr>
  <tr>
    <td rowspan=2><code>TSCellContextImprint</code></td>
    <td><code>wrap(_:, context:)</code><br/><code>wrap</code></td>
    <td><code>encrypt(_:, context:)</code><br/><code>encrypt</code></td>
  </tr>
  <tr>
    <td><code>unwrapData(_:, context:)</code><br/><code>unwrapData</code></td>
    <td><code>decrypt(_:, context:)</code><br/><code>decrypt</code></td>
  </tr>
</table>

Objective-C:

<table>
  <tr><th>Mode</th><th>Deprecation</th><th>Replacement</th></tr>
  <tr>
    <td rowspan=2><code>TSCellSeal</code></td>
    <td><code>wrapData:context:error:</code><br><code>wrapData:error:</code></td>
    <td><code>encrypt:context:error:</code><br><code>encrypt:error:</code></td>
  </tr>
  <tr>
    <td><code>unwrapData:context:error:</code><br><code>unwrapData:error:</code></td>
    <td><code>decrypt:context:error:</code><br><code>decrypt:error:</code></td>
  </tr>
  <tr>
    <td rowspan=2><code>TSCellToken</code></td>
    <td><code>wrapData:context:error:</code><br><code>wrapData:error:</code></td>
    <td><code>encrypt:context:error:</code><br><code>encrypt:error:</code></td>
  </tr>
  <tr>
    <td><code>unwrapData:context:error:</code><br><code>unwrapData:error:</code></td>
    <td><code>decrypt:token:context:error:</code><br><code>decrypt:token:error:</code></td>
  </tr>
  <tr>
    <td rowspan=2><code>TSCellContextImprint</code></td>
    <td><code>wrapData:context:error:</code><br><code>wrapData:error:</code></td>
    <td><code>encrypt:context:error:</code><br><code>encrypt:error:</code></td>
  </tr>
  <tr>
    <td><code>unwrapData:context:error:</code><br><code>unwrapData:error:</code></td>
    <td><code>decrypt:context:error:</code><br><code>decrypt:error:</code></td>
  </tr>
</table>

</details>

## Technical notes

This PR includes significant overhaul of unit test suite for ObjCThemis. It improves coverage and debuggability of ObjCThemis via tests. The test suite also includes compatibility tests.

There are a lot of tedious and repeatative changes there. All modes have roughly the same test suite but with *slight* differences. Objective-C and Swift test suite are identical (Swift one is a translation). However, they are important to pinpoint API details.

There were plans to improve Token Protect encryption API in Swift to return _tuples_:

```swift
let (encrypted, token) = try cell.encrypt(message)

print("Encrypted message:    ", encrypted)
print("Authentication token: ", token)
```

Unfortunately, this turned out to be impossible at the moment due to lack of stable Swift ABI.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] Public API has proper documentation
- [X] ~~Example projects and code samples are up-to-date~~ (no, will update separately)
- [X] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md

P.S. I need to slow down because @vixentael capacity is extremely limited recently.

P.P.S. Why did I even started this?.. It was a perfectly fine API. Yeah, it was _a bit inconvenient_ to use, but it did work. We all know that worse is better, right? Whatever. Here you go.