### PR TITLE
Fix GoReport issues

### DIFF
--- a/docs/examples/go/secure_cell.go
+++ b/docs/examples/go/secure_cell.go
@@ -26,20 +26,7 @@ import (
 	"github.com/cossacklabs/themis/gothemis/keys"
 )
 
-func main() {
-	// Cryptographic parameters. Keep them secret.
-	passphrase := "broccoli"
-	key, err := keys.NewSymmetricKey()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "cannot generate symmetric key: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Input data. Note that you always encrypt bytes so strings need to be encoded.
-	// Here we just cast them into []byte, effectively encoding in UTF-8.
-	message := []byte("Broccoli or cauliflower, which one is green?")
-	context := []byte("Correct! *gunshot*")
-
+func example_seal(key *keys.SymmetricKey, message, context []byte) {
 	fmt.Println("Secure Cell - Seal mode (symmetric key)")
 	// This is the easiest mode to use.
 
@@ -66,7 +53,9 @@ func main() {
 	fmt.Printf("Encrypted: %s\n", base64.StdEncoding.EncodeToString(encrypted))
 	fmt.Printf("Decrypted: %s\n", string(decrypted))
 	fmt.Printf("\n")
+}
 
+func example_seal_with_passphrase(passphrase string, message, context []byte) {
 	fmt.Println("Secure Cell - Seal mode (passphrase)")
 	// This is the easiest mode to use if you need to keep the secret in your head.
 
@@ -75,12 +64,12 @@ func main() {
 		fmt.Fprintf(os.Stderr, "cannot construct Secure Cell: %v\n", err)
 		os.Exit(1)
 	}
-	encrypted, err = scellPW.Encrypt(message, context)
+	encrypted, err := scellPW.Encrypt(message, context)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to encrypt message: %v\n", err)
 		os.Exit(1)
 	}
-	decrypted, err = scellPW.Decrypt(encrypted, context)
+	decrypted, err := scellPW.Decrypt(encrypted, context)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to decrypt message: %v\n", err)
 		os.Exit(1)
@@ -93,7 +82,9 @@ func main() {
 	fmt.Printf("Encrypted: %s\n", base64.StdEncoding.EncodeToString(encrypted))
 	fmt.Printf("Decrypted: %s\n", string(decrypted))
 	fmt.Printf("\n")
+}
 
+func example_token_protect(key *keys.SymmetricKey, message, context []byte) {
 	fmt.Println("Secure Cell - Token Protect mode")
 	// A bit harded to use than Seal mode due to extra "authentication token",
 	// but the encrypted data has the same size as input.
@@ -108,7 +99,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "failed to encrypt message: %v\n", err)
 		os.Exit(1)
 	}
-	decrypted, err = scellTP.Decrypt(encrypted, token, context)
+	decrypted, err := scellTP.Decrypt(encrypted, token, context)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to decrypt message: %v\n", err)
 		os.Exit(1)
@@ -122,7 +113,9 @@ func main() {
 	fmt.Printf("Token:     %s\n", base64.StdEncoding.EncodeToString(token))
 	fmt.Printf("Decrypted: %s\n", string(decrypted))
 	fmt.Printf("\n")
+}
 
+func example_token_imprint(key *keys.SymmetricKey, message, context []byte) {
 	fmt.Println("Secure Cell - Context Imprint mode")
 	// Slightly less secure mode which preserves the input length too.
 	// However, it requires "associated context" to be specified
@@ -133,12 +126,12 @@ func main() {
 		fmt.Fprintf(os.Stderr, "cannot construct Secure Cell: %v\n", err)
 		os.Exit(1)
 	}
-	encrypted, err = scellCI.Encrypt(message, context)
+	encrypted, err := scellCI.Encrypt(message, context)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to encrypt message: %v\n", err)
 		os.Exit(1)
 	}
-	decrypted, err = scellCI.Decrypt(encrypted, context)
+	decrypted, err := scellCI.Decrypt(encrypted, context)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to decrypt message: %v\n", err)
 		os.Exit(1)
@@ -151,4 +144,24 @@ func main() {
 	fmt.Printf("Encrypted: %s\n", base64.StdEncoding.EncodeToString(encrypted))
 	fmt.Printf("Decrypted: %s\n", string(decrypted))
 	fmt.Printf("\n")
+}
+
+func main() {
+	// Cryptographic parameters. Keep them secret.
+	passphrase := "broccoli"
+	key, err := keys.NewSymmetricKey()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cannot generate symmetric key: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Input data. Note that you always encrypt bytes so strings need to be encoded.
+	// Here we just cast them into []byte, effectively encoding in UTF-8.
+	message := []byte("Broccoli or cauliflower, which one is green?")
+	context := []byte("Correct! *gunshot*")
+
+	example_seal(key, message, context)
+	example_seal_with_passphrase(passphrase, message, context)
+	example_token_protect(key, message, context)
+	example_token_imprint(key, message, context)
 }

--- a/gothemis/cell/context_imprint_test.go
+++ b/gothemis/cell/context_imprint_test.go
@@ -163,7 +163,7 @@ func TestContextImprintContextSignificance(t *testing.T) {
 	// You can use a different context to decrypt data, but you'll get garbage.
 	decrypted, err := cell.Decrypt(encrypted, contextB)
 	if err != nil || bytes.Equal(decrypted, message) {
-		t.Error("message is successfuly decrypted into garbage")
+		t.Error("message is successfully decrypted into garbage")
 	}
 
 	// Only the original context will work.
@@ -204,7 +204,7 @@ func TestContextImprintNoDetectCorruptedData(t *testing.T) {
 	// Decrypts successfully but the content is garbage.
 	decrypted, err := cell.Decrypt(encrypted, context)
 	if err != nil || bytes.Equal(decrypted, message) {
-		t.Error("corrupted message is successfuly decrypted into garbage")
+		t.Error("corrupted message is successfully decrypted into garbage")
 	}
 }
 
@@ -228,7 +228,7 @@ func TestContextImprintNoDetectTruncatedData(t *testing.T) {
 
 	decrypted, err := cell.Decrypt(encrypted[:len(encrypted)-1], context)
 	if err != nil || bytes.Equal(decrypted, message) {
-		t.Error("truncated message is successfuly decrypted into garbage")
+		t.Error("truncated message is successfully decrypted into garbage")
 	}
 }
 
@@ -254,7 +254,7 @@ func TestContextImprintNoDetectExtendedData(t *testing.T) {
 
 	decrypted, err := cell.Decrypt(encrypted, context)
 	if err != nil || bytes.Equal(decrypted, message) {
-		t.Error("extended message is successfuly decrypted into garbage")
+		t.Error("extended message is successfully decrypted into garbage")
 	}
 }
 

--- a/gothemis/cell/seal_pw_test.go
+++ b/gothemis/cell/seal_pw_test.go
@@ -187,12 +187,12 @@ func TestSealPWContextSignificance(t *testing.T) {
 		t.Fatal("failed to encrypt message", err)
 	}
 
-	decrypted, err := cell.Decrypt(encrypted, contextB)
+	_, err = cell.Decrypt(encrypted, contextB)
 	if err == nil {
 		t.Error("message should not be decrypted with incorrect context")
 	}
 
-	decrypted, err = cell.Decrypt(encrypted, contextA)
+	decrypted, err := cell.Decrypt(encrypted, contextA)
 	if err != nil {
 		t.Error("correct context should allow decryption", err)
 	}

--- a/gothemis/cell/seal_test.go
+++ b/gothemis/cell/seal_test.go
@@ -214,12 +214,12 @@ func TestSealContextSignificance(t *testing.T) {
 		t.Fatal("failed to encrypt message", err)
 	}
 
-	decrypted, err := cell.Decrypt(encrypted, contextB)
+	_, err = cell.Decrypt(encrypted, contextB)
 	if err == nil {
 		t.Error("message should not be decrypted with incorrect context")
 	}
 
-	decrypted, err = cell.Decrypt(encrypted, contextA)
+	decrypted, err := cell.Decrypt(encrypted, contextA)
 	if err != nil {
 		t.Error("correct context should allow decryption", err)
 	}

--- a/gothemis/cell/token_protect_test.go
+++ b/gothemis/cell/token_protect_test.go
@@ -220,12 +220,12 @@ func TestTokenProtectContextSignificance(t *testing.T) {
 		t.Fatal("failed to encrypt message", err)
 	}
 
-	decrypted, err := cell.Decrypt(encrypted, token, contextB)
+	_, err = cell.Decrypt(encrypted, token, contextB)
 	if err == nil {
 		t.Error("message should not be decrypted with incorrect context")
 	}
 
-	decrypted, err = cell.Decrypt(encrypted, token, contextA)
+	decrypted, err := cell.Decrypt(encrypted, token, contextA)
 	if err != nil {
 		t.Error("correct context should allow decryption", err)
 	}


### PR DESCRIPTION
Few small changes in Go examples and Go tests to make GoReport happy:
* Fix typos
* Replace unused results with `_`
* Rewrite Secure Cell example, split `main()` into few more specific example functions

<!-- Describe your changes here -->

## Checklist

- [X] The [coding guidelines] are followed

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
