### PR TITLE
Use correct libdir for multiarch Debian

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -627,11 +627,11 @@ ifeq ($(shell lsb_release -is 2> /dev/null),Debian)
 #0.9.4-153-g9915004+jessie_amd64.deb.
 	NAME_SUFFIX = $(VERSION)+$(DEB_CODENAME)_$(DEB_ARCHITECTURE).deb
 	OS_CODENAME = $(shell lsb_release -cs)
-	DEB_LIBDIR := /lib/$(shell $(CC) -dumpmachine)
+	DEB_LIBDIR := /lib/$(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 else ifeq ($(shell lsb_release -is 2> /dev/null),Ubuntu)
 	NAME_SUFFIX = $(VERSION)+$(DEB_CODENAME)_$(DEB_ARCHITECTURE).deb
 	OS_CODENAME = $(shell lsb_release -cs)
-	DEB_LIBDIR := /lib/$(shell $(CC) -dumpmachine)
+	DEB_LIBDIR := /lib/$(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 else
 # centos/rpm
 	OS_NAME = $(shell cat /etc/os-release | grep -e "^ID=\".*\"" | cut -d'"' -f2)

--- a/Makefile
+++ b/Makefile
@@ -623,17 +623,13 @@ RPM_DEPENDENCIES_THEMISPP = --depends "$(RPM_DEV_PACKAGE_NAME) = $(RPM_VERSION)-
 RPM_DEPENDENCIES_JNI += --depends "$(PACKAGE_NAME) >= $(RPM_VERSION)-$(RPM_RELEASE_NUM)"
 RPM_RELEASE_NUM = 1
 
-ifeq ($(shell lsb_release -is 2> /dev/null),Debian)
+OS_NAME := $(shell lsb_release -is 2>/dev/null || printf 'unknown')
+ifeq ($(OS_NAME),$(filter $(OS_NAME),Debian Ubuntu))
 #0.9.4-153-g9915004+jessie_amd64.deb.
 	NAME_SUFFIX = $(VERSION)+$(DEB_CODENAME)_$(DEB_ARCHITECTURE).deb
 	OS_CODENAME = $(shell lsb_release -cs)
 	DEB_LIBDIR := /lib/$(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
-else ifeq ($(shell lsb_release -is 2> /dev/null),Ubuntu)
-	NAME_SUFFIX = $(VERSION)+$(DEB_CODENAME)_$(DEB_ARCHITECTURE).deb
-	OS_CODENAME = $(shell lsb_release -cs)
-	DEB_LIBDIR := /lib/$(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
-else
-# centos/rpm
+else ifeq ($(OS_NAME),$(filter $(OS_NAME),RedHatEnterpriseServer CentOS))
 	OS_NAME = $(shell cat /etc/os-release | grep -e "^ID=\".*\"" | cut -d'"' -f2)
 	OS_VERSION = $(shell cat /etc/os-release | grep -i version_id|cut -d'"' -f2)
 	ARCHITECTURE = $(shell arch)


### PR DESCRIPTION
Debian multiarch is a little bit complicated, one particularly important thing is the installation directory for libraries. For multiarch-enabled packages it should include the "target triple". However, for Debian this is not your usual target triple, but [*normalized* target triple][1].

[1]: https://wiki.debian.org/Multiarch/Tuples

This is not really noticeable on x86_64 but on 32-bit x86 systems compilers tend to report `{i386,i486,i586,i686}-linux-gnu` when the _correct_ one is only `i386-linux-gnu`.

We should use the correct, normalized triplet since that's what dynamic loader uses. If the library is installed into an incorrect multiarch subdirectory then it will fail to load.

Instead of asking the compiler, ask **dpkg** for the multiarch-correct triplet for the system on which we are building the package. We always build packages targeting the host system so this is correct approach.

## Checklist

- [X] ~~Change is covered by automated tests~~ (only on BuiltBot)
- [X] The [coding guidelines] are followed
- [X] ~~Changelog is updated~~ (nothing notable)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md