### PR TITLE
Fix Clippy warning

### DIFF
--- a/src/wrappers/themis/rust/src/secure_comparator.rs
+++ b/src/wrappers/themis/rust/src/secure_comparator.rs
@@ -374,10 +374,7 @@ impl SecureComparator {
     /// assert!(!comparison.is_complete());
     /// ```
     pub fn is_complete(&self) -> bool {
-        match self.result() {
-            Err(ref e) if e.kind() == ErrorKind::CompareNotReady => false,
-            _ => true,
-        }
+        !matches!(self.result(), Err(ref e) if e.kind() == ErrorKind::CompareNotReady)
     }
 
     /// Returns the result of comparison.


### PR DESCRIPTION
Rewrite `match` block using `matches` macro as it is now a recommended way to perform such checks

<!-- Describe your changes here -->

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
