### PR TITLE
Keep on-demand configuration enabled

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,13 @@
 # We'd like to enable "configuration on demand" [1] to allow building Themis
 # for Desktop Java without having Android SDK installed, but for some reason
-# it breaks Bintray publishing with a weird error [2]. Keep it disabled.
+# it breaks Bintray publishing with a weird error [2].
+#
+# This option is enabled to keep regular builds working, but you will need
+# to set it to "false" to run "./gradlew :android:bintrayUpload".
 #
 # [1]: https://docs.gradle.org/current/userguide/multi_project_builds.html#sec:configuration_on_demand
 # [2]: https://stackoverflow.com/questions/42552511/cannot-change-dependencies-of-configuration-compile-after-it-has-been-resolve
-org.gradle.configureondemand=false
+org.gradle.configureondemand=true
 
 # Versions of AndroidThemis and JavaThemis packages.
 androidThemisVersion=0.13.0


### PR DESCRIPTION
As previously noted, having this option disabled makes it so that Android SDK is required to build desktop Java targets (`:desktop...`). Unfortunately, this breaks Buildbot checks which does not have Android SDK installed it is build environments.

However, we also need to disable this option to work around an issue in Bintray publishing (#669).

Since publishing to Bintray is a manual action and build checks are automatic, let's favor the automation. We will have to manually disable the option when making AndroidThemis release, but keep it enabled for regular builds to pass. Hopefully, we'll fix the issue some day.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] Public API has proper documentation

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md