### PR TITLE
Deprecate Secure Session serialization API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Changes that are currently in development and have not been released yet.
 - Themis is known to be broken on big-endian architectures ([read more](#0.13.0-big-endian)).
 - Java 7 is no longer supported, breaking Android and Java builds on outdated systems ([read more](#0.13.0-drop-java-7)).
 - Python 2 is no longer supported ([read more](#0.13.0-drop-python-2)).
+- Serialisation of Secure Session state in JavaThemis is now deprecated
+  ([read more](#0.13.0-deprecate-session-save-restore)).
 
 _Code:_
 
@@ -494,6 +496,14 @@ _Code:_
       consider using them instead.
 
       Deprecated API is still supported, there are no plans for its removal.
+
+    - <a id="0.13.0-deprecate-session-save-restore"></a>
+      `SecureSession` methods `save` and `restore` are now deprecated
+      ([#659](https://github.com/cossacklabs/themis/pull/659)).
+
+      An improved API for serialisation might appear in some next version of JavaThemis.
+      For now, please refrain from using `SecureSession#save` and `SecureSession#restore`
+      which may be removed in the future.
 
 - **Node.js**
 

--- a/src/wrappers/themis/java/com/cossacklabs/themis/SecureSession.java
+++ b/src/wrappers/themis/java/com/cossacklabs/themis/SecureSession.java
@@ -283,7 +283,11 @@ public class SecureSession {
 	 * @return session state
 	 * @throws IllegalStateException is the session is already closed
 	 * @throws RuntimeException when cannot serialize session, e.g. if session is not established
+	 * @deprecated since JavaThemis 0.13
+	 * <p>
+	 * This method might be replaced in a next release, please do not use.
 	 */
+	@Deprecated
 	public synchronized byte[] save() {
 		if (0 == sessionPtr) {
 			throw new IllegalStateException("Secure Session is closed");
@@ -303,7 +307,11 @@ public class SecureSession {
 	 * @param callbacks implementation
 	 * @return restored SecureSession
 	 * @throws SecureSessionException when cannot restore session
+	 * @deprecated since JavaThemis 0.13
+	 * <p>
+	 * This method might be replaced in a next release, please do not use.
 	 */
+	@Deprecated
 	public static SecureSession restore(byte[] state, ISessionCallbacks callbacks) throws SecureSessionException {
 		SecureSession session = new SecureSession();
 		

--- a/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureSessionTest.java
+++ b/tests/themis/wrappers/android/com/cossacklabs/themis/test/SecureSessionTest.java
@@ -108,6 +108,8 @@ public class SecureSessionTest {
 		return data;
 	}
 	
+	// Allow deprecated #save and #restore methods.
+	@SuppressWarnings("deprecation")
 	@Test
 	public void runTest() {
 		


### PR DESCRIPTION
For a long time, serialization of Secure Session state has been available only in JavaThemis. This API did not receive much use and/or testing. Recently we have discovered a serious bug in Themis Core which affects serialization (#658). Apparently, no one has noticed it before.

As such, we are not sure that this API is useful in its current form. Let's mark it deprecated for now. It's going to either disappear completely in the next release, or be replaced with a better API after the serialization feature gets more testing, or the existing methods may be un-deprecated back as is.

There is no specific plan for this feature as of Themis 0.13, but eventually it will be supported across all languages and platforms.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] ~~Public API has proper documentation~~ (did not bother)
- [X] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
