### PR TITLE
Carthage and CocoaPods import compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,11 @@ _Code:_
 
 - **Swift**
 
-  - Updated Swift examples (iOS and macOS, Carthage and CocoaPods) to showcase usage of the newest Secure Cell API: generating symmetric keys and using Secure Cell with Passphrase ([#688](https://github.com/cossacklabs/themis/pull/688)) and to use latest Themis 0.13.1 ([#701](https://github.com/cossacklabs/themis/pull/701)).
+  - Updated Swift examples (iOS and macOS, Carthage and CocoaPods) to showcase usage of the newest Secure Cell API: generating symmetric keys and using Secure Cell with Passphrase ([#688](https://github.com/cossacklabs/themis/pull/688)) and to use latest Themis 0.13.1 ([#701](https://github.com/cossacklabs/themis/pull/701), [#703](https://github.com/cossacklabs/themis/pull/703)).
 
 - **Objective-C**
 
-  - Updated Objective-C examples (iOS and macOS, Carthage and CocoaPods) to showcase usage of the newest Secure Cell API: generating symmetric keys and using Secure Cell with Passphrase ([#688](https://github.com/cossacklabs/themis/pull/688)) and to use latest Themis 0.13.1 ([#701](https://github.com/cossacklabs/themis/pull/701)).
+  - Updated Objective-C examples (iOS and macOS, Carthage and CocoaPods) to showcase usage of the newest Secure Cell API: generating symmetric keys and using Secure Cell with Passphrase ([#688](https://github.com/cossacklabs/themis/pull/688)) and to use latest Themis 0.13.1 ([#701](https://github.com/cossacklabs/themis/pull/701), [#703](https://github.com/cossacklabs/themis/pull/703)).
 
 - **Rust**
 

--- a/docs/examples/Themis-server/Obj-C/WorkingWithThemisServer/WorkingWithThemisServer/SMessageClient.m
+++ b/docs/examples/Themis-server/Obj-C/WorkingWithThemisServer/WorkingWithThemisServer/SMessageClient.m
@@ -1,7 +1,6 @@
-#import <objcthemis/smessage.h>
-#import <objcthemis/skeygen.h>
-
 #import "SMessageClient.h"
+
+@import themis;
 
 // ---------------------- IMPORTANT SETUP ---------------------------------------
 

--- a/docs/examples/Themis-server/Obj-C/WorkingWithThemisServer/WorkingWithThemisServer/SSessionClient.m
+++ b/docs/examples/Themis-server/Obj-C/WorkingWithThemisServer/WorkingWithThemisServer/SSessionClient.m
@@ -6,8 +6,9 @@
 //  Copyright © 2015 Cossacklabs. All rights reserved.
 //
 
-#import <objcthemis/objcthemis.h>
 #import "SSessionClient.h"
+
+@import themis;
 
 // ---------------------- IMPORTANT SETUP ---------------------------------------
 

--- a/docs/examples/objc/iOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
+++ b/docs/examples/objc/iOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
@@ -13,8 +13,6 @@
 		9F00EA362241539900EC1EF3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9F00EA352241539900EC1EF3 /* Assets.xcassets */; };
 		9F00EA392241539900EC1EF3 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9F00EA372241539900EC1EF3 /* LaunchScreen.storyboard */; };
 		9F00EA3C2241539900EC1EF3 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F00EA3B2241539900EC1EF3 /* main.m */; };
-		9F00EA4A2241555900EC1EF3 /* openssl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00EA442241555100EC1EF3 /* openssl.framework */; };
-		9F00EA4B2241555900EC1EF3 /* openssl.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00EA442241555100EC1EF3 /* openssl.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F00EA522241563800EC1EF3 /* server.priv in Resources */ = {isa = PBXBuildFile; fileRef = 9F00EA4E2241563800EC1EF3 /* server.priv */; };
 		9F00EA532241563800EC1EF3 /* client.priv in Resources */ = {isa = PBXBuildFile; fileRef = 9F00EA4F2241563800EC1EF3 /* client.priv */; };
 		9F00EA542241563800EC1EF3 /* server.pub in Resources */ = {isa = PBXBuildFile; fileRef = 9F00EA502241563800EC1EF3 /* server.pub */; };
@@ -31,7 +29,6 @@
 			dstSubfolderSpec = 10;
 			files = (
 				9F1444A824E6D3D0008B6C73 /* themis.framework in Embed Frameworks */,
-				9F00EA4B2241555900EC1EF3 /* openssl.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -49,7 +46,6 @@
 		9F00EA382241539900EC1EF3 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		9F00EA3A2241539900EC1EF3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9F00EA3B2241539900EC1EF3 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
-		9F00EA442241555100EC1EF3 /* openssl.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = openssl.framework; path = Carthage/Build/iOS/openssl.framework; sourceTree = "<group>"; };
 		9F00EA4E2241563800EC1EF3 /* server.priv */ = {isa = PBXFileReference; lastKnownFileType = file; path = server.priv; sourceTree = "<group>"; };
 		9F00EA4F2241563800EC1EF3 /* client.priv */ = {isa = PBXFileReference; lastKnownFileType = file; path = client.priv; sourceTree = "<group>"; };
 		9F00EA502241563800EC1EF3 /* server.pub */ = {isa = PBXFileReference; lastKnownFileType = file; path = server.pub; sourceTree = "<group>"; };
@@ -63,7 +59,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				9F1444A724E6D3D0008B6C73 /* themis.framework in Frameworks */,
-				9F00EA4A2241555900EC1EF3 /* openssl.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -108,7 +103,6 @@
 			isa = PBXGroup;
 			children = (
 				9F1444A524E6D3BD008B6C73 /* themis.framework */,
-				9F00EA442241555100EC1EF3 /* openssl.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/docs/examples/objc/iOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
+++ b/docs/examples/objc/iOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
@@ -19,8 +19,8 @@
 		9F00EA532241563800EC1EF3 /* client.priv in Resources */ = {isa = PBXBuildFile; fileRef = 9F00EA4F2241563800EC1EF3 /* client.priv */; };
 		9F00EA542241563800EC1EF3 /* server.pub in Resources */ = {isa = PBXBuildFile; fileRef = 9F00EA502241563800EC1EF3 /* server.pub */; };
 		9F00EA552241563800EC1EF3 /* client.pub in Resources */ = {isa = PBXBuildFile; fileRef = 9F00EA512241563800EC1EF3 /* client.pub */; };
-		9FCAA6A72493CA17002A2CE1 /* objcthemis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FCAA6A52493CA03002A2CE1 /* objcthemis.framework */; };
-		9FCAA6A82493CA17002A2CE1 /* objcthemis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9FCAA6A52493CA03002A2CE1 /* objcthemis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9F1444A724E6D3D0008B6C73 /* themis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F1444A524E6D3BD008B6C73 /* themis.framework */; };
+		9F1444A824E6D3D0008B6C73 /* themis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F1444A524E6D3BD008B6C73 /* themis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -30,7 +30,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				9FCAA6A82493CA17002A2CE1 /* objcthemis.framework in Embed Frameworks */,
+				9F1444A824E6D3D0008B6C73 /* themis.framework in Embed Frameworks */,
 				9F00EA4B2241555900EC1EF3 /* openssl.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -54,7 +54,7 @@
 		9F00EA4F2241563800EC1EF3 /* client.priv */ = {isa = PBXFileReference; lastKnownFileType = file; path = client.priv; sourceTree = "<group>"; };
 		9F00EA502241563800EC1EF3 /* server.pub */ = {isa = PBXFileReference; lastKnownFileType = file; path = server.pub; sourceTree = "<group>"; };
 		9F00EA512241563800EC1EF3 /* client.pub */ = {isa = PBXFileReference; lastKnownFileType = file; path = client.pub; sourceTree = "<group>"; };
-		9FCAA6A52493CA03002A2CE1 /* objcthemis.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = objcthemis.framework; path = Carthage/Build/iOS/objcthemis.framework; sourceTree = "<group>"; };
+		9F1444A524E6D3BD008B6C73 /* themis.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = themis.framework; path = Carthage/Build/iOS/themis.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -62,7 +62,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9FCAA6A72493CA17002A2CE1 /* objcthemis.framework in Frameworks */,
+				9F1444A724E6D3D0008B6C73 /* themis.framework in Frameworks */,
 				9F00EA4A2241555900EC1EF3 /* openssl.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -107,7 +107,7 @@
 		9F00EA422241555100EC1EF3 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				9FCAA6A52493CA03002A2CE1 /* objcthemis.framework */,
+				9F1444A524E6D3BD008B6C73 /* themis.framework */,
 				9F00EA442241555100EC1EF3 /* openssl.framework */,
 			);
 			name = Frameworks;

--- a/docs/examples/objc/iOS-Carthage/ThemisTest/AppDelegate.m
+++ b/docs/examples/objc/iOS-Carthage/ThemisTest/AppDelegate.m
@@ -14,7 +14,7 @@
 
 #import "AppDelegate.h"
 
-#import <objcthemis/objcthemis.h>
+@import themis;
 
 @interface AppDelegate ()
 

--- a/docs/examples/objc/iOS-CocoaPods/ThemisTest/ThemisTest/Classes/AppDelegate.m
+++ b/docs/examples/objc/iOS-CocoaPods/ThemisTest/ThemisTest/Classes/AppDelegate.m
@@ -15,7 +15,8 @@
 */
 
 #import "AppDelegate.h"
-#import <objcthemis/objcthemis.h>
+
+@import themis;
 
 @interface AppDelegate ()
 

--- a/docs/examples/objc/macOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
+++ b/docs/examples/objc/macOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
@@ -11,8 +11,6 @@
 		9F00EA002241348800EC1EF3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9F00E9FF2241348800EC1EF3 /* Assets.xcassets */; };
 		9F00EA032241348800EC1EF3 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9F00EA012241348800EC1EF3 /* MainMenu.xib */; };
 		9F00EA062241348800EC1EF3 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F00EA052241348800EC1EF3 /* main.m */; };
-		9F00EA15224135AD00EC1EF3 /* openssl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00EA0E224135A300EC1EF3 /* openssl.framework */; };
-		9F00EA16224135AD00EC1EF3 /* openssl.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00EA0E224135A300EC1EF3 /* openssl.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F00EA1C22413D1300EC1EF3 /* client.pub in Resources */ = {isa = PBXBuildFile; fileRef = 9F00EA1822413D1300EC1EF3 /* client.pub */; };
 		9F00EA1D22413D1300EC1EF3 /* client.priv in Resources */ = {isa = PBXBuildFile; fileRef = 9F00EA1922413D1300EC1EF3 /* client.priv */; };
 		9F00EA1E22413D1300EC1EF3 /* server.pub in Resources */ = {isa = PBXBuildFile; fileRef = 9F00EA1A22413D1300EC1EF3 /* server.pub */; };
@@ -29,7 +27,6 @@
 			dstSubfolderSpec = 10;
 			files = (
 				9F1444AC24E6D46D008B6C73 /* themis.framework in Embed Frameworks */,
-				9F00EA16224135AD00EC1EF3 /* openssl.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -45,7 +42,6 @@
 		9F00EA042241348800EC1EF3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9F00EA052241348800EC1EF3 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		9F00EA072241348800EC1EF3 /* ThemisTest.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ThemisTest.entitlements; sourceTree = "<group>"; };
-		9F00EA0E224135A300EC1EF3 /* openssl.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = openssl.framework; path = Carthage/Build/Mac/openssl.framework; sourceTree = "<group>"; };
 		9F00EA1822413D1300EC1EF3 /* client.pub */ = {isa = PBXFileReference; lastKnownFileType = file; path = client.pub; sourceTree = "<group>"; };
 		9F00EA1922413D1300EC1EF3 /* client.priv */ = {isa = PBXFileReference; lastKnownFileType = file; path = client.priv; sourceTree = "<group>"; };
 		9F00EA1A22413D1300EC1EF3 /* server.pub */ = {isa = PBXFileReference; lastKnownFileType = file; path = server.pub; sourceTree = "<group>"; };
@@ -59,7 +55,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				9F1444AB24E6D46D008B6C73 /* themis.framework in Frameworks */,
-				9F00EA15224135AD00EC1EF3 /* openssl.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -102,7 +97,6 @@
 			isa = PBXGroup;
 			children = (
 				9F1444A924E6D46A008B6C73 /* themis.framework */,
-				9F00EA0E224135A300EC1EF3 /* openssl.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/docs/examples/objc/macOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
+++ b/docs/examples/objc/macOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
@@ -17,8 +17,8 @@
 		9F00EA1D22413D1300EC1EF3 /* client.priv in Resources */ = {isa = PBXBuildFile; fileRef = 9F00EA1922413D1300EC1EF3 /* client.priv */; };
 		9F00EA1E22413D1300EC1EF3 /* server.pub in Resources */ = {isa = PBXBuildFile; fileRef = 9F00EA1A22413D1300EC1EF3 /* server.pub */; };
 		9F00EA1F22413D1300EC1EF3 /* server.priv in Resources */ = {isa = PBXBuildFile; fileRef = 9F00EA1B22413D1300EC1EF3 /* server.priv */; };
-		9FCAA6AB2493CC35002A2CE1 /* objcthemis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FCAA6A92493CC32002A2CE1 /* objcthemis.framework */; };
-		9FCAA6AC2493CC35002A2CE1 /* objcthemis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9FCAA6A92493CC32002A2CE1 /* objcthemis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9F1444AB24E6D46D008B6C73 /* themis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F1444A924E6D46A008B6C73 /* themis.framework */; };
+		9F1444AC24E6D46D008B6C73 /* themis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F1444A924E6D46A008B6C73 /* themis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -28,7 +28,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				9FCAA6AC2493CC35002A2CE1 /* objcthemis.framework in Embed Frameworks */,
+				9F1444AC24E6D46D008B6C73 /* themis.framework in Embed Frameworks */,
 				9F00EA16224135AD00EC1EF3 /* openssl.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -50,7 +50,7 @@
 		9F00EA1922413D1300EC1EF3 /* client.priv */ = {isa = PBXFileReference; lastKnownFileType = file; path = client.priv; sourceTree = "<group>"; };
 		9F00EA1A22413D1300EC1EF3 /* server.pub */ = {isa = PBXFileReference; lastKnownFileType = file; path = server.pub; sourceTree = "<group>"; };
 		9F00EA1B22413D1300EC1EF3 /* server.priv */ = {isa = PBXFileReference; lastKnownFileType = file; path = server.priv; sourceTree = "<group>"; };
-		9FCAA6A92493CC32002A2CE1 /* objcthemis.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = objcthemis.framework; path = Carthage/Build/Mac/objcthemis.framework; sourceTree = "<group>"; };
+		9F1444A924E6D46A008B6C73 /* themis.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = themis.framework; path = Carthage/Build/Mac/themis.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -58,7 +58,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9FCAA6AB2493CC35002A2CE1 /* objcthemis.framework in Frameworks */,
+				9F1444AB24E6D46D008B6C73 /* themis.framework in Frameworks */,
 				9F00EA15224135AD00EC1EF3 /* openssl.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -101,7 +101,7 @@
 		9F00EA0D224135A300EC1EF3 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				9FCAA6A92493CC32002A2CE1 /* objcthemis.framework */,
+				9F1444A924E6D46A008B6C73 /* themis.framework */,
 				9F00EA0E224135A300EC1EF3 /* openssl.framework */,
 			);
 			name = Frameworks;

--- a/docs/examples/objc/macOS-Carthage/ThemisTest/AppDelegate.m
+++ b/docs/examples/objc/macOS-Carthage/ThemisTest/AppDelegate.m
@@ -14,7 +14,7 @@
 
 #import "AppDelegate.h"
 
-#import <objcthemis/objcthemis.h>
+@import themis;
 
 @implementation AppDelegate
 

--- a/docs/examples/swift/iOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
+++ b/docs/examples/swift/iOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
@@ -18,8 +18,8 @@
 		9F00E9BB2241172400EC1EF3 /* client.pub in Resources */ = {isa = PBXBuildFile; fileRef = 9F00E9B72241172400EC1EF3 /* client.pub */; };
 		9F00E9C122411CD700EC1EF3 /* openssl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E9B0224115C200EC1EF3 /* openssl.framework */; };
 		9F00E9C222411CD700EC1EF3 /* openssl.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E9B0224115C200EC1EF3 /* openssl.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		9FCAA6AF2493D478002A2CE1 /* objcthemis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FCAA6AD2493D46F002A2CE1 /* objcthemis.framework */; };
-		9FCAA6B02493D478002A2CE1 /* objcthemis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9FCAA6AD2493D46F002A2CE1 /* objcthemis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9F1444AF24E6D4ED008B6C73 /* themis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F1444AD24E6D4E7008B6C73 /* themis.framework */; };
+		9F1444B024E6D4ED008B6C73 /* themis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F1444AD24E6D4E7008B6C73 /* themis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -29,7 +29,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				9FCAA6B02493D478002A2CE1 /* objcthemis.framework in Embed Frameworks */,
+				9F1444B024E6D4ED008B6C73 /* themis.framework in Embed Frameworks */,
 				9F00E9C222411CD700EC1EF3 /* openssl.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -50,7 +50,7 @@
 		9F00E9B52241172400EC1EF3 /* client.priv */ = {isa = PBXFileReference; lastKnownFileType = file; path = client.priv; sourceTree = "<group>"; };
 		9F00E9B62241172400EC1EF3 /* server.priv */ = {isa = PBXFileReference; lastKnownFileType = file; path = server.priv; sourceTree = "<group>"; };
 		9F00E9B72241172400EC1EF3 /* client.pub */ = {isa = PBXFileReference; lastKnownFileType = file; path = client.pub; sourceTree = "<group>"; };
-		9FCAA6AD2493D46F002A2CE1 /* objcthemis.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = objcthemis.framework; path = Carthage/Build/iOS/objcthemis.framework; sourceTree = "<group>"; };
+		9F1444AD24E6D4E7008B6C73 /* themis.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = themis.framework; path = Carthage/Build/iOS/themis.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -58,7 +58,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9FCAA6AF2493D478002A2CE1 /* objcthemis.framework in Frameworks */,
+				9F1444AF24E6D4ED008B6C73 /* themis.framework in Frameworks */,
 				9F00E9C122411CD700EC1EF3 /* openssl.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -100,7 +100,7 @@
 		9F00E9AF224113A800EC1EF3 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				9FCAA6AD2493D46F002A2CE1 /* objcthemis.framework */,
+				9F1444AD24E6D4E7008B6C73 /* themis.framework */,
 				9F00E9B0224115C200EC1EF3 /* openssl.framework */,
 			);
 			name = Frameworks;

--- a/docs/examples/swift/iOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
+++ b/docs/examples/swift/iOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
@@ -16,8 +16,6 @@
 		9F00E9B92241172400EC1EF3 /* client.priv in Resources */ = {isa = PBXBuildFile; fileRef = 9F00E9B52241172400EC1EF3 /* client.priv */; };
 		9F00E9BA2241172400EC1EF3 /* server.priv in Resources */ = {isa = PBXBuildFile; fileRef = 9F00E9B62241172400EC1EF3 /* server.priv */; };
 		9F00E9BB2241172400EC1EF3 /* client.pub in Resources */ = {isa = PBXBuildFile; fileRef = 9F00E9B72241172400EC1EF3 /* client.pub */; };
-		9F00E9C122411CD700EC1EF3 /* openssl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E9B0224115C200EC1EF3 /* openssl.framework */; };
-		9F00E9C222411CD700EC1EF3 /* openssl.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E9B0224115C200EC1EF3 /* openssl.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F1444AF24E6D4ED008B6C73 /* themis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F1444AD24E6D4E7008B6C73 /* themis.framework */; };
 		9F1444B024E6D4ED008B6C73 /* themis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F1444AD24E6D4E7008B6C73 /* themis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
@@ -30,7 +28,6 @@
 			dstSubfolderSpec = 10;
 			files = (
 				9F1444B024E6D4ED008B6C73 /* themis.framework in Embed Frameworks */,
-				9F00E9C222411CD700EC1EF3 /* openssl.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -45,7 +42,6 @@
 		9F00E9A022410F7900EC1EF3 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		9F00E9A322410F7900EC1EF3 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		9F00E9A522410F7900EC1EF3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		9F00E9B0224115C200EC1EF3 /* openssl.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = openssl.framework; path = Carthage/Build/iOS/openssl.framework; sourceTree = "<group>"; };
 		9F00E9B42241172400EC1EF3 /* server.pub */ = {isa = PBXFileReference; lastKnownFileType = file; path = server.pub; sourceTree = "<group>"; };
 		9F00E9B52241172400EC1EF3 /* client.priv */ = {isa = PBXFileReference; lastKnownFileType = file; path = client.priv; sourceTree = "<group>"; };
 		9F00E9B62241172400EC1EF3 /* server.priv */ = {isa = PBXFileReference; lastKnownFileType = file; path = server.priv; sourceTree = "<group>"; };
@@ -59,7 +55,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				9F1444AF24E6D4ED008B6C73 /* themis.framework in Frameworks */,
-				9F00E9C122411CD700EC1EF3 /* openssl.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -101,7 +96,6 @@
 			isa = PBXGroup;
 			children = (
 				9F1444AD24E6D4E7008B6C73 /* themis.framework */,
-				9F00E9B0224115C200EC1EF3 /* openssl.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/docs/examples/swift/macOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
+++ b/docs/examples/swift/macOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
@@ -16,8 +16,8 @@
 		9F00E9ED224132A600EC1EF3 /* client.priv in Resources */ = {isa = PBXBuildFile; fileRef = 9F00E9E9224132A600EC1EF3 /* client.priv */; };
 		9F00E9EE224132A600EC1EF3 /* server.priv in Resources */ = {isa = PBXBuildFile; fileRef = 9F00E9EA224132A600EC1EF3 /* server.priv */; };
 		9F00E9EF224132A600EC1EF3 /* client.pub in Resources */ = {isa = PBXBuildFile; fileRef = 9F00E9EB224132A600EC1EF3 /* client.pub */; };
-		9FCAA6B32493D680002A2CE1 /* objcthemis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FCAA6B12493D665002A2CE1 /* objcthemis.framework */; };
-		9FCAA6B42493D680002A2CE1 /* objcthemis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9FCAA6B12493D665002A2CE1 /* objcthemis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9F1294EE24E6D56700434ABB /* themis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F1294EC24E6D56100434ABB /* themis.framework */; };
+		9F1294EF24E6D56700434ABB /* themis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F1294EC24E6D56100434ABB /* themis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -27,7 +27,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				9FCAA6B42493D680002A2CE1 /* objcthemis.framework in Embed Frameworks */,
+				9F1294EF24E6D56700434ABB /* themis.framework in Embed Frameworks */,
 				9F00E9E6224131BD00EC1EF3 /* openssl.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -47,7 +47,7 @@
 		9F00E9E9224132A600EC1EF3 /* client.priv */ = {isa = PBXFileReference; lastKnownFileType = file; path = client.priv; sourceTree = "<group>"; };
 		9F00E9EA224132A600EC1EF3 /* server.priv */ = {isa = PBXFileReference; lastKnownFileType = file; path = server.priv; sourceTree = "<group>"; };
 		9F00E9EB224132A600EC1EF3 /* client.pub */ = {isa = PBXFileReference; lastKnownFileType = file; path = client.pub; sourceTree = "<group>"; };
-		9FCAA6B12493D665002A2CE1 /* objcthemis.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = objcthemis.framework; path = Carthage/Build/Mac/objcthemis.framework; sourceTree = "<group>"; };
+		9F1294EC24E6D56100434ABB /* themis.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = themis.framework; path = Carthage/Build/Mac/themis.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -55,7 +55,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9FCAA6B32493D680002A2CE1 /* objcthemis.framework in Frameworks */,
+				9F1294EE24E6D56700434ABB /* themis.framework in Frameworks */,
 				9F00E9E5224131BD00EC1EF3 /* openssl.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -96,7 +96,7 @@
 		9F00E9DD224131B300EC1EF3 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				9FCAA6B12493D665002A2CE1 /* objcthemis.framework */,
+				9F1294EC24E6D56100434ABB /* themis.framework */,
 				9F00E9DE224131B300EC1EF3 /* openssl.framework */,
 			);
 			name = Frameworks;

--- a/docs/examples/swift/macOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
+++ b/docs/examples/swift/macOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
@@ -10,8 +10,6 @@
 		9F00E9D022412F8900EC1EF3 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F00E9CF22412F8900EC1EF3 /* AppDelegate.swift */; };
 		9F00E9D222412F8B00EC1EF3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9F00E9D122412F8B00EC1EF3 /* Assets.xcassets */; };
 		9F00E9D522412F8B00EC1EF3 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9F00E9D322412F8B00EC1EF3 /* MainMenu.xib */; };
-		9F00E9E5224131BD00EC1EF3 /* openssl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E9DE224131B300EC1EF3 /* openssl.framework */; };
-		9F00E9E6224131BD00EC1EF3 /* openssl.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E9DE224131B300EC1EF3 /* openssl.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F00E9EC224132A600EC1EF3 /* server.pub in Resources */ = {isa = PBXBuildFile; fileRef = 9F00E9E8224132A600EC1EF3 /* server.pub */; };
 		9F00E9ED224132A600EC1EF3 /* client.priv in Resources */ = {isa = PBXBuildFile; fileRef = 9F00E9E9224132A600EC1EF3 /* client.priv */; };
 		9F00E9EE224132A600EC1EF3 /* server.priv in Resources */ = {isa = PBXBuildFile; fileRef = 9F00E9EA224132A600EC1EF3 /* server.priv */; };
@@ -28,7 +26,6 @@
 			dstSubfolderSpec = 10;
 			files = (
 				9F1294EF24E6D56700434ABB /* themis.framework in Embed Frameworks */,
-				9F00E9E6224131BD00EC1EF3 /* openssl.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -42,7 +39,6 @@
 		9F00E9D422412F8B00EC1EF3 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
 		9F00E9D622412F8B00EC1EF3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9F00E9D722412F8B00EC1EF3 /* ThemisTest.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ThemisTest.entitlements; sourceTree = "<group>"; };
-		9F00E9DE224131B300EC1EF3 /* openssl.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = openssl.framework; path = Carthage/Build/Mac/openssl.framework; sourceTree = "<group>"; };
 		9F00E9E8224132A600EC1EF3 /* server.pub */ = {isa = PBXFileReference; lastKnownFileType = file; path = server.pub; sourceTree = "<group>"; };
 		9F00E9E9224132A600EC1EF3 /* client.priv */ = {isa = PBXFileReference; lastKnownFileType = file; path = client.priv; sourceTree = "<group>"; };
 		9F00E9EA224132A600EC1EF3 /* server.priv */ = {isa = PBXFileReference; lastKnownFileType = file; path = server.priv; sourceTree = "<group>"; };
@@ -56,7 +52,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				9F1294EE24E6D56700434ABB /* themis.framework in Frameworks */,
-				9F00E9E5224131BD00EC1EF3 /* openssl.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -97,7 +92,6 @@
 			isa = PBXGroup;
 			children = (
 				9F1294EC24E6D56100434ABB /* themis.framework */,
-				9F00E9DE224131B300EC1EF3 /* openssl.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";


### PR DESCRIPTION
Recently added `objcthemis.framework` turned out to be a mistake (#604). It is not possible to migrate to it because then Swift code will not be able to find it by its module name (`themis`). Revert the changes and relink examples to `themis.framework`.

Applications should use `themis.framework` when Themis is installed via Carthage, as they did in Themis 0.12 and before.

However, since ObjCThemis 0.13.1, `openssl.framework` is now not necessary in applications. It is statically linked into `themis.framework` instead. Remove `openssl.framework` from “Frameworks, Libraries, and Embedded Content”.

Finally, there is a common way to import ObjCThemis whether it is installed via Carthage or CocoaPods:

```objective-c
@import themis;
```

This is now the preferred import form, instead of `#import <objcthemis/objcthemis.h>` or `#import <themis/themis.h>`.

(Currently, out unit tests still use `#import`. They do not work with `@import` for some reason. Since it's not critical, let them be for now.)

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] Example projects and code samples are up-to-date
- [X] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
