### PR TITLE
Switch github actions to Xcode12 [ios, macos]

### DIFF
--- a/.github/workflows/test-objc.yaml
+++ b/.github/workflows/test-objc.yaml
@@ -58,6 +58,10 @@ env:
   HACK_REPOSITORY: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
   HACK_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
+  # let's use Xcode 12.2 to test Xcode12-specifics
+  # TODO: change on default Xcode later
+  DEVELOPER_DIR: /Applications/Xcode_12.2.app/Contents/Developer
+
 jobs:
   unit-tests-cocoapods:
     name: Unit tests (CocoaPods)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ _Code:_
 
 - **Objective-C**
 
+  - Switched to test on Xcode 12.2 ([#721](https://github.com/cossacklabs/themis/pull/721)).
   - Updated Objective-C examples (iOS and macOS, Carthage and CocoaPods) to showcase usage of the newest Secure Cell API: generating symmetric keys and using Secure Cell with Passphrase ([#688](https://github.com/cossacklabs/themis/pull/688)) and to use latest Themis 0.13.2 ([#701](https://github.com/cossacklabs/themis/pull/701), [#703](https://github.com/cossacklabs/themis/pull/703), [#706](https://github.com/cossacklabs/themis/pull/706)).
   - `TSSession` initializer now returns an error (`nil`) when given incorrect key type ([#710](https://github.com/cossacklabs/themis/pull/710)).
 
@@ -44,6 +45,7 @@ _Code:_
 
 - **Swift**
 
+  - Switched to test on Xcode 12.2 ([#721](https://github.com/cossacklabs/themis/pull/721)).
   - Updated Swift examples (iOS and macOS, Carthage and CocoaPods) to showcase usage of the newest Secure Cell API: generating symmetric keys and using Secure Cell with Passphrase ([#688](https://github.com/cossacklabs/themis/pull/688)) and to use latest Themis 0.13.2 ([#701](https://github.com/cossacklabs/themis/pull/701), [#703](https://github.com/cossacklabs/themis/pull/703), [#706](https://github.com/cossacklabs/themis/pull/706)).
   - `TSSession` initializer now returns an error (`nil`) when given incorrect key type ([#710](https://github.com/cossacklabs/themis/pull/710)).
 

--- a/docs/examples/swift/iOS-CocoaPods/Podfile
+++ b/docs/examples/swift/iOS-CocoaPods/Podfile
@@ -23,6 +23,6 @@ use_frameworks!
 
 target :"ThemisSwift" do
 
-  pod 'themis', '0.13.1'
+  pod 'themis', '0.13.3'
 
 end

--- a/docs/examples/swift/iOS-CocoaPods/Podfile.lock
+++ b/docs/examples/swift/iOS-CocoaPods/Podfile.lock
@@ -1,29 +1,29 @@
 PODS:
-  - CLOpenSSL (1.1.107.1)
-  - themis (0.13.1):
-    - themis/openssl-1.1.1 (= 0.13.1)
-  - themis/openssl-1.1.1 (0.13.1):
-    - CLOpenSSL (~> 1.1.107)
-    - themis/openssl-1.1.1/core (= 0.13.1)
-    - themis/openssl-1.1.1/objcwrapper (= 0.13.1)
-  - themis/openssl-1.1.1/core (0.13.1):
-    - CLOpenSSL (~> 1.1.107)
-  - themis/openssl-1.1.1/objcwrapper (0.13.1):
-    - CLOpenSSL (~> 1.1.107)
-    - themis/openssl-1.1.1/core
+  - GRKOpenSSLFramework (1.0.2.18)
+  - themis (0.13.3):
+    - themis/themis-openssl (= 0.13.3)
+  - themis/themis-openssl (0.13.3):
+    - GRKOpenSSLFramework (= 1.0.2.18)
+    - themis/themis-openssl/core (= 0.13.3)
+    - themis/themis-openssl/objcwrapper (= 0.13.3)
+  - themis/themis-openssl/core (0.13.3):
+    - GRKOpenSSLFramework (= 1.0.2.18)
+  - themis/themis-openssl/objcwrapper (0.13.3):
+    - GRKOpenSSLFramework (= 1.0.2.18)
+    - themis/themis-openssl/core
 
 DEPENDENCIES:
-  - themis (= 0.13.1)
+  - themis (= 0.13.3)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
-    - CLOpenSSL
+    - GRKOpenSSLFramework
     - themis
 
 SPEC CHECKSUMS:
-  CLOpenSSL: e57362f6522670f6dc727d19bd6dcd98c23d7cf5
-  themis: ccc8859adda9668dc4fd584bbb2390bf6c696de5
+  GRKOpenSSLFramework: 1d65e55d569af7b23074373041a92cc8bc768a92
+  themis: 00b56e2cdcc5ab1fc846aa0271ef0c2895a1c476
 
-PODFILE CHECKSUM: 89fdc211a52dc15047fd02a93c6824b6ca35b575
+PODFILE CHECKSUM: e64563e8fedfcfc1bb7c0ba89bc856a9b0063d36
 
-COCOAPODS: 1.9.3
+COCOAPODS: 1.9.1

--- a/docs/examples/swift/iOS-CocoaPods/ThemisSwift/ThemisSwift.xcodeproj/project.pbxproj
+++ b/docs/examples/swift/iOS-CocoaPods/ThemisSwift/ThemisSwift.xcodeproj/project.pbxproj
@@ -16,7 +16,7 @@
 		739981441CC449010095138F /* client.pub in Resources */ = {isa = PBXBuildFile; fileRef = 739981381CC449010095138F /* client.pub */; };
 		739981451CC449010095138F /* server.priv in Resources */ = {isa = PBXBuildFile; fileRef = 739981391CC449010095138F /* server.priv */; };
 		739981461CC449010095138F /* server.pub in Resources */ = {isa = PBXBuildFile; fileRef = 7399813A1CC449010095138F /* server.pub */; };
-		8C59F5CA06259E3DEFCCA28A /* Pods_ThemisSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B0C144B5E58FFE4F1D5AD77B /* Pods_ThemisSwift.framework */; };
+		D0062A86D78A7FE69900648F /* Pods_ThemisSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A5A7B68253475CD807D0B68B /* Pods_ThemisSwift.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -32,9 +32,9 @@
 		7399813A1CC449010095138F /* server.pub */ = {isa = PBXFileReference; lastKnownFileType = file; path = server.pub; sourceTree = "<group>"; };
 		739981491CC44ABA0095138F /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7399814A1CC44ABA0095138F /* ThemisSwift-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ThemisSwift-Bridging-Header.h"; sourceTree = "<group>"; };
-		B0C144B5E58FFE4F1D5AD77B /* Pods_ThemisSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ThemisSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		B438CFA58784EBC3F9F321A8 /* Pods-ThemisSwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ThemisSwift.release.xcconfig"; path = "Target Support Files/Pods-ThemisSwift/Pods-ThemisSwift.release.xcconfig"; sourceTree = "<group>"; };
-		E8C425ED4600D843354E4DAB /* Pods-ThemisSwift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ThemisSwift.debug.xcconfig"; path = "Target Support Files/Pods-ThemisSwift/Pods-ThemisSwift.debug.xcconfig"; sourceTree = "<group>"; };
+		A5A7B68253475CD807D0B68B /* Pods_ThemisSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ThemisSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CE11351D5A58651F173D42DE /* Pods-ThemisSwift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ThemisSwift.debug.xcconfig"; path = "Target Support Files/Pods-ThemisSwift/Pods-ThemisSwift.debug.xcconfig"; sourceTree = "<group>"; };
+		D632592253B072B9A8211B11 /* Pods-ThemisSwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ThemisSwift.release.xcconfig"; path = "Target Support Files/Pods-ThemisSwift/Pods-ThemisSwift.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -42,18 +42,18 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8C59F5CA06259E3DEFCCA28A /* Pods_ThemisSwift.framework in Frameworks */,
+				D0062A86D78A7FE69900648F /* Pods_ThemisSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		0DF23A38F8FC16F275032A97 /* Pods */ = {
+		08358F0ADF60F0408656213D /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				E8C425ED4600D843354E4DAB /* Pods-ThemisSwift.debug.xcconfig */,
-				B438CFA58784EBC3F9F321A8 /* Pods-ThemisSwift.release.xcconfig */,
+				CE11351D5A58651F173D42DE /* Pods-ThemisSwift.debug.xcconfig */,
+				D632592253B072B9A8211B11 /* Pods-ThemisSwift.release.xcconfig */,
 			);
 			name = Pods;
 			path = ../Pods;
@@ -64,8 +64,8 @@
 			children = (
 				739981191CC42C880095138F /* ThemisSwift */,
 				739981181CC42C880095138F /* Products */,
-				0DF23A38F8FC16F275032A97 /* Pods */,
-				DCE9D23E7237CDBC712A3D75 /* Frameworks */,
+				08358F0ADF60F0408656213D /* Pods */,
+				B644D47D19D6FBE0C130A796 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -127,10 +127,10 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
-		DCE9D23E7237CDBC712A3D75 /* Frameworks */ = {
+		B644D47D19D6FBE0C130A796 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				B0C144B5E58FFE4F1D5AD77B /* Pods_ThemisSwift.framework */,
+				A5A7B68253475CD807D0B68B /* Pods_ThemisSwift.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -142,12 +142,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 739981291CC42C880095138F /* Build configuration list for PBXNativeTarget "ThemisSwift" */;
 			buildPhases = (
-				706731B24B4D7C0F537917AC /* [CP] Check Pods Manifest.lock */,
+				538E376CC18C58FC73E0B73C /* [CP] Check Pods Manifest.lock */,
 				739981131CC42C880095138F /* Sources */,
 				739981141CC42C880095138F /* Frameworks */,
 				739981151CC42C880095138F /* Resources */,
 				73688AFE1CC4504F00D3C430 /* ShellScript */,
-				BE934335041AFEEF3CC738DA /* [CP] Embed Pods Frameworks */,
+				35F6C062D2BF08043D433D62 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -165,7 +165,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1200;
 				ORGANIZATIONNAME = CossackLabs;
 				TargetAttributes = {
 					739981161CC42C880095138F = {
@@ -212,7 +212,27 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		706731B24B4D7C0F537917AC /* [CP] Check Pods Manifest.lock */ = {
+		35F6C062D2BF08043D433D62 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ThemisSwift/Pods-ThemisSwift-frameworks.sh",
+				"${PODS_ROOT}/GRKOpenSSLFramework/OpenSSL-iOS/bin/openssl.framework",
+				"${BUILT_PRODUCTS_DIR}/themis/themis.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/openssl.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/themis.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ThemisSwift/Pods-ThemisSwift-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		538E376CC18C58FC73E0B73C /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -246,26 +266,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if which swiftlint >/dev/null; then\n# uncomment for autocorrection\n# swiftlint autocorrect\n    swiftlint lint --quiet\nelse\n    echo \"SwiftLint does not exist, download from https://github.com/realm/SwiftLint\"\nfi";
-		};
-		BE934335041AFEEF3CC738DA /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ThemisSwift/Pods-ThemisSwift-frameworks.sh",
-				"${PODS_ROOT}/CLOpenSSL/openssl-dynamic-iPhone.zip/openssl.framework",
-				"${BUILT_PRODUCTS_DIR}/themis/themis.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/openssl.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/themis.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ThemisSwift/Pods-ThemisSwift-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -325,6 +325,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -349,7 +350,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -382,6 +383,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -400,7 +402,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTS_MACCATALYST = NO;
@@ -411,7 +413,7 @@
 		};
 		7399812A1CC42C880095138F /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E8C425ED4600D843354E4DAB /* Pods-ThemisSwift.debug.xcconfig */;
+			baseConfigurationReference = CE11351D5A58651F173D42DE /* Pods-ThemisSwift.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -420,7 +422,7 @@
 				DEVELOPMENT_TEAM = X6X7AHQ2D4;
 				ENABLE_BITCODE = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/ThemisSwift/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.ThemisSwift;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -435,7 +437,7 @@
 		};
 		7399812B1CC42C880095138F /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B438CFA58784EBC3F9F321A8 /* Pods-ThemisSwift.release.xcconfig */;
+			baseConfigurationReference = D632592253B072B9A8211B11 /* Pods-ThemisSwift.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -444,7 +446,7 @@
 				DEVELOPMENT_TEAM = X6X7AHQ2D4;
 				ENABLE_BITCODE = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/ThemisSwift/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.ThemisSwift;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/docs/examples/swift/iOS-CocoaPods/ThemisSwift/ThemisSwift.xcodeproj/xcshareddata/xcschemes/ThemisSwift.xcscheme
+++ b/docs/examples/swift/iOS-CocoaPods/ThemisSwift/ThemisSwift.xcodeproj/xcshareddata/xcschemes/ThemisSwift.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,11 +36,11 @@
             ReferencedContainer = "container:ThemisSwift.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -61,8 +59,6 @@
             ReferencedContainer = "container:ThemisSwift.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
Enable Xcode 12.2 in Github actions, as Themis is switching to Xcode 12 as result of #719 #720.

Expected result: unit-tests-cocoapods workflow should pass.
Example apps are not updated yet.

## Checklist

- [x] The [coding guidelines] are followed
- [x] Changelog is updated (in case of notable or breaking changes)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
