### PR TITLE
Publish source and Javadoc JARs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Changes that are currently in development and have not been released yet.
 
 _Code:_
 
+- **Android**
+
+  - AndroidThemis is now available on JCenter ([#679](https://github.com/cossacklabs/themis/pull/679)).
+
 - **Go**
 
   - Fixed panics on 32-bit systems when processing corrupted data ([#677](https://github.com/cossacklabs/themis/pull/677)).
@@ -13,6 +17,7 @@ _Code:_
 _Infrastructure:_
 
 - Improved package split making `libthemis` thinner ([#678](https://github.com/cossacklabs/themis/pull/678)).
+- AndroidThemis is now available on JCenter ([#679](https://github.com/cossacklabs/themis/pull/679)).
 
 ## [0.13.0](https://github.com/cossacklabs/themis/releases/tag/0.13.0), July 8th 2020
 

--- a/src/wrappers/themis/android/build.gradle
+++ b/src/wrappers/themis/android/build.gradle
@@ -72,8 +72,15 @@ android {
 
     // publishing and bitray upload tasks should not run for ':boringssl' project
     tasks.whenTaskAdded { task ->
-        println "executing $task ..."
-        if (task.name != 'bintrayUpload' && task.name != 'publishProductionPublicationToMavenLocal' && task.name != 'generatePomFileForProductionPublication') {
+        def excludeBoringSSL = [
+            'bintrayUpload',
+            'publishProductionPublicationToMavenLocal',
+            'generatePomFileForProductionPublication',
+            'generateSourceJar',
+            'generateJavadoc',
+            'generateJavadocJar',
+        ]
+        if (!excludeBoringSSL.contains(task.name)) {
             task.dependsOn(':boringssl:' + task.name)
         }
     }
@@ -94,6 +101,36 @@ android {
     }
 }
 
+// Publishing on JCenter requires packages with Java source code and Javadocs.
+// Note that "archiveClassifier" values are important for JCenter.
+
+task generateSourceJar(type: Jar) {
+    description = 'Assembles a JAR with Java source code'
+    archiveClassifier = 'sources'
+    from android.sourceSets.main.java.srcDirs
+}
+
+task generateJavadoc(type: Javadoc) {
+    description = 'Generates Javadocs from the source code'
+    source = android.sourceSets.main.java.srcDirs
+    title = 'Themis API Reference'
+    // Javadoc chokes on non-Java files so exclude non-sources from the source dir.
+    excludes = ['build', 'build.gradle']
+    // Add Android core system and all dependencies to classpath so that Javadoc
+    // finds their classes and links to them correctly.
+    classpath += files(android.bootClasspath)
+    android.libraryVariants.all { variant ->
+        classpath += variant.javaCompile.classpath
+    }
+}
+
+task generateJavadocJar(type: Jar) {
+    description = 'Assembles a JAR with Javadocs'
+    archiveClassifier = 'javadoc'
+    from generateJavadoc.destinationDir
+    dependsOn 'generateJavadoc'
+}
+
 // distribution
 
 apply plugin: 'com.jfrog.bintray'
@@ -103,6 +140,8 @@ publishing {
     publications {
         Production(MavenPublication) {
             artifact("build/outputs/aar/android.aar")
+            artifact generateSourceJar
+            artifact generateJavadocJar
             groupId 'com.cossacklabs.com'
             artifactId 'themis'
             version androidThemisVersion


### PR DESCRIPTION
Add tasks and artifacts for publishing JARs with source code and generated Javadocs. These are required for admission to [Bintray's JCenter](https://bintray.com/bintray/jcenter) – well-known public repository of open-source libraries.

With this, the users will be able to import Themis without adding Cossack Labs repository. It's highly likely that they already have JCenter added for other dependencies:

    repositories {
        jcenter()
    }

Since it's the same package, the dependency is specified as before:

    dependencies {
        implementation 'com.cossacklabs.com:themis:0.13.0'
    }

Many Bothans died to bring us this information. No, really, Gradle documentation on this is less than stellar, and Groovy does not make it easier. *\*sigh\** Android ecosystem 🤷

## Checklist

- [X] ~~Change is covered by automated tests~~ (not really, do we need tests for this?)
- [X] The [coding guidelines] are followed
- [X] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md