### PR TITLE
Test all matrix configurations

### DIFF
--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -37,6 +37,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
+      fail-fast: false
     steps:
       - name: Install system dependencies
         run: |

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -33,6 +33,7 @@ jobs:
     strategy:
       matrix:
         go: ['1.11.13', '1.12.17', '1.13.8', '1.14']
+      fail-fast: false
     steps:
       - name: Install system dependencies
         run: |

--- a/.github/workflows/test-java.yaml
+++ b/.github/workflows/test-java.yaml
@@ -32,6 +32,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
+      fail-fast: false
     steps:
       - name: Install system dependencies
         run: |

--- a/.github/workflows/test-nodejs.yaml
+++ b/.github/workflows/test-nodejs.yaml
@@ -33,6 +33,7 @@ jobs:
           - 8.x   # old LTS
           - 10.x  # current LTS
           - 12.x  # current stable
+      fail-fast: false
     steps:
       - name: Install system dependencies
         run: |

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -54,6 +54,7 @@ jobs:
     strategy:
       matrix:
         python: [python2, python3]
+      fail-fast: false
     env:
       PYTHON: ${{ matrix.python }}
     services:

--- a/.github/workflows/test-wasm.yaml
+++ b/.github/workflows/test-wasm.yaml
@@ -38,6 +38,7 @@ jobs:
           - 8.x   # old LTS
           - 10.x  # current LTS
           - 12.x  # current stable
+      fail-fast: false
     steps:
       - name: Install system dependencies
         run: |


### PR DESCRIPTION
Add `fail-fast: false` to matrix testing strategies so that they continue testing other variant instead of auto-canceling them. For example, if only Node.js v8 fails, we don't want the Node.js v12 job to be canceled. This might be different in future cases, but everywhere we use "strategy: matrix" now, we'd like all items to be tested regardless of their siblings' failures.

## Checklist

- [X] Change is covered by automated tests
- [X] Benchmark results are attached
- [X] The [coding guidelines] are followed
- [X] Public API has proper documentation

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
