### PR TITLE
Improve path-based build triggers

### DIFF
--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -11,6 +11,7 @@ on:
       - 'tests/common/**'
       - 'tests/soter/**'
       - 'tests/themis/**'
+      - '!tests/themis/wrappers/android/**'
       - 'third_party/boringssl/src/**'
       - 'tools/afl/**'
       - '**/*.mk'

--- a/.github/workflows/test-wasm.yaml
+++ b/.github/workflows/test-wasm.yaml
@@ -10,6 +10,7 @@ on:
       - 'tests/common/**'
       - 'tests/soter/**'
       - 'tests/themis/**'
+      - '!tests/themis/wrappers/android/**'
       - 'third_party/boringssl/src/**'
       - '**/*.mk'
       - 'Makefile'


### PR DESCRIPTION
Due to hysterical raisins, JavaThemis test suite is located in `tests/themis` directory (shared with Themis Core tests). Any changes there are triggering Test Core and WasmThemis test runs as well.

Android test suite is heavy enough on its own, no need to make it run longer than necessary.

Add an exclusion to do not trigger Themis Core and WasmThemis test suites when JavaThemis tests are modified.

P.S. This change will nevertheless trigger a build because the build configurations for Themis Core and WasmThemis have changed. This should not be the case for future PRs.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md