### PR TITLE
Correct detecting of installing paths for i386

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -623,17 +623,14 @@ RPM_DEPENDENCIES_THEMISPP = --depends "$(RPM_DEV_PACKAGE_NAME) = $(RPM_VERSION)-
 RPM_DEPENDENCIES_JNI += --depends "$(PACKAGE_NAME) >= $(RPM_VERSION)-$(RPM_RELEASE_NUM)"
 RPM_RELEASE_NUM = 1
 
-ifeq ($(shell lsb_release -is 2> /dev/null),Debian)
+OS_NAME := $(shell lsb_release -is 2>/dev/null || printf 'unknown')
+ifeq ($(OS_NAME),$(filter $(OS_NAME),Debian Ubuntu))
 #0.9.4-153-g9915004+jessie_amd64.deb.
 	NAME_SUFFIX = $(VERSION)+$(DEB_CODENAME)_$(DEB_ARCHITECTURE).deb
 	OS_CODENAME = $(shell lsb_release -cs)
-	DEB_LIBDIR := /lib/$(shell $(CC) -dumpmachine)
-else ifeq ($(shell lsb_release -is 2> /dev/null),Ubuntu)
-	NAME_SUFFIX = $(VERSION)+$(DEB_CODENAME)_$(DEB_ARCHITECTURE).deb
-	OS_CODENAME = $(shell lsb_release -cs)
-	DEB_LIBDIR := /lib/$(shell $(CC) -dumpmachine)
-else
-# centos/rpm
+	CC_DUMPMACHINE := $(shell $(CC) -dumpmachine)
+	DEB_LIBDIR := /lib/$(shell [ $(CC_DUMPMACHINE) == "i686-linux-gnu" ] && printf "i386-linux-gnu" || printf $(CC_DUMPMACHINE))
+else ifeq ($(OS_NAME),$(filter $(OS_NAME),RedHatEnterpriseServer CentOS))
 	OS_NAME = $(shell cat /etc/os-release | grep -e "^ID=\".*\"" | cut -d'"' -f2)
 	OS_VERSION = $(shell cat /etc/os-release | grep -i version_id|cut -d'"' -f2)
 	ARCHITECTURE = $(shell arch)


### PR DESCRIPTION
The approach we used previously, was based on getting the `cc -dumpmachine` value as a part of the target directory. It works well on x86_64, but on i386 the incorrect directory was drawn up.

= x86_64

`[/usr]/lib/x86_64-linux-gnu`

```
$ cc -dumpmachine
x86_64-linux-gnu

$ ld --verbose | grep SEARCH_DIR | tr -s ' ;' \\012
SEARCH_DIR("=/usr/local/lib/x86_64-linux-gnu")
SEARCH_DIR("=/lib/x86_64-linux-gnu")
SEARCH_DIR("=/usr/lib/x86_64-linux-gnu")
SEARCH_DIR("=/usr/lib/x86_64-linux-gnu64")
SEARCH_DIR("=/usr/local/lib64")
SEARCH_DIR("=/lib64")
SEARCH_DIR("=/usr/lib64")
SEARCH_DIR("=/usr/local/lib")
SEARCH_DIR("=/lib")
SEARCH_DIR("=/usr/lib")
SEARCH_DIR("=/usr/x86_64-linux-gnu/lib64")
SEARCH_DIR("=/usr/x86_64-linux-gnu/lib")
```

= i386

`[/usr]/lib/i686-linux-gnu`

```
$ cc -dumpmachine
i686-linux-gnu

$ ld --verbose | grep SEARCH_DIR | tr -s ' ;' \\012
SEARCH_DIR("=/usr/local/lib/i386-linux-gnu")
SEARCH_DIR("=/lib/i386-linux-gnu")
SEARCH_DIR("=/usr/lib/i386-linux-gnu")
SEARCH_DIR("=/usr/local/lib32")
SEARCH_DIR("=/lib32")
SEARCH_DIR("=/usr/lib32")
SEARCH_DIR("=/usr/local/lib")
SEARCH_DIR("=/lib")
SEARCH_DIR("=/usr/lib")
SEARCH_DIR("=/usr/i686-linux-gnu/lib32")
SEARCH_DIR("=/usr/i686-linux-gnu/lib")
```

So the suggested solution is to simply use `i386-linux-gnu` instead of `i686-linux-gnu`, which works well on all i386 Debian/Ubuntu distributives.
