### PR TITLE
Add simple C++ test

### DIFF
--- a/tests/test.mk
+++ b/tests/test.mk
@@ -23,10 +23,12 @@ include tests/soter/soter.mk
 include tests/tools/tools.mk
 include tests/themis/themis.mk
 include tests/themispp/themispp.mk
+include tests/themispp_simple/themispp_simple.mk
 
 soter_test:    $(SOTER_TEST_BIN)
 themis_test:   $(THEMIS_TEST_BIN)
 themispp_test: $(TEST_BIN_PATH)/themispp_test
+themispp_simple_test: $(TEST_BIN_PATH)/themispp_simple_test
 
 $(OBJ_PATH)/tests/%: CFLAGS += -I$(TEST_SRC_PATH)
 
@@ -172,3 +174,11 @@ ifdef NPM_VERSION
 endif
 
 test_all: test prepare_tests_all test_cpp test_php test_python test_ruby test_js test_go test_rust
+
+# requires all dependencies to be installed in system paths
+test_cpp_simple:
+	@echo "------------------------------------------------------------"
+	@echo "Running themissp simple test."
+	@echo "------------------------------------------------------------"
+	$(TEST_BIN_PATH)/themispp_simple_test
+	@echo "------------------------------------------------------------"

--- a/tests/test.mk
+++ b/tests/test.mk
@@ -28,7 +28,6 @@ include tests/themispp_simple/themispp_simple.mk
 soter_test:    $(SOTER_TEST_BIN)
 themis_test:   $(THEMIS_TEST_BIN)
 themispp_test: $(TEST_BIN_PATH)/themispp_test
-themispp_simple_test: $(TEST_BIN_PATH)/themispp_simple_test
 
 $(OBJ_PATH)/tests/%: CFLAGS += -I$(TEST_SRC_PATH)
 
@@ -176,7 +175,7 @@ endif
 test_all: test prepare_tests_all test_cpp test_php test_python test_ruby test_js test_go test_rust
 
 # requires all dependencies to be installed in system paths
-test_cpp_simple:
+test_cpp_simple: $(TEST_BIN_PATH)/themispp_simple_test
 	@echo "------------------------------------------------------------"
 	@echo "Running themissp simple test."
 	@echo "------------------------------------------------------------"

--- a/tests/themispp_simple/main.cpp
+++ b/tests/themispp_simple/main.cpp
@@ -1,0 +1,10 @@
+#include <themispp/secure_keygen.hpp>
+
+int main()
+{
+    std::vector<uint8_t> key = themispp::gen_sym_key();
+    if (key.empty()) {
+        return 1;
+    }
+    return 0;
+}

--- a/tests/themispp_simple/themispp_simple.mk
+++ b/tests/themispp_simple/themispp_simple.mk
@@ -18,5 +18,11 @@ THEMISPP_SIMPLE_TEST_SOURCES = $(wildcard $(TEST_SRC_PATH)/themispp_simple/*.cpp
 
 # Link dynamically against Themis library in the standard system paths.
 # We also need to link against Soter explicitly because of private imports.
-$(TEST_BIN_PATH)/themispp_test: CMD = $(CXX) -o $@ -lthemis -lsoter
+$(TEST_BIN_PATH)/themispp_simple_test: CMD = $(CXX) -o $@ $(THEMISPP_SIMPLE_TEST_SOURCES) -lthemis -lsoter
+$(TEST_BIN_PATH)/themispp_simple_test:
+	@mkdir -p $(@D)
+	@echo -n "build "
 	@$(BUILD_CMD)
+
+clean_themispp_simple_test:
+	@rm -f $(TEST_BIN_PATH)/themispp_simple_test

--- a/tests/themispp_simple/themispp_simple.mk
+++ b/tests/themispp_simple/themispp_simple.mk
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2020 Cossack Labs Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+THEMISPP_SIMPLE_TEST_SOURCES = $(wildcard $(TEST_SRC_PATH)/themispp_simple/*.cpp)
+
+# Link dynamically against Themis library in the standard system paths.
+# We also need to link against Soter explicitly because of private imports.
+$(TEST_BIN_PATH)/themispp_test: CMD = $(CXX) -o $@ -lthemis -lsoter
+	@$(BUILD_CMD)


### PR DESCRIPTION
Builds a primitive C++ application using themis and soter libraries located at standard system paths. This allows us to check that Themis library and Themis C++ development environment have been properly installed on the target system.

```bash
# Build & run test
make test_cpp_simple
# Clean
make clean_themispp_simple_test
```

Yes, naming looks a bit strange, but now this is the approach taken in Makefiles. Hope we can improve it someday.