### PR TITLE
Note big-endian compatibility issues in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changes that are currently in development and have not been released yet.
 - Many languages received Secure Cell API overhaul with parts of the old API becoming deprecated. Refer to individual language sections for details.
 - ObjCThemis installed via Carthage is now called `objcthemis` instead of just `themis` ([read more](#0.13.0-objcthemis-rename)).
 - Themis 0.9.6 compatibility is now disabled by default ([read more](#0.13.0-drop-0.9.6-compat)).
+- Themis is known to be broken on big-endian architectures ([read more](#0.13.0-big-endian)).
 
 _Code:_
 
@@ -46,6 +47,16 @@ _Code:_
       Since Themis 0.13 the workaround for Themis 0.9.6 compatibility is *disabled* by default (as it has performance implications). It can be enabled if needed by compling with `WITH_SCELL_COMPAT`.
 
       We are planning to **remove** the workaround completely after Themis 0.9.6 reaches end-of-life in December 2020. Please use this time to migrate existing data if you have been using Themis 0.9.6. To migrate the data, decrypt it and encrypt it back with the latest Themis version.
+
+    - <a id="0.13.0-big-endian">Themis is known to be broken on big-endian architectures</a> ([#623](https://github.com/cossacklabs/themis/pull/623), [#592](https://github.com/cossacklabs/themis/pull/592)).
+
+      Themis has never committed to supporting machines with big-endian architectures.
+      However, it was expected to accidentally work to some degree on such machines,
+      with certain compatibility restrictions on interaction with little-endian machines.
+
+      Recent changes in Themis Core are known to introduce compatibility issues on big-endian architectures.
+      If you believe you are affected by this change, please reach out to us via
+      [dev@cossacklabs.com](mailto:dev@cossacklabs.com).
 
 - **C++**
 


### PR DESCRIPTION
Recent changes in Secure Cell code to support password-based API and introduction of automated fuzz testing led to refactoring of a lot of code to improve resilience to malicious and erroneous inputs.

This effort has discovered that Themis is likely to be not compatible between little- and big-endian machines. Various parsing and generation code has been using “native” endian order. That is, data encrypted on little-endian machines cannot be read on big-endian machines and vice versa. If usage is strictly confined to exclusively big-endian machines then it's probably fine.

I say “probably” because big-endian architectures have never been a priority for Themis. We have never tested on them and are not sure that Themis works there correctly, even without talking about inter-endian compatibility.

So... Recent changes in Secure Cell start improving the situation by explicitly using little-endian order in data structures. Eventually this will lead to proper support of big-endian architectures which will be able to talk to little-endian machines just fine. But right now this means that data encrypted by Themis 0.12 on big-endian machines will be not readable with Themis 0.13, even on big-endian machines. Similarly, data encrypted by Themis 0.13 on big-endian machines will not be readable by Themis 0.12 on big-endian machines (but *will* be readable on little-endian machines).

Here's a compatibility table:

<table>
  <tr>
    <th colspan="2">Source</th>
    <th colspan="4">Destination</th>
  </tr>
  <tr>
    <td></td>
    <td></td>
    <td colspan="2">Little-endian</td>
    <td colspan="2">Big-endian</td>
  </tr>
  <tr>
    <td></td>
    <td></td>
    <td>0.12</td>
    <td>0.13</td>
    <td>0.12</td>
    <td>0.13</td>
  </tr>
  <tr>
    <td rowspan="2">Little-endian</td>
    <td>0.12</td>
    <td>✅</td>
    <td>✅</td>
    <td>❌<br></td>
    <td>🎉</td>
  </tr>
  <tr>
    <td>0.13</td>
    <td>✅</td>
    <td>✅</td>
    <td>❌</td>
    <td>🎉</td>
  </tr>
  <tr>
    <td rowspan="2">Big-endian</td>
    <td>0.12</td>
    <td>❌</td>
    <td>❌</td>
    <td>🙏🏻<br></td>
    <td>💥</td>
  </tr>
  <tr>
    <td>0.13</td>
    <td>🎉</td>
    <td>🎉</td>
    <td>💥</td>
    <td>🎉</td>
  </tr>
</table>

Legend:

- ✅ — known to work
- ❌ — probably did not work before and will not work in the future
- 🎉 — probably works now and will work in the future
- 🙏🏻 — probably worked before
- 💥 — is likely to be broken since 0.13 and will remain that way

This is for Secure Cell. For any other cryptosystems, big-endian ⟺ big-endian quadrant is likely to be 🙏🏻, and others are filled with ❌.

If you have been using Themis on big-endian machines and it actually worked then I'm pleasantly surprised by the portability of the code. At the same time I offer my condolences for the loss of time we're going to incur on you by doing these changes.

We will announce full big-endian support as soon as it is ready. For now, you're on your own. Themis does not support big-endian machines at the moment.