### PR TITLE
Test Kotlin API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ _Code:_
 
   See also: [Java API updates](#0.13.0-java).
 
+  - Kotlin is now officially supported language on Android
+    ([#637](https://github.com/cossacklabs/themis/pull/637).
+
   - **Breaking changes**
 
     - Android build now uses Gradle 5.6 and requires Java 8 ([#633](https://github.com/cossacklabs/themis/pull/633)).
@@ -378,6 +381,8 @@ _Code:_
   - It is now possible to build desktop Java with Gradle.
     Run `./gradlew :desktop:tasks` to learn more
     ([#633](https://github.com/cossacklabs/themis/pull/633)).
+  - Kotlin is now officially supported language for JavaThemis
+    ([#637](https://github.com/cossacklabs/themis/pull/637).
 
   - Secure Cell API updates:
 
@@ -629,6 +634,8 @@ _Infrastructure:_
 - Automated benchmarking harness is now tracking Themis performance. See [`benches`](https://github.com/cossacklabs/themis/tree/master/benches/) ([#580](https://github.com/cossacklabs/themis/pull/580)).
 - Added automated tests for all code samples in documentation, ensuring they are always up-to-date ([#600](https://github.com/cossacklabs/themis/pull/600)).
 - All 13 supported platforms are verified on GitHub Actions, along with existing CircleCI and Bitrise tests ([#600](https://github.com/cossacklabs/themis/pull/600)).
+- Kotlin API of JavaThemis is now verified by all CI platforms
+  ([#637](https://github.com/cossacklabs/themis/pull/637).
 - New Makefile targets:
   - `make jsthemis` builds JsThemis from source ([#618](https://github.com/cossacklabs/themis/pull/618)).
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,11 +5,16 @@ allprojects {
         repositories {
             google()
             jcenter()
+            mavenCentral()
         }
+
+        // Set common Kotlin version that we are going to use.
+        ext.kotlin_version = '1.3.72'
     }
 
     repositories {
         google()
         jcenter()
+        mavenCentral()
     }
 }

--- a/src/wrappers/themis/android/build.gradle
+++ b/src/wrappers/themis/android/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
 
 buildscript {
     dependencies {
@@ -12,6 +13,9 @@ buildscript {
         // from: https://android.jlelse.eu/how-to-distribute-android-library-in-a-convenient-way-d43fb68304a7
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
+
+        // Kotlin plugin for Android
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -24,6 +28,8 @@ dependencies {
     androidTestImplementation 'androidx.test:rules:1.2.0'
     // Keep it at 1.2, see tests/themis/wrappers/android/com/cossacklabs/themis/test/Base64.java
     androidTestImplementation 'commons-codec:commons-codec:1.2'
+    // Kotlin for instrumentation tests
+    androidTestImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 
 android {
@@ -76,6 +82,15 @@ android {
         ndkBuild {
             path "../../../../jni/Android.mk"
         }
+    }
+
+    // Due to various renames in annotation modules, Android's DEX compiler is confused.
+    // Remove them from compiled code to avoid issues.
+    // https://github.com/vimeo/vimeo-networking-java/issues/285
+    // https://github.com/vimeo/vimeo-networking-java/pull/321
+    configurations {
+        cleanedAnnotations
+        compile.exclude group: 'org.jetbrains' , module:'annotations'
     }
 }
 

--- a/src/wrappers/themis/java/build.gradle
+++ b/src/wrappers/themis/java/build.gradle
@@ -1,4 +1,12 @@
 apply plugin: 'java-library'
+apply plugin: 'kotlin'
+
+buildscript {
+    dependencies {
+        // Kotlin plugin for Java
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
+}
 
 sourceSets {
     main {
@@ -17,6 +25,8 @@ dependencies {
     testImplementation 'junit:junit:4.13'
     // Keep it at 1.2, see tests/themis/wrappers/android/com/cossacklabs/themis/test/Base64.java
     testImplementation 'commons-codec:commons-codec:1.2'
+    // Kotlin for unit tests
+    testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 
 test {

--- a/tests/themis/wrappers/android/com/cossacklabs/themis/test/Assert.java
+++ b/tests/themis/wrappers/android/com/cossacklabs/themis/test/Assert.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cossacklabs.themis.test;
+
+import org.jetbrains.annotations.NotNull;
+
+// We use Java 7 -- particularly for Android support -- where JUnit does not have "assertThrows()".
+// That makes tests very verbose and repetitive. Provide a polyfill a for it.
+
+final class Assert {
+    static <T extends Throwable> T assertThrows(@NotNull Class<T> expected, Runnable runnable) {
+        try {
+            runnable.run();
+        }
+        catch (Throwable e) {
+            if (expected.isInstance(e)) {
+                return expected.cast(e);
+            }
+            throw new AssertionError("expected exception of type "+ expected, e);
+        }
+        throw new AssertionError("no expected exception of type " + expected + " was thrown");
+    }
+}

--- a/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellContextImprintTestKotlin.kt
+++ b/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellContextImprintTestKotlin.kt
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2020 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cossacklabs.themis.test
+
+import java.nio.charset.StandardCharsets
+import kotlin.experimental.inv
+
+import com.cossacklabs.themis.*
+import com.cossacklabs.themis.test.Assert.assertThrows
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class SecureCellContextImprintTestKotlin {
+    @Test
+    fun initWithGenerated() {
+        val cell = SecureCell.ContextImprintWithKey(SymmetricKey())
+        assertNotNull(cell)
+    }
+
+    @Test
+    fun initWithFixed() {
+        val keyBase64 = "UkVDMgAAAC13PCVZAKOczZXUpvkhsC+xvwWnv3CLmlG0Wzy8ZBMnT+2yx/dg"
+        val keyBytes = Base64.getDecoder().decode(keyBase64)
+        val cell = SecureCell.ContextImprintWithKey(keyBytes)
+        assertNotNull(cell)
+    }
+
+    @Test
+    fun initWithEmpty() {
+        assertThrows(NullArgumentException::class.java) {
+            SecureCell.ContextImprintWithKey(null as SymmetricKey?)
+        }
+        assertThrows(NullArgumentException::class.java) {
+            SecureCell.ContextImprintWithKey(null as ByteArray?)
+        }
+        assertThrows(InvalidArgumentException::class.java) {
+            SecureCell.ContextImprintWithKey(byteArrayOf())
+        }
+    }
+
+    @Test
+    fun roundtrip() {
+        val cell = SecureCell.ContextImprintWithKey(SymmetricKey())
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+        val context = "For great justice".toByteArray(StandardCharsets.UTF_8)
+
+        val encrypted = cell.encrypt(message, context)
+        assertNotNull(encrypted)
+
+        val decrypted = cell.decrypt(encrypted, context)
+        assertNotNull(decrypted)
+        assertArrayEquals(message, decrypted)
+    }
+
+    @Test
+    fun dataLengthPreservation() {
+        val cell = SecureCell.ContextImprintWithKey(SymmetricKey())
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+        val context = "For great justice".toByteArray(StandardCharsets.UTF_8)
+
+        val encrypted = cell.encrypt(message, context)
+        assertEquals(message.size.toLong(), encrypted.size.toLong())
+    }
+
+    @Test
+    fun contextInclusion() {
+        val cell = SecureCell.ContextImprintWithKey(SymmetricKey())
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+        val shortContext = ".".toByteArray(StandardCharsets.UTF_8)
+        val longContext = "You have no chance to survive make your time. Ha ha ha ha ...".toByteArray(StandardCharsets.UTF_8)
+
+        val encryptedShort = cell.encrypt(message, shortContext)
+        val encryptedLong = cell.encrypt(message, longContext)
+
+        // Context is not (directly) included into encrypted message.
+        assertEquals(encryptedShort.size.toLong(), encryptedLong.size.toLong())
+    }
+
+    @Test
+    fun contextSignificance() {
+        val cell = SecureCell.ContextImprintWithKey(SymmetricKey())
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+        val correctContext = "We are CATS".toByteArray(StandardCharsets.UTF_8)
+        val incorrectContext = "Captain !!".toByteArray(StandardCharsets.UTF_8)
+
+        val encrypted = cell.encrypt(message, correctContext)
+
+        // You can use a different context to decrypt data, but you'll get garbage.
+        var decrypted = cell.decrypt(encrypted, incorrectContext)
+        assertNotNull(decrypted)
+        assertEquals(message.size.toLong(), decrypted.size.toLong())
+        assertFalse(message.contentEquals(decrypted))
+
+        // Only the original context will work.
+        decrypted = cell.decrypt(encrypted, correctContext)
+        assertArrayEquals(message, decrypted)
+    }
+
+    @Test
+    fun noDetectCorruptedData() {
+        val cell = SecureCell.ContextImprintWithKey(SymmetricKey())
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+        val context = "We are CATS".toByteArray(StandardCharsets.UTF_8)
+
+        val encrypted = cell.encrypt(message, context)
+
+        // Invert every odd byte, this will surely break the message.
+        val corrupted = encrypted.copyOf(encrypted.size)
+        for (i in corrupted.indices) {
+            if (i % 2 == 1) {
+                corrupted[i] = corrupted[i].inv()
+            }
+        }
+
+        // Decrypts successfully but the content is garbage.
+        val decrypted = cell.decrypt(corrupted, context)
+        assertNotNull(decrypted)
+        assertEquals(message.size.toLong(), decrypted.size.toLong())
+        assertFalse(message.contentEquals(decrypted))
+    }
+
+    @Test
+    fun noDetectTruncatedData() {
+        val cell = SecureCell.ContextImprintWithKey(SymmetricKey())
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+        val context = "We are CATS".toByteArray(StandardCharsets.UTF_8)
+
+        val encrypted = cell.encrypt(message, context)
+        val truncated = encrypted.copyOf(encrypted.size - 1)
+
+        // Decrypts successfully but the content is garbage.
+        val decrypted = cell.decrypt(truncated, context)
+        assertNotNull(decrypted)
+        assertEquals(truncated.size.toLong(), decrypted.size.toLong())
+        assertFalse(message.contentEquals(decrypted))
+    }
+
+    @Test
+    fun noDetectExtendedData() {
+        val cell = SecureCell.ContextImprintWithKey(SymmetricKey())
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+        val context = "We are CATS".toByteArray(StandardCharsets.UTF_8)
+
+        val encrypted = cell.encrypt(message, context)
+        val extended = encrypted.copyOf(encrypted.size + 1)
+
+        // Decrypts successfully but the content is garbage.
+        val decrypted = cell.decrypt(extended, context)
+        assertNotNull(decrypted)
+        assertEquals(extended.size.toLong(), decrypted.size.toLong())
+        assertFalse(message.contentEquals(decrypted))
+    }
+
+    @Test
+    fun requiredMessageAndContext() {
+        val cell = SecureCell.ContextImprintWithKey(SymmetricKey())
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+        val context = "We are CATS".toByteArray(StandardCharsets.UTF_8)
+
+        assertThrows(NullArgumentException::class.java) { cell.encrypt(message, null) }
+        assertThrows(NullArgumentException::class.java) { cell.decrypt(message, null) }
+        assertThrows(NullArgumentException::class.java) { cell.encrypt(null, context) }
+        assertThrows(NullArgumentException::class.java) { cell.decrypt(null, context) }
+
+        assertThrows(InvalidArgumentException::class.java) { cell.encrypt(message, byteArrayOf()) }
+        assertThrows(InvalidArgumentException::class.java) { cell.decrypt(message, byteArrayOf()) }
+        assertThrows(InvalidArgumentException::class.java) { cell.encrypt(byteArrayOf(), context) }
+        assertThrows(InvalidArgumentException::class.java) { cell.decrypt(byteArrayOf(), context) }
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    @Throws(SecureCellException::class)
+    fun oldAPI() {
+        val key = SymmetricKey()
+        val newCell = SecureCell.ContextImprintWithKey(key)
+        val oldCell = SecureCell(key.toByteArray(), SecureCell.MODE_CONTEXT_IMPRINT)
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+        val context = "We are CATS".toByteArray(StandardCharsets.UTF_8)
+
+        var encrypted: ByteArray
+        var decrypted: ByteArray?
+        val result = oldCell.protect(context, message)
+        encrypted = result.protectedData
+        assertNotNull(encrypted)
+        decrypted = newCell.decrypt(encrypted, context)
+        assertArrayEquals(message, decrypted)
+
+        encrypted = newCell.encrypt(message, context)
+        assertNotNull(encrypted)
+        decrypted = oldCell.unprotect(context, SecureCellData(encrypted, null))
+        assertArrayEquals(message, decrypted)
+    }
+}

--- a/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellSealTestKotlin.kt
+++ b/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellSealTestKotlin.kt
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2020 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cossacklabs.themis.test
+
+import java.nio.charset.StandardCharsets
+import kotlin.experimental.inv
+
+import com.cossacklabs.themis.*
+import com.cossacklabs.themis.test.Assert.assertThrows
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class SecureCellSealTestKotlin {
+    @Test
+    fun initWithGenerated() {
+        val cell = SecureCell.SealWithKey(SymmetricKey())
+        assertNotNull(cell)
+    }
+
+    @Test
+    fun initWithFixed() {
+        val keyBase64 = "UkVDMgAAAC13PCVZAKOczZXUpvkhsC+xvwWnv3CLmlG0Wzy8ZBMnT+2yx/dg"
+        val keyBytes = Base64.getDecoder().decode(keyBase64)
+        val cell = SecureCell.SealWithKey(keyBytes)
+        assertNotNull(cell)
+    }
+
+    @Test
+    fun initWithEmpty() {
+        assertThrows(NullArgumentException::class.java) {
+            SecureCell.SealWithKey(null as SymmetricKey?)
+        }
+        assertThrows(NullArgumentException::class.java) {
+            SecureCell.SealWithKey(null as ByteArray?)
+        }
+        assertThrows(InvalidArgumentException::class.java) {
+            SecureCell.SealWithKey(byteArrayOf())
+        }
+    }
+
+    @Test
+    @Throws(SecureCellException::class)
+    fun roundtrip() {
+        val cell = SecureCell.SealWithKey(SymmetricKey())
+        val message: ByteArray = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+        val context: ByteArray = "For great justice".toByteArray(StandardCharsets.UTF_8)
+
+        val encrypted = cell.encrypt(message, context)
+        assertNotNull(encrypted)
+
+        val decrypted = cell.decrypt(encrypted, context)
+        assertNotNull(decrypted)
+        assertArrayEquals(message, decrypted)
+    }
+
+    @Test
+    fun dataLengthExtension() {
+        val cell = SecureCell.SealWithKey(SymmetricKey())
+        val message: ByteArray = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+
+        val encrypted = cell.encrypt(message)
+        assertTrue(encrypted.size > message.size)
+    }
+
+    @Test
+    fun contextInclusion() {
+        val cell = SecureCell.SealWithKey(SymmetricKey())
+        val message: ByteArray = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+        val shortContext: ByteArray = ".".toByteArray(StandardCharsets.UTF_8)
+        val longContext: ByteArray = "You have no chance to survive make your time. Ha ha ha ha ...".toByteArray(StandardCharsets.UTF_8)
+
+        val encryptedShort = cell.encrypt(message, shortContext)
+        val encryptedLong = cell.encrypt(message, longContext)
+
+        // Context is not (directly) included into encrypted message.
+        assertEquals(encryptedShort.size, encryptedLong.size)
+    }
+
+    @Test
+    @Throws(SecureCellException::class)
+    fun withoutContext() {
+        val cell = SecureCell.SealWithKey(SymmetricKey())
+        val message: ByteArray = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+
+        // Absent, empty, or nil context are all the same.
+        val encrypted1 = cell.encrypt(message)
+        val encrypted2 = cell.encrypt(message, null)
+        val encrypted3 = cell.encrypt(message, byteArrayOf())
+
+        assertArrayEquals(message, cell.decrypt(encrypted1))
+        assertArrayEquals(message, cell.decrypt(encrypted2))
+        assertArrayEquals(message, cell.decrypt(encrypted3))
+        assertArrayEquals(message, cell.decrypt(encrypted1, null))
+        assertArrayEquals(message, cell.decrypt(encrypted2, null))
+        assertArrayEquals(message, cell.decrypt(encrypted3, null))
+        assertArrayEquals(message, cell.decrypt(encrypted1, byteArrayOf()))
+        assertArrayEquals(message, cell.decrypt(encrypted2, byteArrayOf()))
+        assertArrayEquals(message, cell.decrypt(encrypted3, byteArrayOf()))
+    }
+
+    @Test
+    @Throws(SecureCellException::class)
+    fun contextSignificance() {
+        val cell = SecureCell.SealWithKey(SymmetricKey())
+        val message: ByteArray = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+        val correctContext: ByteArray = "We are CATS".toByteArray(StandardCharsets.UTF_8)
+        val incorrectContext: ByteArray = "Captain !!".toByteArray(StandardCharsets.UTF_8)
+
+        val encrypted = cell.encrypt(message, correctContext)
+
+        // You cannot use a different context to decrypt data.
+        assertThrows(SecureCellException::class.java) {
+            cell.decrypt(encrypted, incorrectContext)
+        }
+
+        // Only the original context will work.
+        val decrypted = cell.decrypt(encrypted, correctContext)
+        assertArrayEquals(message, decrypted)
+    }
+
+    @Test
+    fun detectCorruptedData() {
+        val cell = SecureCell.SealWithKey(SymmetricKey())
+        val message: ByteArray = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+
+        val encrypted = cell.encrypt(message)
+
+        // Invert every odd byte, this will surely break the message.
+        val corrupted = encrypted.copyOf(encrypted.size)
+        for (i in corrupted.indices) {
+            if (i % 2 == 1) {
+                corrupted[i] = corrupted[i].inv()
+            }
+        }
+
+        assertThrows(SecureCellException::class.java) {
+            cell.decrypt(corrupted)
+        }
+    }
+
+    @Test
+    fun detectTruncatedData() {
+        val cell = SecureCell.SealWithKey(SymmetricKey())
+        val message: ByteArray = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+
+        val encrypted = cell.encrypt(message)
+
+        val truncated = encrypted.copyOf(encrypted.size - 1)
+
+        assertThrows(SecureCellException::class.java) {
+            cell.decrypt(truncated)
+        }
+    }
+
+    @Test
+    fun detectExtendedData() {
+        val cell = SecureCell.SealWithKey(SymmetricKey())
+        val message: ByteArray = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+
+        val encrypted = cell.encrypt(message)
+
+        val extended = encrypted.copyOf(encrypted.size + 1)
+
+        assertThrows(SecureCellException::class.java) {
+            cell.decrypt(extended)
+        }
+    }
+
+    @Test
+    @Throws(SecureCellException::class)
+    fun emptyMessage() {
+        val cell = SecureCell.SealWithKey(SymmetricKey())
+
+        assertThrows(NullArgumentException::class.java) { cell.encrypt(null) }
+        assertThrows(NullArgumentException::class.java) { cell.decrypt(null) }
+
+        assertThrows(InvalidArgumentException::class.java) { cell.encrypt(byteArrayOf()) }
+        assertThrows(InvalidArgumentException::class.java) { cell.decrypt(byteArrayOf()) }
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    @Throws(SecureCellException::class)
+    fun oldAPI() {
+        val key = SymmetricKey()
+        val newCell = SecureCell.SealWithKey(key)
+        val oldCell = SecureCell(key.toByteArray(), SecureCell.MODE_SEAL)
+        val message: ByteArray = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+        val context: ByteArray = "We are CATS".toByteArray(StandardCharsets.UTF_8)
+
+        var encrypted: ByteArray
+        var decrypted: ByteArray?
+        val result = oldCell.protect(context, message)
+        encrypted = result.protectedData
+        assertNotNull(encrypted)
+        decrypted = newCell.decrypt(encrypted, context)
+        assertArrayEquals(message, decrypted)
+
+        encrypted = newCell.encrypt(message, context)
+        assertNotNull(encrypted)
+        decrypted = oldCell.unprotect(context, SecureCellData(encrypted, null))
+        assertArrayEquals(message, decrypted)
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    @Throws(SecureCellException::class)
+    fun oldAPIWithoutContext() {
+        val key = SymmetricKey()
+        val newCell = SecureCell.SealWithKey(key)
+        val oldCell = SecureCell(key.toByteArray(), SecureCell.MODE_SEAL)
+        val message: ByteArray = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+
+        var encrypted: ByteArray
+        var decrypted: ByteArray?
+        val result = oldCell.protect(null as ByteArray?, message)
+        encrypted = result.protectedData
+        assertNotNull(encrypted)
+        decrypted = newCell.decrypt(encrypted)
+        assertArrayEquals(message, decrypted)
+
+        encrypted = newCell.encrypt(message)
+        assertNotNull(encrypted)
+        decrypted = oldCell.unprotect(null as ByteArray?, SecureCellData(encrypted, null))
+        assertArrayEquals(message, decrypted)
+    }
+}

--- a/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellSealWithPassphraseTestKotlin.kt
+++ b/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellSealWithPassphraseTestKotlin.kt
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) 2020 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cossacklabs.themis.test
+
+import java.nio.charset.CharacterCodingException
+import java.nio.charset.StandardCharsets
+import kotlin.experimental.inv
+
+import com.cossacklabs.themis.*
+import com.cossacklabs.themis.test.Assert.assertThrows
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class SecureCellSealWithPassphraseTestKotlin {
+    @Test
+    fun initWithString() {
+        val cell = SecureCell.SealWithPassphrase("day 56 of the Q")
+        assertNotNull(cell)
+    }
+
+    @Test
+    fun initWithBytes() {
+        val encoded = "day 56 of the Q".toByteArray(StandardCharsets.US_ASCII)
+        val cell = SecureCell.SealWithPassphrase(encoded)
+        assertNotNull(cell)
+    }
+
+    @Test
+    fun initWithEmpty() {
+        assertThrows(NullArgumentException::class.java) {
+            SecureCell.SealWithPassphrase(null as String?)
+        }
+        assertThrows(NullArgumentException::class.java) {
+            SecureCell.SealWithPassphrase(null as ByteArray?)
+        }
+        assertThrows(NullArgumentException::class.java) {
+            SecureCell.SealWithPassphrase(null, StandardCharsets.UTF_8)
+        }
+        assertThrows(NullArgumentException::class.java) {
+            SecureCell.SealWithPassphrase("day 56 of the Q", null)
+        }
+
+        assertThrows(InvalidArgumentException::class.java) {
+            SecureCell.SealWithPassphrase(byteArrayOf())
+        }
+        assertThrows(InvalidArgumentException::class.java) {
+            SecureCell.SealWithPassphrase("")
+        }
+        assertThrows(InvalidArgumentException::class.java) {
+            SecureCell.SealWithPassphrase("", StandardCharsets.UTF_16BE)
+        }
+    }
+
+    @Test
+    @Throws(SecureCellException::class)
+    fun roundtrip() {
+        val cell = SecureCell.SealWithPassphrase("day 56 of the Q")
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+        val context = "For great justice".toByteArray(StandardCharsets.UTF_8)
+
+        val encrypted = cell.encrypt(message, context)
+        assertNotNull(encrypted)
+
+        val decrypted = cell.decrypt(encrypted, context)
+        assertNotNull(decrypted)
+        assertArrayEquals(message, decrypted)
+    }
+
+    @Test
+    fun dataLengthExtension() {
+        val cell = SecureCell.SealWithPassphrase("day 56 of the Q")
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+
+        val encrypted = cell.encrypt(message)
+        assertTrue(encrypted.size > message.size)
+    }
+
+    @Test
+    fun contextInclusion() {
+        val cell = SecureCell.SealWithPassphrase("day 56 of the Q")
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+        val shortContext = ".".toByteArray(StandardCharsets.UTF_8)
+        val longContext = "You have no chance to survive make your time. Ha ha ha ha ...".toByteArray(StandardCharsets.UTF_8)
+
+        val encryptedShort = cell.encrypt(message, shortContext)
+        val encryptedLong = cell.encrypt(message, longContext)
+
+        // Context is not (directly) included into encrypted message.
+        assertEquals(encryptedShort.size.toLong(), encryptedLong.size.toLong())
+    }
+
+    @Test
+    @Throws(SecureCellException::class)
+    fun withoutContext() {
+        val cell = SecureCell.SealWithPassphrase("day 56 of the Q")
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+
+        // Absent, empty, or nil context are all the same.
+        val encrypted1 = cell.encrypt(message)
+        val encrypted2 = cell.encrypt(message, null)
+        val encrypted3 = cell.encrypt(message, byteArrayOf())
+
+        assertArrayEquals(message, cell.decrypt(encrypted1))
+        assertArrayEquals(message, cell.decrypt(encrypted2))
+        assertArrayEquals(message, cell.decrypt(encrypted3))
+        assertArrayEquals(message, cell.decrypt(encrypted1, null))
+        assertArrayEquals(message, cell.decrypt(encrypted2, null))
+        assertArrayEquals(message, cell.decrypt(encrypted3, null))
+        assertArrayEquals(message, cell.decrypt(encrypted1, byteArrayOf()))
+        assertArrayEquals(message, cell.decrypt(encrypted2, byteArrayOf()))
+        assertArrayEquals(message, cell.decrypt(encrypted3, byteArrayOf()))
+    }
+
+    @Test
+    @Throws(SecureCellException::class)
+    fun contextSignificance() {
+        val cell = SecureCell.SealWithPassphrase("day 56 of the Q")
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+        val correctContext = "We are CATS".toByteArray(StandardCharsets.UTF_8)
+        val incorrectContext = "Captain !!".toByteArray(StandardCharsets.UTF_8)
+
+        val encrypted = cell.encrypt(message, correctContext)
+
+        // You cannot use a different context to decrypt data.
+        assertThrows(SecureCellException::class.java) {
+            cell.decrypt(encrypted, incorrectContext)
+        }
+
+        // Only the original context will work.
+        val decrypted = cell.decrypt(encrypted, correctContext)
+        assertArrayEquals(message, decrypted)
+    }
+
+    @Test
+    fun detectCorruptedData() {
+        val cell = SecureCell.SealWithPassphrase("day 56 of the Q")
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+
+        val encrypted = cell.encrypt(message)
+
+        // Invert every odd byte, this will surely break the message.
+        val corrupted = encrypted.copyOf(encrypted.size)
+        for (i in corrupted.indices) {
+            if (i % 2 == 1) {
+                corrupted[i] = corrupted[i].inv()
+            }
+        }
+
+        assertThrows(SecureCellException::class.java) {
+            cell.decrypt(corrupted)
+        }
+    }
+
+    @Test
+    fun detectTruncatedData() {
+        val cell = SecureCell.SealWithPassphrase("day 56 of the Q")
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+
+        val encrypted = cell.encrypt(message)
+
+        val truncated = encrypted.copyOf(encrypted.size - 1)
+
+        assertThrows(SecureCellException::class.java) {
+            cell.decrypt(truncated)
+        }
+    }
+
+    @Test
+    fun detectExtendedData() {
+        val cell = SecureCell.SealWithPassphrase("day 56 of the Q")
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+
+        val encrypted = cell.encrypt(message)
+
+        val extended = encrypted.copyOf(encrypted.size + 1)
+
+        assertThrows(SecureCellException::class.java) {
+            cell.decrypt(extended)
+        }
+    }
+
+    @Test
+    @Throws(SecureCellException::class)
+    fun emptyMessage() {
+        val cell = SecureCell.SealWithPassphrase("day 56 of the Q")
+
+        assertThrows(NullArgumentException::class.java) { cell.encrypt(null) }
+        assertThrows(NullArgumentException::class.java) { cell.decrypt(null) }
+
+        assertThrows(InvalidArgumentException::class.java) { cell.encrypt(byteArrayOf()) }
+        assertThrows(InvalidArgumentException::class.java) { cell.decrypt(byteArrayOf()) }
+    }
+
+    @Test
+    @Throws(SecureCellException::class)
+    fun defaultEncoding() {
+        // Passphrases are encoded in UTF-8 by default.
+        val passphrase = "暗号"
+        val cellA = SecureCell.SealWithPassphrase(passphrase)
+        val cellB = SecureCell.SealWithPassphrase(passphrase.toByteArray(StandardCharsets.UTF_8))
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+
+        val encrypted = cellA.encrypt(message)
+        val decrypted = cellB.decrypt(encrypted)
+        assertArrayEquals(message, decrypted)
+    }
+
+    @Test
+    @Throws(SecureCellException::class)
+    fun specificEncoding() {
+        val cell = SecureCell.SealWithPassphrase("secret", StandardCharsets.UTF_16BE)
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+
+        // Message encrypted by PyThemis
+        val encrypted = Base64.getDecoder().decode("AAEBQQwAAAAQAAAAHwAAABYAAAA0a7ZiM/EN7xyQSzZ3qD5YWpYMuAOIzi2PRR/mQA0DABAAWBZ+KWU/77jobUZZRM8syUPdwmga46Wdas7QeD9jFgU0Z9nCwgqN06DHer2VH+E=")
+        val decrypted = cell.decrypt(encrypted)
+        assertArrayEquals(message, decrypted)
+    }
+
+    @Test
+    fun passphraseIsNotSymmetricKey() {
+        // Passphrases are not keys. Keys are not passphrases.
+        val secret = SymmetricKey()
+        val cellMK = SecureCell.SealWithKey(secret)
+        val cellPW = SecureCell.SealWithPassphrase(secret.toByteArray())
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+
+        val encryptedMK = cellMK.encrypt(message)
+        val encryptedPW = cellPW.encrypt(message)
+
+        assertThrows(SecureCellException::class.java) { cellPW.decrypt(encryptedMK) }
+        assertThrows(SecureCellException::class.java) { cellMK.decrypt(encryptedPW) }
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    @Throws(SecureCellException::class)
+    fun passphrasesNotCompatibleWithOldAPI() {
+        // Old 'passphrase-like' API is not passphrase API at all. Don't use it.
+        val cellOld = SecureCell("day 56 of the Q", SecureCell.MODE_SEAL)
+        val cellNew = SecureCell.SealWithPassphrase("day 56 of the Q", StandardCharsets.UTF_16)
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+
+        val encryptedOld = cellOld.protect("", message).protectedData
+        val encryptedNew = cellNew.encrypt(message)
+
+        assertThrows(SecureCellException::class.java) { cellNew.decrypt(encryptedOld) }
+        assertThrows(SecureCellException::class.java) {
+            cellOld.unprotect("", SecureCellData(encryptedNew, null))
+        }
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    @Throws(SecureCellException::class)
+    fun oldPassphraseAPIIsActuallyUTF16Key() {
+        // Yes, it's so weird due to hysterical raisins. So don't use it, really.
+        val cellOld = SecureCell("day 56 of the Q", SecureCell.MODE_SEAL)
+        val cellNew = SecureCell.SealWithKey("day 56 of the Q".toByteArray(StandardCharsets.UTF_16))
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+
+        val encryptedOld = cellOld.protect("", message).protectedData
+        val encryptedNew = cellNew.encrypt(message)
+
+        val decryptedOld = cellNew.decrypt(encryptedOld)
+        val decryptedNew = cellOld.unprotect("", SecureCellData(encryptedNew, null))
+
+        assertArrayEquals(message, decryptedOld)
+        assertArrayEquals(message, decryptedNew)
+    }
+
+    @Test
+    fun passphraseEncodingFailure() {
+        // It is an error if the passphrase cannot be represented in the requested charset
+        // without data loss.
+        val e = assertThrows(RuntimeException::class.java) {
+            SecureCell.SealWithPassphrase("пароль", StandardCharsets.US_ASCII)
+        }
+        assertTrue(e.cause is CharacterCodingException)
+    }
+}

--- a/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellTokenProtectTestKotlin.kt
+++ b/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellTokenProtectTestKotlin.kt
@@ -1,0 +1,401 @@
+/*
+ * Copyright (c) 2020 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cossacklabs.themis.test
+
+import java.nio.charset.StandardCharsets
+import java.util.*
+import kotlin.experimental.inv
+
+import com.cossacklabs.themis.*
+import com.cossacklabs.themis.test.Assert.assertThrows
+
+import org.junit.Assert.*
+import org.junit.Ignore
+import org.junit.Test
+
+class SecureCellTokenProtectTestKotlin {
+    @Test
+    fun initWithGenerated() {
+        val cell = SecureCell.TokenProtectWithKey(SymmetricKey())
+        assertNotNull(cell)
+    }
+
+    @Test
+    fun initWithFixed() {
+        val keyBase64 = "UkVDMgAAAC13PCVZAKOczZXUpvkhsC+xvwWnv3CLmlG0Wzy8ZBMnT+2yx/dg"
+        val keyBytes = Base64.getDecoder().decode(keyBase64)
+        val cell = SecureCell.TokenProtectWithKey(keyBytes)
+        assertNotNull(cell)
+    }
+
+    @Test
+    fun initWithEmpty() {
+        assertThrows(NullArgumentException::class.java) {
+            SecureCell.TokenProtectWithKey(null as SymmetricKey?)
+        }
+        assertThrows(NullArgumentException::class.java) {
+            SecureCell.TokenProtectWithKey(null as ByteArray?)
+        }
+        assertThrows(InvalidArgumentException::class.java) {
+            SecureCell.TokenProtectWithKey(byteArrayOf())
+        }
+    }
+
+    @Test
+    @Throws(SecureCellException::class)
+    fun roundtrip() {
+        val cell = SecureCell.TokenProtectWithKey(SymmetricKey())
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+        val context = "For great justice".toByteArray(StandardCharsets.UTF_8)
+
+        val result = cell.encrypt(message, context)
+        assertNotNull(result)
+
+        val encrypted = result.protectedData
+        val authToken = result.additionalData
+        assertNotNull(encrypted)
+        assertNotNull(authToken)
+
+        val decrypted = cell.decrypt(encrypted, authToken, context)
+        assertNotNull(decrypted)
+        assertArrayEquals(message, decrypted)
+    }
+
+    @Test
+    fun dataLengthPreservation() {
+        val cell = SecureCell.TokenProtectWithKey(SymmetricKey())
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+
+        val result = cell.encrypt(message)
+        assertEquals(message.size.toLong(), result.protectedData.size.toLong())
+        assertTrue(result.additionalData.isNotEmpty())
+    }
+
+    @Test
+    fun contextInclusion() {
+        val cell = SecureCell.TokenProtectWithKey(SymmetricKey())
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+        val shortContext = ".".toByteArray(StandardCharsets.UTF_8)
+        val longContext = "You have no chance to survive make your time. Ha ha ha ha ...".toByteArray(StandardCharsets.UTF_8)
+
+        val resultShort = cell.encrypt(message, shortContext)
+        val resultLong = cell.encrypt(message, longContext)
+
+        // Context is not (directly) included into encrypted message.
+        assertEquals(resultShort.protectedData.size.toLong(), resultLong.protectedData.size.toLong())
+        assertEquals(resultShort.additionalData.size.toLong(), resultLong.additionalData.size.toLong())
+    }
+
+    @Test
+    @Throws(SecureCellException::class)
+    fun withoutContext() {
+        val cell = SecureCell.TokenProtectWithKey(SymmetricKey())
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+
+        // Absent, empty, or nil context are all the same.
+        val result1 = cell.encrypt(message)
+        val result2 = cell.encrypt(message, null)
+        val result3 = cell.encrypt(message, byteArrayOf())
+
+        assertArrayEquals(message, cell.decrypt(result1.protectedData, result1.additionalData))
+        assertArrayEquals(message, cell.decrypt(result2.protectedData, result2.additionalData))
+        assertArrayEquals(message, cell.decrypt(result3.protectedData, result3.additionalData))
+        assertArrayEquals(message, cell.decrypt(result1.protectedData, result1.additionalData, null))
+        assertArrayEquals(message, cell.decrypt(result2.protectedData, result2.additionalData, null))
+        assertArrayEquals(message, cell.decrypt(result3.protectedData, result3.additionalData, null))
+        assertArrayEquals(message, cell.decrypt(result1.protectedData, result1.additionalData, byteArrayOf()))
+        assertArrayEquals(message, cell.decrypt(result2.protectedData, result2.additionalData, byteArrayOf()))
+        assertArrayEquals(message, cell.decrypt(result3.protectedData, result3.additionalData, byteArrayOf()))
+    }
+
+    @Test
+    @Throws(SecureCellException::class)
+    fun contextSignificance() {
+        val cell = SecureCell.TokenProtectWithKey(SymmetricKey())
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+        val correctContext = "We are CATS".toByteArray(StandardCharsets.UTF_8)
+        val incorrectContext = "Captain !!".toByteArray(StandardCharsets.UTF_8)
+
+        val result = cell.encrypt(message, correctContext)
+        val encrypted = result.protectedData
+        val authToken = result.additionalData
+
+        // You cannot use a different context to decrypt data.
+        assertThrows(SecureCellException::class.java) {
+            cell.decrypt(encrypted, authToken, incorrectContext)
+        }
+
+        // Only the original context will work.
+        val decrypted = cell.decrypt(encrypted, authToken, correctContext)
+        assertArrayEquals(message, decrypted)
+    }
+
+    @Test
+    @Throws(SecureCellException::class)
+    fun tokenSignificance() {
+        val cell = SecureCell.TokenProtectWithKey(SymmetricKey())
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+
+        val result1 = cell.encrypt(message)
+        val encrypted1 = result1.protectedData
+        val authToken1 = result1.additionalData
+
+        val result2 = cell.encrypt(message)
+        val encrypted2 = result2.protectedData
+        val authToken2 = result2.additionalData
+
+        // You cannot use a different token to decrypt data.
+        assertThrows(SecureCellException::class.java) { cell.decrypt(encrypted1, authToken2) }
+        assertThrows(SecureCellException::class.java) { cell.decrypt(encrypted2, authToken1) }
+
+        // Only the matching token will work.
+        assertArrayEquals(message, cell.decrypt(encrypted1, authToken1))
+        assertArrayEquals(message, cell.decrypt(encrypted2, authToken2))
+    }
+
+    @Test
+    fun detectCorruptedData() {
+        val cell = SecureCell.TokenProtectWithKey(SymmetricKey())
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+
+        val result = cell.encrypt(message)
+        val encrypted = result.protectedData
+        val authToken = result.additionalData
+
+        // Invert every odd byte, this will surely break the message.
+        val corrupted = Arrays.copyOf(encrypted, encrypted.size)
+        for (i in corrupted.indices) {
+            if (i % 2 == 1) {
+                corrupted[i] = corrupted[i].inv()
+            }
+        }
+
+        assertThrows(SecureCellException::class.java) {
+            cell.decrypt(corrupted, authToken)
+        }
+    }
+
+    @Test
+    fun detectTruncatedData() {
+        val cell = SecureCell.TokenProtectWithKey(SymmetricKey())
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+
+        val result = cell.encrypt(message)
+        val encrypted = result.protectedData
+        val authToken = result.additionalData
+
+        val truncated = Arrays.copyOf(encrypted, encrypted.size - 1)
+
+        assertThrows(SecureCellException::class.java) {
+            cell.decrypt(truncated, authToken)
+        }
+    }
+
+    @Test
+    fun detectExtendedData() {
+        val cell = SecureCell.TokenProtectWithKey(SymmetricKey())
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+
+        val result = cell.encrypt(message)
+        val encrypted = result.protectedData
+        val authToken = result.additionalData
+
+        val extended = Arrays.copyOf(encrypted, encrypted.size + 1)
+
+        assertThrows(SecureCellException::class.java) {
+            cell.decrypt(extended, authToken)
+        }
+    }
+
+    @Test // FIXME(ilammy, 2020-05-05): resolve the bug in JNI code to unblock this test (T1607)
+    @Ignore("crashes on Android due to a bug in JNI code")
+    fun detectCorruptedToken() {
+        val cell = SecureCell.TokenProtectWithKey(SymmetricKey())
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+
+        val result = cell.encrypt(message)
+        val encrypted = result.protectedData
+        val authToken = result.additionalData
+
+        // Invert every odd byte, this will surely break the token.
+        val corruptedToken = Arrays.copyOf(authToken, authToken.size)
+        for (i in corruptedToken.indices) {
+            if (i % 2 == 1) {
+                corruptedToken[i] = corruptedToken[i].inv()
+            }
+        }
+
+        // FIXME(ilammy, 2020-05-05): improve Themis Core robustness (T1604)
+        // Currently this call throws NegativeArraySizeException instead of SecureCellException
+        // because the Core library fails to detect corruption and returns negative buffer size
+        // which we cannot allocate, unfortunately.
+        // Expect "SecureCellException.class" here once the issue is resolved.
+        assertThrows(Throwable::class.java) {
+            cell.decrypt(encrypted, corruptedToken)
+        }
+    }
+
+    @Test
+    fun detectTruncatedToken() {
+        val cell = SecureCell.TokenProtectWithKey(SymmetricKey())
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+
+        val result = cell.encrypt(message)
+        val encrypted = result.protectedData
+        val authToken = result.additionalData
+
+        val truncatedToken = Arrays.copyOf(authToken, authToken.size - 1)
+
+        assertThrows(SecureCellException::class.java) {
+            cell.decrypt(encrypted, truncatedToken)
+        }
+    }
+
+    @Test
+    @Throws(SecureCellException::class)
+    fun detectExtendedToken() {
+        val cell = SecureCell.TokenProtectWithKey(SymmetricKey())
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+
+        val result = cell.encrypt(message)
+        val encrypted = result.protectedData
+        val authToken = result.additionalData
+
+        val extendedToken = Arrays.copyOf(authToken, authToken.size + 1)
+
+        // Current implementation of Secure Cell allows the token to be overlong.
+        // Extra data is simply ignored.
+        val decrypted = cell.decrypt(encrypted, extendedToken)
+        assertArrayEquals(message, decrypted)
+    }
+
+    @Test // FIXME(ilammy, 2020-05-05): resolve the bug in JNI code to unblock this test (T1607)
+    @Ignore("crashes on Android due to a bug in JNI code")
+    fun swapTokenAndData() {
+        val cell = SecureCell.TokenProtectWithKey(SymmetricKey())
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+
+        val result = cell.encrypt(message)
+        val encrypted = result.protectedData
+        val authToken = result.additionalData
+
+        // FIXME(ilammy, 2020-05-05): improve Themis Core robustness (T1604)
+        // Currently this call throws OutOfMemoryError instead of SecureCellException
+        // because the Core library fails to detect corruption and returns incorrect buffer size
+        // which we cannot allocate, unfortunately.
+        // Expect "SecureCellException.class" here once the issue is resolved.
+        assertThrows(Throwable::class.java) {
+            cell.decrypt(authToken, encrypted)
+        }
+    }
+
+    @Test
+    fun swapContextAndToken() {
+        val cell = SecureCell.TokenProtectWithKey(SymmetricKey())
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+        val context = "We are CATS".toByteArray(StandardCharsets.UTF_8)
+
+        val result = cell.encrypt(message, context)
+        val encrypted = result.protectedData
+
+        assertThrows(SecureCellException::class.java) {
+            cell.decrypt(encrypted, context)
+        }
+    }
+
+    @Test
+    @Throws(SecureCellException::class)
+    fun emptyMessageOrToken() {
+        val cell = SecureCell.TokenProtectWithKey(SymmetricKey())
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+
+        assertThrows(NullArgumentException::class.java) { cell.encrypt(null) }
+        assertThrows(InvalidArgumentException::class.java) { cell.encrypt(byteArrayOf()) }
+
+        val result = cell.encrypt(message)
+        val encrypted = result.protectedData
+        val authToken = result.additionalData
+
+        assertThrows(NullArgumentException::class.java) { cell.decrypt(encrypted, null) }
+        assertThrows(NullArgumentException::class.java) { cell.decrypt(null, authToken) }
+
+        assertThrows(InvalidArgumentException::class.java) { cell.decrypt(encrypted, byteArrayOf()) }
+        assertThrows(InvalidArgumentException::class.java) { cell.decrypt(byteArrayOf(), authToken) }
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    @Throws(SecureCellException::class)
+    fun oldAPI() {
+        val key = SymmetricKey()
+        val newCell = SecureCell.TokenProtectWithKey(key)
+        val oldCell = SecureCell(key.toByteArray(), SecureCell.MODE_TOKEN_PROTECT)
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+        val context = "We are CATS".toByteArray(StandardCharsets.UTF_8)
+
+        var encrypted: ByteArray
+        var authToken: ByteArray
+        var decrypted: ByteArray?
+        var result = oldCell.protect(context, message)
+        assertNotNull(result)
+        encrypted = result.protectedData
+        authToken = result.additionalData
+        assertNotNull(encrypted)
+        assertNotNull(authToken)
+        decrypted = newCell.decrypt(encrypted, authToken, context)
+        assertArrayEquals(message, decrypted)
+
+        result = newCell.encrypt(message, context)
+        assertNotNull(result)
+        encrypted = result.protectedData
+        authToken = result.additionalData
+        assertNotNull(encrypted)
+        assertNotNull(authToken)
+        decrypted = oldCell.unprotect(context, SecureCellData(encrypted, authToken))
+        assertArrayEquals(message, decrypted)
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    @Throws(SecureCellException::class)
+    fun oldAPIWithoutContext() {
+        val key = SymmetricKey()
+        val newCell = SecureCell.TokenProtectWithKey(key)
+        val oldCell = SecureCell(key.toByteArray(), SecureCell.MODE_TOKEN_PROTECT)
+        val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
+
+        var encrypted: ByteArray
+        var authToken: ByteArray
+        var decrypted: ByteArray?
+        var result = oldCell.protect(null as ByteArray?, message)
+        assertNotNull(result)
+        encrypted = result.protectedData
+        authToken = result.additionalData
+        assertNotNull(encrypted)
+        assertNotNull(authToken)
+        decrypted = newCell.decrypt(encrypted, authToken)
+        assertArrayEquals(message, decrypted)
+
+        result = newCell.encrypt(message)
+        assertNotNull(result)
+        encrypted = result.protectedData
+        authToken = result.additionalData
+        assertNotNull(encrypted)
+        assertNotNull(authToken)
+        decrypted = oldCell.unprotect(null as ByteArray?, SecureCellData(encrypted, authToken))
+        assertArrayEquals(message, decrypted)
+    }
+}

--- a/third_party/boringssl/build.gradle
+++ b/third_party/boringssl/build.gradle
@@ -10,6 +10,9 @@ buildscript {
         // And 3.5.X fails to link ARM binaries correctly, so we're staying
         // on this Gradle version until it breaks or we *need* an upgrade:
         classpath 'com.android.tools.build:gradle:3.2.1'
+
+        // Kotlin plugin for Android
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -19,6 +22,7 @@ repositories {
 }
 
 apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 28


### PR DESCRIPTION
From now on we officially™ support Kotlin API of JavaThemis on Android and desktop JVM.

It was possible to use JavaThemis via Kotlin before but we were not sure in the API we provided and we not guaranteeing its stability. Now we do.

## User notes

### API stability and maturity

All existing Kotlin API is now considered *stable*. That is, we will do our best to avoid breaking it and if there is a need to deprecate some parts of Kotlin API, you will be notified about that.

`SecureCell` APIs are considered mature for Kotlin. That is, we are happy with this API in Kotlin and will not update it unless absolutely necessary.

As of JavaThemis 0.13, other APIs are not yet mature for Kotlin. We *will not* break these APIs, but you might expect some new, improved APIs to appear and some APIs to be deprecated in later releases, until Kotlin API has stabilized and matured.

### Java 1.7 is minimum target for apps, Java 1.8 is needed for compilation

The minimum target for applications using JavaThemis or AndroidThemis is still Java 1.7.

If you get JavaThemis from Maven, you can still use Java 1.7 to compile your applications.

However, JavaThemis now requires Java 1.8 or later for compilation from source. This is the requirement of Kotlin compiler.

## Technical notes

We are using the latest current version of Kotlin: 1.3.72. Kotlin is used *only* for tests. JavaThemis does not and will not require Kotlin at runtime for applications.

Since Kotlin supports lambdas out of the box, a polyfill for `org.junit.Assert#assertThrows` is added. It makes exception testing much more readable.

The tests themselves were automatically converted from Java code by IntelliJ, they are basically the same. Though, they did require some manual cleanup after that.

We currently test only `SecureCell` in Kotlin. Other cryptosystems will require additional review which is out of scope for Themis 0.13. We will get back to them in next releases.

## Checklist

- [X] Change is covered by automated tests
- [X] ~~Benchmark results are attached~~ (nope, not right now)
- [X] The [coding guidelines] are followed
- [X] Public API has proper documentation
- [X] ~~Example projects and code samples are up-to-date~~ (we don't have Kotlin examples, maybe later)
- [X] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
