### PR TITLE
Replace dynamically generated errors with constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ _Code:_
   - `make deb` and `make rpm` with `ENGINE=boringssl` will now produce `libthemis-boringssl` packages with embedded BoringSSL ([#683](https://github.com/cossacklabs/themis/pull/683), [#686](https://github.com/cossacklabs/themis/pull/686)).
   - `secure_session_create()` now allows only EC keys, returning an error for RSA ([#693](https://github.com/cossacklabs/themis/pull/693)).
 
+- **Go**
+
+  - Error `ErrOverflow` is now deprecated in favor of `ErrOutOfMemory`, new error types were added ([711](https://github.com/cossacklabs/themis/pull/711)).
+
 - **Objective-C**
 
   - Updated Objective-C examples (iOS and macOS, Carthage and CocoaPods) to showcase usage of the newest Secure Cell API: generating symmetric keys and using Secure Cell with Passphrase ([#688](https://github.com/cossacklabs/themis/pull/688)) and to use latest Themis 0.13.2 ([#701](https://github.com/cossacklabs/themis/pull/701), [#703](https://github.com/cossacklabs/themis/pull/703), [#706](https://github.com/cossacklabs/themis/pull/706)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _Code:_
 
 - **Go**
 
-  - Error `ErrOverflow` is now deprecated in favor of `ErrOutOfMemory`, new error types were added ([711](https://github.com/cossacklabs/themis/pull/711)).
+  - Error `ErrOverflow` is now deprecated in favor of `ErrOutOfMemory`, new error types were added ([#711](https://github.com/cossacklabs/themis/pull/711)).
 
 - **Objective-C**
 

--- a/gothemis/cell/cell.go
+++ b/gothemis/cell/cell.go
@@ -190,7 +190,7 @@ var (
 	ErrMissingToken      = errors.NewWithCode(errors.InvalidParameter, "authentication token is required in Token Protect mode")
 	ErrMissingContext    = errors.NewWithCode(errors.InvalidParameter, "associated context is required in Context Imprint mode")
 	ErrOutOfMemory       = errors.NewWithCode(errors.NoMemory, "Secure Cell cannot allocate enough memory")
-	// Deprecated: Since 0.13.3. Use ErrOutOfMemory instead.
+	// Deprecated: Since 0.14. Use ErrOutOfMemory instead.
 	ErrOverflow          = ErrOutOfMemory
 )
 

--- a/gothemis/cell/cell.go
+++ b/gothemis/cell/cell.go
@@ -180,6 +180,9 @@ import (
 
 // Errors returned by Secure Cell.
 var (
+	ErrGetOutSize        = errors.New("Failed to get output size")
+	ErrEncryptData       = errors.New("Failed to protect data")
+	ErrDecryptData       = errors.New("Failed to unprotect data")
 	ErrInvalidMode       = errors.NewWithCode(errors.InvalidParameter, "invalid Secure Cell mode specified")
 	ErrMissingKey        = errors.NewWithCode(errors.InvalidParameter, "empty symmetric key for Secure Cell")
 	ErrMissingPassphrase = errors.NewWithCode(errors.InvalidParameter, "empty passphrase for Secure Cell")
@@ -273,7 +276,7 @@ func (sc *SecureCell) Protect(data []byte, context []byte) ([]byte, []byte, erro
 		C.int(sc.mode),
 		&encLen,
 		&addLen)) {
-		return nil, nil, errors.New("Failed to get output size")
+		return nil, nil, ErrGetOutSize
 	}
 	if sizeOverflow(encLen) || sizeOverflow(addLen) {
 		return nil, nil, ErrOverflow
@@ -299,7 +302,7 @@ func (sc *SecureCell) Protect(data []byte, context []byte) ([]byte, []byte, erro
 		encLen,
 		add,
 		addLen)) {
-		return nil, nil, errors.New("Failed to protect data")
+		return nil, nil, ErrEncryptData
 	}
 
 	return encData, addData, nil
@@ -355,7 +358,7 @@ func (sc *SecureCell) Unprotect(protectedData []byte, additionalData []byte, con
 		ctxLen,
 		C.int(sc.mode),
 		&decLen)) {
-		return nil, errors.New("Failed to get output size")
+		return nil, ErrGetOutSize
 	}
 	if sizeOverflow(decLen) {
 		return nil, ErrOverflow
@@ -373,7 +376,7 @@ func (sc *SecureCell) Unprotect(protectedData []byte, additionalData []byte, con
 		C.int(sc.mode),
 		unsafe.Pointer(&decData[0]),
 		decLen)) {
-		return nil, errors.New("Failed to unprotect data")
+		return nil, ErrDecryptData
 	}
 
 	return decData, nil

--- a/gothemis/cell/cell.go
+++ b/gothemis/cell/cell.go
@@ -180,7 +180,7 @@ import (
 
 // Errors returned by Secure Cell.
 var (
-	ErrGetOutSize        = errors.New("Failed to get output size")
+	ErrGetOutputSize     = errors.New("Failed to get output size")
 	ErrEncryptData       = errors.New("Failed to protect data")
 	ErrDecryptData       = errors.New("Failed to unprotect data")
 	ErrInvalidMode       = errors.NewWithCode(errors.InvalidParameter, "invalid Secure Cell mode specified")
@@ -276,7 +276,7 @@ func (sc *SecureCell) Protect(data []byte, context []byte) ([]byte, []byte, erro
 		C.int(sc.mode),
 		&encLen,
 		&addLen)) {
-		return nil, nil, ErrGetOutSize
+		return nil, nil, ErrGetOutputSize
 	}
 	if sizeOverflow(encLen) || sizeOverflow(addLen) {
 		return nil, nil, ErrOverflow
@@ -358,7 +358,7 @@ func (sc *SecureCell) Unprotect(protectedData []byte, additionalData []byte, con
 		ctxLen,
 		C.int(sc.mode),
 		&decLen)) {
-		return nil, ErrGetOutSize
+		return nil, ErrGetOutputSize
 	}
 	if sizeOverflow(decLen) {
 		return nil, ErrOverflow

--- a/gothemis/cell/cell.go
+++ b/gothemis/cell/cell.go
@@ -190,6 +190,8 @@ var (
 	ErrMissingToken      = errors.NewWithCode(errors.InvalidParameter, "authentication token is required in Token Protect mode")
 	ErrMissingContext    = errors.NewWithCode(errors.InvalidParameter, "associated context is required in Context Imprint mode")
 	ErrOutOfMemory       = errors.NewWithCode(errors.NoMemory, "Secure Cell cannot allocate enough memory")
+	// Deprecated: Since 0.13.3. Use ErrOutOfMemory instead.
+	ErrOverflow          = ErrOutOfMemory
 )
 
 // Secure Cell operation mode.

--- a/gothemis/cell/cell.go
+++ b/gothemis/cell/cell.go
@@ -180,9 +180,9 @@ import (
 
 // Errors returned by Secure Cell.
 var (
-	ErrGetOutputSize     = errors.New("Failed to get output size")
-	ErrEncryptData       = errors.New("Failed to protect data")
-	ErrDecryptData       = errors.New("Failed to unprotect data")
+	ErrGetOutputSize     = errors.New("failed to get output size")
+	ErrEncryptData       = errors.New("failed to protect data")
+	ErrDecryptData       = errors.New("failed to unprotect data")
 	ErrInvalidMode       = errors.NewWithCode(errors.InvalidParameter, "invalid Secure Cell mode specified")
 	ErrMissingKey        = errors.NewWithCode(errors.InvalidParameter, "empty symmetric key for Secure Cell")
 	ErrMissingPassphrase = errors.NewWithCode(errors.InvalidParameter, "empty passphrase for Secure Cell")

--- a/gothemis/cell/cell.go
+++ b/gothemis/cell/cell.go
@@ -189,7 +189,7 @@ var (
 	ErrMissingMessage    = errors.NewWithCode(errors.InvalidParameter, "empty message for Secure Cell")
 	ErrMissingToken      = errors.NewWithCode(errors.InvalidParameter, "authentication token is required in Token Protect mode")
 	ErrMissingContext    = errors.NewWithCode(errors.InvalidParameter, "associated context is required in Context Imprint mode")
-	ErrOverflow          = errors.NewWithCode(errors.NoMemory, "Secure Cell cannot allocate enough memory")
+	ErrOutOfMemory       = errors.NewWithCode(errors.NoMemory, "Secure Cell cannot allocate enough memory")
 )
 
 // Secure Cell operation mode.
@@ -279,7 +279,7 @@ func (sc *SecureCell) Protect(data []byte, context []byte) ([]byte, []byte, erro
 		return nil, nil, ErrGetOutputSize
 	}
 	if sizeOverflow(encLen) || sizeOverflow(addLen) {
-		return nil, nil, ErrOverflow
+		return nil, nil, ErrOutOfMemory
 	}
 
 	var addData []byte
@@ -361,7 +361,7 @@ func (sc *SecureCell) Unprotect(protectedData []byte, additionalData []byte, con
 		return nil, ErrGetOutputSize
 	}
 	if sizeOverflow(decLen) {
-		return nil, ErrOverflow
+		return nil, ErrOutOfMemory
 	}
 
 	decData := make([]byte, decLen, decLen)

--- a/gothemis/compare/compare.go
+++ b/gothemis/compare/compare.go
@@ -86,7 +86,7 @@ var (
 	ErrGetOutputSize            = errors.New("Failed to get output size")
 	ErrMissingSecret            = errors.NewWithCode(errors.InvalidParameter, "empty secret for Secure Comparator")
 	ErrMissingData              = errors.NewWithCode(errors.InvalidParameter, "empty comparison message for Secure Comparator")
-	ErrOverflow                 = errors.NewWithCode(errors.NoMemory, "Secure Comparator cannot allocate enough memory")
+	ErrOutOfMemory              = errors.NewWithCode(errors.NoMemory, "Secure Comparator cannot allocate enough memory")
 )
 
 // SecureCompare is an interactive protocol for two parties that compares whether
@@ -152,7 +152,7 @@ func (sc *SecureCompare) Begin() ([]byte, error) {
 		return nil, ErrGetOutputSize
 	}
 	if sizeOverflow(outLen) {
-		return nil, ErrOverflow
+		return nil, ErrOutOfMemory
 	}
 
 	out := make([]byte, outLen)
@@ -177,7 +177,7 @@ func (sc *SecureCompare) Proceed(data []byte) ([]byte, error) {
 		return nil, ErrGetOutputSize
 	}
 	if sizeOverflow(outLen) {
-		return nil, ErrOverflow
+		return nil, ErrOutOfMemory
 	}
 
 	if 0 == outLen {

--- a/gothemis/compare/compare.go
+++ b/gothemis/compare/compare.go
@@ -86,7 +86,7 @@ var (
 	ErrMissingSecret            = errors.NewWithCode(errors.InvalidParameter, "empty secret for Secure Comparator")
 	ErrMissingData              = errors.NewWithCode(errors.InvalidParameter, "empty comparison message for Secure Comparator")
 	ErrOutOfMemory              = errors.NewWithCode(errors.NoMemory, "Secure Comparator cannot allocate enough memory")
-	// Deprecated: Since 0.13.3. Use ErrOutOfMemory instead.
+	// Deprecated: Since 0.14. Use ErrOutOfMemory instead.
 	ErrOverflow                 = ErrOutOfMemory
 )
 

--- a/gothemis/compare/compare.go
+++ b/gothemis/compare/compare.go
@@ -77,12 +77,12 @@ const (
 
 // Errors returned by Secure Comparator.
 var (
-	ErrAppendSecret             = errors.New("Failed to append secret")
-	ErrCreateComparator         = errors.New("Failed to create comparator object")
-	ErrDestroyComparator        = errors.New("Failed to destroy comparator object")
-	ErrProtocolData             = errors.New("Failed to get protocol data")
-	ErrProtocolDataSize         = errors.New("Failed to get protocol data size")
-	ErrNoResult                 = errors.New("Failed to get result")
+	ErrAppendSecret             = errors.New("failed to append secret")
+	ErrCreateComparator         = errors.New("failed to create comparator object")
+	ErrDestroyComparator        = errors.New("failed to destroy comparator object")
+	ErrProtocolData             = errors.New("failed to get protocol data")
+	ErrProtocolDataSize         = errors.New("failed to get protocol data size")
+	ErrNoResult                 = errors.New("failed to get result")
 	ErrMissingSecret            = errors.NewWithCode(errors.InvalidParameter, "empty secret for Secure Comparator")
 	ErrMissingData              = errors.NewWithCode(errors.InvalidParameter, "empty comparison message for Secure Comparator")
 	ErrOutOfMemory              = errors.NewWithCode(errors.NoMemory, "Secure Comparator cannot allocate enough memory")

--- a/gothemis/compare/compare.go
+++ b/gothemis/compare/compare.go
@@ -77,16 +77,16 @@ const (
 
 // Errors returned by Secure Comparator.
 var (
-	ErrAppendSecret  = errors.New("Failed to append secret")
-	ErrCreateObj     = errors.New("Failed to create comparator object")
-	ErrDestroyObj    = errors.New("Failed to destroy comparator object")
-	ErrGetCmpData    = errors.New("Failed to get compare data")
-	ErrGetCmpRes     = errors.New("Failed to get compare result")
-	ErrGetOut        = errors.New("Failed to get output")
-	ErrGetOutSize    = errors.New("Failed to get output size")
-	ErrMissingSecret = errors.NewWithCode(errors.InvalidParameter, "empty secret for Secure Comparator")
-	ErrMissingData   = errors.NewWithCode(errors.InvalidParameter, "empty comparison message for Secure Comparator")
-	ErrOverflow      = errors.NewWithCode(errors.NoMemory, "Secure Comparator cannot allocate enough memory")
+	ErrAppendSecret             = errors.New("Failed to append secret")
+	ErrCreateComparatorObject   = errors.New("Failed to create comparator object")
+	ErrDestroyComparatorObject  = errors.New("Failed to destroy comparator object")
+	ErrGetCmpData               = errors.New("Failed to get compare data")
+	ErrGetCmpResult             = errors.New("Failed to get compare result")
+	ErrGetOutput                = errors.New("Failed to get output")
+	ErrGetOutputSize            = errors.New("Failed to get output size")
+	ErrMissingSecret            = errors.NewWithCode(errors.InvalidParameter, "empty secret for Secure Comparator")
+	ErrMissingData              = errors.NewWithCode(errors.InvalidParameter, "empty comparison message for Secure Comparator")
+	ErrOverflow                 = errors.NewWithCode(errors.NoMemory, "Secure Comparator cannot allocate enough memory")
 )
 
 // SecureCompare is an interactive protocol for two parties that compares whether
@@ -110,7 +110,7 @@ func sizeOverflow(n C.size_t) bool {
 func New() (*SecureCompare, error) {
 	ctx := C.compare_init()
 	if nil == ctx {
-		return nil, ErrCreateObj
+		return nil, ErrCreateComparatorObject
 	}
 
 	sc := &SecureCompare{ctx}
@@ -125,7 +125,7 @@ func (sc *SecureCompare) Close() error {
 		if bool(C.compare_destroy(sc.ctx)) {
 			sc.ctx = nil
 		} else {
-			return ErrDestroyObj
+			return ErrDestroyComparatorObject
 		}
 	}
 
@@ -149,7 +149,7 @@ func (sc *SecureCompare) Begin() ([]byte, error) {
 	var outLen C.size_t
 
 	if !bool(C.compare_begin_size(sc.ctx, &outLen)) {
-		return nil, ErrGetOutSize
+		return nil, ErrGetOutputSize
 	}
 	if sizeOverflow(outLen) {
 		return nil, ErrOverflow
@@ -174,7 +174,7 @@ func (sc *SecureCompare) Proceed(data []byte) ([]byte, error) {
 	}
 
 	if !bool(C.compare_proceed_size(sc.ctx, unsafe.Pointer(&data[0]), C.size_t(len(data)), &outLen)) {
-		return nil, ErrGetOutSize
+		return nil, ErrGetOutputSize
 	}
 	if sizeOverflow(outLen) {
 		return nil, ErrOverflow
@@ -194,7 +194,7 @@ func (sc *SecureCompare) Proceed(data []byte) ([]byte, error) {
 		return out, nil
 	}
 
-	return nil, ErrGetOut
+	return nil, ErrGetOutput
 }
 
 // Result returns the result of the comparison.
@@ -205,5 +205,5 @@ func (sc *SecureCompare) Result() (int, error) {
 		return int(res), nil
 	}
 
-	return NotReady, ErrGetCmpRes
+	return NotReady, ErrGetCmpResult
 }

--- a/gothemis/keys/keypair.go
+++ b/gothemis/keys/keypair.go
@@ -79,7 +79,7 @@ var (
 	ErrGenerateKeypair  = errors.New("Failed to generate keypair")
 	ErrInvalidType      = errors.NewWithCode(errors.InvalidParameter, "invalid key type specified")
 	ErrOutOfMemory      = errors.NewWithCode(errors.NoMemory, "key generator cannot allocate enough memory")
-	// Deprecated: Since 0.13.3. Use ErrOutOfMemory instead.
+	// Deprecated: Since 0.14. Use ErrOutOfMemory instead.
 	ErrOverflow         = ErrOutOfMemory
 )
 

--- a/gothemis/keys/keypair.go
+++ b/gothemis/keys/keypair.go
@@ -79,6 +79,8 @@ var (
 	ErrGenerateKeypair  = errors.New("Failed to generate keypair")
 	ErrInvalidType      = errors.NewWithCode(errors.InvalidParameter, "invalid key type specified")
 	ErrOutOfMemory      = errors.NewWithCode(errors.NoMemory, "key generator cannot allocate enough memory")
+	// Deprecated: Since 0.13.3. Use ErrOutOfMemory instead.
+	ErrOverflow         = ErrOutOfMemory
 )
 
 // PrivateKey stores a ECDSA or RSA private key.

--- a/gothemis/keys/keypair.go
+++ b/gothemis/keys/keypair.go
@@ -78,7 +78,7 @@ var (
 	ErrGetKeySize       = errors.New("Failed to get needed key sizes")
 	ErrGenerateKeypair  = errors.New("Failed to generate keypair")
 	ErrInvalidType      = errors.NewWithCode(errors.InvalidParameter, "invalid key type specified")
-	ErrOverflow         = errors.NewWithCode(errors.NoMemory, "key generator cannot allocate enough memory")
+	ErrOutOfMemory      = errors.NewWithCode(errors.NoMemory, "key generator cannot allocate enough memory")
 )
 
 // PrivateKey stores a ECDSA or RSA private key.
@@ -108,7 +108,7 @@ func New(keytype int) (*Keypair, error) {
 		return nil, ErrGetKeySize
 	}
 	if sizeOverflow(privLen) || sizeOverflow(pubLen) {
-		return nil, ErrOverflow
+		return nil, ErrOutOfMemory
 	}
 
 	priv := make([]byte, int(privLen), int(privLen))

--- a/gothemis/keys/keypair.go
+++ b/gothemis/keys/keypair.go
@@ -75,10 +75,10 @@ const (
 
 // Errors returned by key generation.
 var (
-	ErrGetKeySize  = errors.New("Failed to get needed key sizes")
-	ErrGenKeypair  = errors.New("Failed to generate keypair")
-	ErrInvalidType = errors.NewWithCode(errors.InvalidParameter, "invalid key type specified")
-	ErrOverflow    = errors.NewWithCode(errors.NoMemory, "key generator cannot allocate enough memory")
+	ErrGetKeySize       = errors.New("Failed to get needed key sizes")
+	ErrGenerateKeypair  = errors.New("Failed to generate keypair")
+	ErrInvalidType      = errors.NewWithCode(errors.InvalidParameter, "invalid key type specified")
+	ErrOverflow         = errors.NewWithCode(errors.NoMemory, "key generator cannot allocate enough memory")
 )
 
 // PrivateKey stores a ECDSA or RSA private key.
@@ -115,7 +115,7 @@ func New(keytype int) (*Keypair, error) {
 	pub := make([]byte, int(pubLen), int(pubLen))
 
 	if !bool(C.gen_keys(C.int(keytype), unsafe.Pointer(&priv[0]), privLen, unsafe.Pointer(&pub[0]), pubLen)) {
-		return nil, ErrGenKeypair
+		return nil, ErrGenerateKeypair
 	}
 
 	return &Keypair{

--- a/gothemis/keys/keypair.go
+++ b/gothemis/keys/keypair.go
@@ -75,6 +75,8 @@ const (
 
 // Errors returned by key generation.
 var (
+	ErrGetKeySize  = errors.New("Failed to get needed key sizes")
+	ErrGenKeypair  = errors.New("Failed to generate keypair")
 	ErrInvalidType = errors.NewWithCode(errors.InvalidParameter, "invalid key type specified")
 	ErrOverflow    = errors.NewWithCode(errors.NoMemory, "key generator cannot allocate enough memory")
 )
@@ -103,7 +105,7 @@ func New(keytype int) (*Keypair, error) {
 
 	var privLen, pubLen C.size_t
 	if !bool(C.get_key_size(C.int(keytype), &privLen, &pubLen)) {
-		return nil, errors.New("Failed to get needed key sizes")
+		return nil, ErrGetKeySize
 	}
 	if sizeOverflow(privLen) || sizeOverflow(pubLen) {
 		return nil, ErrOverflow
@@ -113,7 +115,7 @@ func New(keytype int) (*Keypair, error) {
 	pub := make([]byte, int(pubLen), int(pubLen))
 
 	if !bool(C.gen_keys(C.int(keytype), unsafe.Pointer(&priv[0]), privLen, unsafe.Pointer(&pub[0]), pubLen)) {
-		return nil, errors.New("Failed to generate keypair")
+		return nil, ErrGenKeypair
 	}
 
 	return &Keypair{

--- a/gothemis/keys/keypair.go
+++ b/gothemis/keys/keypair.go
@@ -75,8 +75,8 @@ const (
 
 // Errors returned by key generation.
 var (
-	ErrGetKeySize       = errors.New("Failed to get needed key sizes")
-	ErrGenerateKeypair  = errors.New("Failed to generate keypair")
+	ErrGetKeySize       = errors.New("failed to get needed key sizes")
+	ErrGenerateKeypair  = errors.New("failed to generate keypair")
 	ErrInvalidType      = errors.NewWithCode(errors.InvalidParameter, "invalid key type specified")
 	ErrOutOfMemory      = errors.NewWithCode(errors.NoMemory, "key generator cannot allocate enough memory")
 	// Deprecated: Since 0.14. Use ErrOutOfMemory instead.

--- a/gothemis/keys/symmetric.go
+++ b/gothemis/keys/symmetric.go
@@ -27,8 +27,8 @@ import (
 
 // Errors returned by key generation.
 var (
-	ErrGetSymmetricKeySize  = errors.New("Failed to get symmetric key size")
-	ErrGenerateSymmetricKey = errors.New("Failed to generate symmetric key")
+	ErrGetSymmetricKeySize  = errors.New("failed to get symmetric key size")
+	ErrGenerateSymmetricKey = errors.New("failed to generate symmetric key")
 )
 
 // SymmetricKey stores a master key for Secure Cell.

--- a/gothemis/keys/symmetric.go
+++ b/gothemis/keys/symmetric.go
@@ -27,8 +27,8 @@ import (
 
 // Errors returned by key generation.
 var (
-	ErrGetSymmKeySize   = errors.New("Failed to get symmetric key size")
-	ErrGenSymmKey       = errors.New("Failed to generate symmetric key")
+	ErrGetSymmetricKeySize  = errors.New("Failed to get symmetric key size")
+	ErrGenerateSymmetricKey = errors.New("Failed to generate symmetric key")
 )
 
 // SymmetricKey stores a master key for Secure Cell.
@@ -40,7 +40,7 @@ type SymmetricKey struct {
 func NewSymmetricKey() (*SymmetricKey, error) {
 	var len C.size_t
 	if !bool(C.get_sym_key_size(&len)) {
-		return nil, ErrGetSymmKeySize
+		return nil, ErrGetSymmetricKeySize
 	}
 	if sizeOverflow(len) {
 		return nil, ErrOutOfMemory
@@ -48,7 +48,7 @@ func NewSymmetricKey() (*SymmetricKey, error) {
 
 	key := make([]byte, int(len), int(len))
 	if !bool(C.gen_sym_key(unsafe.Pointer(&key[0]), len)) {
-		return nil, ErrGenSymmKey
+		return nil, ErrGenerateSymmetricKey
 	}
 
 	return &SymmetricKey{Value: key}, nil

--- a/gothemis/keys/symmetric.go
+++ b/gothemis/keys/symmetric.go
@@ -43,7 +43,7 @@ func NewSymmetricKey() (*SymmetricKey, error) {
 		return nil, ErrGetSymmKeySize
 	}
 	if sizeOverflow(len) {
-		return nil, ErrOverflow
+		return nil, ErrOutOfMemory
 	}
 
 	key := make([]byte, int(len), int(len))

--- a/gothemis/keys/symmetric.go
+++ b/gothemis/keys/symmetric.go
@@ -25,6 +25,12 @@ import (
 	"github.com/cossacklabs/themis/gothemis/errors"
 )
 
+// Errors returned by key generation.
+var (
+	ErrGetSymmKeySize   = errors.New("Failed to get symmetric key size")
+	ErrGenSymmKey       = errors.New("Failed to generate symmetric key")
+)
+
 // SymmetricKey stores a master key for Secure Cell.
 type SymmetricKey struct {
 	Value []byte
@@ -34,7 +40,7 @@ type SymmetricKey struct {
 func NewSymmetricKey() (*SymmetricKey, error) {
 	var len C.size_t
 	if !bool(C.get_sym_key_size(&len)) {
-		return nil, errors.New("Failed to get symmetric key size")
+		return nil, ErrGetSymmKeySize
 	}
 	if sizeOverflow(len) {
 		return nil, ErrOverflow
@@ -42,7 +48,7 @@ func NewSymmetricKey() (*SymmetricKey, error) {
 
 	key := make([]byte, int(len), int(len))
 	if !bool(C.gen_sym_key(unsafe.Pointer(&key[0]), len)) {
-		return nil, errors.New("Failed to generate symmetric key")
+		return nil, ErrGenSymmKey
 	}
 
 	return &SymmetricKey{Value: key}, nil

--- a/gothemis/message/message.go
+++ b/gothemis/message/message.go
@@ -83,7 +83,7 @@ var (
 	ErrSignMsg           = errors.New("Failed to sign message")
 	ErrVerifyMsg         = errors.New("Failed to verify message")
 	ErrProcessMsg        = errors.New("Failed to process message")
-	ErrGetOutSize        = errors.New("Failed to get output size")
+	ErrGetOutputSize     = errors.New("Failed to get output size")
 	ErrMissingMessage    = errors.NewWithCode(errors.InvalidParameter, "empty message for Secure Cell")
 	ErrMissingPublicKey  = errors.NewWithCode(errors.InvalidParameter, "empty peer public key for Secure Message")
 	ErrMissingPrivateKey = errors.NewWithCode(errors.InvalidParameter, "empty private key for Secure Message")
@@ -141,7 +141,7 @@ func messageProcess(private *keys.PrivateKey, peerPublic *keys.PublicKey, messag
 		C.size_t(len(message)),
 		C.int(mode),
 		&outputLength)) {
-		return nil, ErrGetOutSize
+		return nil, ErrGetOutputSize
 	}
 	if sizeOverflow(outputLength) {
 		return nil, ErrOverflow

--- a/gothemis/message/message.go
+++ b/gothemis/message/message.go
@@ -78,16 +78,18 @@ const (
 
 // Errors returned by Secure Message.
 var (
-	ErrEncryptMsg        = errors.New("Failed to encrypt message")
-	ErrDecryptMsg        = errors.New("Failed to decrypt message")
-	ErrSignMsg           = errors.New("Failed to sign message")
-	ErrVerifyMsg         = errors.New("Failed to verify message")
-	ErrProcessMsg        = errors.New("Failed to process message")
+	ErrEncryptMessage    = errors.New("Failed to encrypt message")
+	ErrDecryptMessage    = errors.New("Failed to decrypt message")
+	ErrSignMessage       = errors.New("Failed to sign message")
+	ErrVerifyMessage     = errors.New("Failed to verify message")
+	ErrProcessMessage    = errors.New("Failed to process message")
 	ErrGetOutputSize     = errors.New("Failed to get output size")
 	ErrMissingMessage    = errors.NewWithCode(errors.InvalidParameter, "empty message for Secure Cell")
 	ErrMissingPublicKey  = errors.NewWithCode(errors.InvalidParameter, "empty peer public key for Secure Message")
 	ErrMissingPrivateKey = errors.NewWithCode(errors.InvalidParameter, "empty private key for Secure Message")
 	ErrOutOfMemory       = errors.NewWithCode(errors.NoMemory, "Secure Message cannot allocate enough memory")
+	// Deprecated: Since 0.13.3. Use ErrOutOfMemory instead.
+	ErrOverflow          = ErrOutOfMemory
 )
 
 // SecureMessage provides a sequence-independent, stateless, contextless messaging system.
@@ -159,15 +161,15 @@ func messageProcess(private *keys.PrivateKey, peerPublic *keys.PublicKey, messag
 		outputLength)) {
 		switch mode {
 		case secureMessageEncrypt:
-			return nil, ErrEncryptMsg
+			return nil, ErrEncryptMessage
 		case secureMessageDecrypt:
-			return nil, ErrDecryptMsg
+			return nil, ErrDecryptMessage
 		case secureMessageSign:
-			return nil, ErrSignMsg
+			return nil, ErrSignMessage
 		case secureMessageVerify:
-			return nil, ErrVerifyMsg
+			return nil, ErrVerifyMessage
 		default:
-			return nil, ErrProcessMsg
+			return nil, ErrProcessMessage
 		}
 	}
 

--- a/gothemis/message/message.go
+++ b/gothemis/message/message.go
@@ -78,12 +78,12 @@ const (
 
 // Errors returned by Secure Message.
 var (
-	ErrEncryptMessage    = errors.New("Failed to encrypt message")
-	ErrDecryptMessage    = errors.New("Failed to decrypt message")
-	ErrSignMessage       = errors.New("Failed to sign message")
-	ErrVerifyMessage     = errors.New("Failed to verify message")
-	ErrProcessMessage    = errors.New("Failed to process message")
-	ErrGetOutputSize     = errors.New("Failed to get output size")
+	ErrEncryptMessage    = errors.New("failed to encrypt message")
+	ErrDecryptMessage    = errors.New("failed to decrypt message")
+	ErrSignMessage       = errors.New("failed to sign message")
+	ErrVerifyMessage     = errors.New("failed to verify message")
+	ErrProcessMessage    = errors.New("failed to process message")
+	ErrGetOutputSize     = errors.New("failed to get output size")
 	ErrMissingMessage    = errors.NewWithCode(errors.InvalidParameter, "empty message for Secure Cell")
 	ErrMissingPublicKey  = errors.NewWithCode(errors.InvalidParameter, "empty peer public key for Secure Message")
 	ErrMissingPrivateKey = errors.NewWithCode(errors.InvalidParameter, "empty private key for Secure Message")

--- a/gothemis/message/message.go
+++ b/gothemis/message/message.go
@@ -87,7 +87,7 @@ var (
 	ErrMissingMessage    = errors.NewWithCode(errors.InvalidParameter, "empty message for Secure Cell")
 	ErrMissingPublicKey  = errors.NewWithCode(errors.InvalidParameter, "empty peer public key for Secure Message")
 	ErrMissingPrivateKey = errors.NewWithCode(errors.InvalidParameter, "empty private key for Secure Message")
-	ErrOverflow          = errors.NewWithCode(errors.NoMemory, "Secure Message cannot allocate enough memory")
+	ErrOutOfMemory       = errors.NewWithCode(errors.NoMemory, "Secure Message cannot allocate enough memory")
 )
 
 // SecureMessage provides a sequence-independent, stateless, contextless messaging system.
@@ -144,7 +144,7 @@ func messageProcess(private *keys.PrivateKey, peerPublic *keys.PublicKey, messag
 		return nil, ErrGetOutputSize
 	}
 	if sizeOverflow(outputLength) {
-		return nil, ErrOverflow
+		return nil, ErrOutOfMemory
 	}
 
 	output := make([]byte, int(outputLength), int(outputLength))

--- a/gothemis/message/message.go
+++ b/gothemis/message/message.go
@@ -88,7 +88,7 @@ var (
 	ErrMissingPublicKey  = errors.NewWithCode(errors.InvalidParameter, "empty peer public key for Secure Message")
 	ErrMissingPrivateKey = errors.NewWithCode(errors.InvalidParameter, "empty private key for Secure Message")
 	ErrOutOfMemory       = errors.NewWithCode(errors.NoMemory, "Secure Message cannot allocate enough memory")
-	// Deprecated: Since 0.13.3. Use ErrOutOfMemory instead.
+	// Deprecated: Since 0.14. Use ErrOutOfMemory instead.
 	ErrOverflow          = ErrOutOfMemory
 )
 

--- a/gothemis/message/message.go
+++ b/gothemis/message/message.go
@@ -78,6 +78,12 @@ const (
 
 // Errors returned by Secure Message.
 var (
+	ErrEncryptMsg        = errors.New("Failed to encrypt message")
+	ErrDecryptMsg        = errors.New("Failed to decrypt message")
+	ErrSignMsg           = errors.New("Failed to sign message")
+	ErrVerifyMsg         = errors.New("Failed to verify message")
+	ErrProcessMsg        = errors.New("Failed to process message")
+	ErrGetOutSize        = errors.New("Failed to get output size")
 	ErrMissingMessage    = errors.NewWithCode(errors.InvalidParameter, "empty message for Secure Cell")
 	ErrMissingPublicKey  = errors.NewWithCode(errors.InvalidParameter, "empty peer public key for Secure Message")
 	ErrMissingPrivateKey = errors.NewWithCode(errors.InvalidParameter, "empty private key for Secure Message")
@@ -135,7 +141,7 @@ func messageProcess(private *keys.PrivateKey, peerPublic *keys.PublicKey, messag
 		C.size_t(len(message)),
 		C.int(mode),
 		&outputLength)) {
-		return nil, errors.New("Failed to get output size")
+		return nil, ErrGetOutSize
 	}
 	if sizeOverflow(outputLength) {
 		return nil, ErrOverflow
@@ -153,15 +159,15 @@ func messageProcess(private *keys.PrivateKey, peerPublic *keys.PublicKey, messag
 		outputLength)) {
 		switch mode {
 		case secureMessageEncrypt:
-			return nil, errors.New("Failed to encrypt message")
+			return nil, ErrEncryptMsg
 		case secureMessageDecrypt:
-			return nil, errors.New("Failed to decrypt message")
+			return nil, ErrDecryptMsg
 		case secureMessageSign:
-			return nil, errors.New("Failed to sign message")
+			return nil, ErrSignMsg
 		case secureMessageVerify:
-			return nil, errors.New("Failed to verify message")
+			return nil, ErrVerifyMsg
 		default:
-			return nil, errors.New("Failed to process message")
+			return nil, ErrProcessMsg
 		}
 	}
 

--- a/gothemis/session/session.go
+++ b/gothemis/session/session.go
@@ -48,7 +48,7 @@ var (
 	ErrMissingPrivateKey         = errors.NewWithCode(errors.InvalidParameter, "empty client private key for Secure Session")
 	ErrMissingMessage            = errors.NewWithCode(errors.InvalidParameter, "empty message for Secure Session")
 	ErrOutOfMemory               = errors.NewWithCode(errors.NoMemory, "Secure Session cannot allocate enough memory")
-	// Deprecated: Since 0.13.3. Use ErrOutOfMemory instead.
+	// Deprecated: Since 0.14. Use ErrOutOfMemory instead.
 	ErrOverflow                  = ErrOutOfMemory
 )
 

--- a/gothemis/session/session.go
+++ b/gothemis/session/session.go
@@ -37,13 +37,13 @@ const (
 
 // Errors returned by Secure Session.
 var (
-	ErrCreateSession             = errors.New("Failed to create secure session object")
-	ErrDestroySession            = errors.New("Failed to destroy secure session object")
-	ErrMessageSize               = errors.New("Failed to get message size")
-	ErrMessageData               = errors.New("Failed to process message data")
-	ErrNoPublicKey               = errors.NewCallbackError("Failed to get public key (get_public_key_by_id callback error)")
-	ErrBadRemoteIDLength         = errors.NewCallbackError("Incorrect remote id length (0)")
-	ErrGetRemoteID               = errors.NewCallbackError("Failed to get session remote id")
+	ErrCreateSession             = errors.New("failed to create secure session object")
+	ErrDestroySession            = errors.New("failed to destroy secure session object")
+	ErrMessageSize               = errors.New("failed to get message size")
+	ErrMessageData               = errors.New("failed to process message data")
+	ErrNoPublicKey               = errors.NewCallbackError("failed to get public key (get_public_key_by_id callback error)")
+	ErrBadRemoteIDLength         = errors.NewCallbackError("incorrect remote id length (0)")
+	ErrGetRemoteID               = errors.NewCallbackError("failed to get session remote id")
 	ErrMissingClientID           = errors.NewWithCode(errors.InvalidParameter, "empty client ID for Secure Session")
 	ErrMissingPrivateKey         = errors.NewWithCode(errors.InvalidParameter, "empty client private key for Secure Session")
 	ErrMissingMessage            = errors.NewWithCode(errors.InvalidParameter, "empty message for Secure Session")

--- a/gothemis/session/session.go
+++ b/gothemis/session/session.go
@@ -53,7 +53,7 @@ var (
 	ErrMissingClientID           = errors.NewWithCode(errors.InvalidParameter, "empty client ID for Secure Session")
 	ErrMissingPrivateKey         = errors.NewWithCode(errors.InvalidParameter, "empty client private key for Secure Session")
 	ErrMissingMessage            = errors.NewWithCode(errors.InvalidParameter, "empty message for Secure Session")
-	ErrOverflow                  = errors.NewWithCode(errors.NoMemory, "Secure Session cannot allocate enough memory")
+	ErrOutOfMemory               = errors.NewWithCode(errors.NoMemory, "Secure Session cannot allocate enough memory")
 )
 
 // SessionCallbacks implements a delegate for SecureSession.
@@ -166,7 +166,7 @@ func (ss *SecureSession) ConnectRequest() ([]byte, error) {
 		return nil, ErrGetRequestSize
 	}
 	if sizeOverflow(reqLen) {
-		return nil, ErrOverflow
+		return nil, ErrOutOfMemory
 	}
 
 	req := make([]byte, reqLen)
@@ -194,7 +194,7 @@ func (ss *SecureSession) Wrap(data []byte) ([]byte, error) {
 		return nil, ErrGetWrappedSize
 	}
 	if sizeOverflow(outLen) {
-		return nil, ErrOverflow
+		return nil, ErrOutOfMemory
 	}
 
 	out := make([]byte, outLen)
@@ -231,7 +231,7 @@ func (ss *SecureSession) Unwrap(data []byte) ([]byte, bool, error) {
 		return nil, false, ErrGetUnwrappedSize
 	}
 	if sizeOverflow(outLen) {
-		return nil, false, ErrOverflow
+		return nil, false, ErrOutOfMemory
 	}
 
 	out := make([]byte, outLen)
@@ -267,7 +267,7 @@ func (ss *SecureSession) GetRemoteID() ([]byte, error) {
 		return nil, ErrCallbackBadRemoteIDLen
 	}
 	if sizeOverflow(outLength) {
-		return nil, ErrOverflow
+		return nil, ErrOutOfMemory
 	}
 	out := make([]byte, int(outLength))
 	if C.secure_session_get_remote_id(ss.ctx.session, (*C.uint8_t)(&out[0]), &outLength) != C.THEMIS_SUCCESS {


### PR DESCRIPTION
Only errors that contain static text message were replaced since they remain constant until the end of runtime.
Packages `cell`, `compare`, `keys`, `message`, `session` now contain more error constants, one may use them to compare with error returned by some function from the same package.
`ErrOverflow` will be deprecated starting from 0.14.0, `ErrOutOfMemory` is recommended instead due to more understandable name.

## Checklist

- [X] The [coding guidelines] are followed
- [X] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
