### PR TITLE
Support PHP Composer 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ _Code:_
 - **PHP**
 
   - `libphpthemis` packages for Debian/Ubuntu now have accurate dependencies ([#683](https://github.com/cossacklabs/themis/pull/683)).
+  - PHP Composer 2.0 is now supported by PHPThemis unit tests ([#730](https://github.com/cossacklabs/themis/pull/730)).
 
 - **Node.js**
 

--- a/tests/phpthemis/composer-php5.6.json
+++ b/tests/phpthemis/composer-php5.6.json
@@ -1,5 +1,5 @@
 {
-    "name": "tests/phpthemis/php-5.6",
+    "name": "phpthemis/test-php-5.6",
     "description": "Some stuff for tests",
     "require": {
         "php": "^5.6",

--- a/tests/phpthemis/composer-php7.2.json
+++ b/tests/phpthemis/composer-php7.2.json
@@ -1,5 +1,5 @@
 {
-    "name": "tests/phpthemis/php-7",
+    "name": "phpthemis/test-php-7",
     "description": "Some stuff for tests",
     "require": {
         "php": "^7",

--- a/tests/phpthemis/composer-php7.json
+++ b/tests/phpthemis/composer-php7.json
@@ -1,5 +1,5 @@
 {
-    "name": "tests/phpthemis/php-7",
+    "name": "phpthemis/test-php-7",
     "description": "Some stuff for tests",
     "require": {
         "php": "^7",


### PR DESCRIPTION
[Recently released major version of PHP Composer][1] introduced ~~arbitrary~~ [restrictions on the package names][2], requiring them to have exactly two alphanumeric parts separated by a slash. Update our test package names to conform to this standard so that our tests work with Composer 2.0.

Since these are internal package names, user code is not affected and there are no compatibility issues.

[1]: https://blog.packagist.com/composer-2-0-is-now-available/
[2]: https://github.com/composer/composer/blob/master/doc/04-schema.md#name

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] ~~Example projects and code samples are up-to-date~~ (no changes other than tests)
- [X] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
