### PR TITLE
Improve GoThemis error introspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ _Code:_
 - **Go**
 
   - New function `keys.NewSymmetricKey()` can be used to generate symmetric keys for Secure Cell ([#561](https://github.com/cossacklabs/themis/pull/561)).
+  - Improved `ThemisError` introspection: added error constants, numeric error codes ([#622](https://github.com/cossacklabs/themis/pull/622)).
 
 - **iOS and macOS**
 

--- a/gothemis/cell/cell.go
+++ b/gothemis/cell/cell.go
@@ -130,6 +130,15 @@ import (
 	"unsafe"
 )
 
+// Errors returned by Secure Cell.
+var (
+	ErrInvalidMode    = errors.NewWithCode(errors.InvalidParameter, "invalid Secure Cell mode specified")
+	ErrMissingKey     = errors.NewWithCode(errors.InvalidParameter, "empty symmetric key for Secure Cell")
+	ErrMissingMessage = errors.NewWithCode(errors.InvalidParameter, "empty message for Secure Cell")
+	ErrMissingToken   = errors.NewWithCode(errors.InvalidParameter, "authentication token is required in Token Protect mode")
+	ErrMissingContext = errors.NewWithCode(errors.InvalidParameter, "associated context is required in Context Imprint mode")
+)
+
 // Secure Cell operation mode.
 const (
 	ModeSeal = iota
@@ -165,20 +174,20 @@ func missing(data []byte) bool {
 // Protect encrypts or signs data with optional user context (depending on the Cell mode).
 func (sc *SecureCell) Protect(data []byte, context []byte) ([]byte, []byte, error) {
 	if (sc.mode < ModeSeal) || (sc.mode > ModeContextImprint) {
-		return nil, nil, errors.New("Invalid mode specified")
+		return nil, nil, ErrInvalidMode
 	}
 
 	if missing(sc.key) {
-		return nil, nil, errors.New("Master key was not provided")
+		return nil, nil, ErrMissingKey
 	}
 
 	if missing(data) {
-		return nil, nil, errors.New("Data was not provided")
+		return nil, nil, ErrMissingMessage
 	}
 
 	if ModeContextImprint == sc.mode {
 		if missing(context) {
-			return nil, nil, errors.New("Context is mandatory for context imprint mode")
+			return nil, nil, ErrMissingContext
 		}
 	}
 
@@ -233,26 +242,26 @@ func (sc *SecureCell) Protect(data []byte, context []byte) ([]byte, []byte, erro
 // Unprotect decrypts or verify data with optional user context (depending on the Cell mode).
 func (sc *SecureCell) Unprotect(protectedData []byte, additionalData []byte, context []byte) ([]byte, error) {
 	if (sc.mode < ModeSeal) || (sc.mode > ModeContextImprint) {
-		return nil, errors.New("Invalid mode specified")
+		return nil, ErrInvalidMode
 	}
 
 	if missing(sc.key) {
-		return nil, errors.New("Master key was not provided")
+		return nil, ErrMissingKey
 	}
 
 	if missing(protectedData) {
-		return nil, errors.New("Data was not provided")
+		return nil, ErrMissingMessage
 	}
 
 	if ModeContextImprint == sc.mode {
 		if missing(context) {
-			return nil, errors.New("Context is mandatory for context imprint mode")
+			return nil, ErrMissingContext
 		}
 	}
 
 	if ModeTokenProtect == sc.mode {
 		if missing(additionalData) {
-			return nil, errors.New("Additional data is mandatory for token protect mode")
+			return nil, ErrMissingToken
 		}
 	}
 

--- a/gothemis/compare/compare.go
+++ b/gothemis/compare/compare.go
@@ -74,6 +74,12 @@ const (
 	COMPARE_NOT_READY = NotReady
 )
 
+// Errors returned by Secure Comparator.
+var (
+	ErrMissingSecret = errors.NewWithCode(errors.InvalidParameter, "empty secret for Secure Comparator")
+	ErrMissingData   = errors.NewWithCode(errors.InvalidParameter, "empty comparison message for Secure Comparator")
+)
+
 // SecureCompare is an interactive protocol for two parties that compares whether
 // they share the same secret or not.
 type SecureCompare struct {
@@ -113,7 +119,7 @@ func (sc *SecureCompare) Close() error {
 // Append adds data to be compared.
 func (sc *SecureCompare) Append(secret []byte) error {
 	if nil == secret || 0 == len(secret) {
-		return errors.New("Secret was not provided")
+		return ErrMissingSecret
 	}
 	if !bool(C.compare_append(sc.ctx, unsafe.Pointer(&secret[0]), C.size_t(len(secret)))) {
 		return errors.New("Failed to append secret")
@@ -145,7 +151,7 @@ func (sc *SecureCompare) Proceed(data []byte) ([]byte, error) {
 	var outLen C.size_t
 
 	if nil == data || 0 == len(data) {
-		return nil, errors.New("Data was not provided")
+		return nil, ErrMissingData
 	}
 
 	if !bool(C.compare_proceed_size(sc.ctx, unsafe.Pointer(&data[0]), C.size_t(len(data)), &outLen)) {

--- a/gothemis/errors/error.go
+++ b/gothemis/errors/error.go
@@ -1,18 +1,71 @@
+/*
+ * Copyright (c) 2016 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package errors describes errors returned by GoThemis functions.
 package errors
 
-// ThemisError is an operational error.
+/*
+#include <themis/themis.h>
+*/
+import "C"
+
+// ThemisErrorCode describes an error reported by Themis Core.
+type ThemisErrorCode int
+
+// Error code constants.
+//
+// These are numeric error codes used by Themis Core (see `<themis/themis_error.h>`).
+const (
+	Success          ThemisErrorCode = C.THEMIS_SUCCESS
+	Fail                             = C.THEMIS_FAIL
+	InvalidParameter                 = C.THEMIS_INVALID_PARAMETER
+	NoMemory                         = C.THEMIS_NO_MEMORY
+	BufferTooSmall                   = C.THEMIS_BUFFER_TOO_SMALL
+	DataCorrupt                      = C.THEMIS_DATA_CORRUPT
+	InvalidSignature                 = C.THEMIS_INVALID_SIGNATURE
+	NotSupported                     = C.THEMIS_NOT_SUPPORTED
+)
+
+// ThemisError is a common type of GoThemis errors.
 type ThemisError struct {
-	msg string
+	description string
+	errorCode   ThemisErrorCode
 }
 
-// Error returns textual description of the error.
+// Error returns human-readable textual description of the error.
 func (e *ThemisError) Error() string {
-	return e.msg
+	return e.description
+}
+
+// Code returns machine-readable numeric error code.
+func (e *ThemisError) Code() ThemisErrorCode {
+	return e.errorCode
 }
 
 // New makes an error with provided description.
-func New(msg string) *ThemisError {
-	return &ThemisError{msg}
+func New(description string) *ThemisError {
+	// This constructor is used by default in legacy CGo code which does not return
+	// accurate Themis Core error codes. Use "Fail" which is likely to be correct
+	// and is a good generic placeholder for an error.
+	return NewWithCode(Fail, description)
+}
+
+// NewWithCode makes an error with provided numeric code and description.
+func NewWithCode(code ThemisErrorCode, description string) *ThemisError {
+	return &ThemisError{description, code}
 }
 
 // ThemisCallbackError is user-generated error returned from Secure Session callback.

--- a/gothemis/keys/keypair.go
+++ b/gothemis/keys/keypair.go
@@ -72,6 +72,11 @@ const (
 	KEYTYPE_RSA = TypeRSA
 )
 
+// Errors returned by key generation.
+var (
+	ErrInvalidType = errors.NewWithCode(errors.InvalidParameter, "invalid key type specified")
+)
+
 // PrivateKey stores a ECDSA or RSA private key.
 type PrivateKey struct {
 	Value []byte
@@ -91,7 +96,7 @@ type Keypair struct {
 // New generates a new random pair of keys of the specified type.
 func New(keytype int) (*Keypair, error) {
 	if (keytype != TypeEC) && (keytype != TypeRSA) {
-		return nil, errors.New("Incorrect key type")
+		return nil, ErrInvalidType
 	}
 
 	var privLen, pubLen C.size_t

--- a/gothemis/message/message.go
+++ b/gothemis/message/message.go
@@ -75,6 +75,13 @@ const (
 	secureMessageVerify
 )
 
+// Errors returned by Secure Message.
+var (
+	ErrMissingMessage    = errors.NewWithCode(errors.InvalidParameter, "empty message for Secure Cell")
+	ErrMissingPublicKey  = errors.NewWithCode(errors.InvalidParameter, "empty peer public key for Secure Message")
+	ErrMissingPrivateKey = errors.NewWithCode(errors.InvalidParameter, "empty private key for Secure Message")
+)
+
 // SecureMessage provides a sequence-independent, stateless, contextless messaging system.
 type SecureMessage struct {
 	private    *keys.PrivateKey
@@ -90,7 +97,7 @@ func New(private *keys.PrivateKey, peerPublic *keys.PublicKey) *SecureMessage {
 
 func messageProcess(private *keys.PrivateKey, peerPublic *keys.PublicKey, message []byte, mode int) ([]byte, error) {
 	if nil == message || 0 == len(message) {
-		return nil, errors.New("No message was provided")
+		return nil, ErrMissingMessage
 	}
 
 	var priv, pub unsafe.Pointer
@@ -152,11 +159,11 @@ func messageProcess(private *keys.PrivateKey, peerPublic *keys.PublicKey, messag
 // Wrap encrypts the provided message.
 func (sm *SecureMessage) Wrap(message []byte) ([]byte, error) {
 	if nil == sm.private || 0 == len(sm.private.Value) {
-		return nil, errors.New("Private key was not provided")
+		return nil, ErrMissingPrivateKey
 	}
 
 	if nil == sm.peerPublic || 0 == len(sm.peerPublic.Value) {
-		return nil, errors.New("Peer public key was not provided")
+		return nil, ErrMissingPublicKey
 	}
 	return messageProcess(sm.private, sm.peerPublic, message, secureMessageEncrypt)
 }
@@ -164,11 +171,11 @@ func (sm *SecureMessage) Wrap(message []byte) ([]byte, error) {
 // Unwrap decrypts the encrypted message.
 func (sm *SecureMessage) Unwrap(message []byte) ([]byte, error) {
 	if nil == sm.private || 0 == len(sm.private.Value) {
-		return nil, errors.New("Private key was not provided")
+		return nil, ErrMissingPrivateKey
 	}
 
 	if nil == sm.peerPublic || 0 == len(sm.peerPublic.Value) {
-		return nil, errors.New("Peer public key was not provided")
+		return nil, ErrMissingPublicKey
 	}
 	return messageProcess(sm.private, sm.peerPublic, message, secureMessageDecrypt)
 }
@@ -176,7 +183,7 @@ func (sm *SecureMessage) Unwrap(message []byte) ([]byte, error) {
 // Sign signs the provided message and returns it signed.
 func (sm *SecureMessage) Sign(message []byte) ([]byte, error) {
 	if nil == sm.private || 0 == len(sm.private.Value) {
-		return nil, errors.New("Private key was not provided")
+		return nil, ErrMissingPrivateKey
 	}
 
 	return messageProcess(sm.private, nil, message, secureMessageSign)
@@ -185,7 +192,7 @@ func (sm *SecureMessage) Sign(message []byte) ([]byte, error) {
 // Verify checks the signature on the message and returns the original message.
 func (sm *SecureMessage) Verify(message []byte) ([]byte, error) {
 	if nil == sm.peerPublic || 0 == len(sm.peerPublic.Value) {
-		return nil, errors.New("Peer public key was not provided")
+		return nil, ErrMissingPublicKey
 	}
 
 	return messageProcess(nil, sm.peerPublic, message, secureMessageVerify)


### PR DESCRIPTION
GoThemis-specific errors (mostly early parameter checks) are now available as constants if you need to check for them specifically.

```go
encrypted, _, err := scell.Protect(message, nil)
if err == errors.ErrMissingKey {
        // you forgot to set the key
}
```

(Normally these are programming errors, so you'd check for such conditions *before* calling GoThemis API. The error constants are for cases when that's not possible.)

Add numeric error code to ThemisError struct, accessible via `Code()` method. Now it will be possible to communicate Themis Core errors to the user code. This is intended for programmatic consumption. Human-readable descriptive message is still available via the standard `Error()` of the `error` interface.

```go
encrypted, err := smessage.Wrap(message)
if err != nil {
        if themisErr, ok := err.(*errors.ThemisError); ok {
                if themisErr.Code() == errors.NotSupported {
                        // uh-oh...
                }
        }
}
```

(Normally, you do *not* need to look at the error code. You can see how verbose this is in the code. This API is introduced mostly to unify error reporting with other platforms that retain error code. Plus, there *are* rare cases in our practice when we need access to original error codes.)

#### For GoThemis developers

Errors with code can be constructed using `NewWithCode()` constructor. Existing code sites have been updated to use it for reporting various early warnings about invalid arguments. Themis Core checks for these violations too, we do these checks in Go to be able to provide more specific descriptions to users.

Note that there are still uses of `errors.New()`. Not all— I mean, *all* CGo call sites right now do not return Themis Core errors. This will be refactored eventually. For now, these call sites with use a placeholder THEMIS_FAIL as the code, which is going to be correct in 99% cases.

Also note that we now export error code constants. All of this makes it easier for user code to decide on an error type. It will also make it easier for us to write new CGo code as we can keep use of C to minimum.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] Public API has proper documentation
- [X] ~~Example projects and code samples are up-to-date~~ (no significant changes)
- [X] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
