### PR TITLE
Update Obj-C/Swift examples to Themis 0.13

### DIFF
--- a/docs/examples/Themis-server/Obj-C/Podfile.lock
+++ b/docs/examples/Themis-server/Obj-C/Podfile.lock
@@ -1,19 +1,19 @@
 PODS:
   - GRKOpenSSLFramework (1.0.2.18)
-  - themis (0.12.2):
-    - themis/themis-openssl (= 0.12.2)
-  - themis/themis-openssl (0.12.2):
+  - themis (0.13.0):
+    - themis/themis-openssl (= 0.13.0)
+  - themis/themis-openssl (0.13.0):
     - GRKOpenSSLFramework (= 1.0.2.18)
-    - themis/themis-openssl/core (= 0.12.2)
-    - themis/themis-openssl/objcwrapper (= 0.12.2)
-  - themis/themis-openssl/core (0.12.2):
+    - themis/themis-openssl/core (= 0.13.0)
+    - themis/themis-openssl/objcwrapper (= 0.13.0)
+  - themis/themis-openssl/core (0.13.0):
     - GRKOpenSSLFramework (= 1.0.2.18)
-  - themis/themis-openssl/objcwrapper (0.12.2):
+  - themis/themis-openssl/objcwrapper (0.13.0):
     - GRKOpenSSLFramework (= 1.0.2.18)
     - themis/themis-openssl/core
 
 DEPENDENCIES:
-  - themis (= 0.12.2)
+  - themis (= 0.13.0)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
@@ -22,8 +22,8 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   GRKOpenSSLFramework: 1d65e55d569af7b23074373041a92cc8bc768a92
-  themis: f4ef6d942670146ad08dca8cc99a34ae040878c0
+  themis: dd1eaa51265a384b20a4cfbac83326cbb3b1b67c
 
-PODFILE CHECKSUM: 0a484fd4a2a45b6c10bd42ee2fabc1b848bf01e4
+PODFILE CHECKSUM: 5a28afa13f7293eb555ebf751d8ca8dcc162d03b
 
-COCOAPODS: 1.8.0
+COCOAPODS: 1.9.3

--- a/docs/examples/Themis-server/swift/Podfile.lock
+++ b/docs/examples/Themis-server/swift/Podfile.lock
@@ -1,19 +1,19 @@
 PODS:
   - GRKOpenSSLFramework (1.0.2.18)
-  - themis (0.12.2):
-    - themis/themis-openssl (= 0.12.2)
-  - themis/themis-openssl (0.12.2):
+  - themis (0.13.0):
+    - themis/themis-openssl (= 0.13.0)
+  - themis/themis-openssl (0.13.0):
     - GRKOpenSSLFramework (= 1.0.2.18)
-    - themis/themis-openssl/core (= 0.12.2)
-    - themis/themis-openssl/objcwrapper (= 0.12.2)
-  - themis/themis-openssl/core (0.12.2):
+    - themis/themis-openssl/core (= 0.13.0)
+    - themis/themis-openssl/objcwrapper (= 0.13.0)
+  - themis/themis-openssl/core (0.13.0):
     - GRKOpenSSLFramework (= 1.0.2.18)
-  - themis/themis-openssl/objcwrapper (0.12.2):
+  - themis/themis-openssl/objcwrapper (0.13.0):
     - GRKOpenSSLFramework (= 1.0.2.18)
     - themis/themis-openssl/core
 
 DEPENDENCIES:
-  - themis (= 0.12.2)
+  - themis (= 0.13.0)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
@@ -22,8 +22,8 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   GRKOpenSSLFramework: 1d65e55d569af7b23074373041a92cc8bc768a92
-  themis: f4ef6d942670146ad08dca8cc99a34ae040878c0
+  themis: dd1eaa51265a384b20a4cfbac83326cbb3b1b67c
 
-PODFILE CHECKSUM: d7dae54b949059d61e288647dc393da42fb7eeec
+PODFILE CHECKSUM: 676d314076224e843e834ed3b41c08a10b072a2c
 
-COCOAPODS: 1.8.0
+COCOAPODS: 1.9.3

--- a/docs/examples/objc/iOS-Carthage/Cartfile.resolved
+++ b/docs/examples/objc/iOS-Carthage/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "cossacklabs/themis" "0.12.1"
+github "cossacklabs/themis" "0.13.0"
 github "krzyzanowskim/OpenSSL" "990bd88219da80d7a77289aeae245b3eb400d834"

--- a/docs/examples/objc/iOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
+++ b/docs/examples/objc/iOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
@@ -13,14 +13,14 @@
 		9F00EA362241539900EC1EF3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9F00EA352241539900EC1EF3 /* Assets.xcassets */; };
 		9F00EA392241539900EC1EF3 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9F00EA372241539900EC1EF3 /* LaunchScreen.storyboard */; };
 		9F00EA3C2241539900EC1EF3 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F00EA3B2241539900EC1EF3 /* main.m */; };
-		9F00EA452241555100EC1EF3 /* themis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00EA432241555100EC1EF3 /* themis.framework */; };
-		9F00EA482241555700EC1EF3 /* themis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00EA432241555100EC1EF3 /* themis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F00EA4A2241555900EC1EF3 /* openssl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00EA442241555100EC1EF3 /* openssl.framework */; };
 		9F00EA4B2241555900EC1EF3 /* openssl.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00EA442241555100EC1EF3 /* openssl.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F00EA522241563800EC1EF3 /* server.priv in Resources */ = {isa = PBXBuildFile; fileRef = 9F00EA4E2241563800EC1EF3 /* server.priv */; };
 		9F00EA532241563800EC1EF3 /* client.priv in Resources */ = {isa = PBXBuildFile; fileRef = 9F00EA4F2241563800EC1EF3 /* client.priv */; };
 		9F00EA542241563800EC1EF3 /* server.pub in Resources */ = {isa = PBXBuildFile; fileRef = 9F00EA502241563800EC1EF3 /* server.pub */; };
 		9F00EA552241563800EC1EF3 /* client.pub in Resources */ = {isa = PBXBuildFile; fileRef = 9F00EA512241563800EC1EF3 /* client.pub */; };
+		9FCAA6A72493CA17002A2CE1 /* objcthemis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FCAA6A52493CA03002A2CE1 /* objcthemis.framework */; };
+		9FCAA6A82493CA17002A2CE1 /* objcthemis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9FCAA6A52493CA03002A2CE1 /* objcthemis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -30,7 +30,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				9F00EA482241555700EC1EF3 /* themis.framework in Embed Frameworks */,
+				9FCAA6A82493CA17002A2CE1 /* objcthemis.framework in Embed Frameworks */,
 				9F00EA4B2241555900EC1EF3 /* openssl.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -49,12 +49,12 @@
 		9F00EA382241539900EC1EF3 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		9F00EA3A2241539900EC1EF3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9F00EA3B2241539900EC1EF3 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
-		9F00EA432241555100EC1EF3 /* themis.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = themis.framework; path = Carthage/Build/iOS/themis.framework; sourceTree = "<group>"; };
 		9F00EA442241555100EC1EF3 /* openssl.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = openssl.framework; path = Carthage/Build/iOS/openssl.framework; sourceTree = "<group>"; };
 		9F00EA4E2241563800EC1EF3 /* server.priv */ = {isa = PBXFileReference; lastKnownFileType = file; path = server.priv; sourceTree = "<group>"; };
 		9F00EA4F2241563800EC1EF3 /* client.priv */ = {isa = PBXFileReference; lastKnownFileType = file; path = client.priv; sourceTree = "<group>"; };
 		9F00EA502241563800EC1EF3 /* server.pub */ = {isa = PBXFileReference; lastKnownFileType = file; path = server.pub; sourceTree = "<group>"; };
 		9F00EA512241563800EC1EF3 /* client.pub */ = {isa = PBXFileReference; lastKnownFileType = file; path = client.pub; sourceTree = "<group>"; };
+		9FCAA6A52493CA03002A2CE1 /* objcthemis.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = objcthemis.framework; path = Carthage/Build/iOS/objcthemis.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -62,8 +62,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9FCAA6A72493CA17002A2CE1 /* objcthemis.framework in Frameworks */,
 				9F00EA4A2241555900EC1EF3 /* openssl.framework in Frameworks */,
-				9F00EA452241555100EC1EF3 /* themis.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -107,8 +107,8 @@
 		9F00EA422241555100EC1EF3 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				9FCAA6A52493CA03002A2CE1 /* objcthemis.framework */,
 				9F00EA442241555100EC1EF3 /* openssl.framework */,
-				9F00EA432241555100EC1EF3 /* themis.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/docs/examples/objc/iOS-Carthage/ThemisTest/AppDelegate.m
+++ b/docs/examples/objc/iOS-Carthage/ThemisTest/AppDelegate.m
@@ -67,10 +67,10 @@
     NSError *themisError;
 
 
-    // context is optional parameter and may be ignored
-    NSData *encryptedMessage = [cellSeal wrapData:[message dataUsingEncoding:NSUTF8StringEncoding]
-                                          context:[context dataUsingEncoding:NSUTF8StringEncoding]
-                                            error:&themisError];
+    // context is optional parameter and may be omitted
+    NSData *encryptedMessage = [cellSeal encrypt:[message dataUsingEncoding:NSUTF8StringEncoding]
+                                         context:[context dataUsingEncoding:NSUTF8StringEncoding]
+                                           error:&themisError];
 
     if (themisError) {
         NSLog(@"%s Error occurred while enrypting %@", sel_getName(_cmd), themisError);
@@ -78,9 +78,9 @@
     }
     NSLog(@"encryptedMessage = %@", encryptedMessage);
 
-    NSData *decryptedMessage = [cellSeal unwrapData:encryptedMessage
-                                            context:[context dataUsingEncoding:NSUTF8StringEncoding]
-                                              error:&themisError];
+    NSData *decryptedMessage = [cellSeal decrypt:encryptedMessage
+                                         context:[context dataUsingEncoding:NSUTF8StringEncoding]
+                                           error:&themisError];
     if (themisError) {
         NSLog(@"%s Error occurred while decrypting %@", sel_getName(_cmd), themisError);
         return;
@@ -105,18 +105,20 @@
     NSString *context = @"I'm a dog";
     NSError *themisError;
 
-    // context is optional parameter and may be ignored
-    TSCellTokenEncryptedData *encryptedMessage = [cellToken wrapData:[message dataUsingEncoding:NSUTF8StringEncoding]
-                                                             context:[context dataUsingEncoding:NSUTF8StringEncoding]
-                                                               error:&themisError];
+    // context is optional parameter and may be omitted
+    TSCellTokenEncryptedResult *encryptedMessage = [cellToken encrypt:[message dataUsingEncoding:NSUTF8StringEncoding]
+                                                              context:[context dataUsingEncoding:NSUTF8StringEncoding]
+                                                                error:&themisError];
     if (themisError) {
         NSLog(@"%s Error occurred while enrypting %@", sel_getName(_cmd), themisError);
         return;
     }
-    NSLog(@"%s\ncipher = %@:\ntoken = %@", sel_getName(_cmd), encryptedMessage.cipherText,encryptedMessage.token);
+    NSLog(@"%s\ncipher = %@:\ntoken = %@", sel_getName(_cmd), encryptedMessage.encrypted, encryptedMessage.token);
 
-    NSData *decryptedMessage = [cellToken unwrapData:encryptedMessage
-                                             context:[context dataUsingEncoding:NSUTF8StringEncoding] error:&themisError];
+    NSData *decryptedMessage = [cellToken decrypt:encryptedMessage.encrypted
+                                            token:encryptedMessage.token
+                                          context:[context dataUsingEncoding:NSUTF8StringEncoding]
+                                            error:&themisError];
     if (themisError) {
         NSLog(@"%s Error occurred while decrypting %@", sel_getName(_cmd), themisError);
         return;
@@ -142,9 +144,9 @@
     NSError *themisError;
 
     // context is not optional parameter here
-    NSData *encryptedMessage = [contextImprint wrapData:[message dataUsingEncoding:NSUTF8StringEncoding]
-                                                context:[context dataUsingEncoding:NSUTF8StringEncoding]
-                                                  error:&themisError];
+    NSData *encryptedMessage = [contextImprint encrypt:[message dataUsingEncoding:NSUTF8StringEncoding]
+                                               context:[context dataUsingEncoding:NSUTF8StringEncoding]
+                                                 error:&themisError];
     if (themisError) {
         NSLog(@"%s Error occurred while enrypting %@", sel_getName(_cmd), themisError);
         return;
@@ -152,9 +154,9 @@
     NSLog(@"%@", encryptedMessage);
 
     // context is not optional parameter here
-    NSData *decryptedMessage = [contextImprint unwrapData:encryptedMessage
-                                                  context:[context dataUsingEncoding:NSUTF8StringEncoding]
-                                                    error:&themisError];
+    NSData *decryptedMessage = [contextImprint decrypt:encryptedMessage
+                                               context:[context dataUsingEncoding:NSUTF8StringEncoding]
+                                                 error:&themisError];
     if (themisError) {
         NSLog(@"%s Error occurred while decrypting %@", sel_getName(_cmd), themisError);
         return;

--- a/docs/examples/objc/iOS-Carthage/ThemisTest/AppDelegate.m
+++ b/docs/examples/objc/iOS-Carthage/ThemisTest/AppDelegate.m
@@ -14,7 +14,7 @@
 
 #import "AppDelegate.h"
 
-#import <themis/themis.h>
+#import <objcthemis/objcthemis.h>
 
 @interface AppDelegate ()
 

--- a/docs/examples/objc/iOS-CocoaPods/Podfile.lock
+++ b/docs/examples/objc/iOS-CocoaPods/Podfile.lock
@@ -1,19 +1,19 @@
 PODS:
   - GRKOpenSSLFramework (1.0.2.18)
-  - themis (0.12.2):
-    - themis/themis-openssl (= 0.12.2)
-  - themis/themis-openssl (0.12.2):
+  - themis (0.13.0):
+    - themis/themis-openssl (= 0.13.0)
+  - themis/themis-openssl (0.13.0):
     - GRKOpenSSLFramework (= 1.0.2.18)
-    - themis/themis-openssl/core (= 0.12.2)
-    - themis/themis-openssl/objcwrapper (= 0.12.2)
-  - themis/themis-openssl/core (0.12.2):
+    - themis/themis-openssl/core (= 0.13.0)
+    - themis/themis-openssl/objcwrapper (= 0.13.0)
+  - themis/themis-openssl/core (0.13.0):
     - GRKOpenSSLFramework (= 1.0.2.18)
-  - themis/themis-openssl/objcwrapper (0.12.2):
+  - themis/themis-openssl/objcwrapper (0.13.0):
     - GRKOpenSSLFramework (= 1.0.2.18)
     - themis/themis-openssl/core
 
 DEPENDENCIES:
-  - themis (= 0.12.2)
+  - themis (= 0.13.0)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
@@ -22,8 +22,8 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   GRKOpenSSLFramework: 1d65e55d569af7b23074373041a92cc8bc768a92
-  themis: f4ef6d942670146ad08dca8cc99a34ae040878c0
+  themis: dd1eaa51265a384b20a4cfbac83326cbb3b1b67c
 
-PODFILE CHECKSUM: fed7ab7061ee5b8f0c8cd13d6f59c51828473cac
+PODFILE CHECKSUM: cd2aec2527fc0d2fd8fff77f34a88585958148ff
 
-COCOAPODS: 1.8.0
+COCOAPODS: 1.9.3

--- a/docs/examples/objc/iOS-CocoaPods/ThemisTest/ThemisTest/Classes/AppDelegate.m
+++ b/docs/examples/objc/iOS-CocoaPods/ThemisTest/ThemisTest/Classes/AppDelegate.m
@@ -81,10 +81,10 @@
     NSError * themisError;
 
 
-    // context is optional parameter and may be ignored
-    NSData * encryptedMessage = [cellSeal wrapData:[message dataUsingEncoding:NSUTF8StringEncoding]
-                                           context:[context dataUsingEncoding:NSUTF8StringEncoding]
-                                             error:&themisError];
+    // context is optional parameter and may be omitted
+    NSData * encryptedMessage = [cellSeal encrypt:[message dataUsingEncoding:NSUTF8StringEncoding]
+                                          context:[context dataUsingEncoding:NSUTF8StringEncoding]
+                                            error:&themisError];
 
     if (themisError) {
         NSLog(@"%s Error occurred while enrypting %@", sel_getName(_cmd), themisError);
@@ -92,9 +92,9 @@
     }
     NSLog(@"encryptedMessage = %@", encryptedMessage);
 
-    NSData * decryptedMessage = [cellSeal unwrapData:encryptedMessage
-                                             context:[context dataUsingEncoding:NSUTF8StringEncoding]
-                                               error:&themisError];
+    NSData * decryptedMessage = [cellSeal decrypt:encryptedMessage
+                                          context:[context dataUsingEncoding:NSUTF8StringEncoding]
+                                            error:&themisError];
     if (themisError) {
         NSLog(@"%s Error occurred while decrypting %@", sel_getName(_cmd), themisError);
         return;
@@ -120,18 +120,20 @@
     NSString * context = @"I'm a dog";
     NSError * themisError;
 
-    // context is optional parameter and may be ignored
-    TSCellTokenEncryptedData * encryptedMessage = [cellToken wrapData:[message dataUsingEncoding:NSUTF8StringEncoding]
-                                                              context:[context dataUsingEncoding:NSUTF8StringEncoding]
-                                                                error:&themisError];
+    // context is optional parameter and may be omitted
+    TSCellTokenEncryptedResult * encryptedMessage = [cellToken encrypt:[message dataUsingEncoding:NSUTF8StringEncoding]
+                                                               context:[context dataUsingEncoding:NSUTF8StringEncoding]
+                                                                 error:&themisError];
     if (themisError) {
         NSLog(@"%s Error occurred while enrypting %@", sel_getName(_cmd), themisError);
         return;
     }
-    NSLog(@"%s\ncipher = %@:\ntoken = %@", sel_getName(_cmd), encryptedMessage.cipherText,encryptedMessage.token);
+    NSLog(@"%s\ncipher = %@:\ntoken = %@", sel_getName(_cmd), encryptedMessage.encrypted, encryptedMessage.token);
 
-    NSData * decryptedMessage = [cellToken unwrapData:encryptedMessage
-                                              context:[context dataUsingEncoding:NSUTF8StringEncoding] error:&themisError];
+    NSData * decryptedMessage = [cellToken decrypt:encryptedMessage.encrypted
+                                             token:encryptedMessage.token
+                                           context:[context dataUsingEncoding:NSUTF8StringEncoding]
+                                             error:&themisError];
     if (themisError) {
         NSLog(@"%s Error occurred while decrypting %@", sel_getName(_cmd), themisError);
         return;
@@ -158,9 +160,9 @@
     NSError * themisError;
 
     // context is not optional parameter here
-    NSData * encryptedMessage = [contextImprint wrapData:[message dataUsingEncoding:NSUTF8StringEncoding]
-                                                 context:[context dataUsingEncoding:NSUTF8StringEncoding]
-                                                   error:&themisError];
+    NSData * encryptedMessage = [contextImprint encrypt:[message dataUsingEncoding:NSUTF8StringEncoding]
+                                                context:[context dataUsingEncoding:NSUTF8StringEncoding]
+                                                  error:&themisError];
     if (themisError) {
         NSLog(@"%s Error occurred while enrypting %@", sel_getName(_cmd), themisError);
         return;
@@ -168,9 +170,9 @@
     NSLog(@"%@", encryptedMessage);
 
     // context is not optional parameter here
-    NSData * decryptedMessage = [contextImprint unwrapData:encryptedMessage
-                                                   context:[context dataUsingEncoding:NSUTF8StringEncoding]
-                                                     error:&themisError];
+    NSData * decryptedMessage = [contextImprint decrypt:encryptedMessage
+                                                context:[context dataUsingEncoding:NSUTF8StringEncoding]
+                                                  error:&themisError];
     if (themisError) {
         NSLog(@"%s Error occurred while decrypting %@", sel_getName(_cmd), themisError);
         return;

--- a/docs/examples/objc/macOS-Carthage/Cartfile.resolved
+++ b/docs/examples/objc/macOS-Carthage/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "cossacklabs/themis" "0.12.1"
+github "cossacklabs/themis" "0.13.0"
 github "krzyzanowskim/OpenSSL" "990bd88219da80d7a77289aeae245b3eb400d834"

--- a/docs/examples/objc/macOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
+++ b/docs/examples/objc/macOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
@@ -11,14 +11,14 @@
 		9F00EA002241348800EC1EF3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9F00E9FF2241348800EC1EF3 /* Assets.xcassets */; };
 		9F00EA032241348800EC1EF3 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9F00EA012241348800EC1EF3 /* MainMenu.xib */; };
 		9F00EA062241348800EC1EF3 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F00EA052241348800EC1EF3 /* main.m */; };
-		9F00EA11224135A300EC1EF3 /* themis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00EA0F224135A300EC1EF3 /* themis.framework */; };
-		9F00EA13224135AB00EC1EF3 /* themis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00EA0F224135A300EC1EF3 /* themis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F00EA15224135AD00EC1EF3 /* openssl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00EA0E224135A300EC1EF3 /* openssl.framework */; };
 		9F00EA16224135AD00EC1EF3 /* openssl.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00EA0E224135A300EC1EF3 /* openssl.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F00EA1C22413D1300EC1EF3 /* client.pub in Resources */ = {isa = PBXBuildFile; fileRef = 9F00EA1822413D1300EC1EF3 /* client.pub */; };
 		9F00EA1D22413D1300EC1EF3 /* client.priv in Resources */ = {isa = PBXBuildFile; fileRef = 9F00EA1922413D1300EC1EF3 /* client.priv */; };
 		9F00EA1E22413D1300EC1EF3 /* server.pub in Resources */ = {isa = PBXBuildFile; fileRef = 9F00EA1A22413D1300EC1EF3 /* server.pub */; };
 		9F00EA1F22413D1300EC1EF3 /* server.priv in Resources */ = {isa = PBXBuildFile; fileRef = 9F00EA1B22413D1300EC1EF3 /* server.priv */; };
+		9FCAA6AB2493CC35002A2CE1 /* objcthemis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FCAA6A92493CC32002A2CE1 /* objcthemis.framework */; };
+		9FCAA6AC2493CC35002A2CE1 /* objcthemis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9FCAA6A92493CC32002A2CE1 /* objcthemis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -28,7 +28,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				9F00EA13224135AB00EC1EF3 /* themis.framework in Embed Frameworks */,
+				9FCAA6AC2493CC35002A2CE1 /* objcthemis.framework in Embed Frameworks */,
 				9F00EA16224135AD00EC1EF3 /* openssl.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -46,11 +46,11 @@
 		9F00EA052241348800EC1EF3 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		9F00EA072241348800EC1EF3 /* ThemisTest.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ThemisTest.entitlements; sourceTree = "<group>"; };
 		9F00EA0E224135A300EC1EF3 /* openssl.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = openssl.framework; path = Carthage/Build/Mac/openssl.framework; sourceTree = "<group>"; };
-		9F00EA0F224135A300EC1EF3 /* themis.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = themis.framework; path = Carthage/Build/Mac/themis.framework; sourceTree = "<group>"; };
 		9F00EA1822413D1300EC1EF3 /* client.pub */ = {isa = PBXFileReference; lastKnownFileType = file; path = client.pub; sourceTree = "<group>"; };
 		9F00EA1922413D1300EC1EF3 /* client.priv */ = {isa = PBXFileReference; lastKnownFileType = file; path = client.priv; sourceTree = "<group>"; };
 		9F00EA1A22413D1300EC1EF3 /* server.pub */ = {isa = PBXFileReference; lastKnownFileType = file; path = server.pub; sourceTree = "<group>"; };
 		9F00EA1B22413D1300EC1EF3 /* server.priv */ = {isa = PBXFileReference; lastKnownFileType = file; path = server.priv; sourceTree = "<group>"; };
+		9FCAA6A92493CC32002A2CE1 /* objcthemis.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = objcthemis.framework; path = Carthage/Build/Mac/objcthemis.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -58,8 +58,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9FCAA6AB2493CC35002A2CE1 /* objcthemis.framework in Frameworks */,
 				9F00EA15224135AD00EC1EF3 /* openssl.framework in Frameworks */,
-				9F00EA11224135A300EC1EF3 /* themis.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -101,8 +101,8 @@
 		9F00EA0D224135A300EC1EF3 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				9FCAA6A92493CC32002A2CE1 /* objcthemis.framework */,
 				9F00EA0E224135A300EC1EF3 /* openssl.framework */,
-				9F00EA0F224135A300EC1EF3 /* themis.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/docs/examples/objc/macOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
+++ b/docs/examples/objc/macOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
@@ -327,8 +327,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ThemisTest/ThemisTest.entitlements;
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/Mac",
@@ -349,8 +351,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ThemisTest/ThemisTest.entitlements;
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/Mac",

--- a/docs/examples/objc/macOS-Carthage/ThemisTest/AppDelegate.m
+++ b/docs/examples/objc/macOS-Carthage/ThemisTest/AppDelegate.m
@@ -61,10 +61,10 @@
     NSError *themisError;
 
 
-    // context is optional parameter and may be ignored
-    NSData *encryptedMessage = [cellSeal wrapData:[message dataUsingEncoding:NSUTF8StringEncoding]
-                                           context:[context dataUsingEncoding:NSUTF8StringEncoding]
-                                             error:&themisError];
+    // context is optional parameter and may be omitted
+    NSData *encryptedMessage = [cellSeal encrypt:[message dataUsingEncoding:NSUTF8StringEncoding]
+                                         context:[context dataUsingEncoding:NSUTF8StringEncoding]
+                                           error:&themisError];
 
     if (themisError) {
         NSLog(@"%s Error occurred while enrypting %@", sel_getName(_cmd), themisError);
@@ -72,9 +72,9 @@
     }
     NSLog(@"encryptedMessage = %@", encryptedMessage);
 
-    NSData *decryptedMessage = [cellSeal unwrapData:encryptedMessage
-                                             context:[context dataUsingEncoding:NSUTF8StringEncoding]
-                                               error:&themisError];
+    NSData *decryptedMessage = [cellSeal decrypt:encryptedMessage
+                                         context:[context dataUsingEncoding:NSUTF8StringEncoding]
+                                           error:&themisError];
     if (themisError) {
         NSLog(@"%s Error occurred while decrypting %@", sel_getName(_cmd), themisError);
         return;
@@ -99,18 +99,20 @@
     NSString *context = @"I'm a dog";
     NSError *themisError;
 
-    // context is optional parameter and may be ignored
-    TSCellTokenEncryptedData *encryptedMessage = [cellToken wrapData:[message dataUsingEncoding:NSUTF8StringEncoding]
+    // context is optional parameter and may be omitted
+    TSCellTokenEncryptedResult *encryptedMessage = [cellToken encrypt:[message dataUsingEncoding:NSUTF8StringEncoding]
                                                               context:[context dataUsingEncoding:NSUTF8StringEncoding]
                                                                 error:&themisError];
     if (themisError) {
         NSLog(@"%s Error occurred while enrypting %@", sel_getName(_cmd), themisError);
         return;
     }
-    NSLog(@"%s\ncipher = %@:\ntoken = %@", sel_getName(_cmd), encryptedMessage.cipherText,encryptedMessage.token);
+    NSLog(@"%s\ncipher = %@:\ntoken = %@", sel_getName(_cmd), encryptedMessage.encrypted, encryptedMessage.token);
 
-    NSData *decryptedMessage = [cellToken unwrapData:encryptedMessage
-                                              context:[context dataUsingEncoding:NSUTF8StringEncoding] error:&themisError];
+    NSData *decryptedMessage = [cellToken decrypt:encryptedMessage.encrypted
+                                            token:encryptedMessage.token
+                                          context:[context dataUsingEncoding:NSUTF8StringEncoding]
+                                            error:&themisError];
     if (themisError) {
         NSLog(@"%s Error occurred while decrypting %@", sel_getName(_cmd), themisError);
         return;
@@ -136,9 +138,9 @@
     NSError *themisError;
 
     // context is not optional parameter here
-    NSData *encryptedMessage = [contextImprint wrapData:[message dataUsingEncoding:NSUTF8StringEncoding]
-                                                 context:[context dataUsingEncoding:NSUTF8StringEncoding]
-                                                   error:&themisError];
+    NSData *encryptedMessage = [contextImprint encrypt:[message dataUsingEncoding:NSUTF8StringEncoding]
+                                               context:[context dataUsingEncoding:NSUTF8StringEncoding]
+                                                 error:&themisError];
     if (themisError) {
         NSLog(@"%s Error occurred while enrypting %@", sel_getName(_cmd), themisError);
         return;
@@ -146,9 +148,9 @@
     NSLog(@"%@", encryptedMessage);
 
     // context is not optional parameter here
-    NSData *decryptedMessage = [contextImprint unwrapData:encryptedMessage
-                                                   context:[context dataUsingEncoding:NSUTF8StringEncoding]
-                                                     error:&themisError];
+    NSData *decryptedMessage = [contextImprint decrypt:encryptedMessage
+                                               context:[context dataUsingEncoding:NSUTF8StringEncoding]
+                                                 error:&themisError];
     if (themisError) {
         NSLog(@"%s Error occurred while decrypting %@", sel_getName(_cmd), themisError);
         return;

--- a/docs/examples/objc/macOS-Carthage/ThemisTest/AppDelegate.m
+++ b/docs/examples/objc/macOS-Carthage/ThemisTest/AppDelegate.m
@@ -14,7 +14,7 @@
 
 #import "AppDelegate.h"
 
-#import <themis/themis.h>
+#import <objcthemis/objcthemis.h>
 
 @implementation AppDelegate
 

--- a/docs/examples/swift/iOS-Carthage/Cartfile.resolved
+++ b/docs/examples/swift/iOS-Carthage/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "cossacklabs/themis" "0.12.1"
+github "cossacklabs/themis" "0.13.0"
 github "krzyzanowskim/OpenSSL" "990bd88219da80d7a77289aeae245b3eb400d834"

--- a/docs/examples/swift/iOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
+++ b/docs/examples/swift/iOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
@@ -16,10 +16,10 @@
 		9F00E9B92241172400EC1EF3 /* client.priv in Resources */ = {isa = PBXBuildFile; fileRef = 9F00E9B52241172400EC1EF3 /* client.priv */; };
 		9F00E9BA2241172400EC1EF3 /* server.priv in Resources */ = {isa = PBXBuildFile; fileRef = 9F00E9B62241172400EC1EF3 /* server.priv */; };
 		9F00E9BB2241172400EC1EF3 /* client.pub in Resources */ = {isa = PBXBuildFile; fileRef = 9F00E9B72241172400EC1EF3 /* client.pub */; };
-		9F00E9BD22411CCF00EC1EF3 /* themis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E9BC22411CCF00EC1EF3 /* themis.framework */; };
-		9F00E9BF22411CD400EC1EF3 /* themis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E9BC22411CCF00EC1EF3 /* themis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F00E9C122411CD700EC1EF3 /* openssl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E9B0224115C200EC1EF3 /* openssl.framework */; };
 		9F00E9C222411CD700EC1EF3 /* openssl.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E9B0224115C200EC1EF3 /* openssl.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9FCAA6AF2493D478002A2CE1 /* objcthemis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FCAA6AD2493D46F002A2CE1 /* objcthemis.framework */; };
+		9FCAA6B02493D478002A2CE1 /* objcthemis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9FCAA6AD2493D46F002A2CE1 /* objcthemis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -29,7 +29,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				9F00E9BF22411CD400EC1EF3 /* themis.framework in Embed Frameworks */,
+				9FCAA6B02493D478002A2CE1 /* objcthemis.framework in Embed Frameworks */,
 				9F00E9C222411CD700EC1EF3 /* openssl.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -50,7 +50,7 @@
 		9F00E9B52241172400EC1EF3 /* client.priv */ = {isa = PBXFileReference; lastKnownFileType = file; path = client.priv; sourceTree = "<group>"; };
 		9F00E9B62241172400EC1EF3 /* server.priv */ = {isa = PBXFileReference; lastKnownFileType = file; path = server.priv; sourceTree = "<group>"; };
 		9F00E9B72241172400EC1EF3 /* client.pub */ = {isa = PBXFileReference; lastKnownFileType = file; path = client.pub; sourceTree = "<group>"; };
-		9F00E9BC22411CCF00EC1EF3 /* themis.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = themis.framework; path = Carthage/Build/iOS/themis.framework; sourceTree = "<group>"; };
+		9FCAA6AD2493D46F002A2CE1 /* objcthemis.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = objcthemis.framework; path = Carthage/Build/iOS/objcthemis.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -58,7 +58,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9F00E9BD22411CCF00EC1EF3 /* themis.framework in Frameworks */,
+				9FCAA6AF2493D478002A2CE1 /* objcthemis.framework in Frameworks */,
 				9F00E9C122411CD700EC1EF3 /* openssl.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -100,7 +100,7 @@
 		9F00E9AF224113A800EC1EF3 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				9F00E9BC22411CCF00EC1EF3 /* themis.framework */,
+				9FCAA6AD2493D46F002A2CE1 /* objcthemis.framework */,
 				9F00E9B0224115C200EC1EF3 /* openssl.framework */,
 			);
 			name = Frameworks;

--- a/docs/examples/swift/iOS-Carthage/ThemisTest/AppDelegate.swift
+++ b/docs/examples/swift/iOS-Carthage/ThemisTest/AppDelegate.swift
@@ -58,9 +58,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         var encryptedMessage: Data = Data()
         do {
-            // context is optional parameter and may be ignored
-            encryptedMessage = try cellSeal.wrap(message.data(using: .utf8)!,
-                                                 context: context.data(using: .utf8)!)
+            // context is optional parameter and may be omitted
+            encryptedMessage = try cellSeal.encrypt(message.data(using: .utf8)!,
+                                                    context: context.data(using: .utf8)!)
             print("decryptedMessagez = \(encryptedMessage)")
 
         } catch let error as NSError {
@@ -69,8 +69,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         do {
-            let decryptedMessage: Data = try cellSeal.unwrapData(encryptedMessage,
-                                                                 context: context.data(using: .utf8)!)
+            let decryptedMessage = try cellSeal.decrypt(encryptedMessage,
+                                                        context: context.data(using: .utf8)!)
             let resultString: String = String(data: decryptedMessage, encoding: .utf8)!
             print("decryptedMessage = \(resultString)")
 
@@ -90,12 +90,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let message: String = "Roses are grey. Violets are grey."
         let context: String = "I'm a dog"
 
-        var encryptedMessage: TSCellTokenEncryptedData = TSCellTokenEncryptedData()
+        var encryptedMessage = TSCellTokenEncryptedResult()
         do {
-            // context is optional parameter and may be ignored
-            encryptedMessage = try cellToken.wrap(message.data(using: .utf8)!,
-                                                  context: context.data(using: .utf8)!)
-            print("encryptedMessage.cipher = \(encryptedMessage.cipherText)")
+            // context is optional parameter and may be omitted
+            encryptedMessage = try cellToken.encrypt(message.data(using: .utf8)!,
+                                                     context: context.data(using: .utf8)!)
+            print("encryptedMessage.encrypted = \(encryptedMessage.encrypted)")
             print("encryptedMessage.token = \(encryptedMessage.token)")
 
         } catch let error as NSError {
@@ -104,8 +104,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         do {
-            let decryptedMessage: Data = try cellToken.unwrapData(encryptedMessage,
-                                                                  context: context.data(using: .utf8)!)
+            let decryptedMessage = try cellToken.decrypt(encryptedMessage.encrypted,
+                                                         token: encryptedMessage.token,
+                                                         context: context.data(using: .utf8)!)
             let resultString: String = String(data: decryptedMessage, encoding: .utf8)!
             print("decryptedMessage = \(resultString)")
 
@@ -128,8 +129,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         var encryptedMessage: Data = Data()
         do {
             // context is NOT optional parameter here
-            encryptedMessage = try contextImprint.wrap(message.data(using: .utf8)!,
-                                                       context: context.data(using: .utf8)!)
+            encryptedMessage = try contextImprint.encrypt(message.data(using: .utf8)!,
+                                                          context: context.data(using: .utf8)!)
             print("encryptedMessage = \(encryptedMessage)")
 
         } catch let error as NSError {
@@ -139,8 +140,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         do {
             // context is NOT optional parameter here
-            let decryptedMessage: Data = try contextImprint.unwrapData(encryptedMessage,
-                                                                       context: context.data(using: .utf8)!)
+            let decryptedMessage = try contextImprint.decrypt(encryptedMessage,
+                                                              context: context.data(using: .utf8)!)
             let resultString: String = String(data: decryptedMessage, encoding: .utf8)!
             print("decryptedMessage = \(resultString)")
 

--- a/docs/examples/swift/iOS-CocoaPods/Podfile.lock
+++ b/docs/examples/swift/iOS-CocoaPods/Podfile.lock
@@ -1,19 +1,19 @@
 PODS:
   - GRKOpenSSLFramework (1.0.2.18)
-  - themis (0.12.2):
-    - themis/themis-openssl (= 0.12.2)
-  - themis/themis-openssl (0.12.2):
+  - themis (0.13.0):
+    - themis/themis-openssl (= 0.13.0)
+  - themis/themis-openssl (0.13.0):
     - GRKOpenSSLFramework (= 1.0.2.18)
-    - themis/themis-openssl/core (= 0.12.2)
-    - themis/themis-openssl/objcwrapper (= 0.12.2)
-  - themis/themis-openssl/core (0.12.2):
+    - themis/themis-openssl/core (= 0.13.0)
+    - themis/themis-openssl/objcwrapper (= 0.13.0)
+  - themis/themis-openssl/core (0.13.0):
     - GRKOpenSSLFramework (= 1.0.2.18)
-  - themis/themis-openssl/objcwrapper (0.12.2):
+  - themis/themis-openssl/objcwrapper (0.13.0):
     - GRKOpenSSLFramework (= 1.0.2.18)
     - themis/themis-openssl/core
 
 DEPENDENCIES:
-  - themis (= 0.12.2)
+  - themis (= 0.13.0)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
@@ -22,8 +22,8 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   GRKOpenSSLFramework: 1d65e55d569af7b23074373041a92cc8bc768a92
-  themis: f4ef6d942670146ad08dca8cc99a34ae040878c0
+  themis: dd1eaa51265a384b20a4cfbac83326cbb3b1b67c
 
-PODFILE CHECKSUM: 0ecce665d872eed22efbc79e9784e8813eba3dd8
+PODFILE CHECKSUM: e0c05d83a39e6247258811a0d61b3eaa99b8889b
 
-COCOAPODS: 1.8.0
+COCOAPODS: 1.9.3

--- a/docs/examples/swift/iOS-CocoaPods/ThemisSwift/ThemisSwift/Classes/AppDelegate.swift
+++ b/docs/examples/swift/iOS-CocoaPods/ThemisSwift/ThemisSwift/Classes/AppDelegate.swift
@@ -58,9 +58,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         var encryptedMessage: Data = Data()
         do {
-            // context is optional parameter and may be ignored
-            encryptedMessage = try cellSeal.wrap(message.data(using: .utf8)!,
-                                                 context: context.data(using: .utf8)!)
+            // context is optional parameter and may be omitted
+            encryptedMessage = try cellSeal.encrypt(message.data(using: .utf8)!,
+                                                    context: context.data(using: .utf8)!)
             print("decryptedMessagez = \(encryptedMessage)")
             
         } catch let error as NSError {
@@ -69,8 +69,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
         
         do {
-            let decryptedMessage: Data = try cellSeal.unwrapData(encryptedMessage,
-                                                       context: context.data(using: .utf8)!)
+            let decryptedMessage = try cellSeal.decrypt(encryptedMessage,
+                                                        context: context.data(using: .utf8)!)
             let resultString: String = String(data: decryptedMessage, encoding: .utf8)!
             print("decryptedMessage = \(resultString)")
             
@@ -91,12 +91,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let message: String = "Roses are grey. Violets are grey."
         let context: String = "I'm a dog"
         
-        var encryptedMessage: TSCellTokenEncryptedData = TSCellTokenEncryptedData()
+        var encryptedMessage = TSCellTokenEncryptedResult()
         do {
-            // context is optional parameter and may be ignored
-            encryptedMessage = try cellToken.wrap(message.data(using: .utf8)!,
-                                                  context: context.data(using: .utf8)!)
-            print("encryptedMessage.cipher = \(encryptedMessage.cipherText)")
+            // context is optional parameter and may be omitted
+            encryptedMessage = try cellToken.encrypt(message.data(using: .utf8)!,
+                                                     context: context.data(using: .utf8)!)
+            print("encryptedMessage.encrypted = \(encryptedMessage.encrypted)")
             print("encryptedMessage.token = \(encryptedMessage.token)")
             
         } catch let error as NSError {
@@ -105,8 +105,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
         
         do {
-            let decryptedMessage: Data = try cellToken.unwrapData(encryptedMessage,
-                                                                  context: context.data(using: .utf8)!)
+            let decryptedMessage = try cellToken.decrypt(encryptedMessage.encrypted,
+                                                         token: encryptedMessage.token,
+                                                         context: context.data(using: .utf8)!)
             let resultString: String = String(data: decryptedMessage, encoding: .utf8)!
             print("decryptedMessage = \(resultString)")
             
@@ -130,8 +131,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         var encryptedMessage: Data = Data()
         do {
             // context is NOT optional parameter here
-            encryptedMessage = try contextImprint.wrap(message.data(using: .utf8)!,
-                                                       context: context.data(using: .utf8)!)
+            encryptedMessage = try contextImprint.encrypt(message.data(using: .utf8)!,
+                                                          context: context.data(using: .utf8)!)
             print("encryptedMessage = \(encryptedMessage)")
             
         } catch let error as NSError {
@@ -141,8 +142,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         do {
             // context is NOT optional parameter here
-            let decryptedMessage: Data = try contextImprint.unwrapData(encryptedMessage,
-                                                                       context: context.data(using: .utf8)!)
+            let decryptedMessage = try contextImprint.decrypt(encryptedMessage,
+                                                              context: context.data(using: .utf8)!)
             let resultString: String = String(data: decryptedMessage, encoding: .utf8)!
             print("decryptedMessage = \(resultString)")
             

--- a/docs/examples/swift/macOS-Carthage/Cartfile.resolved
+++ b/docs/examples/swift/macOS-Carthage/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "cossacklabs/themis" "0.12.1"
+github "cossacklabs/themis" "0.13.0"
 github "krzyzanowskim/OpenSSL" "990bd88219da80d7a77289aeae245b3eb400d834"

--- a/docs/examples/swift/macOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
+++ b/docs/examples/swift/macOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
@@ -10,14 +10,14 @@
 		9F00E9D022412F8900EC1EF3 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F00E9CF22412F8900EC1EF3 /* AppDelegate.swift */; };
 		9F00E9D222412F8B00EC1EF3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9F00E9D122412F8B00EC1EF3 /* Assets.xcassets */; };
 		9F00E9D522412F8B00EC1EF3 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9F00E9D322412F8B00EC1EF3 /* MainMenu.xib */; };
-		9F00E9E1224131B300EC1EF3 /* themis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E9DF224131B300EC1EF3 /* themis.framework */; };
-		9F00E9E3224131BB00EC1EF3 /* themis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E9DF224131B300EC1EF3 /* themis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F00E9E5224131BD00EC1EF3 /* openssl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E9DE224131B300EC1EF3 /* openssl.framework */; };
 		9F00E9E6224131BD00EC1EF3 /* openssl.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E9DE224131B300EC1EF3 /* openssl.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F00E9EC224132A600EC1EF3 /* server.pub in Resources */ = {isa = PBXBuildFile; fileRef = 9F00E9E8224132A600EC1EF3 /* server.pub */; };
 		9F00E9ED224132A600EC1EF3 /* client.priv in Resources */ = {isa = PBXBuildFile; fileRef = 9F00E9E9224132A600EC1EF3 /* client.priv */; };
 		9F00E9EE224132A600EC1EF3 /* server.priv in Resources */ = {isa = PBXBuildFile; fileRef = 9F00E9EA224132A600EC1EF3 /* server.priv */; };
 		9F00E9EF224132A600EC1EF3 /* client.pub in Resources */ = {isa = PBXBuildFile; fileRef = 9F00E9EB224132A600EC1EF3 /* client.pub */; };
+		9FCAA6B32493D680002A2CE1 /* objcthemis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FCAA6B12493D665002A2CE1 /* objcthemis.framework */; };
+		9FCAA6B42493D680002A2CE1 /* objcthemis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9FCAA6B12493D665002A2CE1 /* objcthemis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -27,7 +27,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				9F00E9E3224131BB00EC1EF3 /* themis.framework in Embed Frameworks */,
+				9FCAA6B42493D680002A2CE1 /* objcthemis.framework in Embed Frameworks */,
 				9F00E9E6224131BD00EC1EF3 /* openssl.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -43,11 +43,11 @@
 		9F00E9D622412F8B00EC1EF3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9F00E9D722412F8B00EC1EF3 /* ThemisTest.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ThemisTest.entitlements; sourceTree = "<group>"; };
 		9F00E9DE224131B300EC1EF3 /* openssl.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = openssl.framework; path = Carthage/Build/Mac/openssl.framework; sourceTree = "<group>"; };
-		9F00E9DF224131B300EC1EF3 /* themis.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = themis.framework; path = Carthage/Build/Mac/themis.framework; sourceTree = "<group>"; };
 		9F00E9E8224132A600EC1EF3 /* server.pub */ = {isa = PBXFileReference; lastKnownFileType = file; path = server.pub; sourceTree = "<group>"; };
 		9F00E9E9224132A600EC1EF3 /* client.priv */ = {isa = PBXFileReference; lastKnownFileType = file; path = client.priv; sourceTree = "<group>"; };
 		9F00E9EA224132A600EC1EF3 /* server.priv */ = {isa = PBXFileReference; lastKnownFileType = file; path = server.priv; sourceTree = "<group>"; };
 		9F00E9EB224132A600EC1EF3 /* client.pub */ = {isa = PBXFileReference; lastKnownFileType = file; path = client.pub; sourceTree = "<group>"; };
+		9FCAA6B12493D665002A2CE1 /* objcthemis.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = objcthemis.framework; path = Carthage/Build/Mac/objcthemis.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -55,8 +55,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9FCAA6B32493D680002A2CE1 /* objcthemis.framework in Frameworks */,
 				9F00E9E5224131BD00EC1EF3 /* openssl.framework in Frameworks */,
-				9F00E9E1224131B300EC1EF3 /* themis.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -96,8 +96,8 @@
 		9F00E9DD224131B300EC1EF3 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				9FCAA6B12493D665002A2CE1 /* objcthemis.framework */,
 				9F00E9DE224131B300EC1EF3 /* openssl.framework */,
-				9F00E9DF224131B300EC1EF3 /* themis.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/docs/examples/swift/macOS-Carthage/ThemisTest/AppDelegate.swift
+++ b/docs/examples/swift/macOS-Carthage/ThemisTest/AppDelegate.swift
@@ -56,9 +56,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         var encryptedMessage: Data = Data()
         do {
-            // context is optional parameter and may be ignored
-            encryptedMessage = try cellSeal.wrap(message.data(using: .utf8)!,
-                                                 context: context.data(using: .utf8)!)
+            // context is optional parameter and may be omitted
+            encryptedMessage = try cellSeal.encrypt(message.data(using: .utf8)!,
+                                                    context: context.data(using: .utf8)!)
             print("decryptedMessagez = \(encryptedMessage)")
 
         } catch let error as NSError {
@@ -67,8 +67,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         do {
-            let decryptedMessage: Data = try cellSeal.unwrapData(encryptedMessage,
-                                                                 context: context.data(using: .utf8)!)
+            let decryptedMessage = try cellSeal.decrypt(encryptedMessage,
+                                                        context: context.data(using: .utf8)!)
             let resultString: String = String(data: decryptedMessage, encoding: .utf8)!
             print("decryptedMessage = \(resultString)")
 
@@ -88,12 +88,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let message: String = "Roses are grey. Violets are grey."
         let context: String = "I'm a dog"
 
-        var encryptedMessage: TSCellTokenEncryptedData = TSCellTokenEncryptedData()
+        var encryptedMessage = TSCellTokenEncryptedResult()
         do {
             // context is optional parameter and may be ignored
-            encryptedMessage = try cellToken.wrap(message.data(using: .utf8)!,
-                                                  context: context.data(using: .utf8)!)
-            print("encryptedMessage.cipher = \(encryptedMessage.cipherText)")
+            encryptedMessage = try cellToken.encrypt(message.data(using: .utf8)!,
+                                                     context: context.data(using: .utf8)!)
+            print("encryptedMessage.encrypted = \(encryptedMessage.encrypted)")
             print("encryptedMessage.token = \(encryptedMessage.token)")
 
         } catch let error as NSError {
@@ -102,8 +102,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         do {
-            let decryptedMessage: Data = try cellToken.unwrapData(encryptedMessage,
-                                                                  context: context.data(using: .utf8)!)
+            let decryptedMessage = try cellToken.decrypt(encryptedMessage.encrypted,
+                                                         token: encryptedMessage.token,
+                                                         context: context.data(using: .utf8)!)
             let resultString: String = String(data: decryptedMessage, encoding: .utf8)!
             print("decryptedMessage = \(resultString)")
 
@@ -126,8 +127,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         var encryptedMessage: Data = Data()
         do {
             // context is NOT optional parameter here
-            encryptedMessage = try contextImprint.wrap(message.data(using: .utf8)!,
-                                                       context: context.data(using: .utf8)!)
+            encryptedMessage = try contextImprint.encrypt(message.data(using: .utf8)!,
+                                                          context: context.data(using: .utf8)!)
             print("encryptedMessage = \(encryptedMessage)")
 
         } catch let error as NSError {
@@ -137,8 +138,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         do {
             // context is NOT optional parameter here
-            let decryptedMessage: Data = try contextImprint.unwrapData(encryptedMessage,
-                                                                       context: context.data(using: .utf8)!)
+            let decryptedMessage = try contextImprint.decrypt(encryptedMessage,
+                                                              context: context.data(using: .utf8)!)
             let resultString: String = String(data: decryptedMessage, encoding: .utf8)!
             print("decryptedMessage = \(resultString)")
 


### PR DESCRIPTION
Bring Objective-C and Swift code examples up to date with Themis 0.13:

- Update dependency and lock files to use the latest version
- Relink Carthage projects to objcthemis.framework instead of themis.framework
- Use new import statements in Carthage projects in Objective-C
- Use new Secure Cell API instead of old deprecated API

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] Example projects and code samples are up-to-date

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md