### PR TITLE
Build Themis as regular user

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -93,7 +93,9 @@ jobs:
         with:
           submodules: true
       - name: Install Themis Core
-        run: sudo make install
+        run: |
+          make
+          sudo make install
       - name: Install ThemisPP
         run: sudo make themispp_install
       - name: Install PyThemis

--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -84,7 +84,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Install Themis Core
-        run: sudo make install
+        run: |
+          make
+          sudo make install
       - name: Run examples
         run: |
           cd $GITHUB_WORKSPACE/docs/examples/c/session_buffer_test
@@ -148,7 +150,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Install Themis Core
-        run: sudo make install
+        run: |
+          make
+          sudo make install
       # Cargo pulls in quite a few stuff from the Internet and Rust always
       # (slowly) recompiles dependencies, so make heavy use of caching
       - name: Cache Cargo registry

--- a/.github/workflows/test-cpp.yaml
+++ b/.github/workflows/test-cpp.yaml
@@ -83,7 +83,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Install Themis Core, ThemisPP
-        run: sudo make install themispp_install
+        run: |
+          make
+          sudo make install themispp_install
       - name: Test examples (Secure Cell)
         if: always()
         run: |

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -47,7 +47,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Install Themis Core
-        run: sudo make install
+        run: |
+          make
+          sudo make install
       - name: Install GoThemis
         run: |
           mkdir -p ~/go/src/$GOTHEMIS_IMPORT
@@ -67,7 +69,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Install Themis Core
-        run: sudo make install
+        run: |
+          make
+          sudo make install
       - name: Install GoThemis
         run: |
           mkdir -p $HOME/go/src/$GOTHEMIS_IMPORT

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -87,7 +87,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Install Themis Core
-        run: sudo make install
+        run: |
+          make
+          sudo make install
       - name: Install PyThemis
         run: sudo make pythemis_install
 

--- a/.github/workflows/test-ruby.yaml
+++ b/.github/workflows/test-ruby.yaml
@@ -77,7 +77,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Install Themis Core
-        run: sudo make install
+        run: |
+          make
+          sudo make install
       - name: Install RubyThemis
         run: sudo make rbthemis_install
       - name: Test examples (Secure Cell)

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -43,7 +43,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Install Themis Core
-        run: sudo make install
+        run: |
+          make
+          sudo make install
       # Cargo pulls in quite a few stuff from the Internet and Rust always
       # (slowly) recompiles dependencies, so make heavy use of caching
       - name: Cache Cargo registry
@@ -86,7 +88,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Install Themis Core
-        run: sudo make install
+        run: |
+          make
+          sudo make install
       # Cargo pulls in quite a few stuff from the Internet and Rust always
       # (slowly) recompiles dependencies, so make heavy use of caching
       - name: Cache Cargo registry

--- a/tests/phpthemis/README.md
+++ b/tests/phpthemis/README.md
@@ -4,6 +4,7 @@ For **Themis core library**:
 ```
 git clone https://github.com/cossacklabs/themis.git
 cd themis
+make
 sudo make install
 ```
 


### PR DESCRIPTION
PR #611 keeps on giving! One side effect of performing configuration only once on the first run is that if you initially install Themis with

    sudo make install

without running `make` first then `./configure` will be run as root too, meaning that it may not see some toolchains installed locally for the user, not globally in the system.

Rust's **rustup** is an example of toolchain installer which does not install it's stuff into system *and* configures PATH in such way that its local installation is not visible from within sudo.

This means that `sudo make install` will not see Rust toolchain and will write empty RUST_VERSION variable to _configuration.mk_. This will cause `make test_rust` to do nothing and exit while printing a lovecraftian message during CI runs:

    fatal: No names found, cannot describe anything.
    tput: No value for $TERM and no -T specified
    make: Nothing to be done for 'test_rust'.

(Other messages are unrelated, but funny nevertheless)

So... Install Themis by doing

    make
    sudo make install

to ensure that `./configure` sees Rust toolchain and the tests will actually get run.

While we're here, update all other instances of Themis Core installation with bare `sudo make install` to avoid such issue if it becomes actual. However, most other toolchain installers seems to install their stuff globally so the above issue is not actual for them right now.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md