### PR TITLE
Avoid overflows in JNI allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ _Code:_
 
   - Kotlin is now officially supported language on Android
     ([#637](https://github.com/cossacklabs/themis/pull/637).
+  - Fixed a crash when decrypting corrupted Secure Cell data
+    ([#639](https://github.com/cossacklabs/themis/pull/639)).
 
   - **Breaking changes**
 

--- a/jni/themis_cell.c
+++ b/jni/themis_cell.c
@@ -127,6 +127,15 @@ JNIEXPORT jobjectArray JNICALL Java_com_cossacklabs_themis_SecureCell_encrypt(
         goto err;
     }
 
+    /*
+     * Secure Cell can contain up to 4 GB of data but JVM does not support
+     * byte arrays bigger that 2 GB. We just cannot allocate that much.
+     */
+    if (encrypted_data_length > INT32_MAX || additional_data_length > INT32_MAX) {
+        res = THEMIS_NO_MEMORY;
+        goto err;
+    }
+
     encrypted_data = (*env)->NewByteArray(env, encrypted_data_length);
     if (!encrypted_data) {
         goto err;
@@ -368,6 +377,15 @@ JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureCell_decrypt(
     }
 
     if (THEMIS_BUFFER_TOO_SMALL != res) {
+        goto err;
+    }
+
+    /*
+     * Secure Cell can contain up to 4 GB of data but JVM does not support
+     * byte arrays bigger that 2 GB. We just cannot allocate that much.
+     */
+    if (data_length > INT32_MAX) {
+        res = THEMIS_NO_MEMORY;
         goto err;
     }
 

--- a/jni/themis_compare.c
+++ b/jni/themis_compare.c
@@ -83,6 +83,15 @@ JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureCompare_jniBegin(
         return NULL;
     }
 
+    /*
+     * Normally the messages should not be this big, but just in case, avoid
+     * integer overflow here. JVM cannot allocate more than 2 GB in one chunk.
+     */
+    if (compare_data_length > INT32_MAX) {
+        res = THEMIS_NO_MEMORY;
+        return NULL;
+    }
+
     compare_data = (*env)->NewByteArray(env, compare_data_length);
     if (!compare_data) {
         return NULL;
@@ -139,6 +148,15 @@ JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureCompare_jniProcee
 
     res = secure_comparator_proceed_compare(ctx, compare_data_buf, compare_data_length, NULL, &output_length);
     if (THEMIS_BUFFER_TOO_SMALL != res) {
+        goto err;
+    }
+
+    /*
+     * Normally the messages should not be this big, but just in case, avoid
+     * integer overflow here. JVM cannot allocate more than 2 GB in one chunk.
+     */
+    if (output_length > INT32_MAX) {
+        res = THEMIS_NO_MEMORY;
         goto err;
     }
 

--- a/jni/themis_keygen.c
+++ b/jni/themis_keygen.c
@@ -56,6 +56,15 @@ JNIEXPORT jobjectArray JNICALL Java_com_cossacklabs_themis_KeypairGenerator_gene
         return NULL;
     }
 
+    /*
+     * Normally the keys should not be this big, but just in case, avoid
+     * integer overflow here. JVM cannot allocate more than 2 GB in one chunk.
+     */
+    if (private_key_length > INT32_MAX || public_key_length > INT32_MAX) {
+        res = THEMIS_NO_MEMORY;
+        return NULL;
+    }
+
     private_key = (*env)->NewByteArray(env, private_key_length);
     if (!private_key) {
         return NULL;
@@ -127,6 +136,15 @@ JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SymmetricKey_generateSy
     res = themis_gen_sym_key(NULL, &key_length);
     if (res != THEMIS_BUFFER_TOO_SMALL) {
         goto error;
+    }
+
+    /*
+     * Normally the key should not be this big, but just in case, avoid
+     * integer overflow here. JVM cannot allocate more than 2 GB in one chunk.
+     */
+    if (key_length > INT32_MAX) {
+        res = THEMIS_NO_MEMORY;
+        return NULL;
     }
 
     key = (*env)->NewByteArray(env, key_length);

--- a/jni/themis_message.c
+++ b/jni/themis_message.c
@@ -118,6 +118,15 @@ JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureMessage_process(J
         goto err;
     }
 
+    /*
+     * Secure Message data format can store messages up to 4 GB long, but JVM
+     * cannot allocate more than 2 GB in one chunk. Avoid overflows here.
+     */
+    if (output_length > INT32_MAX) {
+        res = THEMIS_NO_MEMORY;
+        return NULL;
+    }
+
     output = (*env)->NewByteArray(env, output_length);
     if (!output) {
         goto err;

--- a/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellTokenProtectTest.java
+++ b/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellTokenProtectTest.java
@@ -259,8 +259,6 @@ public class SecureCellTokenProtectTest {
 
 
     @Test
-    // FIXME(ilammy, 2020-05-05): resolve the bug in JNI code to unblock this test (T1607)
-    @Ignore("crashes on Android due to a bug in JNI code")
     @SuppressWarnings("ResultOfMethodCallIgnored")
     public void detectCorruptedToken() {
         SecureCell.TokenProtect cell = SecureCell.TokenProtectWithKey(new SymmetricKey());
@@ -278,16 +276,11 @@ public class SecureCellTokenProtectTest {
             }
         }
 
-        // FIXME(ilammy, 2020-05-05): improve Themis Core robustness (T1604)
-        // Currently this call throws NegativeArraySizeException instead of SecureCellException
-        // because the Core library fails to detect corruption and returns negative buffer size
-        // which we cannot allocate, unfortunately.
-        // Expect "SecureCellException.class" here once the issue is resolved.
         try {
             cell.decrypt(encrypted, corruptedToken);
             fail("expected SecureCellException");
         }
-        catch (Throwable ignored) {}
+        catch (SecureCellException ignored) {}
     }
 
     @Test
@@ -327,8 +320,6 @@ public class SecureCellTokenProtectTest {
     }
 
     @Test
-    // FIXME(ilammy, 2020-05-05): resolve the bug in JNI code to unblock this test (T1607)
-    @Ignore("crashes on Android due to a bug in JNI code")
     @SuppressWarnings("ResultOfMethodCallIgnored")
     public void swapTokenAndData() {
         SecureCell.TokenProtect cell = SecureCell.TokenProtectWithKey(new SymmetricKey());
@@ -338,16 +329,11 @@ public class SecureCellTokenProtectTest {
         byte[] encrypted = result.getProtectedData();
         byte[] authToken = result.getAdditionalData();
 
-        // FIXME(ilammy, 2020-05-05): improve Themis Core robustness (T1604)
-        // Currently this call throws OutOfMemoryError instead of SecureCellException
-        // because the Core library fails to detect corruption and returns incorrect buffer size
-        // which we cannot allocate, unfortunately.
-        // Expect "SecureCellException.class" here once the issue is resolved.
         try {
             cell.decrypt(authToken, encrypted);
             fail("expected SecureCellException");
         }
-        catch (Throwable ignored) {}
+        catch (SecureCellException ignored) {}
     }
 
     @Test

--- a/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellTokenProtectTest.java
+++ b/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellTokenProtectTest.java
@@ -333,7 +333,9 @@ public class SecureCellTokenProtectTest {
             cell.decrypt(authToken, encrypted);
             fail("expected SecureCellException");
         }
-        catch (SecureCellException ignored) {}
+        // Depending on how lucky you are, Themis might or might not detect the error early enough.
+        // If it does not, it proceeds to allocate some weird buffer which might be too big.
+        catch (SecureCellException | OutOfMemoryError ignored) {}
     }
 
     @Test

--- a/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellTokenProtectTestKotlin.kt
+++ b/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellTokenProtectTestKotlin.kt
@@ -285,9 +285,12 @@ class SecureCellTokenProtectTestKotlin {
         val encrypted = result.protectedData
         val authToken = result.additionalData
 
-        assertThrows(SecureCellException::class.java) {
+        // Depending on how lucky you are, Themis might or might not detect the error early enough.
+        // If it does not, it proceeds to allocate some weird buffer which might be too big.
+        val e = assertThrows(Throwable::class.java) {
             cell.decrypt(authToken, encrypted)
         }
+        assertTrue(e is SecureCellException || e is OutOfMemoryError)
     }
 
     @Test

--- a/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellTokenProtectTestKotlin.kt
+++ b/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellTokenProtectTestKotlin.kt
@@ -220,8 +220,7 @@ class SecureCellTokenProtectTestKotlin {
         }
     }
 
-    @Test // FIXME(ilammy, 2020-05-05): resolve the bug in JNI code to unblock this test (T1607)
-    @Ignore("crashes on Android due to a bug in JNI code")
+    @Test
     fun detectCorruptedToken() {
         val cell = SecureCell.TokenProtectWithKey(SymmetricKey())
         val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
@@ -238,12 +237,7 @@ class SecureCellTokenProtectTestKotlin {
             }
         }
 
-        // FIXME(ilammy, 2020-05-05): improve Themis Core robustness (T1604)
-        // Currently this call throws NegativeArraySizeException instead of SecureCellException
-        // because the Core library fails to detect corruption and returns negative buffer size
-        // which we cannot allocate, unfortunately.
-        // Expect "SecureCellException.class" here once the issue is resolved.
-        assertThrows(Throwable::class.java) {
+        assertThrows(SecureCellException::class.java) {
             cell.decrypt(encrypted, corruptedToken)
         }
     }
@@ -282,8 +276,7 @@ class SecureCellTokenProtectTestKotlin {
         assertArrayEquals(message, decrypted)
     }
 
-    @Test // FIXME(ilammy, 2020-05-05): resolve the bug in JNI code to unblock this test (T1607)
-    @Ignore("crashes on Android due to a bug in JNI code")
+    @Test
     fun swapTokenAndData() {
         val cell = SecureCell.TokenProtectWithKey(SymmetricKey())
         val message = "All your base are belong to us!".toByteArray(StandardCharsets.UTF_8)
@@ -292,12 +285,7 @@ class SecureCellTokenProtectTestKotlin {
         val encrypted = result.protectedData
         val authToken = result.additionalData
 
-        // FIXME(ilammy, 2020-05-05): improve Themis Core robustness (T1604)
-        // Currently this call throws OutOfMemoryError instead of SecureCellException
-        // because the Core library fails to detect corruption and returns incorrect buffer size
-        // which we cannot allocate, unfortunately.
-        // Expect "SecureCellException.class" here once the issue is resolved.
-        assertThrows(Throwable::class.java) {
+        assertThrows(SecureCellException::class.java) {
             cell.decrypt(authToken, encrypted)
         }
     }


### PR DESCRIPTION
Fix a possible crash on Android systems when handling corrupted input of Secure Cell (and possibly other APIs as well). Now instead of a crash you will get an appropriate exception.

## Technical details

Themis Core API works with `size_t` for buffer size inputs and outputs, that is `uint32_t` on 32-bit systems or `uint64_t` on 64-bit ones. In most cases Themis data structures use `uint32_t` for data length fields, allowing input data to be up to 4 GB long, theoretically.

On the other hand, JVM uses `int` type for its array indices, that is `int32_t` everywhere, regardless of the host system. Note that it is a *signed* integer, meaning that native JVM `byte[]` arrays cannot fit more than 2 GB of data, inclusive. There are hacks to overcome this limit, but with `byte[]` API – as in Themis – you are limited to 2 GB.

JNI type `jsize` reflects this limitation, it is defined to be `jint` which is typically defined as `signed int`, assuming 32-bit int types on most modern platforms. Thanks to C being very safe language, sizes bigger than 2<sup>31</sup> – 1 silently overflow into negative space and then it's up to JNI to handle this situation. Desktop Java systems typically throw a NegativeArraySizeException when trying to allocate an array with negative size, but Android systems typically kill the process due to an assertion failure.

In order to have predictable behavior in this case, check all sizes before trying to allocate an array of that size, and exit with an error if the allocation would overflow. This way instead of crashing we will throw an appropriate Themis subsystem exception.

Note that in some cases the array sizes do not depend on user input, but we still check just in case the Core library does something silly. In other cases the output can get that big due to input being sufficiently big — slightly smaller than 2 GB, but enough for Themis data overhead to push that over the 2 GB limit. However, in most cases this situation can be triggered by corrupted input where the data length fields contain values inconsistent with actual input size.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
