### PR TITLE
Pin emsdk to avoid regression

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -474,6 +474,9 @@ jobs:
             cd $HOME/emsdk
             git reset --hard
             git pull
+            # FIXME(ilammy, 2020-07-07): unpin emsdk version [T1698]
+            # Latest HEAD has a regression, we roll back to last good version.
+            git checkout 92d512faa832b3ff5d6b8bc991b6801e31d8e372
             # FIXME(ilammy, 2020-06-07): migrate to "upstream" flavor
             # LLVM flavor of Emscripten has some issues compiling our code,
             # and latest versions of the fastcomp flavor started giving out
@@ -629,6 +632,9 @@ jobs:
             cd $HOME/emsdk
             git reset --hard
             git pull
+            # FIXME(ilammy, 2020-07-07): unpin emsdk version [T1698]
+            # Latest HEAD has a regression, we roll back to last good version.
+            git checkout 92d512faa832b3ff5d6b8bc991b6801e31d8e372
             # FIXME(ilammy, 2020-06-07): migrate to "upstream" flavor
             # LLVM flavor of Emscripten has some issues compiling our code,
             # and latest versions of the fastcomp flavor started giving out

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -75,6 +75,9 @@ jobs:
           cd $HOME
           git clone https://github.com/emscripten-core/emsdk.git
           cd $HOME/emsdk
+          # FIXME(ilammy, 2020-07-07): unpin emsdk version [T1698]
+          # Latest HEAD has a regression, we roll back to last good version.
+          git checkout 92d512faa832b3ff5d6b8bc991b6801e31d8e372
           # FIXME(ilammy, 2020-06-07): migrate to "upstream" flavor
           # LLVM flavor of Emscripten has some issues compiling our code,
           # and latest versions of the fastcomp flavor started giving out

--- a/.github/workflows/test-wasm.yaml
+++ b/.github/workflows/test-wasm.yaml
@@ -58,6 +58,9 @@ jobs:
           cd $HOME
           git clone https://github.com/emscripten-core/emsdk.git
           cd $HOME/emsdk
+          # FIXME(ilammy, 2020-07-07): unpin emsdk version [T1698]
+          # Latest HEAD has a regression, we roll back to last good version.
+          git checkout 92d512faa832b3ff5d6b8bc991b6801e31d8e372
           # FIXME(ilammy, 2020-06-07): migrate to "upstream" flavor
           # LLVM flavor of Emscripten has some issues compiling our code,
           # and latest versions of the fastcomp flavor started giving out


### PR DESCRIPTION
The current HEAD of emsdk repository includes a change that causes the builds to fail with an error:

    Adding directories to PATH:
    PATH += /home/user/emsdk
    PATH += /home/user/emsdk/fastcomp/emscripten
    PATH += /home/user/emsdk/node/12.18.1_64bit/bin

    Setting environment variables:
    EMSDK = /home/user/emsdk
    EM_CONFIG = /home/user/emsdk/.emscripten
    EM_CACHE = /home/user/emsdk/fastcomp/emscripten/cache
    EMSDK_NODE = /home/user/emsdk/node/12.18.1_64bit/bin/node
    /home/user/emsdk/emsdk_env.sh: line 26: /home/user/emsdk/emsdk_set_env.sh: No such file or directory

[The change][1] has optimized environment variable setup. Apparently, it has issues. To avoid breaking our builds, roll back to the previous known good state for the time being. The issue has been [reported to Emscripten][2], but it's not clear when it's going to be reverted and fixed, so we'd rather not depend on that right now, when Themis release is brewing.

[1]: https://github.com/emscripten-core/emsdk/pull/539
[2]: https://github.com/emscripten-core/emsdk/issues/540

----

@shadinua, this change needs to be applied to Buildbot infra as well. It's currently broken all over the place because of that.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md