### PR TITLE
Pin Emscripten toolchain to 1.39.16-fastcomp

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -473,8 +473,13 @@ jobs:
             cd $HOME/emsdk
             git reset --hard
             git pull
-            ./emsdk install  latest-fastcomp
-            ./emsdk activate latest-fastcomp
+            # FIXME(ilammy, 2020-06-07): migrate to "upstream" flavor
+            # LLVM flavor of Emscripten has some issues compiling our code,
+            # and latest versions of the fastcomp flavor started giving out
+            # compiler warnings (turned into errors by the build system).
+            # We need to migrate, but for the time being use the old version.
+            ./emsdk install  1.39.16-fastcomp
+            ./emsdk activate 1.39.16-fastcomp
       - checkout
       - run:
           name: Sync submodules
@@ -611,8 +616,13 @@ jobs:
             cd $HOME/emsdk
             git reset --hard
             git pull
-            ./emsdk install  latest-fastcomp
-            ./emsdk activate latest-fastcomp
+            # FIXME(ilammy, 2020-06-07): migrate to "upstream" flavor
+            # LLVM flavor of Emscripten has some issues compiling our code,
+            # and latest versions of the fastcomp flavor started giving out
+            # compiler warnings (turned into errors by the build system).
+            # We need to migrate, but for the time being use the old version.
+            ./emsdk install  1.39.16-fastcomp
+            ./emsdk activate 1.39.16-fastcomp
 
       # themis
       - checkout

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -75,9 +75,13 @@ jobs:
           cd $HOME
           git clone https://github.com/emscripten-core/emsdk.git
           cd $HOME/emsdk
-          # "upstream" flavor using LLVM compiler is still unstable for us
-          ./emsdk install  latest-fastcomp
-          ./emsdk activate latest-fastcomp
+          # FIXME(ilammy, 2020-06-07): migrate to "upstream" flavor
+          # LLVM flavor of Emscripten has some issues compiling our code,
+          # and latest versions of the fastcomp flavor started giving out
+          # compiler warnings (turned into errors by the build system).
+          # We need to migrate, but for the time being use the old version.
+          ./emsdk install  1.39.16-fastcomp
+          ./emsdk activate 1.39.16-fastcomp
       - name: Install PHP from PPA
         run: |
           sudo apt install --yes software-properties-common

--- a/.github/workflows/test-wasm.yaml
+++ b/.github/workflows/test-wasm.yaml
@@ -56,9 +56,13 @@ jobs:
           cd $HOME
           git clone https://github.com/emscripten-core/emsdk.git
           cd $HOME/emsdk
-          # "upstream" flavor using LLVM compiler is still unstable for us
-          ./emsdk install  latest-fastcomp
-          ./emsdk activate latest-fastcomp
+          # FIXME(ilammy, 2020-06-07): migrate to "upstream" flavor
+          # LLVM flavor of Emscripten has some issues compiling our code,
+          # and latest versions of the fastcomp flavor started giving out
+          # compiler warnings (turned into errors by the build system).
+          # We need to migrate, but for the time being use the old version.
+          ./emsdk install  1.39.16-fastcomp
+          ./emsdk activate 1.39.16-fastcomp
       - name: Check out code
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Starting with Emscripten 1.39.17-fastcomp, the compiler is now printing warnings, urging to migrate to the upstream flavor:

    emcc: error: the fastomp compiler is deprecated.  Please switch
    to the upstream llvm backend as soon as possible and open issues
    if you have trouble doing so [-Wfastcomp] [-Werror]

Unfortunately, we cannot migrate at the moment because the upstream compiler is not able to build and link everything. While we're investigating the issues, we need this warning gone – we keep a non-negotiable “treat warnings as errors” policy. This makes out builds red.

We cannot suppress this particular warning with `-Wno-fastcomp` because it affects the BoringSSL build as well. They have `-Wall` added *after* all custom flags so we are not able to suppress this warning there.

Therefore, for the time being, let's pin Emscripten toolchain to the latest good version that does not emit warnings. I got the message, I'll work on supporting the upstream flavor in the next release.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] Public API has proper documentation
- [X] ~~Changelog is updated~~ (we'll keep a note it documentation)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
