### PR TITLE
Fix AndroidThemis publishing

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,10 @@
-# Enable "configuration on demand" [1] to allow building Themis for
-# Desktop Java without having Android SDK installed.
+# We'd like to enable "configuration on demand" [1] to allow building Themis
+# for Desktop Java without having Android SDK installed, but for some reason
+# it breaks Bintray publishing with a weird error [2]. Keep it disabled.
 #
 # [1]: https://docs.gradle.org/current/userguide/multi_project_builds.html#sec:configuration_on_demand
-org.gradle.configureondemand=true
+# [2]: https://stackoverflow.com/questions/42552511/cannot-change-dependencies-of-configuration-compile-after-it-has-been-resolve
+org.gradle.configureondemand=false
 
 # Versions of AndroidThemis and JavaThemis packages.
 androidThemisVersion=0.13.0

--- a/src/wrappers/themis/android/build.gradle
+++ b/src/wrappers/themis/android/build.gradle
@@ -102,7 +102,7 @@ apply plugin: 'maven-publish'
 publishing {
     publications {
         Production(MavenPublication) {
-            artifact("$buildDir/outputs/aar/projects-release.aar")
+            artifact("build/outputs/aar/android.aar")
             groupId 'com.cossacklabs.com'
             artifactId 'themis'
             version androidThemisVersion

--- a/src/wrappers/themis/android/build.gradle
+++ b/src/wrappers/themis/android/build.gradle
@@ -114,7 +114,6 @@ bintray {
     // Get Bintray credential from environment variable
     user = System.getenv('BINTRAY_USER') // Get bintray User
     key = System.getenv('BINTRAY_KEY') // Get bintray API Key from https://bintray.com/profile/edit -> APIKey
-    configurations = ['archives']
     pkg {
         repo = 'maven'
         name = 'themis'

--- a/src/wrappers/themis/android/build.gradle
+++ b/src/wrappers/themis/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
         // Two necessary plugins for uploading .aar to bintray
         // from: https://android.jlelse.eu/how-to-distribute-android-library-in-a-convenient-way-d43fb68304a7
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
 
         // Kotlin plugin for Android

--- a/src/wrappers/themis/java/build.gradle
+++ b/src/wrappers/themis/java/build.gradle
@@ -8,15 +8,6 @@ buildscript {
     }
 }
 
-sourceSets {
-    main {
-        java.srcDirs = ['.']
-    }
-    test {
-        java.srcDirs = ['../../../../tests/themis/wrappers/android']
-    }
-}
-
 dependencies {
     // Nullable annotations, etc.
     // Use a compatibility version to support Java 6.
@@ -27,6 +18,15 @@ dependencies {
     testImplementation 'commons-codec:commons-codec:1.2'
     // Kotlin for unit tests
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+}
+
+sourceSets {
+    main {
+        java.srcDirs = ['.']
+    }
+    test {
+        java.srcDirs = ['../../../../tests/themis/wrappers/android']
+    }
 }
 
 test {


### PR DESCRIPTION
During the release procedures we have found that AndroidThemis fails to publish correctly. This seems to be a side effect brought by Gradle configuration changes such as #633 and #637. Since we don't release that often and there is no automated testing for the release flow, the issues have been discovered only now.

Initially I suspected that the configuration was wrong in some way—and it was, but it's not _that_ broken. After several attempts to revert and roll back version of Gradle, its plugin, etc. I have finally found that the Bintray publishing plugin should be upgraded. Apparently, it is required to work with new Gradle plugin. (We need to upgrade Gradle to at least 4.9 to support Kotlin.)

Technical details are in the commit messages. On visible side effect is that Android SDK now must be installed and configured to build desktop JavaThemis. This is because we keep both Android and desktop Java in the same Gradle configuration and Gradle build dependencies are resolved for all subprojects (regardless of what you're building).

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
