### PR TITLE
Avoid overflows on 32-bit systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 Changes that are currently in development and have not been released yet.
 
+_Code:_
+
+- **Go**
+
+  - Fixed panics on 32-bit systems when processing corrupted data ([#677](https://github.com/cossacklabs/themis/pull/677)).
+
 ## [0.13.0](https://github.com/cossacklabs/themis/releases/tag/0.13.0), July 8th 2020
 
 **TL;DR:**

--- a/gothemis/cell/context_imprint.go
+++ b/gothemis/cell/context_imprint.go
@@ -138,6 +138,9 @@ func encryptContextImprint(symmetricKey, plaintext, userContext, ciphertext []by
 		bytesData(ciphertext),
 		&ciphertextLength,
 	)
+	if sizeOverflow(ciphertextLength) {
+		return 0, errors.NoMemory
+	}
 	return int(ciphertextLength), errors.ThemisErrorCode(err)
 }
 
@@ -153,5 +156,8 @@ func decryptContextImprint(symmetricKey, ciphertext, userContext, plaintext []by
 		bytesData(plaintext),
 		&plaintextLength,
 	)
+	if sizeOverflow(plaintextLength) {
+		return 0, errors.NoMemory
+	}
 	return int(plaintextLength), errors.ThemisErrorCode(err)
 }

--- a/gothemis/cell/seal.go
+++ b/gothemis/cell/seal.go
@@ -137,6 +137,9 @@ func encryptSeal(symmetricKey, plaintext, userContext, ciphertext []byte) (int, 
 		bytesData(ciphertext),
 		&ciphertextLength,
 	)
+	if sizeOverflow(ciphertextLength) {
+		return 0, errors.NoMemory
+	}
 	return int(ciphertextLength), errors.ThemisErrorCode(err)
 }
 
@@ -152,5 +155,8 @@ func decryptSeal(symmetricKey, ciphertext, userContext, plaintext []byte) (int, 
 		bytesData(plaintext),
 		&plaintextLength,
 	)
+	if sizeOverflow(plaintextLength) {
+		return 0, errors.NoMemory
+	}
 	return int(plaintextLength), errors.ThemisErrorCode(err)
 }

--- a/gothemis/cell/seal_pw.go
+++ b/gothemis/cell/seal_pw.go
@@ -126,6 +126,9 @@ func encryptSealWithPassphrase(passphrase string, plaintext, userContext, cipher
 		bytesData(ciphertext),
 		&ciphertextLength,
 	)
+	if sizeOverflow(ciphertextLength) {
+		return 0, errors.NoMemory
+	}
 	return int(ciphertextLength), errors.ThemisErrorCode(err)
 }
 
@@ -141,5 +144,8 @@ func decryptSealWithPassphrase(passphrase string, ciphertext, userContext, plain
 		bytesData(plaintext),
 		&plaintextLength,
 	)
+	if sizeOverflow(plaintextLength) {
+		return 0, errors.NoMemory
+	}
 	return int(plaintextLength), errors.ThemisErrorCode(err)
 }

--- a/gothemis/cell/token_protect.go
+++ b/gothemis/cell/token_protect.go
@@ -148,6 +148,9 @@ func encryptTokenProtect(symmetricKey, plaintext, userContext, ciphertext, authT
 		bytesData(ciphertext),
 		&ciphertextLength,
 	)
+	if sizeOverflow(ciphertextLength) || sizeOverflow(authTokenLength) {
+		return 0, 0, errors.NoMemory
+	}
 	return int(ciphertextLength), int(authTokenLength), errors.ThemisErrorCode(err)
 }
 
@@ -165,5 +168,8 @@ func decryptTokenProtect(symmetricKey, ciphertext, authToken, userContext, plain
 		bytesData(plaintext),
 		&plaintextLength,
 	)
+	if sizeOverflow(plaintextLength) {
+		return 0, errors.NoMemory
+	}
 	return int(plaintextLength), errors.ThemisErrorCode(err)
 }

--- a/gothemis/cell/token_protect_test.go
+++ b/gothemis/cell/token_protect_test.go
@@ -359,13 +359,6 @@ func TestTokenProtectDetectExtendedData(t *testing.T) {
 }
 
 func TestTokenProtectDetectCorruptedToken(t *testing.T) {
-	// FIXME(ilammy, 2020-05-25): avoid capacity allocation panics (T1648)
-	// This tests panics on 32-bit architectures due to "int" overflow.
-	// The implementation needs to check for "int" range when casting "C.size_t".
-	if uint64(^uint(0)) == uint64(^uint32(0)) {
-		t.Skip("avoid panic on 32-bit machines")
-	}
-
 	key, err := keys.NewSymmetricKey()
 	if err != nil {
 		t.Fatal("cannot generate symmetric key", err)
@@ -449,13 +442,6 @@ func TestTokenProtectDetectExtendedToken(t *testing.T) {
 }
 
 func TestTokenProtectSwapDataAndToken(t *testing.T) {
-	// FIXME(ilammy, 2020-05-25): avoid capacity allocation panics (T1648)
-	// This tests panics on 32-bit architectures due to "int" overflow.
-	// The implementation needs to check for "int" range when casting "C.size_t".
-	if uint64(^uint(0)) == uint64(^uint32(0)) {
-		t.Skip("avoid panic on 32-bit machines")
-	}
-
 	key, err := keys.NewSymmetricKey()
 	if err != nil {
 		t.Fatal("cannot generate symmetric key", err)

--- a/gothemis/keys/symmetric.go
+++ b/gothemis/keys/symmetric.go
@@ -36,6 +36,9 @@ func NewSymmetricKey() (*SymmetricKey, error) {
 	if !bool(C.get_sym_key_size(&len)) {
 		return nil, errors.New("Failed to get symmetric key size")
 	}
+	if sizeOverflow(len) {
+		return nil, ErrOverflow
+	}
 
 	key := make([]byte, int(len), int(len))
 	if !bool(C.gen_sym_key(unsafe.Pointer(&key[0]), len)) {


### PR DESCRIPTION
#### Avoid overflows in Secure Cell

Themis Core C API works with buffer sizes expressed as `size_t` while in Go lengths are expressed as `int`. Themis containers can typically contain up to 4 GB of data with internal length fields using `uint32_t`.

On typical 64-bit systems this does not cause overflows since `uint32_t` fits into both Go's `int` and C's `size_t`. However, on 32-bit system this can cause overflows. There, `size_t` is unsigned 32-bit value identical to `uint32_t` while `int` is 32-bit *signed* value, so the size may not fit into Go's size range.

We can't do anything about that. On 32-bit systems the buffer sizes are typically limited to 2 GB anyway due to the way memory is distributed. However, if the overflow happens, Go will panic when trying to allocate (effectively) negatively-sized arrays. We should return an error instead.

Add size checks before casting `C.size_t` into `int` and return an error if the size will overflow. Do this for all API, both new and old.

Normally, Themis is not used to encrypt real 2+ GB messages, but this condition can easily happen if the data has been corrupted where the length field is stored. We don't want this to be a source of DOS attacks.

#### Reenable tests for corrupted data

The panic condition has been originally detected by a couple of tests for Secure Cell's Token Protect mode which has the stars properly aligned for the issue to be visible. Now that the issue is fixed, we can enable these tests for 32-bit machines again.

#### Avoid overflows in other cryptosystems

Just like Secure Cell, add more checks to other cryptosystems as well. Unfortunately, we have to duplicate the size check utility. GoThemis does not have a common utility module, and even if it did, it would not work due to the way CGo is implemented (`C.size_t` is a distinct type in different modules).

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] Public API has proper documentation
- [X] Changelog is updated (in case of notable or breaking changes)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
