### PR TITLE
Make Java source ASCII-only

### DIFF
--- a/src/wrappers/themis/java/build.gradle
+++ b/src/wrappers/themis/java/build.gradle
@@ -50,4 +50,9 @@ java {
 // Tweak compiler options.
 compileJava {
     options.deprecation = true // log deprecated API usage
+    options.encoding = "ASCII" // allow only ASCII in source code
+}
+compileTestJava {
+    options.deprecation = true // log deprecated API usage
+    options.encoding = "ASCII" // allow only ASCII in source code
 }

--- a/src/wrappers/themis/java/com/cossacklabs/themis/SecureCell.java
+++ b/src/wrappers/themis/java/com/cossacklabs/themis/SecureCell.java
@@ -27,7 +27,7 @@ import java.nio.charset.StandardCharsets;
 /**
  * Secure Cell for data storage.
  * <p>
- * <strong>Secure Сell</strong> is a high-level cryptographic service
+ * <strong>Secure Cell</strong> is a high-level cryptographic service
  * aimed at protecting arbitrary data stored in various types of storage
  * (e.g., databases, filesystem files, document archives, cloud storage, etc.)
  * It provides both strong symmetric encryption and data authentication mechanism.
@@ -37,7 +37,7 @@ import java.nio.charset.StandardCharsets;
  * <ul>
  *   <li><em>input:</em> some source data to protect</li>
  *   <li><em>secret:</em> symmetric key or a password</li>
- *   <li><em>context:</em> and an optional “context information”</li>
+ *   <li><em>context:</em> and an optional "context information"</li>
  * </ul>
  *
  * Secure Cell will produce:
@@ -120,11 +120,11 @@ public class SecureCell {
      * This is the most secure and easy way to protect stored data.
      * The data is protected by a symmetric key or a passphrase.
      * <p>
-     * Secure Cell in Seal mode will encrypt the data and append an “authentication tag”
+     * Secure Cell in Seal mode will encrypt the data and append an "authentication tag"
      * with auxiliary security information, forming a single sealed container.
      * This means that the encrypted data will be longer than the original input.
      * <p>
-     * Additionally, it is possible to bind the encrypted data to some “associated context”
+     * Additionally, it is possible to bind the encrypted data to some "associated context"
      * (for example, database row number).
      * In this case decryption of the data with incorrect context will fail
      * (even if the correct key is known and the data has not been tampered).
@@ -341,7 +341,7 @@ public class SecureCell {
      * then Token Protect mode can be used instead of Seal mode.
      * <p>
      * Token Protect mode produces authentication tag and other auxiliary data
-     * (aka “authentication token”) in a detached buffer.
+     * (aka "authentication token") in a detached buffer.
      * This keeps the original size of the encrypted data
      * while enabling separate storage of security information.
      * Note that the same token must be provided along with the correct secret
@@ -496,7 +496,7 @@ public class SecureCell {
      * <p>
      * Context Imprint mode is intended for environments where storage constraints
      * do not allow the size of the data to grow and there is no auxiliary storage available.
-     * Context Imprint mode requires an additional “associated context”
+     * Context Imprint mode requires an additional "associated context"
      * to be provided along with the key in order to protect the data.
      * <p>
      * In Context Imprint mode no authentication token is computed or verified.

--- a/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellSealWithPassphraseTest.java
+++ b/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureCellSealWithPassphraseTest.java
@@ -260,7 +260,7 @@ public class SecureCellSealWithPassphraseTest {
     @Test
     public void defaultEncoding() throws SecureCellException {
         // Passphrases are encoded in UTF-8 by default.
-        String passphrase = "暗号";
+        String passphrase = "\u6697\u53F7";
         SecureCell.Seal cellA = SecureCell.SealWithPassphrase(passphrase);
         SecureCell.Seal cellB = SecureCell.SealWithPassphrase(passphrase.getBytes(StandardCharsets.UTF_8));
         byte[] message = "All your base are belong to us!".getBytes(StandardCharsets.UTF_8);
@@ -354,7 +354,7 @@ public class SecureCellSealWithPassphraseTest {
         try {
             // It is an error if the passphrase cannot be represented in the requested charset
             // without data loss.
-            SecureCell.SealWithPassphrase("пароль", StandardCharsets.US_ASCII);
+            SecureCell.SealWithPassphrase("\u043F\u0430\u0440\u043E\u043B\u044C", StandardCharsets.US_ASCII);
             fail("expected RuntimeException(CharacterCodingException)");
         }
         catch (RuntimeException e) {


### PR DESCRIPTION
Some Java compilers use US-ASCII encoding by default and issue warnings when the source file contains non-ASCII characters. Some tests for novel passphrase API must include non-ASCII data so we have to do this.

Replace non-ASCII characters with their ASCII analogues for JavaDoc comments, or escape actual values in the source code. This makes Java compilers happy. (In particular, our own BuildBot should stop being red because of some Java compilers on 32-bit machines using ASCII.)

Set the encoding we pass to `javac` in Gradle files. This way our build system will issue warnings – treated as errors – when non-ASCII characters are used in Java source. Now if the users build Themis tests with their own toolchain, their compilers will not issue warnings as well.

Kotlin source code is always UTF-8 by design and this cannot be changed. We do not need to do anything for Kotlin, the tests may continue using non-ASCII test strings.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
