### PR TITLE
Update JsThemis tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -288,6 +288,7 @@ _Code:_
   - New class `SymmetricKey` can be used to generate symmetric keys for Secure Cell ([#562](https://github.com/cossacklabs/themis/pull/562)).
   - New makefile target `make jsthemis` can be used to build JsThemis from source ([#618](https://github.com/cossacklabs/themis/pull/618)).
   - `SecureCell` now allows `null` to explicitly specify omitted encryption context ([#620](https://github.com/cossacklabs/themis/pull/620)).
+  - `SecureMessage` now allows `null` for omitted keys in sign/verify mode ([#620](https://github.com/cossacklabs/themis/pull/620)).
 
 - **PHP**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -287,6 +287,7 @@ _Code:_
 
   - New class `SymmetricKey` can be used to generate symmetric keys for Secure Cell ([#562](https://github.com/cossacklabs/themis/pull/562)).
   - New makefile target `make jsthemis` can be used to build JsThemis from source ([#618](https://github.com/cossacklabs/themis/pull/618)).
+  - `SecureCell` now allows `null` to explicitly specify omitted encryption context ([#620](https://github.com/cossacklabs/themis/pull/620)).
 
 - **PHP**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,6 +289,7 @@ _Code:_
   - New makefile target `make jsthemis` can be used to build JsThemis from source ([#618](https://github.com/cossacklabs/themis/pull/618)).
   - `SecureCell` now allows `null` to explicitly specify omitted encryption context ([#620](https://github.com/cossacklabs/themis/pull/620)).
   - `SecureMessage` now allows `null` for omitted keys in sign/verify mode ([#620](https://github.com/cossacklabs/themis/pull/620)).
+  - Fixed a crash when an exception is thrown from `SecureSession` callback ([#620](https://github.com/cossacklabs/themis/pull/620)).
 
 - **PHP**
 

--- a/src/wrappers/themis/jsthemis/errors.cpp
+++ b/src/wrappers/themis/jsthemis/errors.cpp
@@ -119,6 +119,16 @@ void ThrowError(const char* domain, themis_status_t status)
     Nan::ThrowError(WithStatus(Nan::Error(message.c_str()), status));
 }
 
+void ThrowTypeError(const char* domain, const char* description)
+{
+    std::string message;
+    message += "themis.";
+    message += domain;
+    message += ": ";
+    message += description;
+    Nan::ThrowError(Nan::TypeError(message.c_str()));
+}
+
 void ThrowParameterError(const char* domain, const char* description)
 {
     std::string message;

--- a/src/wrappers/themis/jsthemis/errors.hpp
+++ b/src/wrappers/themis/jsthemis/errors.hpp
@@ -33,6 +33,8 @@ void Init(v8::Local<v8::Object> exports);
 
 void ThrowError(const char* domain, themis_status_t status);
 
+void ThrowTypeError(const char* domain, const char* description);
+
 void ThrowParameterError(const char* domain, const char* description);
 
 void ThrowSecureSessionError(const char* domain, themis_status_t status);

--- a/src/wrappers/themis/jsthemis/secure_cell_context_imprint.cpp
+++ b/src/wrappers/themis/jsthemis/secure_cell_context_imprint.cpp
@@ -62,8 +62,7 @@ void SecureCellContextImprint::New(const Nan::FunctionCallbackInfo<v8::Value>& a
             return;
         }
         if (!args[0]->IsUint8Array()) {
-            ThrowTypeError("SecureCellContextImprint",
-                           "master key is not a byte buffer");
+            ThrowTypeError("SecureCellContextImprint", "master key is not a byte buffer");
             args.GetReturnValue().SetUndefined();
             return;
         }

--- a/src/wrappers/themis/jsthemis/secure_cell_context_imprint.cpp
+++ b/src/wrappers/themis/jsthemis/secure_cell_context_imprint.cpp
@@ -62,8 +62,8 @@ void SecureCellContextImprint::New(const Nan::FunctionCallbackInfo<v8::Value>& a
             return;
         }
         if (!args[0]->IsUint8Array()) {
-            ThrowParameterError("Secure Cell (Context Imprint) constructor",
-                                "master key is not a byte buffer");
+            ThrowTypeError("SecureCellContextImprint",
+                           "master key is not a byte buffer");
             args.GetReturnValue().SetUndefined();
             return;
         }
@@ -96,8 +96,8 @@ void SecureCellContextImprint::encrypt(const Nan::FunctionCallbackInfo<v8::Value
         return;
     }
     if (!args[0]->IsUint8Array()) {
-        ThrowParameterError("Secure Cell (Context Imprint) failed to encrypt",
-                            "message is not a byte buffer, use ByteBuffer or Uint8Array");
+        ThrowTypeError("SecureCellContextImprint",
+                       "message is not a byte buffer, use ByteBuffer or Uint8Array");
         args.GetReturnValue().SetUndefined();
         return;
     }
@@ -107,8 +107,8 @@ void SecureCellContextImprint::encrypt(const Nan::FunctionCallbackInfo<v8::Value
         return;
     }
     if (!args[1]->IsUint8Array()) {
-        ThrowParameterError("Secure Cell (Context Imprint) failed to encrypt",
-                            "context is not a byte buffer, use ByteBuffer or Uint8Array");
+        ThrowTypeError("SecureCellContextImprint",
+                       "context is not a byte buffer, use ByteBuffer or Uint8Array");
         args.GetReturnValue().SetUndefined();
         return;
     }
@@ -162,8 +162,8 @@ void SecureCellContextImprint::decrypt(const Nan::FunctionCallbackInfo<v8::Value
         return;
     }
     if (!args[0]->IsUint8Array()) {
-        ThrowParameterError("Secure Cell (Context Imprint) failed to decrypt",
-                            "message is not a byte buffer, use ByteBuffer or Uint8Array");
+        ThrowTypeError("SecureCellContextImprint",
+                       "message is not a byte buffer, use ByteBuffer or Uint8Array");
         args.GetReturnValue().SetUndefined();
         return;
     }
@@ -173,8 +173,8 @@ void SecureCellContextImprint::decrypt(const Nan::FunctionCallbackInfo<v8::Value
         return;
     }
     if (!args[1]->IsUint8Array()) {
-        ThrowParameterError("Secure Cell (Context Imprint) failed to decrypt",
-                            "context is not a byte buffer, use ByteBuffer or Uint8Array");
+        ThrowTypeError("SecureCellContextImprint",
+                       "context is not a byte buffer, use ByteBuffer or Uint8Array");
         args.GetReturnValue().SetUndefined();
         return;
     }

--- a/src/wrappers/themis/jsthemis/secure_cell_seal.cpp
+++ b/src/wrappers/themis/jsthemis/secure_cell_seal.cpp
@@ -96,8 +96,7 @@ void SecureCellSeal::encrypt(const Nan::FunctionCallbackInfo<v8::Value>& args)
         return;
     }
     if (!args[0]->IsUint8Array()) {
-        ThrowTypeError("SecureCellSeal",
-                       "message is not a byte buffer, use ByteBuffer or Uint8Array");
+        ThrowTypeError("SecureCellSeal", "message is not a byte buffer, use ByteBuffer or Uint8Array");
         args.GetReturnValue().SetUndefined();
         return;
     }
@@ -161,8 +160,7 @@ void SecureCellSeal::decrypt(const Nan::FunctionCallbackInfo<v8::Value>& args)
         return;
     }
     if (!args[0]->IsUint8Array()) {
-        ThrowTypeError("SecureCellSeal",
-                       "message is not a byte buffer, use ByteBuffer or Uint8Array");
+        ThrowTypeError("SecureCellSeal", "message is not a byte buffer, use ByteBuffer or Uint8Array");
         args.GetReturnValue().SetUndefined();
         return;
     }

--- a/src/wrappers/themis/jsthemis/secure_cell_seal.cpp
+++ b/src/wrappers/themis/jsthemis/secure_cell_seal.cpp
@@ -62,8 +62,8 @@ void SecureCellSeal::New(const Nan::FunctionCallbackInfo<v8::Value>& args)
             return;
         }
         if (!args[0]->IsUint8Array()) {
-            ThrowParameterError("Secure Cell (Seal) constructor",
-                                "master key is not a byte buffer, use ByteBuffer or Uint8Array");
+            ThrowTypeError("SecureCellSeal",
+                           "master key is not a byte buffer, use ByteBuffer or Uint8Array");
             args.GetReturnValue().SetUndefined();
             return;
         }
@@ -96,8 +96,8 @@ void SecureCellSeal::encrypt(const Nan::FunctionCallbackInfo<v8::Value>& args)
         return;
     }
     if (!args[0]->IsUint8Array()) {
-        ThrowParameterError("Secure Cell (Seal) failed to encrypt",
-                            "message is not a byte buffer, use ByteBuffer or Uint8Array");
+        ThrowTypeError("SecureCellSeal",
+                       "message is not a byte buffer, use ByteBuffer or Uint8Array");
         args.GetReturnValue().SetUndefined();
         return;
     }
@@ -111,8 +111,8 @@ void SecureCellSeal::encrypt(const Nan::FunctionCallbackInfo<v8::Value>& args)
     size_t context_length = 0;
     if (args.Length() == 2) {
         if (!args[1]->IsUint8Array()) {
-            ThrowParameterError("Secure Cell (Seal) failed to encrypt",
-                                "context is not a byte buffer, use ByteBuffer or Uint8Array");
+            ThrowTypeError("SecureCellSeal",
+                           "context is not a byte buffer, use ByteBuffer or Uint8Array");
             args.GetReturnValue().SetUndefined();
             return;
         }
@@ -161,8 +161,8 @@ void SecureCellSeal::decrypt(const Nan::FunctionCallbackInfo<v8::Value>& args)
         return;
     }
     if (!args[0]->IsUint8Array()) {
-        ThrowParameterError("Secure Cell (Seal) failed to decrypt",
-                            "message is not a byte buffer, use ByteBuffer or Uint8Array");
+        ThrowTypeError("SecureCellSeal",
+                       "message is not a byte buffer, use ByteBuffer or Uint8Array");
         args.GetReturnValue().SetUndefined();
         return;
     }
@@ -176,8 +176,8 @@ void SecureCellSeal::decrypt(const Nan::FunctionCallbackInfo<v8::Value>& args)
     size_t context_length = 0;
     if (args.Length() == 2) {
         if (!args[1]->IsUint8Array()) {
-            ThrowParameterError("Secure Cell (Seal) failed to decrypt",
-                                "context is not a byte buffer, use ByteBuffer or Uint8Array");
+            ThrowTypeError("SecureCellSeal",
+                           "context is not a byte buffer, use ByteBuffer or Uint8Array");
             args.GetReturnValue().SetUndefined();
             return;
         }

--- a/src/wrappers/themis/jsthemis/secure_cell_seal.cpp
+++ b/src/wrappers/themis/jsthemis/secure_cell_seal.cpp
@@ -109,7 +109,7 @@ void SecureCellSeal::encrypt(const Nan::FunctionCallbackInfo<v8::Value>& args)
     size_t length = 0;
     const uint8_t* context = NULL;
     size_t context_length = 0;
-    if (args.Length() == 2) {
+    if (args.Length() == 2 && !args[1]->IsNull()) {
         if (!args[1]->IsUint8Array()) {
             ThrowTypeError("SecureCellSeal",
                            "context is not a byte buffer, use ByteBuffer or Uint8Array");
@@ -174,7 +174,7 @@ void SecureCellSeal::decrypt(const Nan::FunctionCallbackInfo<v8::Value>& args)
     size_t length = 0;
     const uint8_t* context = NULL;
     size_t context_length = 0;
-    if (args.Length() == 2) {
+    if (args.Length() == 2 && !args[1]->IsNull()) {
         if (!args[1]->IsUint8Array()) {
             ThrowTypeError("SecureCellSeal",
                            "context is not a byte buffer, use ByteBuffer or Uint8Array");

--- a/src/wrappers/themis/jsthemis/secure_cell_token_protect.cpp
+++ b/src/wrappers/themis/jsthemis/secure_cell_token_protect.cpp
@@ -110,7 +110,7 @@ void SecureCellTokenProtect::encrypt(const Nan::FunctionCallbackInfo<v8::Value>&
     size_t token_length = 0;
     const uint8_t* context = NULL;
     size_t context_length = 0;
-    if (args.Length() == 2) {
+    if (args.Length() == 2 && !args[1]->IsNull()) {
         if (!args[1]->IsUint8Array()) {
             ThrowTypeError("SecureCellTokenProtect",
                            "context is not a byte buffer, use ByteBuffer or Uint8Array");
@@ -199,7 +199,7 @@ void SecureCellTokenProtect::decrypt(const Nan::FunctionCallbackInfo<v8::Value>&
     size_t length = 0;
     const uint8_t* context = NULL;
     size_t context_length = 0;
-    if (args.Length() == 3) {
+    if (args.Length() == 3 && !args[2]->IsNull()) {
         if (!args[2]->IsUint8Array()) {
             ThrowTypeError("SecureCellTokenProtect",
                            "context is not a byte buffer, use ByteBuffer or Uint8Array");

--- a/src/wrappers/themis/jsthemis/secure_cell_token_protect.cpp
+++ b/src/wrappers/themis/jsthemis/secure_cell_token_protect.cpp
@@ -62,8 +62,8 @@ void SecureCellTokenProtect::New(const Nan::FunctionCallbackInfo<v8::Value>& arg
             return;
         }
         if (!args[0]->IsUint8Array()) {
-            ThrowParameterError("Secure Cell (Token Protect) constructor",
-                                "master key is not a byte buffer, use ByteBuffer or Uint8Array");
+            ThrowTypeError("SecureCellTokenProtect",
+                           "master key is not a byte buffer, use ByteBuffer or Uint8Array");
             args.GetReturnValue().SetUndefined();
             return;
         }
@@ -96,8 +96,8 @@ void SecureCellTokenProtect::encrypt(const Nan::FunctionCallbackInfo<v8::Value>&
         return;
     }
     if (!args[0]->IsUint8Array()) {
-        ThrowParameterError("Secure Cell (Token Protect) failed to encrypt",
-                            "message is not a byte buffer, use ByteBuffer or Uint8Array");
+        ThrowTypeError("SecureCellTokenProtect",
+                       "message is not a byte buffer, use ByteBuffer or Uint8Array");
         args.GetReturnValue().SetUndefined();
         return;
     }
@@ -112,8 +112,8 @@ void SecureCellTokenProtect::encrypt(const Nan::FunctionCallbackInfo<v8::Value>&
     size_t context_length = 0;
     if (args.Length() == 2) {
         if (!args[1]->IsUint8Array()) {
-            ThrowParameterError("Secure Cell (Token Protect) failed to encrypt",
-                                "context is not a byte buffer, use ByteBuffer or Uint8Array");
+            ThrowTypeError("SecureCellTokenProtect",
+                           "context is not a byte buffer, use ByteBuffer or Uint8Array");
             args.GetReturnValue().SetUndefined();
             return;
         }
@@ -175,8 +175,8 @@ void SecureCellTokenProtect::decrypt(const Nan::FunctionCallbackInfo<v8::Value>&
         return;
     }
     if (!args[0]->IsUint8Array()) {
-        ThrowParameterError("Secure Cell (Token Protect) failed to decrypt",
-                            "message is not a byte buffer, use ByteBuffer or Uint8Array");
+        ThrowTypeError("SecureCellTokenProtect",
+                       "message is not a byte buffer, use ByteBuffer or Uint8Array");
         args.GetReturnValue().SetUndefined();
         return;
     }
@@ -186,8 +186,8 @@ void SecureCellTokenProtect::decrypt(const Nan::FunctionCallbackInfo<v8::Value>&
         return;
     }
     if (!args[1]->IsUint8Array()) {
-        ThrowParameterError("Secure Cell (Token Protect) failed to decrypt",
-                            "token is not a byte buffer, use ByteBuffer or Uint8Array");
+        ThrowTypeError("SecureCellTokenProtect",
+                       "token is not a byte buffer, use ByteBuffer or Uint8Array");
         args.GetReturnValue().SetUndefined();
         return;
     }
@@ -201,8 +201,8 @@ void SecureCellTokenProtect::decrypt(const Nan::FunctionCallbackInfo<v8::Value>&
     size_t context_length = 0;
     if (args.Length() == 3) {
         if (!args[2]->IsUint8Array()) {
-            ThrowParameterError("Secure Cell (Token Protect) failed to decrypt",
-                                "context is not a byte buffer, use ByteBuffer or Uint8Array");
+            ThrowTypeError("SecureCellTokenProtect",
+                           "context is not a byte buffer, use ByteBuffer or Uint8Array");
             args.GetReturnValue().SetUndefined();
             return;
         }

--- a/src/wrappers/themis/jsthemis/secure_comparator.cpp
+++ b/src/wrappers/themis/jsthemis/secure_comparator.cpp
@@ -79,8 +79,8 @@ void SecureComparator::New(const Nan::FunctionCallbackInfo<v8::Value>& args)
             return;
         }
         if (!args[0]->IsUint8Array()) {
-            ThrowParameterError("Secure Comparator constructor",
-                                "secret is not a byte buffer, use ByteBuffer or Uint8Array");
+            ThrowTypeError("SecureComparator",
+                           "secret is not a byte buffer, use ByteBuffer or Uint8Array");
             return;
         }
         if (node::Buffer::Length(args[0]) == 0) {
@@ -133,8 +133,8 @@ void SecureComparator::proceedCompare(const Nan::FunctionCallbackInfo<v8::Value>
         return;
     }
     if (!args[0]->IsUint8Array()) {
-        ThrowParameterError("Secure Comparator failed to proceed comparison",
-                            "message is not a byte buffer, use ByteBuffer or Uint8Array");
+        ThrowTypeError("SecureComparator",
+                       "message is not a byte buffer, use ByteBuffer or Uint8Array");
         return;
     }
     if (node::Buffer::Length(args[0]) == 0) {

--- a/src/wrappers/themis/jsthemis/secure_comparator.cpp
+++ b/src/wrappers/themis/jsthemis/secure_comparator.cpp
@@ -133,8 +133,7 @@ void SecureComparator::proceedCompare(const Nan::FunctionCallbackInfo<v8::Value>
         return;
     }
     if (!args[0]->IsUint8Array()) {
-        ThrowTypeError("SecureComparator",
-                       "message is not a byte buffer, use ByteBuffer or Uint8Array");
+        ThrowTypeError("SecureComparator", "message is not a byte buffer, use ByteBuffer or Uint8Array");
         return;
     }
     if (node::Buffer::Length(args[0]) == 0) {

--- a/src/wrappers/themis/jsthemis/secure_keygen.cpp
+++ b/src/wrappers/themis/jsthemis/secure_keygen.cpp
@@ -59,8 +59,8 @@ void KeyPair::New(const Nan::FunctionCallbackInfo<v8::Value>& args)
     if (args.IsConstructCall()) {
         if (args.Length() == 2) {
             if (!args[0]->IsUint8Array()) {
-                ThrowParameterError("Key Pair constructor",
-                                    "private key is not a byte buffer, use ByteBuffer or Uint8Array");
+                ThrowTypeError("KeyPair",
+                               "private key is not a byte buffer, use ByteBuffer or Uint8Array");
                 return;
             }
             if (node::Buffer::Length(args[0]) == 0) {
@@ -68,8 +68,8 @@ void KeyPair::New(const Nan::FunctionCallbackInfo<v8::Value>& args)
                 return;
             }
             if (!args[1]->IsUint8Array()) {
-                ThrowParameterError("Key Pair constructor",
-                                    "public key is not a byte buffer, use ByteBuffer or Uint8Array");
+                ThrowTypeError("KeyPair",
+                               "public key is not a byte buffer, use ByteBuffer or Uint8Array");
                 return;
             }
             if (node::Buffer::Length(args[1]) == 0) {
@@ -228,8 +228,8 @@ void SymmetricKey::New(const Nan::FunctionCallbackInfo<v8::Value>& args)
     // a byte buffer that we copy.
     v8::Local<v8::Value> value = args[0];
     if (!value->IsUint8Array()) {
-        ThrowParameterError("Themis SymmetricKey",
-                            "key is not a byte buffer (use Buffer or Uint8Array)");
+        ThrowTypeError("SymmetricKey",
+                       "key is not a byte buffer (use Buffer or Uint8Array)");
         args.GetReturnValue().SetUndefined();
         return;
     }

--- a/src/wrappers/themis/jsthemis/secure_keygen.cpp
+++ b/src/wrappers/themis/jsthemis/secure_keygen.cpp
@@ -228,8 +228,7 @@ void SymmetricKey::New(const Nan::FunctionCallbackInfo<v8::Value>& args)
     // a byte buffer that we copy.
     v8::Local<v8::Value> value = args[0];
     if (!value->IsUint8Array()) {
-        ThrowTypeError("SymmetricKey",
-                       "key is not a byte buffer (use Buffer or Uint8Array)");
+        ThrowTypeError("SymmetricKey", "key is not a byte buffer (use Buffer or Uint8Array)");
         args.GetReturnValue().SetUndefined();
         return;
     }
@@ -240,7 +239,6 @@ void SymmetricKey::New(const Nan::FunctionCallbackInfo<v8::Value>& args)
     }
 
     args.GetReturnValue().Set(CopyIntoBuffer(value));
-    return;
 }
 
 // TODO: return properly inherited instances of SymmetricKey

--- a/src/wrappers/themis/jsthemis/secure_message.cpp
+++ b/src/wrappers/themis/jsthemis/secure_message.cpp
@@ -111,6 +111,10 @@ void SecureMessage::New(const Nan::FunctionCallbackInfo<v8::Value>& args)
 bool SecureMessage::ValidateKeys(const std::vector<uint8_t>& private_key,
                                  const std::vector<uint8_t>& public_key)
 {
+    if (private_key.empty() && public_key.empty()) {
+        ThrowParameterError("SecureMessage", "private and public key cannot be both empty");
+        return false;
+    }
     if (!private_key.empty()) {
         if (!IsValidKey(private_key)) {
             ThrowParameterError("Secure Message constructor", "invalid private key");

--- a/src/wrappers/themis/jsthemis/secure_message.cpp
+++ b/src/wrappers/themis/jsthemis/secure_message.cpp
@@ -67,14 +67,14 @@ void SecureMessage::New(const Nan::FunctionCallbackInfo<v8::Value>& args)
             return;
         }
         if (!args[0]->IsUint8Array()) {
-            ThrowParameterError("Secure Message constructor",
-                                "private key is not a byte buffer, use ByteBuffer or Uint8Array");
+            ThrowTypeError("SecureMessage",
+                           "private key is not a byte buffer, use ByteBuffer or Uint8Array");
             args.GetReturnValue().SetUndefined();
             return;
         }
         if (!args[1]->IsUint8Array()) {
-            ThrowParameterError("Secure Message constructor",
-                                "public key is not a byte buffer, use ByteBuffer or Uint8Array");
+            ThrowTypeError("SecureMessage",
+                           "public key is not a byte buffer, use ByteBuffer or Uint8Array");
             args.GetReturnValue().SetUndefined();
             return;
         }
@@ -146,8 +146,8 @@ void SecureMessage::encrypt(const Nan::FunctionCallbackInfo<v8::Value>& args)
         return;
     }
     if (!args[0]->IsUint8Array()) {
-        ThrowParameterError("Secure Message failed to encrypt message",
-                            "message is not a byte buffer, use ByteBuffer or Uint8Array");
+        ThrowTypeError("SecureMessage",
+                       "message is not a byte buffer, use ByteBuffer or Uint8Array");
         args.GetReturnValue().SetUndefined();
         return;
     }
@@ -209,8 +209,8 @@ void SecureMessage::decrypt(const Nan::FunctionCallbackInfo<v8::Value>& args)
         return;
     }
     if (!args[0]->IsUint8Array()) {
-        ThrowParameterError("Secure Message failed to decrypt message",
-                            "message is not a byte buffer, use ByteBuffer or Uint8Array");
+        ThrowTypeError("SecureMessage",
+                       "message is not a byte buffer, use ByteBuffer or Uint8Array");
         args.GetReturnValue().SetUndefined();
         return;
     }
@@ -267,8 +267,8 @@ void SecureMessage::sign(const Nan::FunctionCallbackInfo<v8::Value>& args)
         return;
     }
     if (!args[0]->IsUint8Array()) {
-        ThrowParameterError("Secure Message failed to sign message",
-                            "message is not a byte buffer, use ByteBuffer or Uint8Array");
+        ThrowTypeError("SecureMessage",
+                       "message is not a byte buffer, use ByteBuffer or Uint8Array");
         args.GetReturnValue().SetUndefined();
         return;
     }
@@ -321,8 +321,8 @@ void SecureMessage::verify(const Nan::FunctionCallbackInfo<v8::Value>& args)
         return;
     }
     if (!args[0]->IsUint8Array()) {
-        ThrowParameterError("Secure Message failed to verify signature",
-                            "message is not byte buffer, use ByteBuffer or Uint8Array");
+        ThrowTypeError("SecureMessage",
+                       "message is not byte buffer, use ByteBuffer or Uint8Array");
         args.GetReturnValue().SetUndefined();
         return;
     }

--- a/src/wrappers/themis/jsthemis/secure_message.cpp
+++ b/src/wrappers/themis/jsthemis/secure_message.cpp
@@ -57,9 +57,10 @@ void SecureMessage::Init(v8::Local<v8::Object> exports)
     Nan::Set(exports, className, function);
 }
 
-static inline void assign_buffer_to_vector(std::vector<uint8_t> &vector, const v8::Local<v8::Value> &buffer)
+static inline void assign_buffer_to_vector(std::vector<uint8_t>& vector,
+                                           const v8::Local<v8::Value>& buffer)
 {
-    const uint8_t *data = reinterpret_cast<const uint8_t*>(node::Buffer::Data(buffer));
+    const uint8_t* data = reinterpret_cast<const uint8_t*>(node::Buffer::Data(buffer));
     size_t length = node::Buffer::Length(buffer);
     vector.assign(data, data + length);
 }
@@ -77,7 +78,7 @@ void SecureMessage::New(const Nan::FunctionCallbackInfo<v8::Value>& args)
         if (!args[0]->IsNull()) {
             if (!args[0]->IsUint8Array()) {
                 ThrowTypeError("SecureMessage",
-                            "private key is not a byte buffer, use ByteBuffer or Uint8Array");
+                               "private key is not a byte buffer, use ByteBuffer or Uint8Array");
                 args.GetReturnValue().SetUndefined();
                 return;
             }
@@ -87,7 +88,7 @@ void SecureMessage::New(const Nan::FunctionCallbackInfo<v8::Value>& args)
         if (!args[1]->IsNull()) {
             if (!args[1]->IsUint8Array()) {
                 ThrowTypeError("SecureMessage",
-                            "public key is not a byte buffer, use ByteBuffer or Uint8Array");
+                               "public key is not a byte buffer, use ByteBuffer or Uint8Array");
                 args.GetReturnValue().SetUndefined();
                 return;
             }
@@ -159,8 +160,7 @@ void SecureMessage::encrypt(const Nan::FunctionCallbackInfo<v8::Value>& args)
         return;
     }
     if (!args[0]->IsUint8Array()) {
-        ThrowTypeError("SecureMessage",
-                       "message is not a byte buffer, use ByteBuffer or Uint8Array");
+        ThrowTypeError("SecureMessage", "message is not a byte buffer, use ByteBuffer or Uint8Array");
         args.GetReturnValue().SetUndefined();
         return;
     }
@@ -222,8 +222,7 @@ void SecureMessage::decrypt(const Nan::FunctionCallbackInfo<v8::Value>& args)
         return;
     }
     if (!args[0]->IsUint8Array()) {
-        ThrowTypeError("SecureMessage",
-                       "message is not a byte buffer, use ByteBuffer or Uint8Array");
+        ThrowTypeError("SecureMessage", "message is not a byte buffer, use ByteBuffer or Uint8Array");
         args.GetReturnValue().SetUndefined();
         return;
     }
@@ -280,8 +279,7 @@ void SecureMessage::sign(const Nan::FunctionCallbackInfo<v8::Value>& args)
         return;
     }
     if (!args[0]->IsUint8Array()) {
-        ThrowTypeError("SecureMessage",
-                       "message is not a byte buffer, use ByteBuffer or Uint8Array");
+        ThrowTypeError("SecureMessage", "message is not a byte buffer, use ByteBuffer or Uint8Array");
         args.GetReturnValue().SetUndefined();
         return;
     }
@@ -334,8 +332,7 @@ void SecureMessage::verify(const Nan::FunctionCallbackInfo<v8::Value>& args)
         return;
     }
     if (!args[0]->IsUint8Array()) {
-        ThrowTypeError("SecureMessage",
-                       "message is not byte buffer, use ByteBuffer or Uint8Array");
+        ThrowTypeError("SecureMessage", "message is not byte buffer, use ByteBuffer or Uint8Array");
         args.GetReturnValue().SetUndefined();
         return;
     }

--- a/src/wrappers/themis/jsthemis/secure_session.cpp
+++ b/src/wrappers/themis/jsthemis/secure_session.cpp
@@ -22,8 +22,8 @@
 
 #include <themis/themis.h>
 
-#include "secure_keygen.hpp"
 #include "errors.hpp"
+#include "secure_keygen.hpp"
 
 namespace jsthemis
 {
@@ -37,7 +37,8 @@ int SecureSession::get_public_key_for_id_callback(
         return THEMIS_BUFFER_TOO_SMALL;
     }
     v8::Local<v8::Value> argv[1] = {Nan::CopyBuffer((char*)id, id_length).ToLocalChecked()};
-    Nan::MaybeLocal<v8::Value> result = Nan::Call(reinterpret_cast<SecureSession*>(user_data)->id_to_pub_key_callback_, 1, argv);
+    Nan::MaybeLocal<v8::Value> result =
+        Nan::Call(reinterpret_cast<SecureSession*>(user_data)->id_to_pub_key_callback_, 1, argv);
     if (result.IsEmpty()) {
         return THEMIS_FAIL;
     }
@@ -188,8 +189,7 @@ void SecureSession::wrap(const Nan::FunctionCallbackInfo<v8::Value>& args)
         return;
     }
     if (!args[0]->IsUint8Array()) {
-        ThrowTypeError("SecureSession",
-                       "message is not a byte buffer, use ByteBuffer or Uint8Array");
+        ThrowTypeError("SecureSession", "message is not a byte buffer, use ByteBuffer or Uint8Array");
         args.GetReturnValue().SetUndefined();
         return;
     }
@@ -235,8 +235,7 @@ void SecureSession::unwrap(const Nan::FunctionCallbackInfo<v8::Value>& args)
         return;
     }
     if (!args[0]->IsUint8Array()) {
-        ThrowTypeError("SecureSession",
-                       "message is not a byte buffer, use ByteBuffer or Uint8Array");
+        ThrowTypeError("SecureSession", "message is not a byte buffer, use ByteBuffer or Uint8Array");
         args.GetReturnValue().SetUndefined();
         return;
     }

--- a/src/wrappers/themis/jsthemis/secure_session.cpp
+++ b/src/wrappers/themis/jsthemis/secure_session.cpp
@@ -104,8 +104,8 @@ void SecureSession::New(const Nan::FunctionCallbackInfo<v8::Value>& args)
             return;
         }
         if (!args[0]->IsUint8Array()) {
-            ThrowParameterError("Secure Session constructor",
-                                "client ID is not a byte buffer, use ByteBuffer or Uint8Array");
+            ThrowTypeError("SecureSession",
+                           "client ID is not a byte buffer, use ByteBuffer or Uint8Array");
             args.GetReturnValue().SetUndefined();
             return;
         }
@@ -115,8 +115,8 @@ void SecureSession::New(const Nan::FunctionCallbackInfo<v8::Value>& args)
             return;
         }
         if (!args[1]->IsUint8Array()) {
-            ThrowParameterError("Secure Session constructor",
-                                "private key is not a byte buffer, use ByteBuffer or Uint8Array");
+            ThrowTypeError("SecureSession",
+                           "private key is not a byte buffer, use ByteBuffer or Uint8Array");
             args.GetReturnValue().SetUndefined();
             return;
         }
@@ -179,8 +179,8 @@ void SecureSession::wrap(const Nan::FunctionCallbackInfo<v8::Value>& args)
         return;
     }
     if (!args[0]->IsUint8Array()) {
-        ThrowParameterError("Secure Session failed to encrypt",
-                            "message is not a byte buffer, use ByteBuffer or Uint8Array");
+        ThrowTypeError("SecureSession",
+                       "message is not a byte buffer, use ByteBuffer or Uint8Array");
         args.GetReturnValue().SetUndefined();
         return;
     }
@@ -226,8 +226,8 @@ void SecureSession::unwrap(const Nan::FunctionCallbackInfo<v8::Value>& args)
         return;
     }
     if (!args[0]->IsUint8Array()) {
-        ThrowParameterError("Secure Session failed to decrypt",
-                            "message is not a byte buffer, use ByteBuffer or Uint8Array");
+        ThrowTypeError("SecureSession",
+                       "message is not a byte buffer, use ByteBuffer or Uint8Array");
         args.GetReturnValue().SetUndefined();
         return;
     }

--- a/src/wrappers/themis/jsthemis/secure_session.cpp
+++ b/src/wrappers/themis/jsthemis/secure_session.cpp
@@ -22,6 +22,7 @@
 
 #include <themis/themis.h>
 
+#include "secure_keygen.hpp"
 #include "errors.hpp"
 
 namespace jsthemis
@@ -135,6 +136,11 @@ void SecureSession::New(const Nan::FunctionCallbackInfo<v8::Value>& args)
         std::vector<uint8_t> private_key((uint8_t*)(node::Buffer::Data(args[1])),
                                          (uint8_t*)(node::Buffer::Data(args[1])
                                                     + node::Buffer::Length(args[1])));
+        if (!IsPrivateKey(private_key)) {
+            ThrowParameterError("SecureSession", "invalid private key");
+            args.GetReturnValue().SetUndefined();
+            return;
+        }
         SecureSession* obj = new SecureSession(id, private_key, v8::Local<v8::Function>::Cast(args[2]));
         obj->Wrap(args.This());
         args.GetReturnValue().Set(args.This());

--- a/src/wrappers/themis/jsthemis/secure_session.cpp
+++ b/src/wrappers/themis/jsthemis/secure_session.cpp
@@ -37,8 +37,11 @@ int SecureSession::get_public_key_for_id_callback(
         return THEMIS_BUFFER_TOO_SMALL;
     }
     v8::Local<v8::Value> argv[1] = {Nan::CopyBuffer((char*)id, id_length).ToLocalChecked()};
-    v8::Local<v8::Value> a =
-        Nan::Call(((SecureSession*)(user_data))->id_to_pub_key_callback_, 1, argv).ToLocalChecked();
+    Nan::MaybeLocal<v8::Value> result = Nan::Call(reinterpret_cast<SecureSession*>(user_data)->id_to_pub_key_callback_, 1, argv);
+    if (result.IsEmpty()) {
+        return THEMIS_FAIL;
+    }
+    v8::Local<v8::Value> a = result.ToLocalChecked();
     if (a->IsUint8Array()) {
         v8::Local<v8::Object> buffer = a.As<v8::Object>();
         if (key_buffer_length < node::Buffer::Length(buffer)) {

--- a/src/wrappers/themis/jsthemis/test/test.js
+++ b/src/wrappers/themis/jsthemis/test/test.js
@@ -1,3 +1,17 @@
+// Copyright (c) 2016 Cossack Labs Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 var addon = require('..');
 var assert = require('assert');
 

--- a/src/wrappers/themis/jsthemis/test/test.js
+++ b/src/wrappers/themis/jsthemis/test/test.js
@@ -150,22 +150,10 @@ describe("jsthemis", function(){
             })
             it('leaves signed data in plaintext', function() {
                 let signer = new addon.SecureMessage(privateKeyA, null)
+
                 let signed = signer.sign(testInput)
-                // TODO: there has to be more idiomatic way for this check...
-                for (var i = 0; i < signed.length - testInput.length; i++) {
-                    let slice = signed.slice(i, i + testInput.length)
-                    var allEqual = true
-                    for (var j = 0; j < testInput.length; j++){
-                        if (slice[j] != testInput[j]) {
-                            allEqual = false
-                            break
-                        }
-                    }
-                    if (allEqual) {
-                        return
-                    }
-                }
-                assert.fail('plaintext not found in signed message')
+
+                assert.ok(signed.includes(testInput))
             })
             it('cannot verify with a different key', function() {
                 let signer = new addon.SecureMessage(privateKeyA, null)


### PR DESCRIPTION
This PR updates JsThemis tests and fixes a bunch of issues and inconsistencies that I've discovered while working on this update.

### Updated tests

Existing JsThemis tests are haphazard and incomplete. I've mostly reused WasmThemis tests, adapted them to JsThemis API, and salvaged some JsThemis-specific tests.

### API changes: Secure Cell

It is now possible to use `null` values when the associated context is omitted:

```javascript
let cell = new themis.SecureCellSeal(key)

let encrypted = cell.encrypt(message)
let decrypted = cell.decrypt(encrypted, null)
```

This is consistent with WasmThemis.

### API changes: Secure Message

It is now possible to use `null` values for omitted keys to initialize `SecureMessage` in sign/verify mode:

```javascript
let verifier = new themis.SecureMessage(null, publicKey)
```

This is consistent with other `null` usage in the API.

WasmThemis has a different API for sign/verify mode of Secure Message. Its encryption API does not allow `null` values.

### API changes: Secure Session

`SecureSession` will now validate private key during construction, not on the first use. This is consistent with WasmThemis (and other wrappers).

It is also possible to safely throw JavaScript exceptions from Secure Session public key callback. An exception will be reported as a failure to retrieve public key, instead of aborting the process due to Node.js error checks.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] Public API has proper documentation
- [X] ~~Example projects and code samples are up-to-date~~ (no need)
- [X] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md