### PR TITLE
Hotfix for Themis CocoaPods podspec: support Xcode12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 Changes that are currently in development and have not been released yet.
 
 
-## [0.13.3](https://github.com/cossacklabs/themis/releases/tag/0.13.2), October 12th 2020
+## [0.13.3](https://github.com/cossacklabs/themis/releases/tag/0.13.3), October 12th 2020
 
 **Hotfix for Themis CocoaPods and Xcode12:**
 
@@ -15,7 +15,7 @@ _Code:_
 
 - **Objective-C / Swift**
 
-  - Themis CocoaPods podspec is updated with bitcode fixes and disabling arm64 simulator in order to support Xcode12 builds. This is a podspec change only, no changes in code, headers or whatsoever. Default podspec is set as "themis/themis-openssl", which uses OpenSSL 1.0.2u. Fixes for "themis/openssl" podspec (OpenSSL 1.1.1g) will arrive soon.
+  - Themis CocoaPods podspec is updated with bitcode fixes and disabling arm64 simulator in order to support Xcode12 builds. This is a podspec change only, no changes in code, headers or whatsoever. Default podspec is set as "themis/themis-openssl", which uses OpenSSL 1.0.2u. Fixes for "themis/openssl" podspec (OpenSSL 1.1.1g) might arrive soon.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 Changes that are currently in development and have not been released yet.
 
+
+## [0.13.3](https://github.com/cossacklabs/themis/releases/tag/0.13.2), October 12th 2020
+
+**Hotfix for Themis CocoaPods and Xcode12:**
+
+- Default Themis podspec is using OpenSSL 1.0.2u again ("themis/themis-openssl"). OpenSSL 1.1.1g podspec ("themis/openssl") might be broken for Xcode12, fixing is in progress. BoringSSL podspec ("themis/themis-boringssl") is available too.
+
+_Code:_
+
+- **Objective-C / Swift**
+
+  - Themis CocoaPods podspec is updated with bitcode fixes and disabling arm64 simulator in order to support Xcode12 builds. This is a podspec change only, no changes in code, headers or whatsoever. Default podspec is set as "themis/themis-openssl", which uses OpenSSL 1.0.2u. Fixes for "themis/openssl" podspec (OpenSSL 1.1.1g) will arrive soon.
+
+
+
 ## [0.13.2](https://github.com/cossacklabs/themis/releases/tag/0.13.2), August 14th 2020
 
 **Breaking changes and deprecations:**

--- a/docs/examples/Themis-server/Obj-C/Podfile
+++ b/docs/examples/Themis-server/Obj-C/Podfile
@@ -16,7 +16,7 @@
 
 source 'https://github.com/CocoaPods/Specs.git'
 
-platform :ios, '8.0'
+platform :ios, '10.0'
 project 'WorkingWithThemisServer/WorkingWithThemisServer.xcodeproj'
 inhibit_all_warnings!
 use_frameworks!

--- a/docs/examples/Themis-server/swift/Podfile
+++ b/docs/examples/Themis-server/swift/Podfile
@@ -16,7 +16,7 @@
 
 source 'https://github.com/CocoaPods/Specs.git'
 
-platform :ios, '8.0'
+platform :ios, '10.0'
 project 'SwiftThemisServerExample/SwiftThemisServerExample.xcodeproj'
 inhibit_all_warnings!
 use_frameworks!

--- a/docs/examples/objc/iOS-CocoaPods/Podfile
+++ b/docs/examples/objc/iOS-CocoaPods/Podfile
@@ -16,7 +16,7 @@
 
 source 'https://github.com/CocoaPods/Specs.git'
 
-platform :ios, '8.0'
+platform :ios, '10.0'
 project 'ThemisTest/ThemisTest.xcodeproj'
 inhibit_all_warnings!
 use_frameworks!

--- a/docs/examples/swift/iOS-CocoaPods/Podfile
+++ b/docs/examples/swift/iOS-CocoaPods/Podfile
@@ -16,7 +16,7 @@
 
 source 'https://github.com/CocoaPods/Specs.git'
 
-platform :ios, '8.0'
+platform :ios, '10.0'
 project 'ThemisSwift/ThemisSwift.xcodeproj'
 inhibit_all_warnings!
 use_frameworks!

--- a/tests/objcthemis/Podfile
+++ b/tests/objcthemis/Podfile
@@ -16,7 +16,7 @@
 
 source 'https://github.com/CocoaPods/Specs.git'
 
-platform :ios, '8.0'
+platform :ios, '10.0'
 inhibit_all_warnings!
 
 target "objthemis" do
@@ -25,6 +25,9 @@ target "objthemis" do
   pod 'themis', :git => "https://github.com/cossacklabs/themis.git"
 
 end
+
+#TODO: add tests for openssl1.1.1 target?
+
 
 target "objthemis_boring" do
 

--- a/themis.podspec
+++ b/themis.podspec
@@ -1,19 +1,27 @@
 Pod::Spec.new do |s|
     s.name = "themis"
-    s.version = "0.13.1"
+    s.version = "0.13.3"
     s.summary = "Data security library for network communication and data storage for iOS and mac OS"
     s.description = "Themis is a convenient cryptographic library for data protection. It provides secure messaging with forward secrecy and secure data storage. Themis is aimed at modern development practices and has a unified API across 12 platforms, including iOS/macOS, Ruby, JavaScript, Python, and Java/Android."
     s.homepage = "https://cossacklabs.com"
     s.license = { :type => 'Apache 2.0'}
 
-    s.source = { :git => "https://github.com/cossacklabs/themis.git", :tag => "#{s.version}" }
+    # TODO(vixentael, 11 oct 2020): 0.13.3 is a hotfix, it changes only this podspec, new tag was nit set, so use 0.13.2.
+    # Revert this change with new "normal" release in future.
+    s.source = { :git => "https://github.com/cossacklabs/themis.git", :tag => "0.13.2" }
+    #s.source = { :git => "https://github.com/cossacklabs/themis.git", :tag => "#{s.version}" }
+  
     s.author = {'cossacklabs' => 'info@cossacklabs.com'}
 
     s.module_name = 'themis'
-    s.default_subspec = 'openssl-1.1.1'
+    
+    # TODO(vixentael, 11 oct 2020): as xcode12 introduces new arm64 architecture, our own openssl framework doesn't work yet
+    # Change openssl-1.1.1 to default when fix our openssl
+    #s.default_subspec = 'openssl-1.1.1'
+    s.default_subspec = 'themis-openssl'
 
-    s.ios.deployment_target = '8.0'
-    s.osx.deployment_target = '10.9'
+    s.ios.deployment_target = '10.0'
+    s.osx.deployment_target = '10.11'
     s.ios.frameworks = 'UIKit', 'Foundation'
 
     # TODO(ilammy, 2020-03-02): resolve "pod spec lint" warnings due to dependencies
@@ -77,17 +85,33 @@ Pod::Spec.new do |s|
 
     # use `themis/themis-openssl` as separate target to use Themis with OpenSSL
     s.subspec 'themis-openssl' do |so|
-        # Enable bitcode for openssl only, unfortunately boringssl with bitcode not available at the moment
-        so.ios.pod_target_xcconfig = {'ENABLE_BITCODE' => 'YES' }
-
+        # Enable bitcode for OpenSSL in a very specific way, but it works, thanks to @deszip 
+        #so.ios.pod_target_xcconfig = {'ENABLE_BITCODE' => 'YES' }
+        so.ios.pod_target_xcconfig = {
+            'OTHER_CFLAGS[config=Debug]'                => '$(inherited) -fembed-bitcode-marker',
+            'OTHER_CFLAGS[config=Release]'              => '$(inherited) -fembed-bitcode',
+            'BITCODE_GENERATION_MODE[config=Release]'   => 'bitcode',
+            'BITCODE_GENERATION_MODE[config=Debug]'     => 'bitcode-marker'
+        }
+        
+        # Xcode12, arm64 simulator issues https://stackoverflow.com/a/63955114
+        # disable building for arm64 simulator for now
+        
+        so.ios.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+        so.ios.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+        
+        
         # TODO: due to error in symbols in GRKOpenSSLFramework 219 release, we've manually switched to 218
         # which doesn't sound like a good decision, so when GRKOpenSSLFramework will be updated –
         # please bring back correct dependency version
         # https://github.com/cossacklabs/themis/issues/538
         # 26 sept 2019
         #so.dependency 'GRKOpenSSLFramework', '~> 1.0.1' # <-- this is good
+        # 11 oct 2020 update: trying 1.0.2.20, but it also gives linking errors, so postponed
+        # https://github.com/levigroker/GRKOpenSSLFramework/issues/10
+        #so.dependency 'GRKOpenSSLFramework', '1.0.2.20'  # 1.0.2u, latest in 1.0.2 branch
 
-        so.dependency 'GRKOpenSSLFramework', '1.0.2.18'  # <-- this is bad and temp
+        so.dependency 'GRKOpenSSLFramework', '1.0.2.18'  # <-- this is temp
 
 
         so.ios.xcconfig = { 'OTHER_CFLAGS' => '-DLIBRESSL', 'USE_HEADERMAP' => 'NO',

--- a/themis.podspec
+++ b/themis.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name = "themis"
-    s.version = "0.13.2"
+    s.version = "0.13.3"
     s.summary = "Data security library for network communication and data storage for iOS and mac OS"
     s.description = "Themis is a convenient cryptographic library for data protection. It provides secure messaging with forward secrecy and secure data storage. Themis is aimed at modern development practices and has a unified API across 12 platforms, including iOS/macOS, Ruby, JavaScript, Python, and Java/Android."
     s.homepage = "https://cossacklabs.com"
@@ -11,10 +11,6 @@ Pod::Spec.new do |s|
     s.author = {'cossacklabs' => 'info@cossacklabs.com'}
 
     s.module_name = 'themis'
-    
-    # TODO(vixentael, 11 oct 2020): as xcode12 introduces new arm64 architecture, our own openssl framework doesn't work yet
-    # Change openssl-1.1.1 to default when fix our openssl
-    #s.default_subspec = 'openssl-1.1.1'
     s.default_subspec = 'themis-openssl'
 
     s.ios.deployment_target = '10.0'
@@ -25,6 +21,8 @@ Pod::Spec.new do |s|
     # If you update dependencies, please check whether we can remove "--allow-warnings"
     # from podspec validation in .github/workflows/test-objc.yaml
 
+    # TODO(vixentael, 11 oct 2020): as xcode12 introduces new arm64 architecture, our own openssl framework doesn't work yet
+    # Change openssl-1.1.1 to default when fix our openssl
     # This variant uses the current stable, non-legacy version of OpenSSL.
     s.subspec 'openssl-1.1.1' do |so|
         # OpenSSL 1.1.1g

--- a/themis.podspec
+++ b/themis.podspec
@@ -1,15 +1,12 @@
 Pod::Spec.new do |s|
     s.name = "themis"
-    s.version = "0.13.3"
+    s.version = "0.13.2"
     s.summary = "Data security library for network communication and data storage for iOS and mac OS"
     s.description = "Themis is a convenient cryptographic library for data protection. It provides secure messaging with forward secrecy and secure data storage. Themis is aimed at modern development practices and has a unified API across 12 platforms, including iOS/macOS, Ruby, JavaScript, Python, and Java/Android."
     s.homepage = "https://cossacklabs.com"
     s.license = { :type => 'Apache 2.0'}
 
-    # TODO(vixentael, 11 oct 2020): 0.13.3 is a hotfix, it changes only this podspec, new tag was nit set, so use 0.13.2.
-    # Revert this change with new "normal" release in future.
-    s.source = { :git => "https://github.com/cossacklabs/themis.git", :tag => "0.13.2" }
-    #s.source = { :git => "https://github.com/cossacklabs/themis.git", :tag => "#{s.version}" }
+    s.source = { :git => "https://github.com/cossacklabs/themis.git", :tag => "#{s.version}" }
   
     s.author = {'cossacklabs' => 'info@cossacklabs.com'}
 


### PR DESCRIPTION
This is a hotfix that touches only themis.podspec.

The reason is Xcode 12 updates: arm64 simulator and some bitcode changes.

### Things done:

- switched the default spec to `themis/themis-openssl` (OpenSSL 1.0.2u)
- added more bitcode-related flags for debug and release (kudos to [@deszip](https://github.com/deszip) who insisted on these and verified that it's working)
- excluded 'arm64' architecture for simulator (these [stackoverflow suggestions](https://stackoverflow.com/questions/63607158/xcode-12-building-for-ios-simulator-but-linking-in-object-file-built-for-ios) and [@deszip](https://github.com/deszip) were helpful)
- increased iOS target to 10.0 and macOS target to 10.11
- re-tested GRKOpenSSLFramework version, but unfortunately due to  https://github.com/levigroker/GRKOpenSSLFramework/issues/10, we use the same old 1.0.2.18
- i'm using the same 0.13.2 tag, because there's no need for new tag, as code wasn't touched at all

### Testing:

- validated podspec with allow-warnings true
- built Swift&Objc example apps in Release build, pushed app to appcenter, pushed to testflight, installed on device — all good here


### Some resources:

- excluding `arm64` from active architectures for your app, [stackoverflow](https://stackoverflow.com/a/63955114)
- more about Xcode12 and various hacks to be able to build apps while running on laptop with Intel CPUs, [stackoverflow](https://stackoverflow.com/a/64139830) 
- [thread on devforums](https://developer.apple.com/forums/thread/658424)


## Checklist

- [x] Changelog is updated (in case of notable or breaking changes)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
