### PR TITLE
Fix path in `themis_jni_install` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -676,10 +676,11 @@ THEMISPP_PACKAGE_FILES += $(includedir)/themispp/
 
 JNI_PACKAGE_FILES += $(jnidir)/$(LIBTHEMISJNI_SO)
 
+deb: MODE_PACKAGING = 1
 deb: DESTDIR = $(BIN_PATH)/deb/root
 deb: PREFIX = /usr
-deb: libdir = $(PREFIX)/$(DEB_LIBDIR)
-deb: jnidir = $(PREFIX)/$(DEB_LIBDIR)/jni
+deb: libdir = $(PREFIX)$(DEB_LIBDIR)
+deb: jnidir = $(PREFIX)$(DEB_LIBDIR)/jni
 
 deb: install themispp_install themis_jni_install
 	@printf "ldconfig" > $(POST_INSTALL_SCRIPT)
@@ -757,6 +758,7 @@ deb: install themispp_install themis_jni_install
 
 	@find $(BIN_PATH) -name \*.deb
 
+rpm: MODE_PACKAGING = 1
 rpm: DESTDIR = $(BIN_PATH)/rpm/root
 rpm: PREFIX = /usr
 rpm: libdir = $(PREFIX)/$(RPM_LIBDIR)
@@ -893,6 +895,7 @@ PHP_PRE_UNINSTALL_SCRIPT:=./scripts/phpthemis_preuninstall.sh
 PHP_API:=$(shell php -i 2>/dev/null|grep 'PHP API'|sed 's/PHP API => //')
 PHP_LIB_MAP:=./src/wrappers/themis/$(PHP_FOLDER)/.libs/phpthemis.so=/usr/lib/php/$(PHP_API)/
 
+deb_php: MODE_PACKAGING = 1
 deb_php:
 	@mkdir -p $(BIN_PATH)/deb
 	@fpm --input-type dir \

--- a/Makefile
+++ b/Makefile
@@ -639,7 +639,7 @@ else
 	ARCHITECTURE = $(shell arch)
 	RPM_VERSION = $(shell echo -n "$(VERSION)"|sed s/-/_/g)
 	NAME_SUFFIX = $(RPM_VERSION).$(OS_NAME)$(OS_VERSION).$(ARCHITECTURE).rpm
-	RPM_LIBDIR := $(shell [ $$(arch) == "x86_64" ] && echo "lib64" || echo "lib")
+	RPM_LIBDIR := /$(shell [ $$(arch) == "x86_64" ] && echo "lib64" || echo "lib")
 endif
 
 PACKAGE_NAME = libthemis
@@ -761,7 +761,7 @@ deb: install themispp_install themis_jni_install
 rpm: MODE_PACKAGING = 1
 rpm: DESTDIR = $(BIN_PATH)/rpm/root
 rpm: PREFIX = /usr
-rpm: libdir = $(PREFIX)/$(RPM_LIBDIR)
+rpm: libdir = $(PREFIX)$(RPM_LIBDIR)
 
 rpm: install themispp_install themis_jni_install
 	@printf "ldconfig" > $(POST_INSTALL_SCRIPT)

--- a/jni/themis_jni.mk
+++ b/jni/themis_jni.mk
@@ -69,7 +69,7 @@ ifdef IS_MACOS
 	@install_name_tool -change "$(BIN_PATH)/$(LIBTHEMIS_SO)" "$(libdir)/$(LIBTHEMIS_SO)" "$(DESTDIR)$(jnidir)/$(LIBTHEMISJNI_SO)"
 endif
 	@$(PRINT_OK_)
-	@java_library_path=$$(\
+	@[ $(MODE_PACKAGING) -eq 1 ] || (java_library_path=$$(\
 	    java -XshowSettings:properties -version 2>&1 \
 	    | sed -E 's/^ +[^=]+ =/_&/' \
 	    | awk -v prop=java.library.path \
@@ -81,7 +81,7 @@ endif
 	         } \
 	       }' \
 	 ) && \
-	 jnidir=$$(cd "$(DESTDIR)$(jnidir)" && pwd) && \
+	 jnidir=$$(cd "$(jnidir)" && pwd) && \
 	 if ! echo "$$java_library_path" | grep -q "^$${jnidir}$$"; \
 	 then \
 	     echo ''; \
@@ -94,7 +94,7 @@ endif
 	     echo 'on application startup, or to move $(LIBTHEMISJNI_SO) manually'; \
 	     echo 'to one of these locations so that Java could find it.'; \
 	     echo ''; \
-	 fi
+	 fi)
 
 themis_jni_uninstall:
 	@echo -n "uninstall Themis JNI "

--- a/jni/themis_jni.mk
+++ b/jni/themis_jni.mk
@@ -81,7 +81,7 @@ endif
 	         } \
 	       }' \
 	 ) && \
-	 jnidir=$$(cd "$(jnidir)" && pwd) && \
+	 jnidir=$$(cd "$(DESTDIR)$(jnidir)" && pwd) && \
 	 if ! echo "$$java_library_path" | grep -q "^$${jnidir}$$"; \
 	 then \
 	     echo ''; \


### PR DESCRIPTION
It did not take into account `DESTDIR` variable, so the directory in `cd` command was incorrect.
