### PR TITLE
Build ObjCThemis for generic iOS devices

### DIFF
--- a/.github/workflows/test-objc.yaml
+++ b/.github/workflows/test-objc.yaml
@@ -233,6 +233,34 @@ jobs:
         with:
           path: ~/.cocoapods
           key: ${{ runner.os }}-cocoapods-common
+      # Try building Themis for all iOS device architectures. We do it here
+      # because CocoaPods does not allow to check that directly but with
+      # example projects it's more or less possible.
+      - name: Build ObjCThemis for Generic Device (Carthage)
+        if: always()
+        run: |
+          carthage bootstrap --platform iOS
+          rm -rf DerivedData
+          xcodebuild \
+            -derivedDataPath DerivedData \
+            -project ObjCThemis.xcodeproj \
+            -scheme "ObjCThemis (iOS)" \
+            -sdk iphoneos \
+            -destination "generic/platform=iOS" \
+            build
+      - name: Build ObjCThemis for Generic Device (CocoaPods)
+        if: always()
+        run: |
+          cd $GITHUB_WORKSPACE/docs/examples/objc/iOS-CocoaPods
+          pod install
+          rm -rf DerivedData
+          xcodebuild \
+            -derivedDataPath DerivedData \
+            -workspace ThemisTest.xcworkspace \
+            -scheme "Pods-ThemisTest" \
+            -sdk iphoneos \
+            -destination "generic/platform=iOS" \
+            build
       # Since all code examples are macOS/iOS applications, not command-line
       # utilities, we only verify that they build. This is fine.
       #


### PR DESCRIPTION
Verify builds of ObjCThemis for iOS not only for the simulator (i386, x86_64) but for "generic device" as well, using architectures required by iOS (ARM64, ARMv7). This is not equivalent to building an "archived" build of application – which requires provisioning profiles and all that other stuff – and it does not verify bitcode, but it's a good stopgap measure against OpenSSL maintainers forgetting to include ARM builds into their precompiled framework binaries.

With Carthage we have an Xcode project so we can build it directly. CocoaPods does not generate standalone project so we use one of the examples and build the pods library. We cannot build the example for "generic device" because of provisioning profiles, etc., but we can build the framework alone which is enough to check that all symbols required by ObjCThemis are actually present.

Now I can sleep more soundly.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] Public API has proper documentation
- [X] ~~Changelog is updated~~ (not interesting)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
