### PR TITLE
Fix NodeJS SecureSession handling nullptr

### DIFF
--- a/src/wrappers/themis/jsthemis/secure_session.cpp
+++ b/src/wrappers/themis/jsthemis/secure_session.cpp
@@ -146,6 +146,13 @@ void SecureSession::New(const Nan::FunctionCallbackInfo<v8::Value>& args)
             return;
         }
         SecureSession* obj = new SecureSession(id, private_key, v8::Local<v8::Function>::Cast(args[2]));
+        if (!obj->isCreated()) {
+            // secure_session_create() inside SecureSession::SecureSession()
+            // may fail, we need to catch this and throw exception to JS
+            ThrowParameterError("SecureSession", "unsupported private key");
+            args.GetReturnValue().SetUndefined();
+            return;
+        }
         obj->Wrap(args.This());
         args.GetReturnValue().Set(args.This());
     } else {

--- a/src/wrappers/themis/jsthemis/secure_session.hpp
+++ b/src/wrappers/themis/jsthemis/secure_session.hpp
@@ -31,16 +31,16 @@ class SecureSession : public Nan::ObjectWrap
 public:
     static void Init(v8::Local<v8::Object> exports);
 
-    bool isCreated()
-    {
-        return session_ != nullptr;
-    }
-
 private:
     explicit SecureSession(const std::vector<uint8_t>& id,
                            const std::vector<uint8_t>& private_key,
                            v8::Local<v8::Function> get_pub_by_id_callback);
     ~SecureSession();
+
+    bool isCreated()
+    {
+        return session_ != nullptr;
+    }
 
     static void New(const Nan::FunctionCallbackInfo<v8::Value>& args);
     static void connectRequest(const Nan::FunctionCallbackInfo<v8::Value>& args);

--- a/src/wrappers/themis/jsthemis/secure_session.hpp
+++ b/src/wrappers/themis/jsthemis/secure_session.hpp
@@ -31,6 +31,11 @@ class SecureSession : public Nan::ObjectWrap
 public:
     static void Init(v8::Local<v8::Object> exports);
 
+    bool isCreated()
+    {
+        return session_ != nullptr;
+    }
+
 private:
     explicit SecureSession(const std::vector<uint8_t>& id,
                            const std::vector<uint8_t>& private_key,


### PR DESCRIPTION
Checking whether passed key is a private key is not enough since not all
private keys are supported. For example, `secure_session_create()` may
return NULL for RSA key. In this case, we get no exception on JS side
but as soon as we try to connect to other peer (or accept connection)
using created object, we get error. This commit makes sure we throw JS
exception in case `secure_session_create()` returns NULL.

Not sure whether this is the best way to do the check but AFAIK using C++ exceptions
inside NodeJS bindings may not be a good idea. Other idea was to throw something from
`SecureSession::SecureSession()` and then put `SecureSession* obj = new SecureSession(...);`
into `try {}` block. Also, why throw the exception if it will be immediately checked afterwards,
and it does not contain any useful information, just failed or succeed (no exception).

<!-- Describe your changes here -->

## Checklist

- [X] ~Change is covered by automated tests~
This change (obviously) does not break existing tests.
However, tests like "make sure SecureSession does now allow RSA private keys (as well as any public)"
will be done as part of different PR. And it won't be NodeJS wrapper only.
- [X] The [coding guidelines] are followed

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
