### PR TITLE
Make selectable languages in integration tests

### DIFF
--- a/tests/_integration/tests_generator.py
+++ b/tests/_integration/tests_generator.py
@@ -4,7 +4,7 @@ import os
 from collections import namedtuple
 
 generate_for_languages = os.environ.get(
-    'GENERATE_LANGUAGES', 'ruby,python,js,node,go,php,rust')
+    'THEMIS_TEST_LANGUAGES', 'ruby,python,js,node,go,php,rust')
 generate_for_languages = generate_for_languages.split(',')
 
 LanguageSetting = namedtuple(

--- a/tests/tools/check_keygen.sh
+++ b/tests/tools/check_keygen.sh
@@ -2,6 +2,12 @@
 
 . tests/_integration/utils.sh
 
+THEMIS_TEST_LANGUAGES="${THEMIS_TEST_LANGUAGES:-ruby,python,js,node,go,php,rust}"
+
+test_lang() {
+  [[ " $(echo "$THEMIS_TEST_LANGUAGES" | sed 's/,/ /g') " =~ " $1 " ]]
+}
+
 test_keygen () {
     rm --force key key.pub test_key test_key.pub
     bash -c "$1 $2"
@@ -19,12 +25,12 @@ test_keygen () {
     check_result_zero
 }
 
-test_keygen python tools/python/keygen.py
-test_keygen node tools/js/jsthemis/keygen.js
-test_keygen node tools/js/wasm-themis/keygen.js
-test_keygen "php -f" tools/php/keygen.php
-test_keygen ruby tools/ruby/keygen.rb
-test_keygen "go run" tools/go/keygen.go
-test_keygen env tools/rust/keygen_tool.rust
+test_lang 'python' && test_keygen python tools/python/keygen.py
+test_lang 'node' && test_keygen node tools/js/jsthemis/keygen.js
+test_lang 'js' && test_keygen node tools/js/wasm-themis/keygen.js
+test_lang 'php' && test_keygen "php -f" tools/php/keygen.php
+test_lang 'ruby' && test_keygen ruby tools/ruby/keygen.rb
+test_lang 'go' && test_keygen "go run" tools/go/keygen.go
+test_lang 'rust' && test_keygen env tools/rust/keygen_tool.rust
 
 exit ${status}


### PR DESCRIPTION
When testing on legacy OS we know in advance that some tests for unsupported modules will fail. We want to make the testing behaviour meet real expectations so it is convenient to have configurable set of modules to test.

It was already implemented in the `tests_generator.py` script as environment variable `GENERATE_LANGUAGES`.

In this commit:
* the same behaviour was added to the `check_keygen.sh` script.
* `GENERATE_LANGUAGES` was renamed to `THEMIS_TEST_LANGUAGES`
