### PR TITLE
Update JavaThemis Secure Cell API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -379,6 +379,21 @@ _Code:_
     Run `./gradlew :desktop:tasks` to learn more
     ([#633](https://github.com/cossacklabs/themis/pull/633)).
 
+  - Secure Cell API updates:
+
+    - New encryption/decryption API with consistent naming: `encrypt` and `decrypt`
+      ([#634](https://github.com/cossacklabs/themis/pull/634)).
+    - Improved Token Protect API
+      ([#634](https://github.com/cossacklabs/themis/pull/634)).
+      - Decryption no longer requires an intermediate `SecureCellData` object.
+    - Secure Cell mode can now be selected by instantiating an appropriate interface:
+
+      | New API | Old API |
+      | ------- | ------- |
+      | `SecureCell.SealWithKey(key)`                 | `new SecureCell(key, SecureCell.MODE_SEAL)` |
+      | `SecureCell.TokenProtectWithKey(key)`         | `new SecureCell(key, SecureCell.MODE_TOKEN_PROTECT)` |
+      | `SecureCell.ContextImprintWithKey(key)`       | `new SecureCell(key, SecureCell.MODE_CONTEXT_IMPRINT)` |
+
 - **Node.js**
 
   - New class `SymmetricKey` can be used to generate symmetric keys for Secure Cell ([#562](https://github.com/cossacklabs/themis/pull/562)).

--- a/src/wrappers/themis/android/build.gradle
+++ b/src/wrappers/themis/android/build.gradle
@@ -17,8 +17,8 @@ buildscript {
 
 dependencies {
     implementation project(":boringssl")
-    // Nullable annotations, etc.
-    implementation 'org.jetbrains:annotations:16.0.2'
+    // Use a compatibility version to support Java 6.
+    implementation 'org.jetbrains:annotations-java5:16.0.2'
     // Instrumentation tests
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test:rules:1.2.0'
@@ -35,6 +35,12 @@ android {
         targetSdkVersion 28
         // Our tests are written in JUnit, set default runner appropriately
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    // Compile for Java 7.
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_7
+        targetCompatibility JavaVersion.VERSION_1_7
     }
 
     sourceSets {

--- a/src/wrappers/themis/android/build.gradle
+++ b/src/wrappers/themis/android/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     // Instrumentation tests
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test:rules:1.2.0'
+    androidTestImplementation 'commons-codec:commons-codec:1.14'
 }
 
 android {

--- a/src/wrappers/themis/android/build.gradle
+++ b/src/wrappers/themis/android/build.gradle
@@ -17,6 +17,8 @@ buildscript {
 
 dependencies {
     implementation project(":boringssl")
+    // Nullable annotations, etc.
+    implementation 'org.jetbrains:annotations:16.0.2'
     // Instrumentation tests
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test:rules:1.2.0'

--- a/src/wrappers/themis/android/build.gradle
+++ b/src/wrappers/themis/android/build.gradle
@@ -22,7 +22,8 @@ dependencies {
     // Instrumentation tests
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test:rules:1.2.0'
-    androidTestImplementation 'commons-codec:commons-codec:1.14'
+    // Keep it at 1.2, see tests/themis/wrappers/android/com/cossacklabs/themis/test/Base64.java
+    androidTestImplementation 'commons-codec:commons-codec:1.2'
 }
 
 android {

--- a/src/wrappers/themis/java/build.gradle
+++ b/src/wrappers/themis/java/build.gradle
@@ -15,7 +15,8 @@ dependencies {
     implementation 'org.jetbrains:annotations-java5:16.0.2'
     // Unit tests
     testImplementation 'junit:junit:4.13'
-    testImplementation 'commons-codec:commons-codec:1.14'
+    // Keep it at 1.2, see tests/themis/wrappers/android/com/cossacklabs/themis/test/Base64.java
+    testImplementation 'commons-codec:commons-codec:1.2'
 }
 
 test {

--- a/src/wrappers/themis/java/build.gradle
+++ b/src/wrappers/themis/java/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     implementation 'org.jetbrains:annotations-java5:16.0.2'
     // Unit tests
     testImplementation 'junit:junit:4.13'
+    testImplementation 'commons-codec:commons-codec:1.14'
 }
 
 test {

--- a/src/wrappers/themis/java/build.gradle
+++ b/src/wrappers/themis/java/build.gradle
@@ -11,7 +11,8 @@ sourceSets {
 
 dependencies {
     // Nullable annotations, etc.
-    implementation 'org.jetbrains:annotations:16.0.2'
+    // Use a compatibility version to support Java 6.
+    implementation 'org.jetbrains:annotations-java5:16.0.2'
     // Unit tests
     testImplementation 'junit:junit:4.13'
 }
@@ -28,10 +29,10 @@ archivesBaseName = 'java-themis'
 version = javaThemisVersion
 group = 'com.cossacklabs'
 
-// Compile for Java 8.
+// Compile for Java 7.
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility JavaVersion.VERSION_1_7
+    targetCompatibility JavaVersion.VERSION_1_7
 }
 
 // Tweak compiler options.

--- a/src/wrappers/themis/java/build.gradle
+++ b/src/wrappers/themis/java/build.gradle
@@ -10,6 +10,9 @@ sourceSets {
 }
 
 dependencies {
+    // Nullable annotations, etc.
+    implementation 'org.jetbrains:annotations:16.0.2'
+    // Unit tests
     testImplementation 'junit:junit:4.13'
 }
 

--- a/src/wrappers/themis/java/com/cossacklabs/themis/SecureCell.java
+++ b/src/wrappers/themis/java/com/cossacklabs/themis/SecureCell.java
@@ -16,6 +16,10 @@
 
 package com.cossacklabs.themis;
 
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
@@ -162,7 +166,9 @@ public class SecureCell {
          * @throws RuntimeException on internal encryption failure
          *         (with {@link SecureCellException} as its cause)
          */
-        byte[] encrypt(byte[] data, byte[] context);
+        @NotNull
+        @Contract(pure = true)
+        byte[] encrypt(byte[] data, @Nullable byte[] context);
 
         /**
          * Encrypts the provided message.
@@ -179,6 +185,8 @@ public class SecureCell {
          * @throws RuntimeException on internal encryption failure
          *         (with {@link SecureCellException} as its cause)
          */
+        @NotNull
+        @Contract(pure = true)
         byte[] encrypt(byte[] data);
 
         /**
@@ -199,7 +207,9 @@ public class SecureCell {
          *         or if the associated context does not match the one used to encrypt the data
          * @throws InvalidArgumentException if data is empty
          */
-        byte[] decrypt(byte[] data, byte[] context) throws SecureCellException;
+        @NotNull
+        @Contract(pure = true)
+        byte[] decrypt(byte[] data, @Nullable byte[] context) throws SecureCellException;
 
         /**
          * Decrypts the provided message with associated context.
@@ -218,6 +228,8 @@ public class SecureCell {
          *         or if the associated context does not match the one used to encrypt the data
          * @throws InvalidArgumentException if data is empty
          */
+        @NotNull
+        @Contract(pure = true)
         byte[] decrypt(byte[] data) throws SecureCellException;
     }
 
@@ -230,6 +242,8 @@ public class SecureCell {
      *
      * @since JavaThemis 0.13
      */
+    @NotNull
+    @Contract(value = "_ -> new", pure = true)
     public static Seal SealWithKey(SymmetricKey key) {
         if (key == null) {
             throw new NullArgumentException("key cannot be null");
@@ -247,6 +261,8 @@ public class SecureCell {
      *
      * @since JavaThemis 0.13
      */
+    @NotNull
+    @Contract(value = "_ -> new", pure = true)
     public static Seal SealWithKey(byte[] key) {
         return new SecureCellSeal(new SymmetricKey(key));
     }
@@ -307,7 +323,9 @@ public class SecureCell {
          * @throws RuntimeException on internal encryption failure
          *         (with {@link SecureCellException} as its cause)
          */
-        SecureCellData encrypt(byte[] data, byte[] context);
+        @NotNull
+        @Contract(pure = true)
+        SecureCellData encrypt(byte[] data, @Nullable byte[] context);
 
         /**
          * Encrypts the provided message with associated context.
@@ -325,6 +343,8 @@ public class SecureCell {
          * @throws RuntimeException on internal encryption failure
          *         (with {@link SecureCellException} as its cause)
          */
+        @NotNull
+        @Contract(pure = true)
         SecureCellData encrypt(byte[] data);
 
         /**
@@ -346,7 +366,9 @@ public class SecureCell {
          *         or if the associated context does not match the one used to encrypt the data
          * @throws InvalidArgumentException if data or token is empty
          */
-        byte[] decrypt(byte[] data, byte[] token, byte[] context) throws SecureCellException;
+        @NotNull
+        @Contract(pure = true)
+        byte[] decrypt(byte[] data, byte[] token, @Nullable  byte[] context) throws SecureCellException;
 
         /**
          * Decrypts the provided message with associated context.
@@ -366,6 +388,8 @@ public class SecureCell {
          *         or if the associated context does not match the one used to encrypt the data
          * @throws InvalidArgumentException if data or token is empty
          */
+        @NotNull
+        @Contract(pure = true)
         byte[] decrypt(byte[] data, byte[] token) throws SecureCellException;
     }
 
@@ -378,6 +402,8 @@ public class SecureCell {
      *
      * @since JavaThemis 0.13
      */
+    @NotNull
+    @Contract(value = "_ -> new", pure = true)
     public static TokenProtect TokenProtectWithKey(SymmetricKey key) {
         if (key == null) {
             throw new NullArgumentException("key cannot be null");
@@ -395,6 +421,8 @@ public class SecureCell {
      *
      * @since JavaThemis 0.13
      */
+    @NotNull
+    @Contract(value = "_ -> new", pure = true)
     public static TokenProtect TokenProtectWithKey(byte[] key) {
         return new SecureCellTokenProtect(new SymmetricKey(key));
     }
@@ -448,6 +476,8 @@ public class SecureCell {
          * @throws RuntimeException on internal encryption failure
          *         (with {@link SecureCellException} as its cause)
          */
+        @NotNull
+        @Contract(pure = true)
         byte[] encrypt(byte[] data, byte[] context);
 
         /**
@@ -470,6 +500,8 @@ public class SecureCell {
          * @throws RuntimeException on internal decryption failure
          *         (with {@link SecureCellException} as its cause)
          */
+        @NotNull
+        @Contract(pure = true)
         byte[] decrypt(byte[] data, byte[] context);
     }
 
@@ -482,6 +514,8 @@ public class SecureCell {
      *
      * @since JavaThemis 0.13
      */
+    @NotNull
+    @Contract(value = "_ -> new", pure = true)
     public static ContextImprint ContextImprintWithKey(SymmetricKey key) {
         if (key == null) {
             throw new NullArgumentException("key cannot be null");
@@ -499,6 +533,8 @@ public class SecureCell {
      *
      * @since JavaThemis 0.13
      */
+    @NotNull
+    @Contract(value = "_ -> new", pure = true)
     public static ContextImprint ContextImprintWithKey(byte[] key) {
         return new SecureCellContextImprint(new SymmetricKey(key));
     }

--- a/src/wrappers/themis/java/com/cossacklabs/themis/SecureCell.java
+++ b/src/wrappers/themis/java/com/cossacklabs/themis/SecureCell.java
@@ -222,6 +222,36 @@ public class SecureCell {
     }
 
     /**
+     * Makes a new Secure Cell in Seal mode secured by symmetric key.
+     *
+     * @param key symmetric key to use
+     *
+     * @return a new {@link SecureCell.Seal} instance
+     *
+     * @since JavaThemis 0.13
+     */
+    public static Seal SealWithKey(SymmetricKey key) {
+        if (key == null) {
+            throw new NullArgumentException("key cannot be null");
+        }
+        return new SecureCellSeal(key);
+    }
+
+    /**
+     * Makes a new Secure Cell in Seal mode secured by symmetric key.
+     *
+     * @param key symmetric key bytes to use
+     *
+     * @return a new {@link SecureCell.Seal} instance
+     * @throws InvalidArgumentException if {@code key} is empty
+     *
+     * @since JavaThemis 0.13
+     */
+    public static Seal SealWithKey(byte[] key) {
+        return new SecureCellSeal(new SymmetricKey(key));
+    }
+
+    /**
      * Secure Cell in <em>Token Protect</em> operation mode.
      * <p>
      * This is a modified Seal mode for constrained environments.
@@ -340,6 +370,36 @@ public class SecureCell {
     }
 
     /**
+     * Makes a new Secure Cell in Token Protect mode secured by symmetric key.
+     *
+     * @param key symmetric key to use
+     *
+     * @return a new {@link SecureCell.TokenProtect} instance
+     *
+     * @since JavaThemis 0.13
+     */
+    public static TokenProtect TokenProtectWithKey(SymmetricKey key) {
+        if (key == null) {
+            throw new NullArgumentException("key cannot be null");
+        }
+        return new SecureCellTokenProtect(key);
+    }
+
+    /**
+     * Makes a new Secure Cell in Token Protect mode secured by symmetric key.
+     *
+     * @param key symmetric key bytes to use
+     *
+     * @return a new {@link SecureCell.TokenProtect} instance
+     * @throws InvalidArgumentException if {@code key} is empty
+     *
+     * @since JavaThemis 0.13
+     */
+    public static TokenProtect TokenProtectWithKey(byte[] key) {
+        return new SecureCellTokenProtect(new SymmetricKey(key));
+    }
+
+    /**
      * Secure Cell in <em>Context Imprint</em> operation mode.
      * <p>
      * This is an advanced mode for constrained environments.
@@ -411,6 +471,36 @@ public class SecureCell {
          *         (with {@link SecureCellException} as its cause)
          */
         byte[] decrypt(byte[] data, byte[] context);
+    }
+
+    /**
+     * Makes a new Secure Cell in Context Imprint mode secured by symmetric key.
+     *
+     * @param key symmetric key to use
+     *
+     * @return a new {@link SecureCell.ContextImprint} instance
+     *
+     * @since JavaThemis 0.13
+     */
+    public static ContextImprint ContextImprintWithKey(SymmetricKey key) {
+        if (key == null) {
+            throw new NullArgumentException("key cannot be null");
+        }
+        return new SecureCellContextImprint(key);
+    }
+
+    /**
+     * Makes a new Secure Cell in Context Imprint mode secured by symmetric key.
+     *
+     * @param key symmetric key bytes to use
+     *
+     * @return a new {@link SecureCell.ContextImprint} instance
+     * @throws InvalidArgumentException if {@code key} is empty
+     *
+     * @since JavaThemis 0.13
+     */
+    public static ContextImprint ContextImprintWithKey(byte[] key) {
+        return new SecureCellContextImprint(new SymmetricKey(key));
     }
 
 	/**

--- a/src/wrappers/themis/java/com/cossacklabs/themis/SecureCell.java
+++ b/src/wrappers/themis/java/com/cossacklabs/themis/SecureCell.java
@@ -20,14 +20,399 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 /**
- * Themis secure cell
+ * Secure Cell for data storage.
+ * <p>
+ * <strong>Secure Сell</strong> is a high-level cryptographic service
+ * aimed at protecting arbitrary data stored in various types of storage
+ * (e.g., databases, filesystem files, document archives, cloud storage, etc.)
+ * It provides both strong symmetric encryption and data authentication mechanism.
+ * <p>
+ * The general approach is that given:
+ *
+ * <ul>
+ *   <li><em>input:</em> some source data to protect</li>
+ *   <li><em>secret:</em> symmetric key or a password</li>
+ *   <li><em>context:</em> and an optional “context information”</li>
+ * </ul>
+ *
+ * Secure Cell will produce:
+ *
+ * <ul>
+ *   <li><em>cell:</em> the encrypted data</li>
+ *   <li><em>authentication token:</em> some authentication data</li>
+ * </ul>
+ *
+ * <p>
+ * The purpose of the optional context information (e.g., a database row number or file name)
+ * is to establish a secure association between this context and the protected data.
+ * In short, even when the secret is known, if the context is incorrect then decryption will fail.
+ * <p>
+ * The purpose of the authentication data is to validate that given a correct key or passphrase
+ * (and context), the decrypted data is indeed the same as the original source data.
+ * <p>
+ * The authentication data must be stored somewhere. The most convenient way is to simply
+ * append it to the encrypted data, but this is not always possible due to the storage
+ * architecture of your application. Secure Cell offers variants that address this issue
+ * in different ways.
+ * <p>
+ * By default, Secure Cell uses AES-256 for encryption.
+ * Authentication data takes additional 44 bytes when symmetric keys are used
+ * and 70 bytes in case the data is secured with a passphrase.
+ * <p>
+ * Secure Cell supports 2 kinds of secrets:
+ *
+ * <ul>
+ *   <li>
+ *     <strong>Symmetric keys</strong> are convenient to store and efficient to use for machines.
+ *     However, they are relatively long and hard for humans to remember.
+ *     <p>
+ *     New symmetric keys can be generated with {@link SymmetricKey}.
+ *   <li>
+ *     <strong>Passphrases</strong>, in contrast, can be shorter and easier to remember.
+ *     <p>
+ *     However, passphrases are typically much less random than keys.
+ *     Secure Cell uses a <em>key derivation function</em> (KDF) to compensate for that
+ *     and achieves security comparable to keys with shorter passphrases.
+ *     This comes at a significant performance cost though.
+ * </ul>
+ *
+ * Use {@code ...WithKey} or {@code ...WithPassphrase} methods
+ * to construct a Secure Cell with a particular kind of secret in particular mode.
+ * <p>
+ * Secure Cell supports 3 operation modes:
+ *
+ * <ul>
+ *   <li>
+ *     {@link SecureCell.Seal} mode is the most secure and easy to use.
+ *     Your best choice most of the time.
+ *     This is also the only mode that supports passphrases at the moment.
+ *   <li>
+ *     {@link SecureCell.TokenProtect} mode is just as secure, but a bit harder to use.
+ *     This is your choice if you need to keep authentication data separate.
+ *   <li>
+ *     {@link SecureCell.ContextImprint} mode is a length-preserving version of Secure Cell
+ *     with no additional data stored. Should be used carefully.
+ * </ul>
+ *
+ * The operation mode is selected via an appropriate method of {@code SecureCell}.
+ * For example, {@link SecureCell#SealWithKey(SymmetricKey)} constructs Secure Cell in Seal mode
+ * using a symmetric key.
+ * <p>
+ * <a href="https://docs.cossacklabs.com/pages/secure-cell-cryptosystem/">Here you can learn more</a>
+ * about the underlying considerations, limitations, and features of each mode.
+ *
+ * @since JavaThemis 0.9
  */
 public class SecureCell {
 	
 	static {
 		System.loadLibrary("themis_jni");
 	}
-	
+
+    /**
+     * Secure Cell in <em>Seal</em> operation mode.
+     * <p>
+     * This is the most secure and easy way to protect stored data.
+     * The data is protected by a symmetric key or a passphrase.
+     * <p>
+     * Secure Cell in Seal mode will encrypt the data and append an “authentication tag”
+     * with auxiliary security information, forming a single sealed container.
+     * This means that the encrypted data will be longer than the original input.
+     * <p>
+     * Additionally, it is possible to bind the encrypted data to some “associated context”
+     * (for example, database row number).
+     * In this case decryption of the data with incorrect context will fail
+     * (even if the correct key is known and the data has not been tampered).
+     * This establishes a cryptographically secure association between the protected data
+     * and the context in which it is used.
+     * With database row numbers this prevents the attacker from swapping encrypted password hashes
+     * in the database so the system will not accept credentials of a different user.
+     * <p>
+     * Security of symmetric key operation mode depends on the quality of the key,
+     * with short and incorrectly generated keys being easier to crack.
+     * You can use {@link SymmetricKey} to generate good random keys of sufficient length,
+     * then use {@link SecureCell#SealWithKey(SymmetricKey)} to construct a Secure Cell.
+     * <p>
+     * If you need to use a short and easy to remember passphrase,
+     * use passphrase API instead: {@link SecureCell#SealWithPassphrase(String)}.
+     * <p>
+     * You can read more about Seal mode
+     * <a href="https://docs.cossacklabs.com/pages/secure-cell-cryptosystem/#seal-mode">in documentation</a>.
+     *
+     * @since JavaThemis 0.13
+     */
+    public interface Seal {
+        /**
+         * Encrypts the provided message with associated context.
+         * <p>
+         * Data is encrypted and authentication token is appended to form a single sealed buffer.
+         * Use {@link #decrypt(byte[], byte[])} to decrypt the result later.
+         * <p>
+         * The context is cryptographically mixed with the data
+         * but not included into the resulting encrypted message.
+         * You will have to provide the same context again during decryption.
+         * Usually this is some plaintext data associated with encrypted data,
+         * such as database row number, protocol message ID, etc.
+         *
+         * @param data      data to encrypt, must not be empty
+         * @param context   associated context, may be empty or {@code null}
+         *
+         * @return encrypted data as a single buffer
+         * @throws InvalidArgumentException if data is empty
+         * @throws RuntimeException on internal encryption failure
+         *         (with {@link SecureCellException} as its cause)
+         */
+        byte[] encrypt(byte[] data, byte[] context);
+
+        /**
+         * Encrypts the provided message.
+         * <p>
+         * Data is encrypted and authentication token is appended to form a single sealed buffer.
+         * Use {@link #decrypt(byte[])} to decrypt the result later.
+         * <p>
+         * This call is equivalent to {@link #encrypt(byte[], byte[])} with an empty associated context.
+         *
+         * @param data  data to encrypt, must not be empty
+         *
+         * @return encrypted data as a single buffer
+         * @throws InvalidArgumentException if data is empty
+         * @throws RuntimeException on internal encryption failure
+         *         (with {@link SecureCellException} as its cause)
+         */
+        byte[] encrypt(byte[] data);
+
+        /**
+         * Decrypts the provided message with associated context.
+         * <p>
+         * Secure Cell validates association with the context data, decrypts the message,
+         * and verifies its integrity using authentication data embedded into the message.
+         * <p>
+         * You need to provide the same context data as provided to {@link #encrypt(byte[], byte[])}.
+         * You can also decrypt data encrypted with {@link #encrypt(byte[])} by using an empty context.
+         *
+         * @param data      encrypted data, cannot be empty
+         * @param context   associated context, may be empty or {@code null}
+         *
+         * @return decrypted data if everything goes well
+         * @throws SecureCellException if decryption failed: for example,
+         *         if the data has been tampered with, if the secret is incorrect,
+         *         or if the associated context does not match the one used to encrypt the data
+         * @throws InvalidArgumentException if data is empty
+         */
+        byte[] decrypt(byte[] data, byte[] context) throws SecureCellException;
+
+        /**
+         * Decrypts the provided message with associated context.
+         * <p>
+         * Secure Cell decrypts the message and verifies its integrity
+         * using authentication data embedded into the message.
+         * <p>
+         * Use this method to decrypt data encrypted with {@link #encrypt(byte[])}.
+         * If you use associated context, call {@link #decrypt(byte[], byte[])} instead.
+         *
+         * @param data  encrypted data, cannot be empty
+         *
+         * @return decrypted data if everything goes well
+         * @throws SecureCellException if decryption failed: for example,
+         *         if the data has been tampered with, if the secret is incorrect,
+         *         or if the associated context does not match the one used to encrypt the data
+         * @throws InvalidArgumentException if data is empty
+         */
+        byte[] decrypt(byte[] data) throws SecureCellException;
+    }
+
+    /**
+     * Secure Cell in <em>Token Protect</em> operation mode.
+     * <p>
+     * This is a modified Seal mode for constrained environments.
+     * The data is protected by a symmetric key.
+     * <p>
+     * Token Protect mode is designed for cases when underlying storage constraints
+     * do not allow the size of the data to grow (so {@link SecureCell.Seal} cannot be used).
+     * However, if you have access to a different storage location
+     * (e.g., another table in the database) where additional security parameters can be stored
+     * then Token Protect mode can be used instead of Seal mode.
+     * <p>
+     * Token Protect mode produces authentication tag and other auxiliary data
+     * (aka “authentication token”) in a detached buffer.
+     * This keeps the original size of the encrypted data
+     * while enabling separate storage of security information.
+     * Note that the same token must be provided along with the correct secret
+     * and matching associated context in order for the data to be decrypted successfully.
+     * <p>
+     * Since {@link SecureCell.TokenProtect} uses the same security parameters as {@link SecureCell.Seal}
+     * (just stored in a different location), these modes have the same highest security level.
+     * Token Protect mode only requires slightly more programming effort
+     * in exchange for preserving the original data size.
+     * <p>
+     * Security of symmetric key operation mode depends on the quality of the key,
+     * with short and incorrectly generated keys being easier to crack.
+     * You can use {@link SymmetricKey} to generate good random keys of sufficient length,
+     * then use {@link SecureCell#TokenProtectWithKey(SymmetricKey)} to construct a Secure Cell.
+     * <p>
+     * You can read more about Token Protect mode
+     * <a href="https://docs.cossacklabs.com/pages/secure-cell-cryptosystem/#token-protect-mode">in documentation</a>.
+     *
+     * @since JavaThemis 0.13
+     */
+    public interface TokenProtect {
+        /**
+         * Encrypts the provided message with associated context.
+         * <p>
+         * Data is encrypted and authentication token is produced separately.
+         * Use {@link #decrypt(byte[], byte[], byte[])} to decrypt the result later,
+         * providing both encrypted data and corresponding token.
+         * <p>
+         * The context is cryptographically mixed with the data
+         * but not included into the resulting encrypted message.
+         * You will have to provide the same context again during decryption.
+         * Usually this is some plaintext data associated with encrypted data,
+         * such as database row number, protocol message ID, etc.
+         *
+         * @param data      data to encrypt, must not be empty
+         * @param context   associated context, may be empty or {@code null}
+         *
+         * @return an object containing encrypted data and authentication token
+         * @throws InvalidArgumentException if data is empty
+         * @throws RuntimeException on internal encryption failure
+         *         (with {@link SecureCellException} as its cause)
+         */
+        SecureCellData encrypt(byte[] data, byte[] context);
+
+        /**
+         * Encrypts the provided message with associated context.
+         * <p>
+         * Data is encrypted and authentication token is produced separately.
+         * Use {@link #decrypt(byte[], byte[])} to decrypt the result later,
+         * providing both encrypted data and corresponding token.
+         * <p>
+         * This call is equivalent to {@link #encrypt(byte[], byte[])} with an empty associated context.
+         *
+         * @param data  data to encrypt, must not be empty
+         *
+         * @return an object containing encrypted data and authentication token
+         * @throws InvalidArgumentException if data is empty
+         * @throws RuntimeException on internal encryption failure
+         *         (with {@link SecureCellException} as its cause)
+         */
+        SecureCellData encrypt(byte[] data);
+
+        /**
+         * Decrypts the provided message with associated context.
+         * <p>
+         * Secure Cell validates association with the context data, decrypts the message,
+         * and verifies its integrity using the provided authentication token.
+         * <p>
+         * You need to provide the same context data as provided to {@link #encrypt(byte[], byte[])}.
+         * You can also decrypt data encrypted with {@link #encrypt(byte[])} by using an empty context.
+         *
+         * @param data      encrypted data, cannot be empty
+         * @param token     authentication token, cannot be empty
+         * @param context   associated context, may be empty or {@code null}
+         *
+         * @return decrypted data if everything goes well
+         * @throws SecureCellException if decryption failed: for example,
+         *         if the data has been tampered with, if the secret is incorrect,
+         *         or if the associated context does not match the one used to encrypt the data
+         * @throws InvalidArgumentException if data or token is empty
+         */
+        byte[] decrypt(byte[] data, byte[] token, byte[] context) throws SecureCellException;
+
+        /**
+         * Decrypts the provided message with associated context.
+         * <p>
+         * Secure Cell decrypts the message and verifies its integrity
+         * using the provided authentication token.
+         * <p>
+         * Use this method to decrypt data encrypted with {@link #encrypt(byte[])}.
+         * If you use associated context, call {@link #decrypt(byte[], byte[], byte[])} instead.
+         *
+         * @param data  encrypted data, cannot be empty
+         * @param token authentication token, cannot be empty
+         *
+         * @return decrypted data if everything goes well
+         * @throws SecureCellException if decryption failed: for example,
+         *         if the data has been tampered with, if the secret is incorrect,
+         *         or if the associated context does not match the one used to encrypt the data
+         * @throws InvalidArgumentException if data or token is empty
+         */
+        byte[] decrypt(byte[] data, byte[] token) throws SecureCellException;
+    }
+
+    /**
+     * Secure Cell in <em>Context Imprint</em> operation mode.
+     * <p>
+     * This is an advanced mode for constrained environments.
+     * The data is protected by a symmetric key.
+     * <p>
+     * Context Imprint mode is intended for environments where storage constraints
+     * do not allow the size of the data to grow and there is no auxiliary storage available.
+     * Context Imprint mode requires an additional “associated context”
+     * to be provided along with the key in order to protect the data.
+     * <p>
+     * In Context Imprint mode no authentication token is computed or verified.
+     * This means that integrity of the data is not enforced,
+     * so the overall security level is slightly lower than in Seal or Token Protect modes.
+     * <p>
+     * Security of symmetric key operation mode depends on the quality of the key,
+     * with short and incorrectly generated keys being easier to crack.
+     * You can use {@link SymmetricKey} to generate good random keys of sufficient length.
+     * then use {@link SecureCell#ContextImprintWithKey(SymmetricKey)} to construct a Secure Cell.
+     * <p>
+     * To ensure the highest security level possible,
+     * supply a different associated context for each encryption invocation with the same key.
+     * <p>
+     * You can read more about Context Imprint mode
+     * <a href="https://docs.cossacklabs.com/pages/secure-cell-cryptosystem/#context-imprint-mode">in documentation</a>.
+     *
+     * @since JavaThemis 0.13
+     */
+    public interface ContextImprint {
+        /**
+         * Encrypts the provided message with associated context.
+         * <p>
+         * Data is encrypted and combined with the provided context.
+         * Use {@link #decrypt(byte[], byte[])} to decrypt the result later.
+         * <p>
+         * The context is cryptographically mixed with the data
+         * but not included into the resulting encrypted message.
+         * You will have to provide the same context again during decryption.
+         * Usually this is some plaintext data associated with encrypted data,
+         * such as database row number, protocol message ID, etc.
+         *
+         * @param data      data to encrypt, must not be empty
+         * @param context   associated context, must not be empty
+         *
+         * @return encrypted data of the same size as input
+         * @throws InvalidArgumentException if data or context is empty
+         * @throws RuntimeException on internal encryption failure
+         *         (with {@link SecureCellException} as its cause)
+         */
+        byte[] encrypt(byte[] data, byte[] context);
+
+        /**
+         * Decrypts the provided message with associated context.
+         * <p>
+         * Secure Cell validates association with the context data and decrypts the message.
+         * You need to provide the same context data as provided to {@link #encrypt(byte[], byte[])}.
+         *
+         * @param data      encrypted data, cannot be empty
+         * @param context   associated context, cannot be empty
+         *
+         * @return decrypted data if everything goes well
+         * <p>
+         * Note that in Context Imprint mode messages do not include any authentication token
+         * for integrity validation.
+         * If data has been corrupted or the context is incorrect,
+         * Secure Cell will most likely successfully return corrupted non-empty output.
+         *
+         * @throws InvalidArgumentException if data or context is empty
+         * @throws RuntimeException on internal decryption failure
+         *         (with {@link SecureCellException} as its cause)
+         */
+        byte[] decrypt(byte[] data, byte[] context);
+    }
+
 	/**
 	 * Creates new SecureCell in specified mode
 	 * @param SecureCell mode

--- a/src/wrappers/themis/java/com/cossacklabs/themis/SecureCellContextImprint.java
+++ b/src/wrappers/themis/java/com/cossacklabs/themis/SecureCellContextImprint.java
@@ -1,13 +1,19 @@
 package com.cossacklabs.themis;
 
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
 class SecureCellContextImprint implements SecureCell.ContextImprint {
 
+    @NotNull
     private final SymmetricKey key;
 
-    SecureCellContextImprint(SymmetricKey key) {
+    @Contract(pure = true)
+    SecureCellContextImprint(@NotNull SymmetricKey key) {
         this.key = key;
     }
 
+    @NotNull
     @Override
     public byte[] encrypt(byte[] data, byte[] context) {
         if (data == null) {
@@ -31,6 +37,7 @@ class SecureCellContextImprint implements SecureCell.ContextImprint {
         return result[0];
     }
 
+    @NotNull
     @Override
     public byte[] decrypt(byte[] data, byte[] context) {
         if (data == null) {

--- a/src/wrappers/themis/java/com/cossacklabs/themis/SecureCellContextImprint.java
+++ b/src/wrappers/themis/java/com/cossacklabs/themis/SecureCellContextImprint.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.cossacklabs.themis;
 
 import org.jetbrains.annotations.Contract;

--- a/src/wrappers/themis/java/com/cossacklabs/themis/SecureCellContextImprint.java
+++ b/src/wrappers/themis/java/com/cossacklabs/themis/SecureCellContextImprint.java
@@ -1,0 +1,57 @@
+package com.cossacklabs.themis;
+
+class SecureCellContextImprint implements SecureCell.ContextImprint {
+
+    private final SymmetricKey key;
+
+    SecureCellContextImprint(SymmetricKey key) {
+        this.key = key;
+    }
+
+    @Override
+    public byte[] encrypt(byte[] data, byte[] context) {
+        if (data == null) {
+            throw new NullArgumentException("data cannot be null");
+        }
+        if (data.length == 0) {
+            throw new InvalidArgumentException("data cannot be empty");
+        }
+        if (context == null) {
+            throw new NullArgumentException("context cannot be null");
+        }
+        if (context.length == 0) {
+            throw new InvalidArgumentException("context cannot be empty");
+        }
+        byte[] keyBytes = this.key.key;
+        byte[][] result = SecureCell.encrypt(keyBytes, context, data, SecureCell.MODE_CONTEXT_IMPRINT);
+        // TODO(ilammy, 2020-05-05): teach SecureCell#encrypt to throw SecureCellException (T1605)
+        if (result == null) {
+            throw new RuntimeException(new SecureCellException());
+        }
+        return result[0];
+    }
+
+    @Override
+    public byte[] decrypt(byte[] data, byte[] context) {
+        if (data == null) {
+            throw new NullArgumentException("data cannot be null");
+        }
+        if (data.length == 0) {
+            throw new InvalidArgumentException("data cannot be empty");
+        }
+        if (context == null) {
+            throw new NullArgumentException("context cannot be null");
+        }
+        if (context.length == 0) {
+            throw new InvalidArgumentException("context cannot be empty");
+        }
+        byte[] keyBytes = this.key.key;
+        byte[][] encrypted = {data, null};
+        byte[] result = SecureCell.decrypt(keyBytes, context, encrypted, SecureCell.MODE_CONTEXT_IMPRINT);
+        // TODO(ilammy, 2020-05-05): teach SecureCell#decrypt to throw SecureCellException (T1605)
+        if (result == null) {
+            throw new RuntimeException(new SecureCellException());
+        }
+        return result;
+    }
+}

--- a/src/wrappers/themis/java/com/cossacklabs/themis/SecureCellSeal.java
+++ b/src/wrappers/themis/java/com/cossacklabs/themis/SecureCellSeal.java
@@ -1,15 +1,22 @@
 package com.cossacklabs.themis;
 
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 class SecureCellSeal implements SecureCell.Seal {
 
+    @NotNull
     private final SymmetricKey key;
 
-    SecureCellSeal(SymmetricKey key) {
+    @Contract(pure = true)
+    SecureCellSeal(@NotNull SymmetricKey key) {
         this.key = key;
     }
 
+    @NotNull
     @Override
-    public byte[] encrypt(byte[] data, byte[] context) {
+    public byte[] encrypt(byte[] data, @Nullable byte[] context) {
         if (data == null) {
             throw new NullArgumentException("data cannot be null");
         }
@@ -25,13 +32,15 @@ class SecureCellSeal implements SecureCell.Seal {
         return result[0];
     }
 
+    @NotNull
     @Override
     public byte[] encrypt(byte[] data) {
         return encrypt(data, null);
     }
 
+    @NotNull
     @Override
-    public byte[] decrypt(byte[] data, byte[] context) throws SecureCellException {
+    public byte[] decrypt(byte[] data, @Nullable byte[] context) throws SecureCellException {
         if (data == null) {
             throw new NullArgumentException("data cannot be null");
         }
@@ -48,6 +57,7 @@ class SecureCellSeal implements SecureCell.Seal {
         return result;
     }
 
+    @NotNull
     @Override
     public byte[] decrypt(byte[] data) throws SecureCellException {
         return decrypt(data, null);

--- a/src/wrappers/themis/java/com/cossacklabs/themis/SecureCellSeal.java
+++ b/src/wrappers/themis/java/com/cossacklabs/themis/SecureCellSeal.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.cossacklabs.themis;
 
 import org.jetbrains.annotations.Contract;

--- a/src/wrappers/themis/java/com/cossacklabs/themis/SecureCellSeal.java
+++ b/src/wrappers/themis/java/com/cossacklabs/themis/SecureCellSeal.java
@@ -1,0 +1,55 @@
+package com.cossacklabs.themis;
+
+class SecureCellSeal implements SecureCell.Seal {
+
+    private final SymmetricKey key;
+
+    SecureCellSeal(SymmetricKey key) {
+        this.key = key;
+    }
+
+    @Override
+    public byte[] encrypt(byte[] data, byte[] context) {
+        if (data == null) {
+            throw new NullArgumentException("data cannot be null");
+        }
+        if (data.length == 0) {
+            throw new InvalidArgumentException("data cannot be empty");
+        }
+        byte[] keyBytes = this.key.key;
+        byte[][] result = SecureCell.encrypt(keyBytes, context, data, SecureCell.MODE_SEAL);
+        // TODO(ilammy, 2020-05-05): teach SecureCell#encrypt to throw SecureCellException (T1605)
+        if (result == null) {
+            throw new RuntimeException(new SecureCellException());
+        }
+        return result[0];
+    }
+
+    @Override
+    public byte[] encrypt(byte[] data) {
+        return encrypt(data, null);
+    }
+
+    @Override
+    public byte[] decrypt(byte[] data, byte[] context) throws SecureCellException {
+        if (data == null) {
+            throw new NullArgumentException("data cannot be null");
+        }
+        if (data.length == 0) {
+            throw new InvalidArgumentException("data cannot be empty");
+        }
+        byte[] keyBytes = this.key.key;
+        byte[][] encrypted = {data, null};
+        byte[] result = SecureCell.decrypt(keyBytes, context, encrypted, SecureCell.MODE_SEAL);
+        // TODO(ilammy, 2020-05-05): teach SecureCell#decrypt to throw SecureCellException (T1605)
+        if (result == null) {
+            throw new SecureCellException();
+        }
+        return result;
+    }
+
+    @Override
+    public byte[] decrypt(byte[] data) throws SecureCellException {
+        return decrypt(data, null);
+    }
+}

--- a/src/wrappers/themis/java/com/cossacklabs/themis/SecureCellTokenProtect.java
+++ b/src/wrappers/themis/java/com/cossacklabs/themis/SecureCellTokenProtect.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.cossacklabs.themis;
 
 import org.jetbrains.annotations.Contract;

--- a/src/wrappers/themis/java/com/cossacklabs/themis/SecureCellTokenProtect.java
+++ b/src/wrappers/themis/java/com/cossacklabs/themis/SecureCellTokenProtect.java
@@ -1,15 +1,22 @@
 package com.cossacklabs.themis;
 
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 class SecureCellTokenProtect implements SecureCell.TokenProtect {
 
+    @NotNull
     private final SymmetricKey key;
 
-    SecureCellTokenProtect(SymmetricKey key) {
+    @Contract(pure = true)
+    SecureCellTokenProtect(@NotNull SymmetricKey key) {
         this.key = key;
     }
 
+    @NotNull
     @Override
-    public SecureCellData encrypt(byte[] data, byte[] context) {
+    public SecureCellData encrypt(byte[] data, @Nullable byte[] context) {
         if (data == null) {
             throw new NullArgumentException("data cannot be null");
         }
@@ -25,13 +32,15 @@ class SecureCellTokenProtect implements SecureCell.TokenProtect {
         return new SecureCellData(result[0], result[1]);
     }
 
+    @NotNull
     @Override
     public SecureCellData encrypt(byte[] data) {
         return encrypt(data, null);
     }
 
+    @NotNull
     @Override
-    public byte[] decrypt(byte[] data, byte[] token, byte[] context) throws SecureCellException {
+    public byte[] decrypt(byte[] data, byte[] token, @Nullable byte[] context) throws SecureCellException {
         if (data == null) {
             throw new NullArgumentException("data cannot be null");
         }
@@ -54,6 +63,7 @@ class SecureCellTokenProtect implements SecureCell.TokenProtect {
         return result;
     }
 
+    @NotNull
     @Override
     public byte[] decrypt(byte[] data, byte[] token) throws SecureCellException {
         return decrypt(data, token, null);

--- a/src/wrappers/themis/java/com/cossacklabs/themis/SecureCellTokenProtect.java
+++ b/src/wrappers/themis/java/com/cossacklabs/themis/SecureCellTokenProtect.java
@@ -1,0 +1,61 @@
+package com.cossacklabs.themis;
+
+class SecureCellTokenProtect implements SecureCell.TokenProtect {
+
+    private final SymmetricKey key;
+
+    SecureCellTokenProtect(SymmetricKey key) {
+        this.key = key;
+    }
+
+    @Override
+    public SecureCellData encrypt(byte[] data, byte[] context) {
+        if (data == null) {
+            throw new NullArgumentException("data cannot be null");
+        }
+        if (data.length == 0) {
+            throw new InvalidArgumentException("data cannot be empty");
+        }
+        byte[] keyBytes = this.key.key;
+        byte[][] result = SecureCell.encrypt(keyBytes, context, data, SecureCell.MODE_TOKEN_PROTECT);
+        // TODO(ilammy, 2020-05-05): teach SecureCell#encrypt to throw SecureCellException (T1605)
+        if (result == null) {
+            throw new RuntimeException(new SecureCellException());
+        }
+        return new SecureCellData(result[0], result[1]);
+    }
+
+    @Override
+    public SecureCellData encrypt(byte[] data) {
+        return encrypt(data, null);
+    }
+
+    @Override
+    public byte[] decrypt(byte[] data, byte[] token, byte[] context) throws SecureCellException {
+        if (data == null) {
+            throw new NullArgumentException("data cannot be null");
+        }
+        if (data.length == 0) {
+            throw new InvalidArgumentException("data cannot be empty");
+        }
+        if (token == null) {
+            throw new NullArgumentException("token cannot be null");
+        }
+        if (token.length == 0) {
+            throw new InvalidArgumentException("token cannot be empty");
+        }
+        byte[] keyBytes = this.key.key;
+        byte[][] encrypted = {data, token};
+        byte[] result = SecureCell.decrypt(keyBytes, context, encrypted, SecureCell.MODE_TOKEN_PROTECT);
+        // TODO(ilammy, 2020-05-05): teach SecureCell#encrypt to throw SecureCellException (T1605)
+        if (result == null) {
+            throw new SecureCellException();
+        }
+        return result;
+    }
+
+    @Override
+    public byte[] decrypt(byte[] data, byte[] token) throws SecureCellException {
+        return decrypt(data, token, null);
+    }
+}

--- a/tests/themis/wrappers/android/com/cossacklabs/themis/test/Base64.java
+++ b/tests/themis/wrappers/android/com/cossacklabs/themis/test/Base64.java
@@ -16,17 +16,15 @@
 
 package com.cossacklabs.themis.test;
 
-import javax.xml.bind.DatatypeConverter;
-
 // Java 8 and above has "java.utils.Base64", but it's not available on all Android API levels.
 // Android has its own "android.util.Base64" (with a different API) and it requires API 26+ too.
-// Of course we could pull Apache Commons or Guava, but that's an overkill for base64 decoding.
-// We provide our own polyfill using an obscure but standard JRE class instead.
+// Java also has an obscure "javax.xml.bind.DatatypeConverter" class which is not available on
+// Android, unfortunately. We provide our own polyfill for java.utils.Base64 using Apache Commons.
 
 final class Base64 {
     static final class Decoder {
         byte[] decode(String src) {
-            return DatatypeConverter.parseBase64Binary(src);
+            return org.apache.commons.codec.binary.Base64.decodeBase64(src);
         }
     }
 

--- a/tests/themis/wrappers/android/com/cossacklabs/themis/test/Base64.java
+++ b/tests/themis/wrappers/android/com/cossacklabs/themis/test/Base64.java
@@ -16,15 +16,23 @@
 
 package com.cossacklabs.themis.test;
 
+import java.nio.charset.StandardCharsets;
+
 // Java 8 and above has "java.utils.Base64", but it's not available on all Android API levels.
 // Android has its own "android.util.Base64" (with a different API) and it requires API 26+ too.
 // Java also has an obscure "javax.xml.bind.DatatypeConverter" class which is not available on
 // Android, unfortunately. We provide our own polyfill for java.utils.Base64 using Apache Commons.
+//
+// Also note that some older Android systems already include an older version of Apache Commons
+// (version 1.2, it seems) loaded from "/system/framework/org.apache.http.legacy.boot.jar",
+// which overrides whatever is specified in Gradle dependencies. Use 1.2 API only.
 
 final class Base64 {
     static final class Decoder {
         byte[] decode(String src) {
-            return org.apache.commons.codec.binary.Base64.decodeBase64(src);
+            // Modern versions can accept String directly, but Android makes it hard.
+            byte[] base64bytes = src.getBytes(StandardCharsets.US_ASCII);
+            return org.apache.commons.codec.binary.Base64.decodeBase64(base64bytes);
         }
     }
 

--- a/tests/themis/wrappers/android/com/cossacklabs/themis/test/Base64.java
+++ b/tests/themis/wrappers/android/com/cossacklabs/themis/test/Base64.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2020 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cossacklabs.themis.test;
+
+import javax.xml.bind.DatatypeConverter;
+
+// Java 8 and above has "java.utils.Base64", but it's not available on all Android API levels.
+// Android has its own "android.util.Base64" (with a different API) and it requires API 26+ too.
+// Of course we could pull Apache Commons or Guava, but that's an overkill for base64 decoding.
+// We provide our own polyfill using an obscure but standard JRE class instead.
+
+final class Base64 {
+    static final class Decoder {
+        byte[] decode(String src) {
+            return DatatypeConverter.parseBase64Binary(src);
+        }
+    }
+
+    static Decoder getDecoder() {
+        return new Decoder();
+    }
+}

--- a/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellContextImprintTest.java
+++ b/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellContextImprintTest.java
@@ -52,9 +52,21 @@ public class SecureCellContextImprintTest {
     @Test
     @SuppressWarnings("ResultOfMethodCallIgnored")
     public void initWithEmpty() {
-        assertThrows(NullArgumentException.class, () -> SecureCell.ContextImprintWithKey((SymmetricKey)null));
-        assertThrows(NullArgumentException.class, () -> SecureCell.ContextImprintWithKey((byte[])null));
-        assertThrows(InvalidArgumentException.class, () -> SecureCell.ContextImprintWithKey(new byte[]{}));
+        try {
+            SecureCell.ContextImprintWithKey((SymmetricKey)null);
+            fail("expected NullArgumentException");
+        }
+        catch (NullArgumentException ignored) {}
+        try {
+            SecureCell.ContextImprintWithKey((byte[])null);
+            fail("expected NullArgumentException");
+        }
+        catch (NullArgumentException ignored) {}
+        try {
+            SecureCell.ContextImprintWithKey(new byte[]{});
+            fail("expected InvalidArgumentException");
+        }
+        catch (InvalidArgumentException ignored) {}
     }
 
     @Test
@@ -181,15 +193,47 @@ public class SecureCellContextImprintTest {
         byte[] message = "All your base are belong to us!".getBytes(StandardCharsets.UTF_8);
         byte[] context = "We are CATS".getBytes(StandardCharsets.UTF_8);
 
-        assertThrows(NullArgumentException.class, () -> cell.encrypt(message, null));
-        assertThrows(NullArgumentException.class, () -> cell.decrypt(message, null));
-        assertThrows(NullArgumentException.class, () -> cell.encrypt(null, context));
-        assertThrows(NullArgumentException.class, () -> cell.decrypt(null, context));
+        try {
+            cell.encrypt(message, null);
+            fail("expected NullArgumentException");
+        }
+        catch (NullArgumentException ignored) {}
+        try {
+            cell.decrypt(message, null);
+            fail("expected NullArgumentException");
+        }
+        catch (NullArgumentException ignored) {}
+        try {
+            cell.encrypt(null, context);
+            fail("expected NullArgumentException");
+        }
+        catch (NullArgumentException ignored) {}
+        try {
+            cell.decrypt(null, context);
+            fail("expected NullArgumentException");
+        }
+        catch (NullArgumentException ignored) {}
 
-        assertThrows(InvalidArgumentException.class, () -> cell.encrypt(message, new byte[]{}));
-        assertThrows(InvalidArgumentException.class, () -> cell.decrypt(message, new byte[]{}));
-        assertThrows(InvalidArgumentException.class, () -> cell.encrypt(new byte[]{}, context));
-        assertThrows(InvalidArgumentException.class, () -> cell.decrypt(new byte[]{}, context));
+        try {
+            cell.encrypt(message, new byte[]{});
+            fail("expected InvalidArgumentException");
+        }
+        catch (InvalidArgumentException ignored) {}
+        try {
+            cell.decrypt(message, new byte[]{});
+            fail("expected InvalidArgumentException");
+        }
+        catch (InvalidArgumentException ignored) {}
+        try {
+            cell.encrypt(new byte[]{}, context);
+            fail("expected InvalidArgumentException");
+        }
+        catch (InvalidArgumentException ignored) {}
+        try {
+            cell.decrypt(new byte[]{}, context);
+            fail("expected InvalidArgumentException");
+        }
+        catch (InvalidArgumentException ignored) {}
     }
 
     @Test

--- a/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellContextImprintTest.java
+++ b/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellContextImprintTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2020 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cossacklabs.themis.test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
+
+import com.cossacklabs.themis.InvalidArgumentException;
+import com.cossacklabs.themis.NullArgumentException;
+import com.cossacklabs.themis.SecureCell;
+import com.cossacklabs.themis.SecureCellData;
+import com.cossacklabs.themis.SecureCellException;
+import com.cossacklabs.themis.SymmetricKey;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+public class SecureCellContextImprintTest {
+
+    @Test
+    public void initWithGenerated() {
+        SecureCell.ContextImprint cell = SecureCell.ContextImprintWithKey(new SymmetricKey());
+
+        assertNotNull(cell);
+    }
+
+    @Test
+    public void initWithFixed() {
+        String keyBase64 = "UkVDMgAAAC13PCVZAKOczZXUpvkhsC+xvwWnv3CLmlG0Wzy8ZBMnT+2yx/dg";
+        byte[] keyBytes = Base64.getDecoder().decode(keyBase64);
+
+        SecureCell.ContextImprint cell = SecureCell.ContextImprintWithKey(keyBytes);
+
+        assertNotNull(cell);
+    }
+
+    @Test
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    public void initWithEmpty() {
+        assertThrows(NullArgumentException.class, () -> SecureCell.ContextImprintWithKey((SymmetricKey)null));
+        assertThrows(NullArgumentException.class, () -> SecureCell.ContextImprintWithKey((byte[])null));
+        assertThrows(InvalidArgumentException.class, () -> SecureCell.ContextImprintWithKey(new byte[]{}));
+    }
+
+    @Test
+    public void roundtrip() {
+        SecureCell.ContextImprint cell = SecureCell.ContextImprintWithKey(new SymmetricKey());
+        byte[] message = "All your base are belong to us!".getBytes(StandardCharsets.UTF_8);
+        byte[] context = "For great justice".getBytes(StandardCharsets.UTF_8);
+
+        byte[] encrypted = cell.encrypt(message, context);
+        assertNotNull(encrypted);
+
+        byte[] decrypted = cell.decrypt(encrypted, context);
+        assertNotNull(decrypted);
+
+        assertArrayEquals(message, decrypted);
+    }
+
+    @Test
+    public void dataLengthPreservation() {
+        SecureCell.ContextImprint cell = SecureCell.ContextImprintWithKey(new SymmetricKey());
+        byte[] message = "All your base are belong to us!".getBytes(StandardCharsets.UTF_8);
+        byte[] context = "For great justice".getBytes(StandardCharsets.UTF_8);
+
+        byte[] encrypted = cell.encrypt(message, context);
+
+        assertEquals(message.length, encrypted.length);
+    }
+
+    @Test
+    public void contextInclusion() {
+        SecureCell.ContextImprint cell = SecureCell.ContextImprintWithKey(new SymmetricKey());
+        byte[] message = "All your base are belong to us!".getBytes(StandardCharsets.UTF_8);
+        byte[] shortContext = ".".getBytes(StandardCharsets.UTF_8);
+        byte[] longContext = "You have no chance to survive make your time. Ha ha ha ha ...".getBytes(StandardCharsets.UTF_8);
+
+        byte[] encryptedShort = cell.encrypt(message, shortContext);
+        byte[] encryptedLong = cell.encrypt(message, longContext);
+
+        // Context is not (directly) included into encrypted message.
+        assertEquals(encryptedShort.length, encryptedLong.length);
+    }
+
+    @Test
+    public void contextSignificance() {
+        SecureCell.ContextImprint cell = SecureCell.ContextImprintWithKey(new SymmetricKey());
+        byte[] message = "All your base are belong to us!".getBytes(StandardCharsets.UTF_8);
+        byte[] correctContext = "We are CATS".getBytes(StandardCharsets.UTF_8);
+        byte[] incorrectContext = "Captain !!".getBytes(StandardCharsets.UTF_8);
+
+        byte[] encrypted = cell.encrypt(message, correctContext);
+
+        // You can use a different context to decrypt data, but you'll get garbage.
+        byte[] decrypted = cell.decrypt(encrypted, incorrectContext);
+        assertNotNull(decrypted);
+        assertEquals(message.length, decrypted.length);
+        assertFalse(Arrays.equals(message, decrypted));
+
+        // Only the original context will work.
+        decrypted = cell.decrypt(encrypted, correctContext);
+        assertArrayEquals(message, decrypted);
+    }
+
+    @Test
+    public void noDetectCorruptedData() {
+        SecureCell.ContextImprint cell = SecureCell.ContextImprintWithKey(new SymmetricKey());
+        byte[] message = "All your base are belong to us!".getBytes(StandardCharsets.UTF_8);
+        byte[] context = "We are CATS".getBytes(StandardCharsets.UTF_8);
+
+        byte[] encrypted = cell.encrypt(message, context);
+
+        // Invert every odd byte, this will surely break the message.
+        byte[] corrupted = Arrays.copyOf(encrypted, encrypted.length);
+        for (int i = 0; i < corrupted.length; i++) {
+            if (i % 2 == 1) {
+                corrupted[i] = (byte)~corrupted[i];
+            }
+        }
+
+        // Decrypts successfully but the content is garbage.
+        byte[] decrypted = cell.decrypt(corrupted, context);
+        assertNotNull(decrypted);
+        assertEquals(message.length, decrypted.length);
+        assertFalse(Arrays.equals(message, decrypted));
+    }
+
+    @Test
+    public void noDetectTruncatedData() {
+        SecureCell.ContextImprint cell = SecureCell.ContextImprintWithKey(new SymmetricKey());
+        byte[] message = "All your base are belong to us!".getBytes(StandardCharsets.UTF_8);
+        byte[] context = "We are CATS".getBytes(StandardCharsets.UTF_8);
+
+        byte[] encrypted = cell.encrypt(message, context);
+
+        byte[] truncated = Arrays.copyOf(encrypted, encrypted.length - 1);
+
+        // Decrypts successfully but the content is garbage.
+        byte[] decrypted = cell.decrypt(truncated, context);
+        assertNotNull(decrypted);
+        assertEquals(truncated.length, decrypted.length);
+        assertFalse(Arrays.equals(message, decrypted));
+    }
+
+    @Test
+    public void noDetectExtendedData() {
+        SecureCell.ContextImprint cell = SecureCell.ContextImprintWithKey(new SymmetricKey());
+        byte[] message = "All your base are belong to us!".getBytes(StandardCharsets.UTF_8);
+        byte[] context = "We are CATS".getBytes(StandardCharsets.UTF_8);
+
+        byte[] encrypted = cell.encrypt(message, context);
+
+        byte[] extended = Arrays.copyOf(encrypted, encrypted.length + 1);
+
+        // Decrypts successfully but the content is garbage.
+        byte[] decrypted = cell.decrypt(extended, context);
+        assertNotNull(decrypted);
+        assertEquals(extended.length, decrypted.length);
+        assertFalse(Arrays.equals(message, decrypted));
+    }
+
+    @Test
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    public void requiredMessageAndContext() {
+        SecureCell.ContextImprint cell = SecureCell.ContextImprintWithKey(new SymmetricKey());
+        byte[] message = "All your base are belong to us!".getBytes(StandardCharsets.UTF_8);
+        byte[] context = "We are CATS".getBytes(StandardCharsets.UTF_8);
+
+        assertThrows(NullArgumentException.class, () -> cell.encrypt(message, null));
+        assertThrows(NullArgumentException.class, () -> cell.decrypt(message, null));
+        assertThrows(NullArgumentException.class, () -> cell.encrypt(null, context));
+        assertThrows(NullArgumentException.class, () -> cell.decrypt(null, context));
+
+        assertThrows(InvalidArgumentException.class, () -> cell.encrypt(message, new byte[]{}));
+        assertThrows(InvalidArgumentException.class, () -> cell.decrypt(message, new byte[]{}));
+        assertThrows(InvalidArgumentException.class, () -> cell.encrypt(new byte[]{}, context));
+        assertThrows(InvalidArgumentException.class, () -> cell.decrypt(new byte[]{}, context));
+    }
+
+    @Test
+    public void oldAPI() throws SecureCellException {
+        SymmetricKey key = new SymmetricKey();
+        SecureCell.ContextImprint newCell = SecureCell.ContextImprintWithKey(key);
+        SecureCell oldCell = new SecureCell(key.toByteArray(), SecureCell.MODE_CONTEXT_IMPRINT);
+        byte[] message = "All your base are belong to us!".getBytes(StandardCharsets.UTF_8);
+        byte[] context = "We are CATS".getBytes(StandardCharsets.UTF_8);
+        byte[] encrypted, decrypted;
+
+        SecureCellData result = oldCell.protect(context, message);
+        encrypted = result.getProtectedData();
+        assertNotNull(encrypted);
+
+        decrypted = newCell.decrypt(encrypted, context);
+        assertArrayEquals(message, decrypted);
+
+        encrypted = newCell.encrypt(message, context);
+        assertNotNull(encrypted);
+
+        decrypted = oldCell.unprotect(context, new SecureCellData(encrypted, null));
+        assertArrayEquals(message, decrypted);
+    }
+}

--- a/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellContextImprintTest.java
+++ b/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellContextImprintTest.java
@@ -18,7 +18,6 @@ package com.cossacklabs.themis.test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.Base64;
 
 import com.cossacklabs.themis.InvalidArgumentException;
 import com.cossacklabs.themis.NullArgumentException;

--- a/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellSealTest.java
+++ b/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellSealTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2020 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cossacklabs.themis.test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
+
+import com.cossacklabs.themis.InvalidArgumentException;
+import com.cossacklabs.themis.NullArgumentException;
+import com.cossacklabs.themis.SecureCell;
+import com.cossacklabs.themis.SecureCellData;
+import com.cossacklabs.themis.SecureCellException;
+import com.cossacklabs.themis.SymmetricKey;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+public class SecureCellSealTest {
+
+    @Test
+    public void initWithGenerated() {
+        SecureCell.Seal cell = SecureCell.SealWithKey(new SymmetricKey());
+
+        assertNotNull(cell);
+    }
+
+    @Test
+    public void initWithFixed() {
+        String keyBase64 = "UkVDMgAAAC13PCVZAKOczZXUpvkhsC+xvwWnv3CLmlG0Wzy8ZBMnT+2yx/dg";
+        byte[] keyBytes = Base64.getDecoder().decode(keyBase64);
+
+        SecureCell.Seal cell = SecureCell.SealWithKey(keyBytes);
+
+        assertNotNull(cell);
+    }
+
+    @Test
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    public void initWithEmpty() {
+        assertThrows(NullArgumentException.class, () -> SecureCell.SealWithKey((SymmetricKey)null));
+        assertThrows(NullArgumentException.class, () -> SecureCell.SealWithKey((byte[])null));
+        assertThrows(InvalidArgumentException.class, () -> SecureCell.SealWithKey(new byte[]{}));
+    }
+
+    @Test
+    public void roundtrip() throws SecureCellException {
+        SecureCell.Seal cell = SecureCell.SealWithKey(new SymmetricKey());
+        byte[] message = "All your base are belong to us!".getBytes(StandardCharsets.UTF_8);
+        byte[] context = "For great justice".getBytes(StandardCharsets.UTF_8);
+
+        byte[] encrypted = cell.encrypt(message, context);
+        assertNotNull(encrypted);
+
+        byte[] decrypted = cell.decrypt(encrypted, context);
+        assertNotNull(decrypted);
+
+        assertArrayEquals(message, decrypted);
+    }
+
+    @Test
+    public void dataLengthExtension() {
+        SecureCell.Seal cell = SecureCell.SealWithKey(new SymmetricKey());
+        byte[] message = "All your base are belong to us!".getBytes(StandardCharsets.UTF_8);
+
+        byte[] encrypted = cell.encrypt(message);
+
+        assertTrue(encrypted.length > message.length);
+    }
+
+    @Test
+    public void contextInclusion() {
+        SecureCell.Seal cell = SecureCell.SealWithKey(new SymmetricKey());
+        byte[] message = "All your base are belong to us!".getBytes(StandardCharsets.UTF_8);
+        byte[] shortContext = ".".getBytes(StandardCharsets.UTF_8);
+        byte[] longContext = "You have no chance to survive make your time. Ha ha ha ha ...".getBytes(StandardCharsets.UTF_8);
+
+        byte[] encryptedShort = cell.encrypt(message, shortContext);
+        byte[] encryptedLong = cell.encrypt(message, longContext);
+
+        // Context is not (directly) included into encrypted message.
+        assertEquals(encryptedShort.length, encryptedLong.length);
+    }
+
+    @Test
+    public void withoutContext() throws SecureCellException {
+        SecureCell.Seal cell = SecureCell.SealWithKey(new SymmetricKey());
+        byte[] message = "All your base are belong to us!".getBytes(StandardCharsets.UTF_8);
+
+        // Absent, empty, or nil context are all the same.
+        byte[] encrypted1 = cell.encrypt(message);
+        byte[] encrypted2 = cell.encrypt(message, null);
+        byte[] encrypted3 = cell.encrypt(message, new byte[]{});
+
+        assertArrayEquals(message, cell.decrypt(encrypted1));
+        assertArrayEquals(message, cell.decrypt(encrypted2));
+        assertArrayEquals(message, cell.decrypt(encrypted3));
+
+        assertArrayEquals(message, cell.decrypt(encrypted1, null));
+        assertArrayEquals(message, cell.decrypt(encrypted2, null));
+        assertArrayEquals(message, cell.decrypt(encrypted3, null));
+
+        assertArrayEquals(message, cell.decrypt(encrypted1, new byte[]{}));
+        assertArrayEquals(message, cell.decrypt(encrypted2, new byte[]{}));
+        assertArrayEquals(message, cell.decrypt(encrypted3, new byte[]{}));
+    }
+
+    @Test
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    public void contextSignificance() throws SecureCellException {
+        SecureCell.Seal cell = SecureCell.SealWithKey(new SymmetricKey());
+        byte[] message = "All your base are belong to us!".getBytes(StandardCharsets.UTF_8);
+        byte[] correctContext = "We are CATS".getBytes(StandardCharsets.UTF_8);
+        byte[] incorrectContext = "Captain !!".getBytes(StandardCharsets.UTF_8);
+
+        byte[] encrypted = cell.encrypt(message, correctContext);
+
+        // You cannot use a different context to decrypt data.
+        assertThrows(SecureCellException.class, () -> cell.decrypt(encrypted, incorrectContext));
+
+        // Only the original context will work.
+        byte[] decrypted = cell.decrypt(encrypted, correctContext);
+
+        assertArrayEquals(message, decrypted);
+    }
+
+    @Test
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    public void detectCorruptedData() {
+        SecureCell.Seal cell = SecureCell.SealWithKey(new SymmetricKey());
+        byte[] message = "All your base are belong to us!".getBytes(StandardCharsets.UTF_8);
+
+        byte[] encrypted = cell.encrypt(message);
+
+        // Invert every odd byte, this will surely break the message.
+        byte[] corrupted = Arrays.copyOf(encrypted, encrypted.length);
+        for (int i = 0; i < corrupted.length; i++) {
+            if (i % 2 == 1) {
+                corrupted[i] = (byte)~corrupted[i];
+            }
+        }
+
+        assertThrows(SecureCellException.class, () -> cell.decrypt(corrupted));
+    }
+
+    @Test
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    public void detectTruncatedData() {
+        SecureCell.Seal cell = SecureCell.SealWithKey(new SymmetricKey());
+        byte[] message = "All your base are belong to us!".getBytes(StandardCharsets.UTF_8);
+
+        byte[] encrypted = cell.encrypt(message);
+
+        byte[] truncated = Arrays.copyOf(encrypted, encrypted.length - 1);
+
+        assertThrows(SecureCellException.class, () -> cell.decrypt(truncated));
+    }
+
+    @Test
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    public void detectExtendedData() {
+        SecureCell.Seal cell = SecureCell.SealWithKey(new SymmetricKey());
+        byte[] message = "All your base are belong to us!".getBytes(StandardCharsets.UTF_8);
+
+        byte[] encrypted = cell.encrypt(message);
+
+        byte[] extended = Arrays.copyOf(encrypted, encrypted.length + 1);
+
+        assertThrows(SecureCellException.class, () -> cell.decrypt(extended));
+    }
+
+    @Test
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    public void emptyMessage() {
+        SecureCell.Seal cell = SecureCell.SealWithKey(new SymmetricKey());
+
+        assertThrows(NullArgumentException.class, () -> cell.encrypt(null));
+        assertThrows(NullArgumentException.class, () -> cell.decrypt(null));
+        assertThrows(InvalidArgumentException.class, () -> cell.encrypt(new byte[]{}));
+        assertThrows(InvalidArgumentException.class, () -> cell.decrypt(new byte[]{}));
+    }
+
+    @Test
+    public void oldAPI() throws SecureCellException {
+        SymmetricKey key = new SymmetricKey();
+        SecureCell.Seal newCell = SecureCell.SealWithKey(key);
+        SecureCell oldCell = new SecureCell(key.toByteArray(), SecureCell.MODE_SEAL);
+        byte[] message = "All your base are belong to us!".getBytes(StandardCharsets.UTF_8);
+        byte[] context = "We are CATS".getBytes(StandardCharsets.UTF_8);
+        byte[] encrypted, decrypted;
+
+        SecureCellData result = oldCell.protect(context, message);
+        encrypted = result.getProtectedData();
+        assertNotNull(encrypted);
+
+        decrypted = newCell.decrypt(encrypted, context);
+        assertArrayEquals(message, decrypted);
+
+        encrypted = newCell.encrypt(message, context);
+        assertNotNull(encrypted);
+
+        decrypted = oldCell.unprotect(context, new SecureCellData(encrypted, null));
+        assertArrayEquals(message, decrypted);
+    }
+
+    @Test
+    public void oldAPIWithoutContext() throws SecureCellException {
+        SymmetricKey key = new SymmetricKey();
+        SecureCell.Seal newCell = SecureCell.SealWithKey(key);
+        SecureCell oldCell = new SecureCell(key.toByteArray(), SecureCell.MODE_SEAL);
+        byte[] message = "All your base are belong to us!".getBytes(StandardCharsets.UTF_8);
+        byte[] encrypted, decrypted;
+
+        SecureCellData result = oldCell.protect((byte[])null, message);
+        encrypted = result.getProtectedData();
+        assertNotNull(encrypted);
+
+        decrypted = newCell.decrypt(encrypted);
+        assertArrayEquals(message, decrypted);
+
+        encrypted = newCell.encrypt(message);
+        assertNotNull(encrypted);
+
+        decrypted = oldCell.unprotect((byte[])null, new SecureCellData(encrypted, null));
+        assertArrayEquals(message, decrypted);
+    }
+}

--- a/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellSealTest.java
+++ b/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellSealTest.java
@@ -52,9 +52,21 @@ public class SecureCellSealTest {
     @Test
     @SuppressWarnings("ResultOfMethodCallIgnored")
     public void initWithEmpty() {
-        assertThrows(NullArgumentException.class, () -> SecureCell.SealWithKey((SymmetricKey)null));
-        assertThrows(NullArgumentException.class, () -> SecureCell.SealWithKey((byte[])null));
-        assertThrows(InvalidArgumentException.class, () -> SecureCell.SealWithKey(new byte[]{}));
+        try {
+            SecureCell.SealWithKey((SymmetricKey)null);
+            fail("expected NullArgumentException");
+        }
+        catch (NullArgumentException ignored) {}
+        try {
+            SecureCell.SealWithKey((byte[])null);
+            fail("expected NullArgumentException");
+        }
+        catch (NullArgumentException ignored) {}
+        try {
+            SecureCell.SealWithKey(new byte[]{});
+            fail("expected InvalidArgumentException");
+        }
+        catch (InvalidArgumentException ignored) {}
     }
 
     @Test
@@ -130,7 +142,11 @@ public class SecureCellSealTest {
         byte[] encrypted = cell.encrypt(message, correctContext);
 
         // You cannot use a different context to decrypt data.
-        assertThrows(SecureCellException.class, () -> cell.decrypt(encrypted, incorrectContext));
+        try {
+            cell.decrypt(encrypted, incorrectContext);
+            fail("expected SecureCellException");
+        }
+        catch (SecureCellException ignored) {}
 
         // Only the original context will work.
         byte[] decrypted = cell.decrypt(encrypted, correctContext);
@@ -154,7 +170,11 @@ public class SecureCellSealTest {
             }
         }
 
-        assertThrows(SecureCellException.class, () -> cell.decrypt(corrupted));
+        try {
+            cell.decrypt(corrupted);
+            fail("expected SecureCellException");
+        }
+        catch (SecureCellException ignored) {}
     }
 
     @Test
@@ -167,7 +187,12 @@ public class SecureCellSealTest {
 
         byte[] truncated = Arrays.copyOf(encrypted, encrypted.length - 1);
 
-        assertThrows(SecureCellException.class, () -> cell.decrypt(truncated));
+        try {
+            cell.decrypt(truncated);
+            fail("expected SecureCellException");
+        }
+        catch (SecureCellException ignored) {}
+
     }
 
     @Test
@@ -180,18 +205,38 @@ public class SecureCellSealTest {
 
         byte[] extended = Arrays.copyOf(encrypted, encrypted.length + 1);
 
-        assertThrows(SecureCellException.class, () -> cell.decrypt(extended));
+        try {
+            cell.decrypt(extended);
+            fail("expected SecureCellException");
+        }
+        catch (SecureCellException ignored) {}
     }
 
     @Test
     @SuppressWarnings("ResultOfMethodCallIgnored")
-    public void emptyMessage() {
+    public void emptyMessage() throws SecureCellException {
         SecureCell.Seal cell = SecureCell.SealWithKey(new SymmetricKey());
 
-        assertThrows(NullArgumentException.class, () -> cell.encrypt(null));
-        assertThrows(NullArgumentException.class, () -> cell.decrypt(null));
-        assertThrows(InvalidArgumentException.class, () -> cell.encrypt(new byte[]{}));
-        assertThrows(InvalidArgumentException.class, () -> cell.decrypt(new byte[]{}));
+        try {
+            cell.encrypt(null);
+            fail("expected NullArgumentException");
+        }
+        catch (NullArgumentException ignored) {}
+        try {
+            cell.decrypt(null);
+            fail("expected NullArgumentException");
+        }
+        catch (NullArgumentException ignored) {}
+        try {
+            cell.encrypt(new byte[]{});
+            fail("expected InvalidArgumentException");
+        }
+        catch (InvalidArgumentException ignored) {}
+        try {
+            cell.decrypt(new byte[]{});
+            fail("expected InvalidArgumentException");
+        }
+        catch (InvalidArgumentException ignored) {}
     }
 
     @Test

--- a/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellSealTest.java
+++ b/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellSealTest.java
@@ -18,7 +18,6 @@ package com.cossacklabs.themis.test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.Base64;
 
 import com.cossacklabs.themis.InvalidArgumentException;
 import com.cossacklabs.themis.NullArgumentException;

--- a/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellTokenProtectTest.java
+++ b/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellTokenProtectTest.java
@@ -28,6 +28,8 @@ import com.cossacklabs.themis.SecureCellException;
 import com.cossacklabs.themis.SymmetricKey;
 
 import static org.junit.Assert.*;
+
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class SecureCellTokenProtectTest {
@@ -258,6 +260,8 @@ public class SecureCellTokenProtectTest {
 
 
     @Test
+    // FIXME(ilammy, 2020-05-05): resolve the bug in JNI code to unblock this test (T1607)
+    @Ignore("crashes on Android due to a bug in JNI code")
     @SuppressWarnings("ResultOfMethodCallIgnored")
     public void detectCorruptedToken() {
         SecureCell.TokenProtect cell = SecureCell.TokenProtectWithKey(new SymmetricKey());
@@ -324,6 +328,8 @@ public class SecureCellTokenProtectTest {
     }
 
     @Test
+    // FIXME(ilammy, 2020-05-05): resolve the bug in JNI code to unblock this test (T1607)
+    @Ignore("crashes on Android due to a bug in JNI code")
     @SuppressWarnings("ResultOfMethodCallIgnored")
     public void swapTokenAndData() {
         SecureCell.TokenProtect cell = SecureCell.TokenProtectWithKey(new SymmetricKey());

--- a/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellTokenProtectTest.java
+++ b/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellTokenProtectTest.java
@@ -52,9 +52,21 @@ public class SecureCellTokenProtectTest {
     @Test
     @SuppressWarnings("ResultOfMethodCallIgnored")
     public void initWithEmpty() {
-        assertThrows(NullArgumentException.class, () -> SecureCell.TokenProtectWithKey((SymmetricKey)null));
-        assertThrows(NullArgumentException.class, () -> SecureCell.TokenProtectWithKey((byte[])null));
-        assertThrows(InvalidArgumentException.class, () -> SecureCell.TokenProtectWithKey(new byte[]{}));
+        try {
+            SecureCell.TokenProtectWithKey((SymmetricKey)null);
+            fail("expected NullArgumentException");
+        }
+        catch (NullArgumentException ignored) {}
+        try {
+            SecureCell.TokenProtectWithKey((byte[])null);
+            fail("expected NullArgumentException");
+        }
+        catch (NullArgumentException ignored) {}
+        try {
+            SecureCell.TokenProtectWithKey(new byte[]{});
+            fail("expected InvalidArgumentException");
+        }
+        catch (InvalidArgumentException ignored) {}
     }
 
     @Test
@@ -138,7 +150,11 @@ public class SecureCellTokenProtectTest {
         byte[] authToken = result.getAdditionalData();
 
         // You cannot use a different context to decrypt data.
-        assertThrows(SecureCellException.class, () -> cell.decrypt(encrypted, authToken, incorrectContext));
+        try {
+            cell.decrypt(encrypted, authToken, incorrectContext);
+            fail("expected SecureCellException");
+        }
+        catch (SecureCellException ignored) {}
 
         // Only the original context will work.
         byte[] decrypted = cell.decrypt(encrypted, authToken, correctContext);
@@ -161,8 +177,16 @@ public class SecureCellTokenProtectTest {
         byte[] authToken2 = result2.getAdditionalData();
 
         // You cannot use a different token to decrypt data.
-        assertThrows(SecureCellException.class, () -> cell.decrypt(encrypted1, authToken2));
-        assertThrows(SecureCellException.class, () -> cell.decrypt(encrypted2, authToken1));
+        try {
+            cell.decrypt(encrypted1, authToken2);
+            fail("expected SecureCellException");
+        }
+        catch (SecureCellException ignored) {}
+        try {
+            cell.decrypt(encrypted2, authToken1);
+            fail("expected SecureCellException");
+        }
+        catch (SecureCellException ignored) {}
 
         // Only the matching token will work.
         assertArrayEquals(message, cell.decrypt(encrypted1, authToken1));
@@ -187,7 +211,11 @@ public class SecureCellTokenProtectTest {
             }
         }
 
-        assertThrows(SecureCellException.class, () -> cell.decrypt(corrupted, authToken));
+        try {
+            cell.decrypt(corrupted, authToken);
+            fail("expected SecureCellException");
+        }
+        catch (SecureCellException ignored) {}
     }
 
     @Test
@@ -202,7 +230,11 @@ public class SecureCellTokenProtectTest {
 
         byte[] truncated = Arrays.copyOf(encrypted, encrypted.length - 1);
 
-        assertThrows(SecureCellException.class, () -> cell.decrypt(truncated, authToken));
+        try {
+            cell.decrypt(truncated, authToken);
+            fail("expected SecureCellException");
+        }
+        catch (SecureCellException ignored) {}
     }
 
     @Test
@@ -217,7 +249,11 @@ public class SecureCellTokenProtectTest {
 
         byte[] extended = Arrays.copyOf(encrypted, encrypted.length + 1);
 
-        assertThrows(SecureCellException.class, () -> cell.decrypt(extended, authToken));
+        try {
+            cell.decrypt(extended, authToken);
+            fail("expected SecureCellException");
+        }
+        catch (SecureCellException ignored) {}
     }
 
 
@@ -244,7 +280,11 @@ public class SecureCellTokenProtectTest {
         // because the Core library fails to detect corruption and returns negative buffer size
         // which we cannot allocate, unfortunately.
         // Expect "SecureCellException.class" here once the issue is resolved.
-        assertThrows(Throwable.class, () -> cell.decrypt(encrypted, corruptedToken));
+        try {
+            cell.decrypt(encrypted, corruptedToken);
+            fail("expected SecureCellException");
+        }
+        catch (Throwable ignored) {}
     }
 
     @Test
@@ -259,7 +299,11 @@ public class SecureCellTokenProtectTest {
 
         byte[] truncatedToken = Arrays.copyOf(authToken, authToken.length - 1);
 
-        assertThrows(SecureCellException.class, () -> cell.decrypt(encrypted, truncatedToken));
+        try {
+            cell.decrypt(encrypted, truncatedToken);
+            fail("expected SecureCellException");
+        }
+        catch (SecureCellException ignored) {}
     }
 
     @Test
@@ -294,7 +338,11 @@ public class SecureCellTokenProtectTest {
         // because the Core library fails to detect corruption and returns incorrect buffer size
         // which we cannot allocate, unfortunately.
         // Expect "SecureCellException.class" here once the issue is resolved.
-        assertThrows(Throwable.class, () -> cell.decrypt(authToken, encrypted));
+        try {
+            cell.decrypt(authToken, encrypted);
+            fail("expected SecureCellException");
+        }
+        catch (Throwable ignored) {}
     }
 
     @Test
@@ -307,26 +355,54 @@ public class SecureCellTokenProtectTest {
         SecureCellData result = cell.encrypt(message, context);
         byte[] encrypted = result.getProtectedData();
 
-        assertThrows(SecureCellException.class, () -> cell.decrypt(encrypted, context));
+        try {
+            cell.decrypt(encrypted, context);
+            fail("expected SecureCellException");
+        }
+        catch (SecureCellException ignored) {}
     }
 
     @Test
     @SuppressWarnings("ResultOfMethodCallIgnored")
-    public void emptyMessageOrToken() {
+    public void emptyMessageOrToken() throws SecureCellException {
         SecureCell.TokenProtect cell = SecureCell.TokenProtectWithKey(new SymmetricKey());
         byte[] message = "All your base are belong to us!".getBytes(StandardCharsets.UTF_8);
 
-        assertThrows(NullArgumentException.class, () -> cell.encrypt(null));
-        assertThrows(InvalidArgumentException.class, () -> cell.encrypt(new byte[]{}));
+        try {
+            cell.encrypt(null);
+            fail("expected NullArgumentException");
+        }
+        catch (NullArgumentException ignored) {}
+        try {
+            cell.encrypt(new byte[]{});
+            fail("expected InvalidArgumentException");
+        }
+        catch (InvalidArgumentException ignored) {}
 
         SecureCellData result = cell.encrypt(message);
         byte[] encrypted = result.getProtectedData();
         byte[] authToken = result.getAdditionalData();
 
-        assertThrows(NullArgumentException.class, () -> cell.decrypt(encrypted, null));
-        assertThrows(NullArgumentException.class, () -> cell.decrypt(null, authToken));
-        assertThrows(InvalidArgumentException.class, () -> cell.decrypt(encrypted, new byte[]{}));
-        assertThrows(InvalidArgumentException.class, () -> cell.decrypt(new byte[]{}, authToken));
+        try {
+            cell.decrypt(encrypted, null);
+            fail("expected NullArgumentException");
+        }
+        catch (NullArgumentException ignored) {}
+        try {
+            cell.decrypt(null, authToken);
+            fail("expected NullArgumentException");
+        }
+        catch (NullArgumentException ignored) {}
+        try {
+            cell.decrypt(encrypted, new byte[]{});
+            fail("expected InvalidArgumentException");
+        }
+        catch (InvalidArgumentException ignored) {}
+        try {
+            cell.decrypt(new byte[]{}, authToken);
+            fail("expected InvalidArgumentException");
+        }
+        catch (InvalidArgumentException ignored) {}
     }
 
     @Test

--- a/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellTokenProtectTest.java
+++ b/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellTokenProtectTest.java
@@ -18,7 +18,6 @@ package com.cossacklabs.themis.test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.Base64;
 
 import com.cossacklabs.themis.InvalidArgumentException;
 import com.cossacklabs.themis.NullArgumentException;


### PR DESCRIPTION
This PR makes preparatory changes for new passphrase API by updating existing API of Secure Cell in JavaThemis to more easy to use and similar to other Themis wrappers. The API is described in RFC 3.9.

## User notes

`SecureCell` class now provides improved Secure Cell interfaces:

- `SecureCell.Seal`
- `SecureCell.TokenProtect`
- `SecureCell.ContextImprint`

as well as new static factory methods for them, accepting symmetric keys:

- `SecureCell#SealWithKey`
- `SecureCell#TokenProtectWithKey`
- `SecureCell#ContextImprintWithKey`

All of this can be used like this in Java:

```java
import com.cossacklabs.themis.SecureCell;
import com.cossacklabs.themis.SymmetricKey;

SymmetricKey masterKey = new SymmetricKey();

SecureCell.Seal cell = SecureCell.SealWithKey(masterKey);

byte[] message = "precious message".getBytes(StandardCharsets.UTF_8);

byte[] encrypted = cell.encrypt(message);
byte[] decrypted = cell.decrypt(encrypted);

assertArrayEquals(message, decrypted);
```

### Optional associated context

All `encrypt` and `decrypt` methods now have an overload without an optional argument for associated context. This makes the code that does not use it more concise. (Of course you can still pass `null` there if you must.)

### Nullability annotations

New interface are properly annotated with `@NotNull` and `@Nullable` which improves IDE experience and enables more static checks.

### SecureCellData usage

Note that with new interfaces you no longer have to construct `SecureCellData` objects to decrypt data. Just pass your `byte[]` with encrypted data directly to `decrypt()` methods. In Token Protect mode you pass encrypted data and authentication token as separate `byte[]` arrays too.

Similarly, Seal and Context Imprint modes return encrypted `byte[]` directly. You no longer have to `getProtectedData()` from the returned `SecureCellData` object.

Token Protect mode still returns `SecureCellData` from its `encrypt()` method. That's the way it is with Java, which has no multiple return values. This will be improved for Kotlin a bit later.

### Pending deprecations

This PR does not deprecate the old API, but consider it deprecated.

- Construction of `SecureCell` with `new`.
- `protect` and `unprotect` methods.

(This list will be updated when the API is actually deprecated.)

## Technical notes

Full rationale may be found in RFC 3.9. Main gripes with the old API were run-time mode-setting with its impact on API, syntactic noise when using more popular Seal mode, and idiosyncratic naming of methods, inconsistent with other wrappers and our own documentation.

New API does not accept `String` values. The old API encoded strings in platform-specific UTF-16 which was quite unique and not portable to other platforms. Furthermore, it suggested that strings can be used as passphrases, which is not secure in typical case.

At last, in order to decrypt Sealed data, instead of writing

```java
byte[] decrypted = cell.unprotect(null, new SecureCellData(encrypted, null));
```

you can write much more readable code:

```java
byte[] decrypted = cell.decrypt(encrypted);
```

And yes, the context now comes *after* the data, as in all other wrappers.

Last but not least, Secure Cell gets an expanded and updated test suite (translated from whatever was done for SwiftThemis). This will definitely come handy if we are going to reimplement JavaThemis in pure JVM code some day.

Note that JNI API and ABI does not change. We decided to keep compatibility here.

### Targeting Java 7

I have discovered that Android compiles its code for Java 7 by default. I wanted to use Java 8 features in tests initially, but given the Android story I think we should use Java 7 even for desktop Java code.

Note that embedded Gradle wrapper still requires Java 8 to run. However, the compiled code will run on Java 7 too.

### New TODOs and FIXMEs

This PR adds a bunch of new TODOs in the code. While it's not nice, I don't want to block further development with those issues. They will be resolved later:

- Fix a bug in JNI code that crashes tests on Android.
- Fix an issue in Themis Core which causes the same test to behave unexpectedly.
- Signal exceptions from within JNI code instead of checking for `null` in Java code.

### Next tasks

- **Add passphrase API.** Can be done in parallel, will be submitted after this PR is merged.
- **Deprecate old API.** Since we will have to deprecate _a lot_ and provide good migration instructions, I decided to split this out into a new PR.
- **Add Kotlin tests.** It will be nice to actually see how our code can be used from Kotlin. Adding it is trivial, but not *quite* trivial.
- **Improve Kotlin support.** RFC 3.9 plans several additional changes in Token Protect API to improve its usability in Kotlin.
- **Update examples.** Both in-repo and external ones. They are quite outdated so it may require additional refactoring.

## Checklist

- [X] Change is covered by automated tests
- [X] ~~Benchmark results are attached~~ (we have no JVM benchmarks)
- [X] The [coding guidelines] are followed
- [X] Public API has proper documentation
- [X] ~~Example projects and code samples are up-to-date~~ (will do later)
- [X] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
