### PR TITLE
Themis 0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 Changes that are currently in development and have not been released yet.
 
+## [0.13.1](https://github.com/cossacklabs/themis/releases/tag/0.13.1), August 13th 2020
+
+**TL;DR:**
+
+- AndroidThemis is now available on JCenter
+- ObjCThemis and SwiftThemis get latest OpenSSL update
+- Minor security fixes in GoThemis, JsThemis, WasmThemis
+
 _Code:_
 
 - **Core**

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,8 +10,8 @@
 org.gradle.configureondemand=true
 
 # Versions of AndroidThemis and JavaThemis packages.
-androidThemisVersion=0.13.0
-javaThemisVersion=0.13.0
+androidThemisVersion=0.13.1
+javaThemisVersion=0.13.1
 
 # Android Studio insists that this is set to use JUnit test runner.
 android.useAndroidX=true

--- a/src/wrappers/themis/jsthemis/package-lock.json
+++ b/src/wrappers/themis/jsthemis/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jsthemis",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/wrappers/themis/jsthemis/package.json
+++ b/src/wrappers/themis/jsthemis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsthemis",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Themis is a convenient cryptographic library for data protection.",
   "main": "build/Release/jsthemis.node",
   "scripts": {

--- a/src/wrappers/themis/wasm/package-lock.json
+++ b/src/wrappers/themis/wasm/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wasm-themis",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/wrappers/themis/wasm/package.json
+++ b/src/wrappers/themis/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wasm-themis",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Themis is a convenient cryptographic library for data protection.",
   "main": "src/index.js",
   "scripts": {

--- a/themis.podspec
+++ b/themis.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name = "themis"
-    s.version = "0.13.0"
+    s.version = "0.13.1"
     s.summary = "Data security library for network communication and data storage for iOS and mac OS"
     s.description = "Themis is a convenient cryptographic library for data protection. It provides secure messaging with forward secrecy and secure data storage. Themis is aimed at modern development practices and has a unified API across 12 platforms, including iOS/macOS, Ruby, JavaScript, Python, and Java/Android."
     s.homepage = "https://cossacklabs.com"


### PR DESCRIPTION
Update the changelog. Bump versions of the language wrappers that we are going to update, except for Go and Carthage which need a tag. A provisional tag `0.13.1` is already placed on this commit for the podspec to validate correctly. (I am sorry, Carthage users, you chose your poison well.)

There are no significant changes in Core (aside from OpenSSL 1.1.1 compatibility meaningful only for ObjCThemis). We do not have to release 0.13.1 there.

## Checklist

- [X] Change is covered by automated tests (hopefully)
- [X] ~~Example projects and code samples are up-to-date~~ (no API changes)
- [X] Changelog is updated