### PR TITLE
Support Node.js v14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -457,6 +457,7 @@ jobs:
             nvm install v8
             nvm install v10
             nvm install v12
+            nvm install v14
       # Install Emscripten toolchain for Wasm support
       # See https://emscripten.org/docs/getting_started/downloads.html
       - restore_cache:
@@ -505,7 +506,7 @@ jobs:
             # Run JsThemis tests
             make test_js
       - run:
-          name: Test with Node.js v8 (maintenance)
+          name: Test with Node.js v8
           when: always
           command: |
             # Activate Node.js v8
@@ -517,7 +518,7 @@ jobs:
             # Run WasmThemis tests
             make BUILD_PATH=build-wasm test_wasm
       - run:
-          name: Test with Node.js v10 (LTS)
+          name: Test with Node.js v10
           when: always
           command: |
             # Activate Node.js v10
@@ -529,11 +530,23 @@ jobs:
             # Run WasmThemis tests
             make BUILD_PATH=build-wasm test_wasm
       - run:
-          name: Test with Node.js v12 (stable)
+          name: Test with Node.js v12
           when: always
           command: |
             # Activate Node.js v12
             nvm use v12
+            echo "node --version: $(node --version)"
+            echo "npm --version:  $(npm --version)"
+            # Run JsThemis tests
+            make test_js
+            # Run WasmThemis tests
+            make BUILD_PATH=build-wasm test_wasm
+      - run:
+          name: Test with Node.js v14
+          when: always
+          command: |
+            # Activate Node.js v14
+            nvm use v14
             echo "node --version: $(node --version)"
             echo "npm --version:  $(npm --version)"
             # Run JsThemis tests

--- a/.github/workflows/test-nodejs.yaml
+++ b/.github/workflows/test-nodejs.yaml
@@ -30,9 +30,10 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 8.x   # old LTS
-          - 10.x  # current LTS
-          - 12.x  # current stable
+          - 8.x   # legacy
+          - 10.x  # old LTS
+          - 12.x  # current LTS
+          - 14.x  # current stable
       fail-fast: false
     steps:
       - name: Install system dependencies

--- a/.github/workflows/test-wasm.yaml
+++ b/.github/workflows/test-wasm.yaml
@@ -35,9 +35,10 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 8.x   # old LTS
-          - 10.x  # current LTS
-          - 12.x  # current stable
+          - 8.x   # legacy
+          - 10.x  # old LTS
+          - 12.x  # current LTS
+          - 14.x  # current stable
       fail-fast: false
     steps:
       - name: Install system dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -502,6 +502,8 @@ _Code:_
   - `SecureCell` now allows `null` to explicitly specify omitted encryption context ([#620](https://github.com/cossacklabs/themis/pull/620)).
   - `SecureMessage` now allows `null` for omitted keys in sign/verify mode ([#620](https://github.com/cossacklabs/themis/pull/620)).
   - Fixed a crash when an exception is thrown from `SecureSession` callback ([#620](https://github.com/cossacklabs/themis/pull/620)).
+  - Node.js v14 is now supported
+    ([#654](https://github.com/cossacklabs/themis/issues/654)).
 
   - Passphrase API support in Secure Cell ([#621](https://github.com/cossacklabs/themis/pull/621)).
 
@@ -652,6 +654,8 @@ _Code:_
   - New class `SymmetricKey` can be used to generate symmetric keys for Secure Cell ([#561](https://github.com/cossacklabs/themis/pull/561)).
   - Updated embedded BoringSSL to the latest version
     ([#643](https://github.com/cossacklabs/themis/pull/643)).
+  - Node.js v14 is now supported
+    ([#654](https://github.com/cossacklabs/themis/issues/654)).
 
   - Passphrase API support in Secure Cell ([#616](https://github.com/cossacklabs/themis/pull/616)).
 


### PR DESCRIPTION
This is the version which is going to turn into LTS in October 2020. It's the current stable release. LTS is recommended for general use, but some packages already deliver the stable version (e.g., Homebrew).

There are probably some deprecations that we need to take care of, but otherwise we can squeese this support claim into the release window for JsThemis 0.13 and WasmThemis 0.13.

See https://nodejs.org/en/download/ for information on current Node.js releases.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] Public API has proper documentation
- [X] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
