### PR TITLE
Bump BoringSSL submodule version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ _Code:_
     ([#637](https://github.com/cossacklabs/themis/pull/637).
   - Fixed a crash when decrypting corrupted Secure Cell data
     ([#639](https://github.com/cossacklabs/themis/pull/639)).
+  - Updated embedded BoringSSL to the latest version
+    ([#643](https://github.com/cossacklabs/themis/pull/643)).
 
   - **Breaking changes**
 
@@ -641,6 +643,8 @@ _Code:_
 - **WebAssembly**
 
   - New class `SymmetricKey` can be used to generate symmetric keys for Secure Cell ([#561](https://github.com/cossacklabs/themis/pull/561)).
+  - Updated embedded BoringSSL to the latest version
+    ([#643](https://github.com/cossacklabs/themis/pull/643)).
 
   - Passphrase API support in Secure Cell ([#616](https://github.com/cossacklabs/themis/pull/616)).
 


### PR DESCRIPTION
Pull latest updates for BoringSSL. Since BoringSSL does not have release schedule or versions, we just pull the latest stuff from master branch.

This affects mostly AndroidThemis and WasmThemis since they are using BoringSSL by default. Other platforms normally rely on OpenSSL.

## Checklist

- [X] Change is covered by automated tests
- [X] Changelog is updated