### PR TITLE
Update Carthage examples to use Themis 0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,11 @@ _Code:_
 
 - **Swift**
 
-  - Updated Swift examples (iOS and macOS, Carthage and CocoaPods) to showcase usage of the newest Secure Cell API: generating symmetric keys and using Secure Cell with Passphrase ([#688](https://github.com/cossacklabs/themis/pull/688)) and to use latest Themis 0.13.1 ([#701](https://github.com/cossacklabs/themis/pull/701), [#703](https://github.com/cossacklabs/themis/pull/703)).
+  - Updated Swift examples (iOS and macOS, Carthage and CocoaPods) to showcase usage of the newest Secure Cell API: generating symmetric keys and using Secure Cell with Passphrase ([#688](https://github.com/cossacklabs/themis/pull/688)) and to use latest Themis 0.13.2 ([#701](https://github.com/cossacklabs/themis/pull/701), [#703](https://github.com/cossacklabs/themis/pull/703), [#706](https://github.com/cossacklabs/themis/pull/706)).
 
 - **Objective-C**
 
-  - Updated Objective-C examples (iOS and macOS, Carthage and CocoaPods) to showcase usage of the newest Secure Cell API: generating symmetric keys and using Secure Cell with Passphrase ([#688](https://github.com/cossacklabs/themis/pull/688)) and to use latest Themis 0.13.1 ([#701](https://github.com/cossacklabs/themis/pull/701), [#703](https://github.com/cossacklabs/themis/pull/703)).
+  - Updated Objective-C examples (iOS and macOS, Carthage and CocoaPods) to showcase usage of the newest Secure Cell API: generating symmetric keys and using Secure Cell with Passphrase ([#688](https://github.com/cossacklabs/themis/pull/688)) and to use latest Themis 0.13.2 ([#701](https://github.com/cossacklabs/themis/pull/701), [#703](https://github.com/cossacklabs/themis/pull/703), [#706](https://github.com/cossacklabs/themis/pull/706)).
 
 - **Rust**
 

--- a/docs/examples/objc/iOS-Carthage/Cartfile
+++ b/docs/examples/objc/iOS-Carthage/Cartfile
@@ -1,1 +1,1 @@
-github "cossacklabs/themis" ~> 0.13.1
+github "cossacklabs/themis" ~> 0.13.2

--- a/docs/examples/objc/iOS-Carthage/Cartfile.resolved
+++ b/docs/examples/objc/iOS-Carthage/Cartfile.resolved
@@ -1,3 +1,3 @@
 binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-MacOSX.json" "1.1.107"
 binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-iPhone.json" "1.1.107"
-github "cossacklabs/themis" "gothemis/v0.13.1"
+github "cossacklabs/themis" "0.13.2"

--- a/docs/examples/objc/macOS-Carthage/Cartfile
+++ b/docs/examples/objc/macOS-Carthage/Cartfile
@@ -1,1 +1,1 @@
-github "cossacklabs/themis" ~> 0.13.1
+github "cossacklabs/themis" ~> 0.13.2

--- a/docs/examples/objc/macOS-Carthage/Cartfile.resolved
+++ b/docs/examples/objc/macOS-Carthage/Cartfile.resolved
@@ -1,3 +1,3 @@
 binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-MacOSX.json" "1.1.107"
 binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-iPhone.json" "1.1.107"
-github "cossacklabs/themis" "gothemis/v0.13.1"
+github "cossacklabs/themis" "0.13.2"

--- a/docs/examples/swift/iOS-Carthage/Cartfile
+++ b/docs/examples/swift/iOS-Carthage/Cartfile
@@ -1,1 +1,1 @@
-github "cossacklabs/themis" ~> 0.13.1
+github "cossacklabs/themis" ~> 0.13.2

--- a/docs/examples/swift/iOS-Carthage/Cartfile.resolved
+++ b/docs/examples/swift/iOS-Carthage/Cartfile.resolved
@@ -1,3 +1,3 @@
 binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-MacOSX.json" "1.1.107"
 binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-iPhone.json" "1.1.107"
-github "cossacklabs/themis" "gothemis/v0.13.1"
+github "cossacklabs/themis" "0.13.2"

--- a/docs/examples/swift/macOS-Carthage/Cartfile
+++ b/docs/examples/swift/macOS-Carthage/Cartfile
@@ -1,1 +1,1 @@
-github "cossacklabs/themis" ~> 0.13.1
+github "cossacklabs/themis" ~> 0.13.2

--- a/docs/examples/swift/macOS-Carthage/Cartfile.resolved
+++ b/docs/examples/swift/macOS-Carthage/Cartfile.resolved
@@ -1,3 +1,3 @@
 binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-MacOSX.json" "1.1.107"
 binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-iPhone.json" "1.1.107"
-github "cossacklabs/themis" "gothemis/v0.13.1"
+github "cossacklabs/themis" "0.13.2"


### PR DESCRIPTION
After #705 0.13.2 release, let's keep iOS/macOS Carthage examples fresh!

Blocked by #707. 

## Checklist

- [x] Changelog is updated (in case of notable or breaking changes)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
