### PR TITLE
GoThemis README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ _Code:_
 - **Go**
 
   - Fixed panics on 32-bit systems when processing corrupted data ([#677](https://github.com/cossacklabs/themis/pull/677)).
-  - Improved GoThemis package README and documentation ([#699](https://github.com/cossacklabs/themis/pull/c)).
+  - Improved GoThemis package README and documentation ([#699](https://github.com/cossacklabs/themis/pull/699)).
 
 - **Node.js**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ _Code:_
 - **Go**
 
   - Fixed panics on 32-bit systems when processing corrupted data ([#677](https://github.com/cossacklabs/themis/pull/677)).
+  - Improved GoThemis package README and documentation ([#699](https://github.com/cossacklabs/themis/pull/c)).
 
 - **Node.js**
 

--- a/gothemis/README.md
+++ b/gothemis/README.md
@@ -1,0 +1,42 @@
+# GoThemis
+
+[![pkg.go.dev][pkg-go-dev-badge]][pkg-go-dev]
+[![CircleCI][circle-ci-badge]][circle-ci]
+[![License][license-badge]][license]
+
+_Go_ wrapper for [**Themis** crypto library][themis].
+
+Themis is an open-source high-level cryptographic services library that provides secure data exchange, authentication, and storage protection.
+Themis provides ready-made building components, which simplifies the usage of core cryptographic security operations.
+
+[themis]: https://github.com/cossacklabs/themis
+[pkg-go-dev]: https://pkg.go.dev/mod/github.com/cossacklabs/themis/gothemis
+[pkg-go-dev-badge]: https://pkg.go.dev/badge/mod/github.com/cossacklabs/themis/gothemis
+[circle-ci]: https://circleci.com/gh/cossacklabs/themis/tree/master
+[circle-ci-badge]: https://circleci.com/gh/cossacklabs/themis/tree/master.svg?style=shield
+[license]: https://github.com/cossacklabs/themis/blob/master/LICENSE
+[license-badge]: https://img.shields.io/github/license/cossacklabs/themis
+
+## Getting started
+
+GoThemis requires a native Themis library.
+Please refer to the [Installation guide][installation] for the instructions.
+
+See also:
+
+ - [In-depth documentation on Cossack Labs Documentation Server][docs]
+ - [Go API documentation on pkg.go.dev][pkg-go-dev]
+ - [Changelog on GitHub][CHANGELOG]
+
+You can start experimenting with [Examples][examples] or take a look at [Tests][tests]
+to get a feeling of how Themis can be used.
+
+[installation]: https://docs.cossacklabs.com/themis/languages/go/installation/
+[docs]: https://docs.cossacklabs.com/themis/
+[CHANGELOG]: https://github.com/cossacklabs/themis/blob/master/CHANGELOG.md
+[examples]: https://github.com/cossacklabs/themis/tree/master/docs/examples/go
+[tests]: https://github.com/cossacklabs/themis/tree/master/gothemis
+
+## Licensing
+
+The code is distributed under [Apache 2.0 license][license].


### PR DESCRIPTION
pkg.go.dev does not look at the repository README, it needs a file (not a symlink) near the `go.mod` file. Use a short README for Go, similar to the one used by RustThemis, to minimize maintenance effort.

Note that pkg.go.dev cannot resolve relative links to files outside of the Go module directory (`gothemis`) so we can't link to examples and license like that. Instead, direct links to the master branch of the repository are provided. It's not optimal, but a good compromise.

## Checklist

- [X] Changelog is updated