### PR TITLE
Use "/usr/bin/env" in shebangs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ _Infrastructure:_
 - Optimized dependencies of `libthemis` DEB and RPM packages ([#682](https://github.com/cossacklabs/themis/pull/682)).
 - AndroidThemis is now available on JCenter ([#679](https://github.com/cossacklabs/themis/pull/679)).
 - `make deb` and `make rpm` with `ENGINE=boringssl` will now produce `libthemis-boringssl` packages with embedded BoringSSL ([#683](https://github.com/cossacklabs/themis/pull/683)).
+- Build system and tests now respect the `PATH` settings ([#685](https://github.com/cossacklabs/themis/pull/685)).
 
 ## [0.13.0](https://github.com/cossacklabs/themis/releases/tag/0.13.0), July 8th 2020
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@
 .DEFAULT_GOAL := all
 
 # Set shell for target commands
-SHELL = /bin/bash
+SHELL = bash
 
 # Disable built-in rules
 MAKEFLAGS += --no-builtin-rules

--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 #
 # Configure Themis build.
 #

--- a/docs/examples/Themis-server/python/smessage_client.py
+++ b/docs/examples/Themis-server/python/smessage_client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import httplib, urllib
 from pythemis import smessage

--- a/docs/examples/Themis-server/python/ssession_client.py
+++ b/docs/examples/Themis-server/python/ssession_client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import httplib, urllib
 from pythemis import ssession

--- a/scripts/phpthemis_postinstall.sh
+++ b/scripts/phpthemis_postinstall.sh
@@ -1,4 +1,4 @@
-#/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright (c) 2017 Cossack Labs Limited
 #
@@ -13,6 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+set -eu
 
 CONFCONT="extension=phpthemis.so"
 SEARCH="Scan this dir for additional .ini files => "

--- a/scripts/phpthemis_postinstall.sh
+++ b/scripts/phpthemis_postinstall.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -eu
+set -euo pipefail
 
 CONFCONT="extension=phpthemis.so"
 SEARCH="Scan this dir for additional .ini files => "

--- a/scripts/phpthemis_preuninstall.sh
+++ b/scripts/phpthemis_preuninstall.sh
@@ -1,4 +1,4 @@
-#/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright (c) 2017 Cossack Labs Limited
 #
@@ -13,6 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+set -eu
 
 CONFCONT="extension=phpthemis.so"
 SEARCH="Scan this dir for additional .ini files => "

--- a/scripts/phpthemis_preuninstall.sh
+++ b/scripts/phpthemis_preuninstall.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -eu
+set -euo pipefail
 
 CONFCONT="extension=phpthemis.so"
 SEARCH="Scan this dir for additional .ini files => "

--- a/scripts/pp.sh
+++ b/scripts/pp.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2017 Cossack Labs Limited
 #

--- a/src/wrappers/themis/rust/libthemis-sys/bindgen.sh
+++ b/src/wrappers/themis/rust/libthemis-sys/bindgen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Generate "src/lib.rs" file with bindings
 #

--- a/tests/_integration/base.template
+++ b/tests/_integration/base.template
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 
 # import functions
 . tests/_integration/utils.sh

--- a/tests/_integration/base.template
+++ b/tests/_integration/base.template
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
+
+set -eu
 
 # import functions
 . tests/_integration/utils.sh

--- a/tests/_integration/decrypt_folder.sh
+++ b/tests/_integration/decrypt_folder.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
+
+set -eu
 
 TEST_IN=$1
 

--- a/tests/_integration/decrypt_folder.sh
+++ b/tests/_integration/decrypt_folder.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 
 TEST_IN=$1
 

--- a/tests/_integration/encrypt_folder.sh
+++ b/tests/_integration/encrypt_folder.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
+
+set -eu
 
 HOST_NAME=$1
 

--- a/tests/_integration/encrypt_folder.sh
+++ b/tests/_integration/encrypt_folder.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 
 HOST_NAME=$1
 

--- a/tests/_integration/utils.sh
+++ b/tests/_integration/utils.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
+
+set -eu
 
 export TOP_PID=$$
 trap "exit 1" TERM

--- a/tests/_integration/utils.sh
+++ b/tests/_integration/utils.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 
 export TOP_PID=$$
 trap "exit 1" TERM

--- a/tests/_integration/utils.sh
+++ b/tests/_integration/utils.sh
@@ -7,11 +7,11 @@ trap "exit 1" TERM
 export status=0
 
 fail () {
-    printf "\033[1m\033[31m ${2} fail \x1b[0m\n"
+    printf "\033[1m\033[31m ${2:-} fail \x1b[0m\n"
 }
 
 success () {
-    printf "\033[1m\033[32m ${2} success \x1b[0m\n"
+    printf "\033[1m\033[32m ${2:-} success \x1b[0m\n"
 }
 
 check_result_zero (){

--- a/tests/check_ios_test.sh
+++ b/tests/check_ios_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 
 while true; do

--- a/tests/phpthemis/composer-setup.sh
+++ b/tests/phpthemis/composer-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 
 EXPECTED_SIGNATURE="$(wget -q -O - https://composer.github.io/installer.sig)"
 php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"

--- a/tests/phpthemis/composer-setup.sh
+++ b/tests/phpthemis/composer-setup.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
+
+set -eu
 
 EXPECTED_SIGNATURE="$(wget -q -O - https://composer.github.io/installer.sig)"
 php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"

--- a/tests/phpthemis/init_env-php5.6.sh
+++ b/tests/phpthemis/init_env-php5.6.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 
 rm -f composer.json
 ln -s composer-php5.6.json composer.json

--- a/tests/phpthemis/init_env-php5.6.sh
+++ b/tests/phpthemis/init_env-php5.6.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
+
+set -eu
 
 rm -f composer.json
 ln -s composer-php5.6.json composer.json

--- a/tests/phpthemis/init_env-php7.sh
+++ b/tests/phpthemis/init_env-php7.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
+
+set -eu
 
 rm -f composer.json
 

--- a/tests/phpthemis/init_env-php7.sh
+++ b/tests/phpthemis/init_env-php7.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 
 rm -f composer.json
 

--- a/tests/phpthemis/run_tests.sh
+++ b/tests/phpthemis/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $DIR

--- a/tests/phpthemis/run_tests.sh
+++ b/tests/phpthemis/run_tests.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
+
+set -eu
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $DIR

--- a/tests/rust/run_tests.sh
+++ b/tests/rust/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 set -e
 

--- a/tests/soter/nist-sts/makefile
+++ b/tests/soter/nist-sts/makefile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-CC ?= /usr/bin/gcc
+CC ?= gcc
 
 CFLAGS  += -Wall -Wno-unused
 LDFLAGS += -lm

--- a/tests/start_ios_test.sh
+++ b/tests/start_ios_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 START_BUILD_NUMBER=`curl -X POST --header "Accept: application/json" https://circleci.com/api/v1/project/cossacklabs/themis-ios-tests/tree/master\?circle-token=$OBJCTHEMIS_TEST_TOKEN | python -m json.tool | sed -n -e '/"build_num":/ s/^.*"build_num": \(.*\),/\1/p' | sed -n -e '1s/^\([0-9]*\).*/\1/p'`
 echo $START_BUILD_NUMBER

--- a/tests/test.mk
+++ b/tests/test.mk
@@ -46,14 +46,16 @@ prepare_tests_basic: soter_test themis_test
 prepare_tests_all: prepare_tests_basic themispp_test
 ifdef PHP_VERSION
 	@echo -n "make tests for phpthemis "
-	@echo "#!/usr/bin/env bash -e" > ./$(BIN_PATH)/tests/phpthemis_test.sh
+	@echo "#!/usr/bin/env bash" > ./$(BIN_PATH)/tests/phpthemis_test.sh
+	@echo "set -eu" >> ./$(BIN_PATH)/tests/phpthemis_test.sh
 	@echo "cd tests/phpthemis; bash ./run_tests.sh" >> ./$(BIN_PATH)/tests/phpthemis_test.sh
 	@chmod a+x ./$(BIN_PATH)/tests/phpthemis_test.sh
 	@$(PRINT_OK_)
 endif
 ifdef RUBY_GEM_VERSION
 	@echo -n "make tests for rbthemis "
-	@echo "#!/usr/bin/env bash -e" > ./$(BIN_PATH)/tests/rbthemis_test.sh
+	@echo "#!/usr/bin/env bash" > ./$(BIN_PATH)/tests/rbthemis_test.sh
+	@echo "set -eu" >> ./$(BIN_PATH)/tests/rbthemis_test.sh
 	@echo "ruby ./tests/rbthemis/scell_test.rb" >> ./$(BIN_PATH)/tests/rbthemis_test.sh
 	@echo "ruby ./tests/rbthemis/smessage_test.rb" >> ./$(BIN_PATH)/tests/rbthemis_test.sh
 	@echo "ruby ./tests/rbthemis/ssession_test.rb" >> ./$(BIN_PATH)/tests/rbthemis_test.sh
@@ -63,7 +65,8 @@ ifdef RUBY_GEM_VERSION
 endif
 ifdef PYTHON3_VERSION
 	@echo -n "make tests for pythemis with python3 "
-	@echo "#!/usr/bin/env bash -e" > ./$(PYTHON3_TEST_SCRIPT)
+	@echo "#!/usr/bin/env bash" > ./$(PYTHON3_TEST_SCRIPT)
+	@echo "set -eu" >> ./$(PYTHON3_TEST_SCRIPT)
 	@echo "python3 -m unittest discover -s tests/pythemis" >> ./$(PYTHON3_TEST_SCRIPT)
 	@chmod a+x ./$(PYTHON3_TEST_SCRIPT)
 	@$(PRINT_OK_)

--- a/tests/test.mk
+++ b/tests/test.mk
@@ -46,14 +46,14 @@ prepare_tests_basic: soter_test themis_test
 prepare_tests_all: prepare_tests_basic themispp_test
 ifdef PHP_VERSION
 	@echo -n "make tests for phpthemis "
-	@echo "#!/bin/bash -e" > ./$(BIN_PATH)/tests/phpthemis_test.sh
+	@echo "#!/usr/bin/env bash -e" > ./$(BIN_PATH)/tests/phpthemis_test.sh
 	@echo "cd tests/phpthemis; bash ./run_tests.sh" >> ./$(BIN_PATH)/tests/phpthemis_test.sh
 	@chmod a+x ./$(BIN_PATH)/tests/phpthemis_test.sh
 	@$(PRINT_OK_)
 endif
 ifdef RUBY_GEM_VERSION
 	@echo -n "make tests for rbthemis "
-	@echo "#!/bin/bash -e" > ./$(BIN_PATH)/tests/rbthemis_test.sh
+	@echo "#!/usr/bin/env bash -e" > ./$(BIN_PATH)/tests/rbthemis_test.sh
 	@echo "ruby ./tests/rbthemis/scell_test.rb" >> ./$(BIN_PATH)/tests/rbthemis_test.sh
 	@echo "ruby ./tests/rbthemis/smessage_test.rb" >> ./$(BIN_PATH)/tests/rbthemis_test.sh
 	@echo "ruby ./tests/rbthemis/ssession_test.rb" >> ./$(BIN_PATH)/tests/rbthemis_test.sh
@@ -63,7 +63,7 @@ ifdef RUBY_GEM_VERSION
 endif
 ifdef PYTHON3_VERSION
 	@echo -n "make tests for pythemis with python3 "
-	@echo "#!/bin/bash -e" > ./$(PYTHON3_TEST_SCRIPT)
+	@echo "#!/usr/bin/env bash -e" > ./$(PYTHON3_TEST_SCRIPT)
 	@echo "python3 -m unittest discover -s tests/pythemis" >> ./$(PYTHON3_TEST_SCRIPT)
 	@chmod a+x ./$(PYTHON3_TEST_SCRIPT)
 	@$(PRINT_OK_)

--- a/tools/afl/analyze_crashes.sh
+++ b/tools/afl/analyze_crashes.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 #
 # Analyze crashes found by American Fuzzy Lop
 #


### PR DESCRIPTION
Instead of directly executing stuff from `/bin` or `/usr/bin`, do it via `/usr/bin/env` to allow overriding the binaries via PATH. For example, if the user has some local installation of Bash or Python which is set as a priority in PATH, it will be used instead of the one from hardcoded `/usr/bin` location.

@shadinua has pointed out this observation in #681. This PR applies the same change throughout the entire code base for consistency. Now if someone uses existing scripts as examples, they should notice the `/usr/bin/env` usage and do the same.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] Example projects and code samples are up-to-date
- [X] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
