### PR TITLE
Move static libs and link files into dev packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Changes that are currently in development and have not been released yet.
 
 _Infrastructure:_
 
-- Improved package split make `libthemis` thinner ([#678](https://github.com/cossacklabs/themis/pull/678)).
+- Improved package split making `libthemis` thinner ([#678](https://github.com/cossacklabs/themis/pull/678)).
 
 ## [0.13.0](https://github.com/cossacklabs/themis/releases/tag/0.13.0), July 8th 2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Changes that are currently in development and have not been released yet.
 
+_Infrastructure:_
+
+- Improved package split make `libthemis` thinner ([#678](https://github.com/cossacklabs/themis/pull/678)).
+
 ## [0.13.0](https://github.com/cossacklabs/themis/releases/tag/0.13.0), July 8th 2020
 
 **TL;DR:**

--- a/Makefile
+++ b/Makefile
@@ -660,13 +660,13 @@ POST_UNINSTALL_SCRIPT := $(BIN_PATH)/post_uninstall.sh
 DEV_PACKAGE_FILES += $(includedir)/soter/
 DEV_PACKAGE_FILES += $(includedir)/themis/
 DEV_PACKAGE_FILES += $(pkgconfigdir)/
+DEV_PACKAGE_FILES += $(libdir)/$(LIBSOTER_A)
+DEV_PACKAGE_FILES += $(libdir)/$(LIBSOTER_LINK)
+DEV_PACKAGE_FILES += $(libdir)/$(LIBTHEMIS_A)
+DEV_PACKAGE_FILES += $(libdir)/$(LIBTHEMIS_LINK)
 
-LIB_PACKAGE_FILES += $(libdir)/$(LIBSOTER_A)
 LIB_PACKAGE_FILES += $(libdir)/$(LIBSOTER_SO)
-LIB_PACKAGE_FILES += $(libdir)/$(LIBSOTER_LINK)
-LIB_PACKAGE_FILES += $(libdir)/$(LIBTHEMIS_A)
 LIB_PACKAGE_FILES += $(libdir)/$(LIBTHEMIS_SO)
-LIB_PACKAGE_FILES += $(libdir)/$(LIBTHEMIS_LINK)
 
 THEMISPP_PACKAGE_FILES += $(includedir)/themispp/
 


### PR DESCRIPTION
Normally the “library” packages on Debian and RHEL contain only shared library files. Headers, static libraries, and shared library links go into the “development” package which is necessary to build software that uses the library (but not run it). On RHEL the static libraries are often moved into their own `-static` package to avoid bloating the `-devel` package (as dynamic linkage is customary).

Historically, we've been putting everything into the “library” package but let's follow the conventions from now on.

libthemis:
- `libsoter.so.0` and `libthemis.so.0`

libthemis-devel:
- header files
- pkg-config files
- `libsoter.a` and `lbthemis.a`
- `libsoter.so` and `libthemis.so` symlinks

We already recommend to install “development” packages to develop software that uses Themis. Some language wrappers – dynamic languages like Python and Ruby – will need that as they resolve Themis dynamic library dynamically and need the symlink to be present.

## Checklist

- [X] ~~Change is covered by automated tests~~ (somewhat? on Buildbot? maybe)
- [X] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md