### PR TITLE
Update iOS and macOS examples to use Themis 0.13.1 and OpenSSL 1.1.1g

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,11 @@ _Code:_
 
 - **Swift**
 
-  - Updated Swift examples (iOS and macOS, Carthage and CocoaPods) to showcase usage of the newest Secure Cell API: generating symmetric keys and using Secure Cell with Passphrase ([#688](https://github.com/cossacklabs/themis/pull/688)).
+  - Updated Swift examples (iOS and macOS, Carthage and CocoaPods) to showcase usage of the newest Secure Cell API: generating symmetric keys and using Secure Cell with Passphrase ([#688](https://github.com/cossacklabs/themis/pull/688)) and to use latest Themis 0.13.1 ([#700](https://github.com/cossacklabs/themis/pull/700)).
 
 - **Objective-C**
 
-  - Updated Objective-C examples (iOS and macOS, Carthage and CocoaPods) to showcase usage of the newest Secure Cell API: generating symmetric keys and using Secure Cell with Passphrase ([#688](https://github.com/cossacklabs/themis/pull/688)).
+  - Updated Objective-C examples (iOS and macOS, Carthage and CocoaPods) to showcase usage of the newest Secure Cell API: generating symmetric keys and using Secure Cell with Passphrase ([#688](https://github.com/cossacklabs/themis/pull/688)) and to use latest Themis 0.13.1 ([#700](https://github.com/cossacklabs/themis/pull/700)).
 
 - **Rust**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,11 @@ _Code:_
 
 - **Swift**
 
-  - Updated Swift examples (iOS and macOS, Carthage and CocoaPods) to showcase usage of the newest Secure Cell API: generating symmetric keys and using Secure Cell with Passphrase ([#688](https://github.com/cossacklabs/themis/pull/688)) and to use latest Themis 0.13.1 ([#700](https://github.com/cossacklabs/themis/pull/700)).
+  - Updated Swift examples (iOS and macOS, Carthage and CocoaPods) to showcase usage of the newest Secure Cell API: generating symmetric keys and using Secure Cell with Passphrase ([#688](https://github.com/cossacklabs/themis/pull/688)) and to use latest Themis 0.13.1 ([#701](https://github.com/cossacklabs/themis/pull/701)).
 
 - **Objective-C**
 
-  - Updated Objective-C examples (iOS and macOS, Carthage and CocoaPods) to showcase usage of the newest Secure Cell API: generating symmetric keys and using Secure Cell with Passphrase ([#688](https://github.com/cossacklabs/themis/pull/688)) and to use latest Themis 0.13.1 ([#700](https://github.com/cossacklabs/themis/pull/700)).
+  - Updated Objective-C examples (iOS and macOS, Carthage and CocoaPods) to showcase usage of the newest Secure Cell API: generating symmetric keys and using Secure Cell with Passphrase ([#688](https://github.com/cossacklabs/themis/pull/688)) and to use latest Themis 0.13.1 ([#701](https://github.com/cossacklabs/themis/pull/701)).
 
 - **Rust**
 

--- a/docs/examples/Themis-server/Obj-C/Podfile
+++ b/docs/examples/Themis-server/Obj-C/Podfile
@@ -23,6 +23,6 @@ use_frameworks!
 
 target :"WorkingWithThemisServer" do
 
-  pod 'themis', '0.13.0'
+  pod 'themis', '0.13.1'
 
 end

--- a/docs/examples/Themis-server/Obj-C/Podfile.lock
+++ b/docs/examples/Themis-server/Obj-C/Podfile.lock
@@ -1,29 +1,29 @@
 PODS:
-  - GRKOpenSSLFramework (1.0.2.18)
-  - themis (0.13.0):
-    - themis/themis-openssl (= 0.13.0)
-  - themis/themis-openssl (0.13.0):
-    - GRKOpenSSLFramework (= 1.0.2.18)
-    - themis/themis-openssl/core (= 0.13.0)
-    - themis/themis-openssl/objcwrapper (= 0.13.0)
-  - themis/themis-openssl/core (0.13.0):
-    - GRKOpenSSLFramework (= 1.0.2.18)
-  - themis/themis-openssl/objcwrapper (0.13.0):
-    - GRKOpenSSLFramework (= 1.0.2.18)
-    - themis/themis-openssl/core
+  - CLOpenSSL (1.1.107.1)
+  - themis (0.13.1):
+    - themis/openssl-1.1.1 (= 0.13.1)
+  - themis/openssl-1.1.1 (0.13.1):
+    - CLOpenSSL (~> 1.1.107)
+    - themis/openssl-1.1.1/core (= 0.13.1)
+    - themis/openssl-1.1.1/objcwrapper (= 0.13.1)
+  - themis/openssl-1.1.1/core (0.13.1):
+    - CLOpenSSL (~> 1.1.107)
+  - themis/openssl-1.1.1/objcwrapper (0.13.1):
+    - CLOpenSSL (~> 1.1.107)
+    - themis/openssl-1.1.1/core
 
 DEPENDENCIES:
-  - themis (= 0.13.0)
+  - themis (= 0.13.1)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
-    - GRKOpenSSLFramework
+    - CLOpenSSL
     - themis
 
 SPEC CHECKSUMS:
-  GRKOpenSSLFramework: 1d65e55d569af7b23074373041a92cc8bc768a92
-  themis: dd1eaa51265a384b20a4cfbac83326cbb3b1b67c
+  CLOpenSSL: e57362f6522670f6dc727d19bd6dcd98c23d7cf5
+  themis: ccc8859adda9668dc4fd584bbb2390bf6c696de5
 
-PODFILE CHECKSUM: 5a28afa13f7293eb555ebf751d8ca8dcc162d03b
+PODFILE CHECKSUM: c1990926b3115ef550a5921173238889bef305c1
 
 COCOAPODS: 1.9.3

--- a/docs/examples/Themis-server/Obj-C/WorkingWithThemisServer/WorkingWithThemisServer.xcodeproj/project.pbxproj
+++ b/docs/examples/Themis-server/Obj-C/WorkingWithThemisServer/WorkingWithThemisServer.xcodeproj/project.pbxproj
@@ -311,7 +311,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-WorkingWithThemisServer/Pods-WorkingWithThemisServer-frameworks.sh",
-				"${PODS_ROOT}/GRKOpenSSLFramework/OpenSSL-iOS/bin/openssl.framework",
+				"${PODS_ROOT}/CLOpenSSL/openssl-dynamic-iPhone.zip/openssl.framework",
 				"${BUILT_PRODUCTS_DIR}/themis/themis.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -524,7 +524,7 @@
 				DEVELOPMENT_TEAM = X6X7AHQ2D4;
 				INFOPLIST_FILE = WorkingWithThemisServer/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.stanfy.WorkingWithThemisServer;
+				PRODUCT_BUNDLE_IDENTIFIER = com.cl.WorkingWithThemisServer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTS_MACCATALYST = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -539,7 +539,7 @@
 				DEVELOPMENT_TEAM = X6X7AHQ2D4;
 				INFOPLIST_FILE = WorkingWithThemisServer/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.stanfy.WorkingWithThemisServer;
+				PRODUCT_BUNDLE_IDENTIFIER = com.cl.WorkingWithThemisServer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTS_MACCATALYST = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/docs/examples/Themis-server/Obj-C/WorkingWithThemisServer/WorkingWithThemisServer/Base.lproj/LaunchScreen.storyboard
+++ b/docs/examples/Themis-server/Obj-C/WorkingWithThemisServer/WorkingWithThemisServer/Base.lproj/LaunchScreen.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -22,16 +20,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Themis Server Example ObjC" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YtC-cy-O2u">
-                                <rect key="frame" x="76" y="156" width="223" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Copyright (c) 2015-2019 Cossack Labs. All rights reserved." textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tSF-Q5-9YO">
-                                <rect key="frame" x="43" y="547" width="289" height="57"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="57" id="y18-5p-OEg"/>
-                                </constraints>
+                                <rect key="frame" x="76" y="136" width="223" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -39,9 +28,6 @@
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="xb3-aO-Qok" firstAttribute="top" secondItem="tSF-Q5-9YO" secondAttribute="bottom" constant="63" id="5CW-sO-PYk"/>
-                            <constraint firstItem="tSF-Q5-9YO" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="5q6-10-B6f"/>
-                            <constraint firstItem="tSF-Q5-9YO" firstAttribute="leading" secondItem="Ze5-6b-2t3" secondAttribute="leadingMargin" constant="27" id="99g-sJ-ieZ"/>
                             <constraint firstItem="YtC-cy-O2u" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Ze5-6b-2t3" secondAttribute="leadingMargin" id="W6S-R8-04m"/>
                             <constraint firstItem="YtC-cy-O2u" firstAttribute="top" secondItem="Llm-lL-Icb" secondAttribute="bottom" constant="136" id="X5K-1R-N4Z"/>
                             <constraint firstItem="YtC-cy-O2u" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="mcB-VR-VyY"/>

--- a/docs/examples/Themis-server/Obj-C/WorkingWithThemisServer/WorkingWithThemisServer/Base.lproj/Main.storyboard
+++ b/docs/examples/Themis-server/Obj-C/WorkingWithThemisServer/WorkingWithThemisServer/Base.lproj/Main.storyboard
@@ -1,8 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -14,20 +16,20 @@
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Open console" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KTK-Ta-BV8">
-                                <rect key="frame" x="183" y="286" width="234" height="29"/>
+                                <rect key="frame" x="90" y="433.5" width="234" height="29"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="234" id="hsF-pW-Ppw"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="24"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="KTK-Ta-BV8" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="Jeo-Wf-2o8"/>
                             <constraint firstItem="KTK-Ta-BV8" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="X92-Yd-qm8"/>

--- a/docs/examples/Themis-server/swift/Podfile
+++ b/docs/examples/Themis-server/swift/Podfile
@@ -23,6 +23,6 @@ use_frameworks!
 
 target :"SwiftThemisServerExample" do
 
-  pod 'themis', '0.13.0'
+  pod 'themis', '0.13.1'
 
 end

--- a/docs/examples/Themis-server/swift/Podfile.lock
+++ b/docs/examples/Themis-server/swift/Podfile.lock
@@ -1,29 +1,29 @@
 PODS:
-  - GRKOpenSSLFramework (1.0.2.18)
-  - themis (0.13.0):
-    - themis/themis-openssl (= 0.13.0)
-  - themis/themis-openssl (0.13.0):
-    - GRKOpenSSLFramework (= 1.0.2.18)
-    - themis/themis-openssl/core (= 0.13.0)
-    - themis/themis-openssl/objcwrapper (= 0.13.0)
-  - themis/themis-openssl/core (0.13.0):
-    - GRKOpenSSLFramework (= 1.0.2.18)
-  - themis/themis-openssl/objcwrapper (0.13.0):
-    - GRKOpenSSLFramework (= 1.0.2.18)
-    - themis/themis-openssl/core
+  - CLOpenSSL (1.1.107.1)
+  - themis (0.13.1):
+    - themis/openssl-1.1.1 (= 0.13.1)
+  - themis/openssl-1.1.1 (0.13.1):
+    - CLOpenSSL (~> 1.1.107)
+    - themis/openssl-1.1.1/core (= 0.13.1)
+    - themis/openssl-1.1.1/objcwrapper (= 0.13.1)
+  - themis/openssl-1.1.1/core (0.13.1):
+    - CLOpenSSL (~> 1.1.107)
+  - themis/openssl-1.1.1/objcwrapper (0.13.1):
+    - CLOpenSSL (~> 1.1.107)
+    - themis/openssl-1.1.1/core
 
 DEPENDENCIES:
-  - themis (= 0.13.0)
+  - themis (= 0.13.1)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
-    - GRKOpenSSLFramework
+    - CLOpenSSL
     - themis
 
 SPEC CHECKSUMS:
-  GRKOpenSSLFramework: 1d65e55d569af7b23074373041a92cc8bc768a92
-  themis: dd1eaa51265a384b20a4cfbac83326cbb3b1b67c
+  CLOpenSSL: e57362f6522670f6dc727d19bd6dcd98c23d7cf5
+  themis: ccc8859adda9668dc4fd584bbb2390bf6c696de5
 
-PODFILE CHECKSUM: 676d314076224e843e834ed3b41c08a10b072a2c
+PODFILE CHECKSUM: 467f141f0cc7f02726ed8d83f1ed28ac32238ee5
 
 COCOAPODS: 1.9.3

--- a/docs/examples/Themis-server/swift/SwiftThemisServerExample/SwiftThemisServerExample.xcodeproj/project.pbxproj
+++ b/docs/examples/Themis-server/swift/SwiftThemisServerExample/SwiftThemisServerExample.xcodeproj/project.pbxproj
@@ -176,7 +176,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-SwiftThemisServerExample/Pods-SwiftThemisServerExample-frameworks.sh",
-				"${PODS_ROOT}/GRKOpenSSLFramework/OpenSSL-iOS/bin/openssl.framework",
+				"${PODS_ROOT}/CLOpenSSL/openssl-dynamic-iPhone.zip/openssl.framework",
 				"${BUILT_PRODUCTS_DIR}/themis/themis.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";

--- a/docs/examples/Themis-server/swift/SwiftThemisServerExample/SwiftThemisServerExample/Base.lproj/LaunchScreen.storyboard
+++ b/docs/examples/Themis-server/swift/SwiftThemisServerExample/SwiftThemisServerExample/Base.lproj/LaunchScreen.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -21,17 +19,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Themis Server Example Swift" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hyi-62-rC2">
-                                <rect key="frame" x="41" y="99" width="293" height="20.5"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Copyright (c) 2015-2019 Cossack Labs. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EAS-Rf-BOf">
-                                <rect key="frame" x="41" y="548" width="293" height="68"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="68" id="gMf-Mk-NiC"/>
-                                </constraints>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Themis Server Example Swift" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hyi-62-rC2">
+                                <rect key="frame" x="41" y="79" width="293" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -39,12 +28,7 @@
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="EAS-Rf-BOf" firstAttribute="leading" secondItem="Ze5-6b-2t3" secondAttribute="leadingMargin" constant="25" id="28g-sU-btK"/>
-                            <constraint firstItem="EAS-Rf-BOf" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="BK7-oT-QGr"/>
-                            <constraint firstItem="xb3-aO-Qok" firstAttribute="top" secondItem="EAS-Rf-BOf" secondAttribute="bottom" constant="51" id="HOe-ov-5ls"/>
                             <constraint firstItem="hyi-62-rC2" firstAttribute="top" secondItem="Llm-lL-Icb" secondAttribute="bottom" constant="79" id="U21-8B-qr8"/>
-                            <constraint firstItem="EAS-Rf-BOf" firstAttribute="leading" secondItem="hyi-62-rC2" secondAttribute="leading" id="atZ-Sb-PlU"/>
-                            <constraint firstItem="EAS-Rf-BOf" firstAttribute="trailing" secondItem="hyi-62-rC2" secondAttribute="trailing" id="g7m-0K-Uhs"/>
                         </constraints>
                     </view>
                 </viewController>

--- a/docs/examples/objc/iOS-Carthage/Cartfile
+++ b/docs/examples/objc/iOS-Carthage/Cartfile
@@ -1,1 +1,1 @@
-github "cossacklabs/themis" ~> 0.13.0
+github "cossacklabs/themis" ~> 0.13.1

--- a/docs/examples/objc/iOS-Carthage/Cartfile.resolved
+++ b/docs/examples/objc/iOS-Carthage/Cartfile.resolved
@@ -1,2 +1,3 @@
-github "cossacklabs/themis" "gothemis/v0.13.0"
-github "krzyzanowskim/OpenSSL" "990bd88219da80d7a77289aeae245b3eb400d834"
+binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-MacOSX.json" "1.1.107"
+binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-iPhone.json" "1.1.107"
+github "cossacklabs/themis" "gothemis/v0.13.1"

--- a/docs/examples/objc/iOS-CocoaPods/Podfile
+++ b/docs/examples/objc/iOS-CocoaPods/Podfile
@@ -23,6 +23,6 @@ use_frameworks!
 
 target :"ThemisTest" do
 
-  pod 'themis', '0.13.0'
+  pod 'themis', '0.13.1'
 
 end

--- a/docs/examples/objc/iOS-CocoaPods/Podfile.lock
+++ b/docs/examples/objc/iOS-CocoaPods/Podfile.lock
@@ -1,29 +1,29 @@
 PODS:
-  - GRKOpenSSLFramework (1.0.2.18)
-  - themis (0.13.0):
-    - themis/themis-openssl (= 0.13.0)
-  - themis/themis-openssl (0.13.0):
-    - GRKOpenSSLFramework (= 1.0.2.18)
-    - themis/themis-openssl/core (= 0.13.0)
-    - themis/themis-openssl/objcwrapper (= 0.13.0)
-  - themis/themis-openssl/core (0.13.0):
-    - GRKOpenSSLFramework (= 1.0.2.18)
-  - themis/themis-openssl/objcwrapper (0.13.0):
-    - GRKOpenSSLFramework (= 1.0.2.18)
-    - themis/themis-openssl/core
+  - CLOpenSSL (1.1.107.1)
+  - themis (0.13.1):
+    - themis/openssl-1.1.1 (= 0.13.1)
+  - themis/openssl-1.1.1 (0.13.1):
+    - CLOpenSSL (~> 1.1.107)
+    - themis/openssl-1.1.1/core (= 0.13.1)
+    - themis/openssl-1.1.1/objcwrapper (= 0.13.1)
+  - themis/openssl-1.1.1/core (0.13.1):
+    - CLOpenSSL (~> 1.1.107)
+  - themis/openssl-1.1.1/objcwrapper (0.13.1):
+    - CLOpenSSL (~> 1.1.107)
+    - themis/openssl-1.1.1/core
 
 DEPENDENCIES:
-  - themis (= 0.13.0)
+  - themis (= 0.13.1)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
-    - GRKOpenSSLFramework
+    - CLOpenSSL
     - themis
 
 SPEC CHECKSUMS:
-  GRKOpenSSLFramework: 1d65e55d569af7b23074373041a92cc8bc768a92
-  themis: dd1eaa51265a384b20a4cfbac83326cbb3b1b67c
+  CLOpenSSL: e57362f6522670f6dc727d19bd6dcd98c23d7cf5
+  themis: ccc8859adda9668dc4fd584bbb2390bf6c696de5
 
-PODFILE CHECKSUM: cd2aec2527fc0d2fd8fff77f34a88585958148ff
+PODFILE CHECKSUM: f65ea1fb698f1f04fc9d39f5954a08a023079ef2
 
 COCOAPODS: 1.9.3

--- a/docs/examples/objc/iOS-CocoaPods/ThemisTest/ThemisTest.xcodeproj/project.pbxproj
+++ b/docs/examples/objc/iOS-CocoaPods/ThemisTest/ThemisTest.xcodeproj/project.pbxproj
@@ -316,7 +316,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-ThemisTest/Pods-ThemisTest-frameworks.sh",
-				"${PODS_ROOT}/GRKOpenSSLFramework/OpenSSL-iOS/bin/openssl.framework",
+				"${PODS_ROOT}/CLOpenSSL/openssl-dynamic-iPhone.zip/openssl.framework",
 				"${BUILT_PRODUCTS_DIR}/themis/themis.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";

--- a/docs/examples/objc/macOS-Carthage/Cartfile
+++ b/docs/examples/objc/macOS-Carthage/Cartfile
@@ -1,1 +1,1 @@
-github "cossacklabs/themis" ~> 0.13.0
+github "cossacklabs/themis" ~> 0.13.1

--- a/docs/examples/objc/macOS-Carthage/Cartfile.resolved
+++ b/docs/examples/objc/macOS-Carthage/Cartfile.resolved
@@ -1,2 +1,3 @@
-github "cossacklabs/themis" "gothemis/v0.13.0"
-github "krzyzanowskim/OpenSSL" "990bd88219da80d7a77289aeae245b3eb400d834"
+binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-MacOSX.json" "1.1.107"
+binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-iPhone.json" "1.1.107"
+github "cossacklabs/themis" "gothemis/v0.13.1"

--- a/docs/examples/swift/iOS-Carthage/Cartfile
+++ b/docs/examples/swift/iOS-Carthage/Cartfile
@@ -1,1 +1,1 @@
-github "cossacklabs/themis" ~> 0.13.0
+github "cossacklabs/themis" ~> 0.13.1

--- a/docs/examples/swift/iOS-Carthage/Cartfile.resolved
+++ b/docs/examples/swift/iOS-Carthage/Cartfile.resolved
@@ -1,2 +1,3 @@
-github "cossacklabs/themis" "gothemis/v0.13.0"
-github "krzyzanowskim/OpenSSL" "990bd88219da80d7a77289aeae245b3eb400d834"
+binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-MacOSX.json" "1.1.107"
+binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-iPhone.json" "1.1.107"
+github "cossacklabs/themis" "gothemis/v0.13.1"

--- a/docs/examples/swift/iOS-CocoaPods/Podfile
+++ b/docs/examples/swift/iOS-CocoaPods/Podfile
@@ -23,6 +23,6 @@ use_frameworks!
 
 target :"ThemisSwift" do
 
-  pod 'themis', '0.13.0'
+  pod 'themis', '0.13.1'
 
 end

--- a/docs/examples/swift/iOS-CocoaPods/Podfile.lock
+++ b/docs/examples/swift/iOS-CocoaPods/Podfile.lock
@@ -1,29 +1,29 @@
 PODS:
-  - GRKOpenSSLFramework (1.0.2.18)
-  - themis (0.13.0):
-    - themis/themis-openssl (= 0.13.0)
-  - themis/themis-openssl (0.13.0):
-    - GRKOpenSSLFramework (= 1.0.2.18)
-    - themis/themis-openssl/core (= 0.13.0)
-    - themis/themis-openssl/objcwrapper (= 0.13.0)
-  - themis/themis-openssl/core (0.13.0):
-    - GRKOpenSSLFramework (= 1.0.2.18)
-  - themis/themis-openssl/objcwrapper (0.13.0):
-    - GRKOpenSSLFramework (= 1.0.2.18)
-    - themis/themis-openssl/core
+  - CLOpenSSL (1.1.107.1)
+  - themis (0.13.1):
+    - themis/openssl-1.1.1 (= 0.13.1)
+  - themis/openssl-1.1.1 (0.13.1):
+    - CLOpenSSL (~> 1.1.107)
+    - themis/openssl-1.1.1/core (= 0.13.1)
+    - themis/openssl-1.1.1/objcwrapper (= 0.13.1)
+  - themis/openssl-1.1.1/core (0.13.1):
+    - CLOpenSSL (~> 1.1.107)
+  - themis/openssl-1.1.1/objcwrapper (0.13.1):
+    - CLOpenSSL (~> 1.1.107)
+    - themis/openssl-1.1.1/core
 
 DEPENDENCIES:
-  - themis (= 0.13.0)
+  - themis (= 0.13.1)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
-    - GRKOpenSSLFramework
+    - CLOpenSSL
     - themis
 
 SPEC CHECKSUMS:
-  GRKOpenSSLFramework: 1d65e55d569af7b23074373041a92cc8bc768a92
-  themis: dd1eaa51265a384b20a4cfbac83326cbb3b1b67c
+  CLOpenSSL: e57362f6522670f6dc727d19bd6dcd98c23d7cf5
+  themis: ccc8859adda9668dc4fd584bbb2390bf6c696de5
 
-PODFILE CHECKSUM: e0c05d83a39e6247258811a0d61b3eaa99b8889b
+PODFILE CHECKSUM: 89fdc211a52dc15047fd02a93c6824b6ca35b575
 
 COCOAPODS: 1.9.3

--- a/docs/examples/swift/iOS-CocoaPods/ThemisSwift/ThemisSwift.xcodeproj/project.pbxproj
+++ b/docs/examples/swift/iOS-CocoaPods/ThemisSwift/ThemisSwift.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		589E3AB46FEFED757B4131A9 /* Pods_ThemisSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C62EC44DF5B1717D370F9794 /* Pods_ThemisSwift.framework */; };
 		7399813E1CC449010095138F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7399812E1CC449010095138F /* AppDelegate.swift */; };
 		7399813F1CC449010095138F /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7399812F1CC449010095138F /* ViewController.swift */; };
 		739981401CC449010095138F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 739981311CC449010095138F /* Assets.xcassets */; };
@@ -17,11 +16,10 @@
 		739981441CC449010095138F /* client.pub in Resources */ = {isa = PBXBuildFile; fileRef = 739981381CC449010095138F /* client.pub */; };
 		739981451CC449010095138F /* server.priv in Resources */ = {isa = PBXBuildFile; fileRef = 739981391CC449010095138F /* server.priv */; };
 		739981461CC449010095138F /* server.pub in Resources */ = {isa = PBXBuildFile; fileRef = 7399813A1CC449010095138F /* server.pub */; };
+		8C59F5CA06259E3DEFCCA28A /* Pods_ThemisSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B0C144B5E58FFE4F1D5AD77B /* Pods_ThemisSwift.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		15D4143D2B7DBBB08E9F6D96 /* Pods-ThemisSwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ThemisSwift.release.xcconfig"; path = "Target Support Files/Pods-ThemisSwift/Pods-ThemisSwift.release.xcconfig"; sourceTree = "<group>"; };
-		267D206279DDBB5EEEAE5D0A /* Pods-ThemisSwift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ThemisSwift.debug.xcconfig"; path = "Target Support Files/Pods-ThemisSwift/Pods-ThemisSwift.debug.xcconfig"; sourceTree = "<group>"; };
 		739981171CC42C880095138F /* ThemisSwift.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ThemisSwift.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7399812E1CC449010095138F /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7399812F1CC449010095138F /* ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -34,7 +32,9 @@
 		7399813A1CC449010095138F /* server.pub */ = {isa = PBXFileReference; lastKnownFileType = file; path = server.pub; sourceTree = "<group>"; };
 		739981491CC44ABA0095138F /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7399814A1CC44ABA0095138F /* ThemisSwift-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ThemisSwift-Bridging-Header.h"; sourceTree = "<group>"; };
-		C62EC44DF5B1717D370F9794 /* Pods_ThemisSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ThemisSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B0C144B5E58FFE4F1D5AD77B /* Pods_ThemisSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ThemisSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B438CFA58784EBC3F9F321A8 /* Pods-ThemisSwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ThemisSwift.release.xcconfig"; path = "Target Support Files/Pods-ThemisSwift/Pods-ThemisSwift.release.xcconfig"; sourceTree = "<group>"; };
+		E8C425ED4600D843354E4DAB /* Pods-ThemisSwift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ThemisSwift.debug.xcconfig"; path = "Target Support Files/Pods-ThemisSwift/Pods-ThemisSwift.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -42,20 +42,30 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				589E3AB46FEFED757B4131A9 /* Pods_ThemisSwift.framework in Frameworks */,
+				8C59F5CA06259E3DEFCCA28A /* Pods_ThemisSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0DF23A38F8FC16F275032A97 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				E8C425ED4600D843354E4DAB /* Pods-ThemisSwift.debug.xcconfig */,
+				B438CFA58784EBC3F9F321A8 /* Pods-ThemisSwift.release.xcconfig */,
+			);
+			name = Pods;
+			path = ../Pods;
+			sourceTree = "<group>";
+		};
 		7399810E1CC42C880095138F = {
 			isa = PBXGroup;
 			children = (
 				739981191CC42C880095138F /* ThemisSwift */,
 				739981181CC42C880095138F /* Products */,
-				9730B30D6BDD6DFEC487F94C /* Pods */,
-				806F350E0AF2ABB0202825C6 /* Frameworks */,
+				0DF23A38F8FC16F275032A97 /* Pods */,
+				DCE9D23E7237CDBC712A3D75 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -117,22 +127,12 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
-		806F350E0AF2ABB0202825C6 /* Frameworks */ = {
+		DCE9D23E7237CDBC712A3D75 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				C62EC44DF5B1717D370F9794 /* Pods_ThemisSwift.framework */,
+				B0C144B5E58FFE4F1D5AD77B /* Pods_ThemisSwift.framework */,
 			);
 			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		9730B30D6BDD6DFEC487F94C /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				267D206279DDBB5EEEAE5D0A /* Pods-ThemisSwift.debug.xcconfig */,
-				15D4143D2B7DBBB08E9F6D96 /* Pods-ThemisSwift.release.xcconfig */,
-			);
-			name = Pods;
-			path = ../Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -142,12 +142,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 739981291CC42C880095138F /* Build configuration list for PBXNativeTarget "ThemisSwift" */;
 			buildPhases = (
-				C88190DDBFC5CE3874543DB5 /* [CP] Check Pods Manifest.lock */,
+				706731B24B4D7C0F537917AC /* [CP] Check Pods Manifest.lock */,
 				739981131CC42C880095138F /* Sources */,
 				739981141CC42C880095138F /* Frameworks */,
 				739981151CC42C880095138F /* Resources */,
 				73688AFE1CC4504F00D3C430 /* ShellScript */,
-				CEAB072F8AB94A91A7A953E7 /* [CP] Embed Pods Frameworks */,
+				BE934335041AFEEF3CC738DA /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -212,20 +212,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		73688AFE1CC4504F00D3C430 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n# uncomment for autocorrection\n# swiftlint autocorrect\n    swiftlint lint --quiet\nelse\n    echo \"SwiftLint does not exist, download from https://github.com/realm/SwiftLint\"\nfi";
-		};
-		C88190DDBFC5CE3874543DB5 /* [CP] Check Pods Manifest.lock */ = {
+		706731B24B4D7C0F537917AC /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -247,14 +234,27 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		CEAB072F8AB94A91A7A953E7 /* [CP] Embed Pods Frameworks */ = {
+		73688AFE1CC4504F00D3C430 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n# uncomment for autocorrection\n# swiftlint autocorrect\n    swiftlint lint --quiet\nelse\n    echo \"SwiftLint does not exist, download from https://github.com/realm/SwiftLint\"\nfi";
+		};
+		BE934335041AFEEF3CC738DA /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-ThemisSwift/Pods-ThemisSwift-frameworks.sh",
-				"${PODS_ROOT}/GRKOpenSSLFramework/OpenSSL-iOS/bin/openssl.framework",
+				"${PODS_ROOT}/CLOpenSSL/openssl-dynamic-iPhone.zip/openssl.framework",
 				"${BUILT_PRODUCTS_DIR}/themis/themis.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -411,7 +411,7 @@
 		};
 		7399812A1CC42C880095138F /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 267D206279DDBB5EEEAE5D0A /* Pods-ThemisSwift.debug.xcconfig */;
+			baseConfigurationReference = E8C425ED4600D843354E4DAB /* Pods-ThemisSwift.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -435,7 +435,7 @@
 		};
 		7399812B1CC42C880095138F /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 15D4143D2B7DBBB08E9F6D96 /* Pods-ThemisSwift.release.xcconfig */;
+			baseConfigurationReference = B438CFA58784EBC3F9F321A8 /* Pods-ThemisSwift.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";

--- a/docs/examples/swift/macOS-Carthage/Cartfile
+++ b/docs/examples/swift/macOS-Carthage/Cartfile
@@ -1,1 +1,1 @@
-github "cossacklabs/themis" ~> 0.13.0
+github "cossacklabs/themis" ~> 0.13.1

--- a/docs/examples/swift/macOS-Carthage/Cartfile.resolved
+++ b/docs/examples/swift/macOS-Carthage/Cartfile.resolved
@@ -1,2 +1,3 @@
-github "cossacklabs/themis" "gothemis/v0.13.0"
-github "krzyzanowskim/OpenSSL" "990bd88219da80d7a77289aeae245b3eb400d834"
+binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-MacOSX.json" "1.1.107"
+binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-iPhone.json" "1.1.107"
+github "cossacklabs/themis" "gothemis/v0.13.1"

--- a/docs/examples/swift/macOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
+++ b/docs/examples/swift/macOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
@@ -146,6 +146,7 @@
 				TargetAttributes = {
 					9F00E9CB22412F8900EC1EF3 = {
 						CreatedOnToolsVersion = 10.1;
+						LastSwiftMigration = 1160;
 					};
 				};
 			};
@@ -341,7 +342,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis.ThemisTest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -365,7 +366,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis.ThemisTest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Updated iOS and macOS examples to use Themis 0.13.1 and OpenSSL 1.1.1g.


## Checklist

- ~[] Change is covered by automated tests~
- ~[] Benchmark results are attached (if applicable)~
- [x] The [coding guidelines] are followed
- ~[] Public API has proper documentation~
- [x] Example projects and code samples are up-to-date (in case of API changes)
- [x] Changelog is updated (in case of notable or breaking changes)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
