### PR TITLE
"configure" script for platform detection

### DIFF
--- a/.github/workflows/test-php.yaml
+++ b/.github/workflows/test-php.yaml
@@ -59,6 +59,7 @@ jobs:
           sudo update-alternatives --set php-config /usr/bin/php-config5.6
           sudo update-alternatives --set phpize     /usr/bin/phpize5.6
           sudo git clean -fxd src
+          ./configure
           sudo make phpthemis_install
           make test_php
       - name: Run test suite (PHP 7.0)
@@ -68,6 +69,7 @@ jobs:
           sudo update-alternatives --set php-config /usr/bin/php-config7.0
           sudo update-alternatives --set phpize     /usr/bin/phpize7.0
           sudo git clean -fxd src
+          ./configure
           sudo make phpthemis_install
           make test_php
       - name: Run test suite (PHP 7.1)
@@ -77,6 +79,7 @@ jobs:
           sudo update-alternatives --set php-config /usr/bin/php-config7.1
           sudo update-alternatives --set phpize     /usr/bin/phpize7.1
           sudo git clean -fxd src
+          ./configure
           sudo make phpthemis_install
           make test_php
       - name: Run test suite (PHP 7.2)
@@ -86,6 +89,7 @@ jobs:
           sudo update-alternatives --set php-config /usr/bin/php-config7.2
           sudo update-alternatives --set phpize     /usr/bin/phpize7.2
           sudo git clean -fxd src
+          ./configure
           sudo make phpthemis_install
           make test_php
       - name: Run test suite (PHP 7.3)
@@ -95,6 +99,7 @@ jobs:
           sudo update-alternatives --set php-config /usr/bin/php-config7.3
           sudo update-alternatives --set phpize     /usr/bin/phpize7.3
           sudo git clean -fxd src
+          ./configure
           sudo make phpthemis_install
           make test_php
       - name: Run test suite (PHP 7.4)
@@ -104,6 +109,7 @@ jobs:
           sudo update-alternatives --set php-config /usr/bin/php-config7.4
           sudo update-alternatives --set phpize     /usr/bin/phpize7.4
           sudo git clean -fxd src
+          ./configure
           sudo make phpthemis_install
           make test_php
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,30 @@
 # limitations under the License.
 #
 
-########################################################################
+#===== Early setup =============================================================
+
+# Set default goal for "make"
+.DEFAULT_GOAL := all
+
+# Set shell for target commands
+SHELL = /bin/bash
+
+# Disable built-in rules
+MAKEFLAGS += --no-builtin-rules
+.SUFFIXES:
+
+## build directory
+BUILD_PATH ?= build
+
+# Include system configuration file, creating it if necessary
+-include $(BUILD_PATH)/configure.mk
+
+$(BUILD_PATH)/configure.mk:
+	@./configure
+
+#===== Variables ===============================================================
+
+#----- Versioning --------------------------------------------------------------
 
 # Increment VERSION when making a new release of Themis.
 #
@@ -23,42 +46,51 @@
 VERSION := $(shell test -d .git && git describe --tags || cat VERSION)
 LIBRARY_SO_VERSION = 0
 
-########################################################################
-#
-# Overridable default paths to applications and build/install directories
-#
+#----- Toolchain ---------------------------------------------------------------
 
-CMAKE = cmake
-SHELL = /bin/bash
+CMAKE ?= cmake
 
 CLANG_FORMAT ?= clang-format
 CLANG_TIDY   ?= clang-tidy
 
-INSTALL = install
-INSTALL_PROGRAM = $(INSTALL)
-INSTALL_DATA    = $(INSTALL) -m 644
+INSTALL         ?= install
+INSTALL_PROGRAM ?= $(INSTALL)
+INSTALL_DATA    ?= $(INSTALL) -m 644
 
-BUILD_PATH ?= build
+#----- Build directories -------------------------------------------------------
 
 SRC_PATH = src
 BIN_PATH = $(BUILD_PATH)
 OBJ_PATH = $(BIN_PATH)/obj
 AUD_PATH = $(BIN_PATH)/for_audit
+
 TEST_SRC_PATH = tests
 TEST_BIN_PATH = $(BIN_PATH)/tests
 
+#----- Installation paths ------------------------------------------------------
+
+## installation prefix
 PREFIX ?= /usr/local
 
-prefix       = $(PREFIX)
-exec_prefix  = $(prefix)
-bindir       = $(prefix)/bin
-includedir   = $(prefix)/include
-libdir       = $(exec_prefix)/lib
-jnidir       = $(libdir)
-pkgconfigdir = $(libdir)/pkgconfig
+# Advanced variables for fine-tuning installation paths
+prefix       ?= $(PREFIX)
+exec_prefix  ?= $(prefix)
+bindir       ?= $(prefix)/bin
+includedir   ?= $(prefix)/include
+libdir       ?= $(exec_prefix)/lib
+jnidir       ?= $(libdir)
+pkgconfigdir ?= $(libdir)/pkgconfig
 
-CFLAGS += -I$(SRC_PATH) -I$(SRC_PATH)/wrappers/themis/ -fPIC
+#----- Basic compiler flags ----------------------------------------------------
+
+# Add Themis source directory to search paths
+CFLAGS  += -I$(SRC_PATH) -I$(SRC_PATH)/wrappers/themis/
 LDFLAGS += -L$(BIN_PATH)
+# Not all platforms include /usr/local in default search path
+CFLAGS  += -I/usr/local/include
+LDFLAGS += -L/usr/local/lib
+# Build shared libraries
+CFLAGS  += -fPIC
 
 ########################################################################
 #
@@ -85,80 +117,6 @@ PRINT_WARNING = printf "$@ $(WARN_STRING)\n" && printf "$(CMD)\n$$LOG\n"
 PRINT_WARNING_ = printf "$(WARN_STRING)\n" && printf "$(CMD)\n$$LOG\n"
 BUILD_CMD = LOG=$$($(CMD) 2>&1) ; if [ $$? -ne 0 ]; then $(PRINT_ERROR); elif [ "$$LOG" != "" ] ; then $(PRINT_WARNING); else $(PRINT_OK); fi;
 BUILD_CMD_ = LOG=$$($(CMD) 2>&1) ; if [ $$? -ne 0 ]; then $(PRINT_ERROR_); elif [ "$$LOG" != "" ] ; then $(PRINT_WARNING_); else $(PRINT_OK_); fi;
-
-########################################################################
-#
-# Platform detection macros and default tweaks
-#
-
-UNAME := $(shell uname)
-
-ifeq ($(UNAME),Darwin)
-	IS_MACOS := true
-else ifeq ($(UNAME),Linux)
-	IS_LINUX := true
-else ifeq ($(shell uname -o),Msys)
-	IS_MSYS := true
-endif
-
-ifneq ($(shell $(CC) --version 2>&1 | grep -oi "Emscripten"),)
-	IS_EMSCRIPTEN := true
-endif
-ifneq ($(shell $(CC) --version 2>&1 | grep -E -i -c "clang version"),0)
-	IS_CLANG_COMPILER := true
-endif
-
-SHARED_EXT = so
-
-ifdef IS_MACOS
-SHARED_EXT = dylib
-ifneq ($(SDK),)
-SDK_PLATFORM_VERSION=$(shell xcrun --sdk $(SDK) --show-sdk-platform-version)
-XCODE_BASE=$(shell xcode-select --print-path)
-CC=$(XCODE_BASE)/usr/bin/gcc
-BASE=$(shell xcrun --sdk $(SDK) --show-sdk-platform-path)
-SDK_BASE=$(shell xcrun --sdk $(SDK) --show-sdk-path)
-FRAMEWORKS=$(SDK_BASE)/System/Library/Frameworks/
-SDK_INCLUDES=$(SDK_BASE)/usr/include
-CFLAGS += -isysroot $(SDK_BASE)
-endif
-ifneq ($(ARCH),)
-CFLAGS += -arch $(ARCH)
-endif
-endif
-
-ifdef IS_MSYS
-SHARED_EXT = dll
-endif
-
-ifdef IS_EMSCRIPTEN
-# Recent versions of Emscripten toolchain provide new "emcmake" utility
-# specifically for CMake. Older versions rely on generic "emconfigure".
-ifeq ($(shell which emcmake >/dev/null 2>&1 && echo yes),yes)
-CMAKE = emcmake cmake
-else
-CMAKE = emconfigure cmake
-endif
-endif
-
-# Not all platforms include /usr/local into default search path
-CFLAGS  += -I/usr/local/include
-LDFLAGS += -L/usr/local/lib
-
-########################################################################
-#
-# Detecting installed language runtimes and their versions
-#
-
-PHP_VERSION := $(shell php -r "echo PHP_MAJOR_VERSION;" 2>/dev/null)
-RUBY_GEM_VERSION := $(shell gem --version 2>/dev/null)
-RUST_VERSION := $(shell rustc --version 2>/dev/null)
-GO_VERSION := $(shell which go >/dev/null 2>&1 && go version 2>&1)
-NODE_VERSION := $(shell node --version 2>/dev/null)
-NPM_VERSION := $(shell npm --version 2>/dev/null)
-PIP_VERSION := $(shell pip --version 2>/dev/null)
-PYTHON2_VERSION := $(shell which python2 >/dev/null 2>&1 && python2 --version 2>&1)
-PYTHON3_VERSION := $(shell python3 --version 2>/dev/null)
 
 ########################################################################
 #
@@ -192,10 +150,9 @@ CFLAGS += $(CRYPTO_ENGINE_CFLAGS)
 # Homebrew's OpenSSL instead of the system one by default.
 ifdef IS_MACOS
 	ifeq ($(CRYPTO_ENGINE_PATH),openssl)
-		OPENSSL_PATH := $(shell brew --prefix openssl)
-		ifneq ($(OPENSSL_PATH),)
-			CRYPTO_ENGINE_INCLUDE_PATH = $(OPENSSL_PATH)/include
-			CRYPTO_ENGINE_LIB_PATH = $(OPENSSL_PATH)/lib
+		ifneq ($(HOMEBREW_OPENSSL_PATH),)
+			CRYPTO_ENGINE_INCLUDE_PATH = $(HOMEBREW_OPENSSL_PATH)/include
+			CRYPTO_ENGINE_LIB_PATH = $(HOMEBREW_OPENSSL_PATH)/lib
 		endif
 	endif
 endif
@@ -412,8 +369,6 @@ endif
 #
 # Principal Makefile targets
 #
-
-.DEFAULT_GOAL := all
 
 all: themis_static soter_static themis_shared soter_shared themis_pkgconfig soter_pkgconfig
 	@echo $(VERSION)

--- a/configure
+++ b/configure
@@ -1,0 +1,265 @@
+#!/bin/sh
+#
+# Configure Themis build.
+#
+# Normally you should not need to call this script explicitly as "make"
+# executes it automatically if needed. But by all means, you can do
+#
+#     ./configure
+#     make
+#     sudo make install
+#
+# to install Themis in a traditional way, or if you need to configure
+# something non-standard.
+#
+# Important environment variables:
+#
+#     BUILD_PATH - path to build directory (default: "build")
+#
+# ./configure expects to be run from the source root with build directory
+# configured by BUILD_PATH if necessary.
+#
+# Run
+#
+#     ./configure --help
+#
+# to see available options.
+
+set -eu
+
+BUILD_PATH=${BUILD_PATH:-build}
+
+CC=${CC:-cc}
+CMAKE=${CMAKE:-cmake}
+
+usage() {
+    cat <<EOF
+Usage:
+    $0 [options...] [<var>=<value>...]
+
+Options:
+    --prefix=path           installation prefix
+    --bindir=path           installation path for binaries
+    --includedir=path       installation path for headers
+    --libdir=path           installation path for shared libraries
+    --jnidir=path           installation path for JNI libraries
+    --pkgconfigdir=path     installation path for pkg-config files
+
+    --help                  read this help
+EOF
+}
+
+die() {
+    exec >&2
+    echo $@
+    echo
+    usage
+    exit 1
+}
+
+configure_mk="$BUILD_PATH/configure.mk"
+
+write_boilerplate() {
+    mkdir -p "$(dirname "$configure_mk")"
+    cat > "$configure_mk"  <<EOF
+# DO NOT EDIT
+#
+# Generated automatically by $0
+
+EOF
+}
+
+set_variable() {
+    eval "$1=\"$2\""
+    echo "$1 = $2" >> "$configure_mk"
+}
+
+append_variable() {
+    eval "$1=\"$1 $2\""
+    echo "$1 += $2" >> "$configure_mk"
+}
+
+standard_dirs="prefix bindir includedir libdir jnidir pkgconfigdir"
+
+is_standard_dir() {
+    for dir in $standard_dirs
+    do
+        if [ "$1" = "$dir" ]
+        then
+            return 0
+        fi
+    done
+    return 1
+}
+
+parse_variable_override() {
+    case "$1" in
+      --*=*)
+        var=${1#--}
+        value=${var#*=}
+        var=${var%%=*}
+        if is_standard_dir "$var"
+        then
+            set_variable "$var" "$value"
+            nshift=1
+            return 0
+        fi
+        die "unrecognized option: $1"
+        ;;
+
+      --*)
+        var=${1#--}
+        if is_standard_dir "$var"
+        then
+            if [ $# = 1 ]
+            then
+                die "option $1 expects an argument"
+            fi
+            value=$2
+            set_variable "$var" "$value"
+            nshift=2
+            return 0
+        fi
+        die "unrecognized option: $1"
+        ;;
+
+      *=*)
+        var=${1%%=*}
+        value=${1#*=}
+        set_variable "$var" "$value"
+        nshift=1
+        return 0
+        ;;
+    esac
+    return 1
+}
+
+parse_commandline() {
+    while [ $# -gt 0 ]
+    do
+        if [ "$1" = "--help" ]
+        then
+            usage
+            exit
+        fi
+
+        if parse_variable_override "$@"
+        then
+            shift $nshift
+            continue
+        fi
+
+        die "unrecognized argument: $1"
+    done
+}
+
+detect_platform() {
+    case "$(uname)" in
+      Darwin)
+        set_variable IS_MACOS "true"
+        ;;
+      Linux)
+        set_variable IS_LINUX "true"
+        ;;
+      *)
+        case "$(uname -o)" in
+          Msys)
+            set_variable IS_MSYS "true"
+            ;;
+        esac
+        ;;
+    esac
+
+    if $CC --version 2>&1 | grep -qi Emscripten
+    then
+        set_variable IS_EMSCRIPTEN "true"
+    fi
+}
+
+detect_compiler() {
+    if $CC --version 2>&1 | grep -qi "clang version"
+    then
+        set_variable IS_CLANG_COMPILER "true"
+    fi
+}
+
+select_shared_object_extension() {
+    if [ -n "${IS_MSYS:-}" ]
+    then
+        set_variable SHARED_EXT "dll"
+    elif [ -n "${IS_MACOS:-}" ]
+    then
+        set_variable SHARED_EXT "dylib"
+    else
+        set_variable SHARED_EXT "so"
+    fi
+}
+
+select_cmake_for_emscripten() {
+    [ -z "${IS_EMSCRIPTEN:-}" ] && return
+    # Recent versions of Emscripten toolchain provide new "emcmake" utility
+    # specifically for CMake. Older versions rely on generic "emconfigure".
+    if which emcmake >/dev/null 2>&1
+    then
+        set_variable CMAKE "emcmake $CMAKE"
+    else
+        set_variable CMAKE "emconfigure $CMAKE"
+    fi
+}
+
+configure_macos_toolchain() {
+    [ -z "${IS_MACOS:-}" ] && return
+
+    if [ -n "${SDK:-}" ]
+    then
+        set_variable SDK_PLATFORM_VERSION "$(xcrun --sdk "$SDK" --show-sdk-platform-version)"
+        set_variable XCODE_BASE "$(xcode-select --print-path)"
+        set_variable CC         "$XCODE_BASE/usr/bin/gcc"
+        set_variable BASE       "$(xcrun --sdk "$SDK" --show-sdk-platform-path)"
+        set_variable SDK_BASE   "$(xcrun --sdk "$SDK" --show-sdk-path)"
+        set_variable FRAMEWORKS   "$SDK_BASE/System/Library/Frameworks/"
+        set_variable SDK_INCLUDES "$SDK_BASE/usr/include"
+        append_variable CFLAGS "-isysroot \"$SDK_BASE\""
+    fi
+
+    if [ -n "${ARCH:-}" ]
+    then
+        append_variable CFLAGS "-arch $ARCH"
+    fi
+}
+
+find_macos_openssl() {
+    [ -z "${IS_MACOS:-}" ] && return
+    local path="$(brew --prefix openssl 2> /dev/null || true)"
+    if [ -n "$path" ]
+    then
+        set_variable HOMEBREW_OPENSSL_PATH "$path"
+    fi
+}
+
+detect_language_runtimes() {
+    set_variable PHP_VERSION        "$(exec 2>/dev/null; which php     >/dev/null && php -r "echo PHP_MAJOR_VERSION;")"
+    set_variable RUBY_GEM_VERSION   "$(exec 2>/dev/null; which gem     >/dev/null && gem --version)"
+    set_variable RUST_VERSION       "$(exec 2>/dev/null; which rustc   >/dev/null && rustc --version)"
+    set_variable GO_VERSION         "$(exec 2>/dev/null; which go      >/dev/null && go version)"
+    set_variable NODE_VERSION       "$(exec 2>/dev/null; which node    >/dev/null && node --version)"
+    set_variable NPM_VERSION        "$(exec 2>/dev/null; which npm     >/dev/null && npm --version)"
+    set_variable PIP_VERSION        "$(exec 2>/dev/null; which pip     >/dev/null && pip --version)"
+    set_variable PYTHON2_VERSION    "$(exec 2>/dev/null; which python2 >/dev/null && python2 --version)"
+    set_variable PYTHON3_VERSION    "$(exec 2>/dev/null; which python3 >/dev/null && python3 --version)"
+}
+
+main() {
+    write_boilerplate
+    parse_commandline "$@"
+    detect_platform
+    detect_compiler
+    select_shared_object_extension
+    select_cmake_for_emscripten
+    configure_macos_toolchain
+    find_macos_openssl
+    detect_language_runtimes
+    echo "configuration written to $configure_mk"
+}
+
+main "$@"


### PR DESCRIPTION
Move most of the platform detection logic out from the Makefile into a traditional `configure` script, Since the system is unlike to change, this allows to run (costly) platform detection things only once at the first build. Incremental builds during development become much faster.

<table>
<tr><td></td><th colspan="2">macOS</th><th colspan="2">Linux</th></tr>
<tr><td></td><th>Before</th><th>After</th><th>Before</th><th>After</th></tr>
<tr><td><code>make clean</code> in empty dir</td>        <td> 3.196</td> <td> 2.858</td> <td>0.890</td> <td>1.166</td> </tr>
<tr><td><code>make all</code> from scratch</td>          <td>11.762</td> <td>12.183</td> <td>6.226</td> <td>6.273</td> </tr>
<tr><td><code>make all</code> again with no changes</td> <td> 3.231</td> <td> 0.504</td> <td>0.936</td> <td>0.300</td> </tr>
<tr><td><code>make all</code> with one changed file</td> <td> 3.247</td> <td> 0.816</td> <td>1.101</td> <td>0.553</td> </tr>
<tr><td><code>make clean</code> after build</td>         <td> 4.564</td> <td> 0.939</td> <td>0.896</td> <td>0.328</td> </tr>
</table>

After a while you get *really* annoyed by every make operation taking usually around three seconds and up to 8 (eight, Carl!) seconds if caches are cold. Lowering it to sub-second range is more tolerable.

### Why so slow?

The main culprit here is Homebrew that really takes its time to locate OpenSSL installation directory. Thankfully, it does not update the formula database now, but it did before. Some people [complained][1] about this simple operation taking enormous amount of time but the maintainer said this is fine and not a bug.

[1]: https://github.com/Homebrew/brew/issues/3097

All other scripting languages combined can be treated as accomplices. Each individual version check looks cheap on its own, but doing them altogether takes a couple of seconds.

Surprisingly, the `supported` calls to check C compiler flags are fast enough so I did not bother moving them out to ./configure (though it's a task traditionally performed by it). There's also some weird interplay with AFL there, so that's left for the future.

### On ./configure

The script follows [GNU conventions][2] expected from it though there is not much configuration involved. We also diverge from the usual approach to out-of-source builds. The traditional way is to call configure from the build directory with `--srcdir`, but we keep using BUILD_PATH to set
the build directory and expect `make` to be call from tree root.

[2]: https://www.gnu.org/prep/standards/html_node/Configuration.html

Note that it is not necessary to explicitly call ./configure before the build. Make will check if it has not been called and will configure the build if necessary. So for most of the users the happy path is still

    make
    sudo make install

But you can use ./configure if, say, you want a different installation prefix:

    ./configure --prefix=/opt/themis
    make
    sudo make install

The entire script is an exercise in portable POSIX shell scripting. Don't you dare utter "Au\*\*\*\*\*ls" in this house.

### What are those fancy comment sections?

We're (slowly) unifying the makefile structure across projects. This is the new way™ of doing things.

## Checklist

- [X] Change is covered by automated tests
- [X] Benchmark results are attached (if applicable)
- [X] The [coding guidelines] are followed
- [X] Public API has proper documentation

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md