### PR TITLE
Run long KDF tests of GitHub Actions

### DIFF
--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -34,6 +34,8 @@ jobs:
   unit-tests:
     name: Unit tests
     runs-on: ${{ matrix.os }}
+    env:
+      SOTER_KDF_RUN_LONG_TESTS: yes
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]


### PR DESCRIPTION
PR #574 introduced KDF API as well as some long running tests which are normally not run, but CircleCI was given SOTER_KDF_RUN_LONG_TESTS variable to enable those tests.

Use SOTER_KDF_RUN_LONG_TESTS in GitHub Actions too to exercise long KDF when running unit tests. Don't do it for `sanitizers` and `leak-check` jobs which are already running slow.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md