### PR TITLE
Make Themis a static framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ _Code:_
   - Switched to test on Xcode 12.0, disable ARM64 builds for Themis CocoaPods and Themis Carthage ([#721](https://github.com/cossacklabs/themis/pull/721), [#722](https://github.com/cossacklabs/themis/pull/722)).
   - Updated Objective-C examples (iOS and macOS, Carthage and CocoaPods) to showcase usage of the newest Secure Cell API: generating symmetric keys and using Secure Cell with Passphrase ([#688](https://github.com/cossacklabs/themis/pull/688)) and to use latest Themis 0.13.2, 0.13.3 ([#701](https://github.com/cossacklabs/themis/pull/701), [#703](https://github.com/cossacklabs/themis/pull/703), [#706](https://github.com/cossacklabs/themis/pull/706), [#723](https://github.com/cossacklabs/themis/pull/723), [#724](https://github.com/cossacklabs/themis/pull/724), [#726](https://github.com/cossacklabs/themis/pull/726)).
   - `TSSession` initializer now returns an error (`nil`) when given incorrect key type ([#710](https://github.com/cossacklabs/themis/pull/710)).
+  - CocoaPods will now link ObjCThemis statically into application ([#731](https://github.com/cossacklabs/themis/pull/731)).
 
 - **PHP**
 
@@ -49,6 +50,7 @@ _Code:_
   - Switched to test on Xcode 12.0, disable ARM64 builds for Themis CocoaPods and Themis Carthage ([#721](https://github.com/cossacklabs/themis/pull/721), [#722](https://github.com/cossacklabs/themis/pull/722)).
   - Updated Swift examples (iOS and macOS, Carthage and CocoaPods) to showcase usage of the newest Secure Cell API: generating symmetric keys and using Secure Cell with Passphrase ([#688](https://github.com/cossacklabs/themis/pull/688)) and to use latest Themis 0.13.2, 0.13.3 ([#701](https://github.com/cossacklabs/themis/pull/701), [#703](https://github.com/cossacklabs/themis/pull/703), [#706](https://github.com/cossacklabs/themis/pull/706)).
   - `TSSession` initializer now returns an error (`nil`) when given incorrect key type ([#710](https://github.com/cossacklabs/themis/pull/710)).
+  - CocoaPods will now link SwiftThemis statically into application ([#731](https://github.com/cossacklabs/themis/pull/731)).
 
 _Infrastructure:_
 

--- a/themis.podspec
+++ b/themis.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
     s.license = { :type => 'Apache 2.0'}
 
     s.source = { :git => "https://github.com/cossacklabs/themis.git", :tag => "#{s.version}" }
-  
+
     s.author = {'cossacklabs' => 'info@cossacklabs.com'}
 
     s.module_name = 'themis'
@@ -30,17 +30,17 @@ Pod::Spec.new do |s|
     #     # OpenSSL 1.1.1g
     #     so.dependency 'CLOpenSSL', '~> 1.1.107'
 
-    #     # Enable bitcode for OpenSSL in a very specific way, but it works, thanks to @deszip 
+    #     # Enable bitcode for OpenSSL in a very specific way, but it works, thanks to @deszip
     #     so.ios.pod_target_xcconfig = {
     #         'OTHER_CFLAGS[config=Debug]'                => '$(inherited) -fembed-bitcode-marker',
     #         'OTHER_CFLAGS[config=Release]'              => '$(inherited) -fembed-bitcode',
     #         'BITCODE_GENERATION_MODE[config=Release]'   => 'bitcode',
     #         'BITCODE_GENERATION_MODE[config=Debug]'     => 'bitcode-marker'
     #     }
-        
+
     #     # Xcode12, arm64 simulator issues https://stackoverflow.com/a/63955114
     #     # disable building for arm64 simulator for now
-        
+
     #     so.ios.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
     #     so.ios.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 
@@ -93,21 +93,21 @@ Pod::Spec.new do |s|
 
     # use `themis/themis-openssl` as separate target to use Themis with OpenSSL
     s.subspec 'themis-openssl' do |so|
-        # Enable bitcode for OpenSSL in a very specific way, but it works, thanks to @deszip 
+        # Enable bitcode for OpenSSL in a very specific way, but it works, thanks to @deszip
         so.ios.pod_target_xcconfig = {
             'OTHER_CFLAGS[config=Debug]'                => '$(inherited) -fembed-bitcode-marker',
             'OTHER_CFLAGS[config=Release]'              => '$(inherited) -fembed-bitcode',
             'BITCODE_GENERATION_MODE[config=Release]'   => 'bitcode',
             'BITCODE_GENERATION_MODE[config=Debug]'     => 'bitcode-marker'
         }
-        
+
         # Xcode12, arm64 simulator issues https://stackoverflow.com/a/63955114
         # disable building for arm64 simulator for now
-        
+
         so.ios.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
         so.ios.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-        
-        
+
+
         # TODO: due to error in symbols in GRKOpenSSLFramework 219 release, we've manually switched to 218
         # which doesn't sound like a good decision, so when GRKOpenSSLFramework will be updated –
         # please bring back correct dependency version

--- a/themis.podspec
+++ b/themis.podspec
@@ -17,6 +17,10 @@ Pod::Spec.new do |s|
     s.osx.deployment_target = '10.11'
     s.ios.frameworks = 'UIKit', 'Foundation'
 
+    # Tell CocoaPods that the frameworks we publish are "static frameworks".
+    # This ensures correct resolution of transitive dependencies.
+    s.static_framework = true
+
     # TODO(ilammy, 2020-03-02): resolve "pod spec lint" warnings due to dependencies
     # If you update dependencies, please check whether we can remove "--allow-warnings"
     # from podspec validation in .github/workflows/test-objc.yaml


### PR DESCRIPTION
Tell CocoaPods to build ObjCThemis as a 'static framework'. That is, your usual framework bundle but with a static library inside, not a dynamic one as you would have normally use.

Using static linkage greatly simplifies our life on iOS platforms which tend to be very picky about dynamic linkage and loading of frameworks. These issues are not really visible until you archive the app for distribution, actually install it on the device, and try launching it. Debugging these issues takes enormous amount amount of time which we don't have. Let Apple engineers fiddle with dynamic linkage for system frameworks. That at least makes sense.

Using static linkage for Themis has advantages, such as improved startup time (no extra symbol resolution) and improved app size (unused parts of Themis and its dependencies could be cut out by the linker). As Themis is distributed under a permissive license, there are no legal downsides of including it as an integral part of an application, it does not have to be a completely separate binary.

On the other hand, there are not many advantages of dynamic linkage. We don't get to share the memory and storage as Themis is not a system framework. The only real advantage is that it's easier to verify that Themis binaries have not been tampered with and to check Themis version, but iOS deployment process is know to heavily process the binaries, making this point mostly moot.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md

Required reviews:
- [x] @vixentael