### PR TITLE
Fix RPM packaging and installation on CentOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -695,6 +695,9 @@ _Infrastructure:_
   ([#637](https://github.com/cossacklabs/themis/pull/637).
 - New Makefile targets:
   - `make jsthemis` builds JsThemis from source ([#618](https://github.com/cossacklabs/themis/pull/618)).
+- Resolved issues with library search paths on CentOS
+  when Themis Core is built from source and installed with `make install`
+  ([#637](https://github.com/cossacklabs/themis/pull/637).
 
 - **Breaking changes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -697,7 +697,7 @@ _Infrastructure:_
   - `make jsthemis` builds JsThemis from source ([#618](https://github.com/cossacklabs/themis/pull/618)).
 - Resolved issues with library search paths on CentOS
   when Themis Core is built from source and installed with `make install`
-  ([#637](https://github.com/cossacklabs/themis/pull/637).
+  ([#645](https://github.com/cossacklabs/themis/pull/645).
 
 - **Breaking changes**
 

--- a/Makefile
+++ b/Makefile
@@ -685,7 +685,7 @@ deb: install themispp_install themis_jni_install
 	@printf "ldconfig" > $(POST_INSTALL_SCRIPT)
 	@printf "ldconfig" > $(POST_UNINSTALL_SCRIPT)
 
-	@find $(DESTDIR) -name '*.$(SHARED_EXT)*' -exec strip -o {} {} \;
+	@find $(DESTDIR) -name '*.$(SHARED_EXT)*' -type f -exec strip -o {} {} \;
 
 	@fpm --input-type dir \
 		 --output-type deb \
@@ -765,7 +765,7 @@ rpm: install themispp_install themis_jni_install
 	@printf "ldconfig" > $(POST_INSTALL_SCRIPT)
 	@printf "ldconfig" > $(POST_UNINSTALL_SCRIPT)
 
-	@find $(DESTDIR) -name '*.$(SHARED_EXT)*' -exec strip -o {} {} \;
+	@find $(DESTDIR) -name '*.$(SHARED_EXT)*' -type f -exec strip -o {} {} \;
 
 	@fpm --input-type dir \
          --output-type rpm \

--- a/Makefile
+++ b/Makefile
@@ -639,7 +639,7 @@ else
 	ARCHITECTURE = $(shell arch)
 	RPM_VERSION = $(shell echo -n "$(VERSION)"|sed s/-/_/g)
 	NAME_SUFFIX = $(RPM_VERSION).$(OS_NAME)$(OS_VERSION).$(ARCHITECTURE).rpm
-	RPM_LIBDIR := $(shell [ $$(arch) == "x86_64" ] && echo "/lib64" || echo "/lib")
+	RPM_LIBDIR := $(shell [ $$(arch) == "x86_64" ] && echo "lib64" || echo "lib")
 endif
 
 PACKAGE_NAME = libthemis

--- a/jni/themis_jni.mk
+++ b/jni/themis_jni.mk
@@ -81,10 +81,11 @@ endif
 	         } \
 	       }' \
 	 ) && \
-	 if echo "$$java_library_path" | grep -vq '^$(jnidir)$$'; \
+	 jnidir=$$(cd "$(jnidir)" && pwd) && \
+	 if ! echo "$$java_library_path" | grep -q "^$${jnidir}$$"; \
 	 then \
 	     echo ''; \
-	     echo 'Your Java installation does not seem to have "$(jnidir)" in its'; \
+	     echo "Your Java installation does not seem to have \"$${jnidir}\" in its"; \
 	     echo 'search path for JNI libraries:'; \
 	     echo ''; \
 	     echo "$$java_library_path" | sed 's/^/    /'; \

--- a/jni/themis_jni.mk
+++ b/jni/themis_jni.mk
@@ -35,6 +35,13 @@ ifeq ($(JDK_INCLUDE_PATH),)
 		jvm_includes += -I$(JAVA_HOME)/include
 		ifdef IS_LINUX
 			jvm_includes += -I$(JAVA_HOME)/include/linux
+			# On some systems (like CentOS) "java.home" value reported by Java
+			# points to "/usr/lib/jvm/${java_version}/jre" when the real Java
+			# home is located in "/usr/lib/jvm/${java_version}" and JDK headers
+			# are located in "/usr/lib/jvm/${java_version}/include". Workaround:
+			# look one directory above the apparent Java home too.
+			jvm_includes += -I$(JAVA_HOME)/../include
+			jvm_includes += -I$(JAVA_HOME)/../include/linux
 		endif
 		ifdef IS_MACOS
 			jvm_includes += -I$(JAVA_HOME)/include/darwin


### PR DESCRIPTION
Improve various aspects of RPM packaging (such as making it run successfully) as well as local installation on RHEL-based systems (e.g., CentOS that we support).

* Add `/usr/local/lib` to linker search path on CentOS so that Themis is immediately usable after installation from source via`make install`. CentOS does not include `/usr/local/lib` into its default search paths, and we use that directory as the default installation path.
* Fix JDK location autodetection on CentOS so that it actually works automatically there. JDK autodetection was improved in #551 but apparently it was not tested on CentOS. With these changes it is actually possible to build RPM packages added in #553.
* Miscellaneous minor tweaks in path reporting that remove false negatives, unnecessary warnings, etc.

More details are available in commit messages.

## Checklist

- [X] Change is covered by automated tests (BuildBot)
- [X] The [coding guidelines] are followed
- [X] Public API has proper documentation
- [x] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
