### PR TITLE
Update CocoaPods repository

### DIFF
--- a/.github/workflows/test-objc.yaml
+++ b/.github/workflows/test-objc.yaml
@@ -78,6 +78,9 @@ jobs:
         with:
           path: ~/.cocoapods
           key: ${{ runner.os }}-cocoapods-common
+      - name: Update CocoaPods repo
+        run: |
+          pod repo update
       - name: Install Themis via CocoaPods
         run: |
           cd $GITHUB_WORKSPACE/tests/objcthemis
@@ -234,6 +237,9 @@ jobs:
         with:
           path: ~/.cocoapods
           key: ${{ runner.os }}-cocoapods-common
+      - name: Update CocoaPods repo
+        run: |
+          pod repo update
       # Try building Themis for all iOS device architectures. We do it here
       # because CocoaPods does not allow to check that directly but with
       # example projects it's more or less possible.


### PR DESCRIPTION
After restoring CocoaPods from cache we also need to fetch the latest updates which were not cached yet. This is not noticeable most of the time, but otherwise it breaks builds right after a new version of Themis is released on CocoaPods and we can't fetch it because the repo is not updated yet.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
