### PR TITLE
Require Themis 0.13 in example projects

### DIFF
--- a/docs/examples/Themis-server/Obj-C/Podfile
+++ b/docs/examples/Themis-server/Obj-C/Podfile
@@ -23,6 +23,6 @@ use_frameworks!
 
 target :"WorkingWithThemisServer" do
 
-  pod 'themis', '0.12.2'
+  pod 'themis', '0.13.0'
 
 end

--- a/docs/examples/Themis-server/swift/Podfile
+++ b/docs/examples/Themis-server/swift/Podfile
@@ -23,6 +23,6 @@ use_frameworks!
 
 target :"SwiftThemisServerExample" do
 
-  pod 'themis', '0.12.2'
+  pod 'themis', '0.13.0'
 
 end

--- a/docs/examples/objc/iOS-Carthage/Cartfile
+++ b/docs/examples/objc/iOS-Carthage/Cartfile
@@ -1,1 +1,1 @@
-github "cossacklabs/themis" ~> 0.12.1
+github "cossacklabs/themis" ~> 0.13.0

--- a/docs/examples/objc/iOS-CocoaPods/Podfile
+++ b/docs/examples/objc/iOS-CocoaPods/Podfile
@@ -23,6 +23,6 @@ use_frameworks!
 
 target :"ThemisTest" do
 
-  pod 'themis', '0.12.2'
+  pod 'themis', '0.13.0'
 
 end

--- a/docs/examples/objc/macOS-Carthage/Cartfile
+++ b/docs/examples/objc/macOS-Carthage/Cartfile
@@ -1,1 +1,1 @@
-github "cossacklabs/themis" ~> 0.12.1
+github "cossacklabs/themis" ~> 0.13.0

--- a/docs/examples/swift/iOS-Carthage/Cartfile
+++ b/docs/examples/swift/iOS-Carthage/Cartfile
@@ -1,1 +1,1 @@
-github "cossacklabs/themis" ~> 0.12.1
+github "cossacklabs/themis" ~> 0.13.0

--- a/docs/examples/swift/iOS-CocoaPods/Podfile
+++ b/docs/examples/swift/iOS-CocoaPods/Podfile
@@ -23,6 +23,6 @@ use_frameworks!
 
 target :"ThemisSwift" do
 
-  pod 'themis', '0.12.2'
+  pod 'themis', '0.13.0'
 
 end

--- a/docs/examples/swift/macOS-Carthage/Cartfile
+++ b/docs/examples/swift/macOS-Carthage/Cartfile
@@ -1,1 +1,1 @@
-github "cossacklabs/themis" ~> 0.12.1
+github "cossacklabs/themis" ~> 0.13.0


### PR DESCRIPTION
The current release playbook implied that this should be updated after the release is complete, but apparently example project versions need to be updated simultaneously with tagging 0.13.0.

## Checklist

- [X] Change is covered by automated tests
- [X] Example projects and code samples are up-to-date