### PR TITLE
Exclude macOS from arm64 builds with GRKOpenSSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ _Code:_
 
 - **Objective-C**
 
-  - Switched to test on Xcode 12.0, disable ARM64 builds for Themis CocoaPods and Themis Carthage ([#721](https://github.com/cossacklabs/themis/pull/721), [#722](https://github.com/cossacklabs/themis/pull/722)).
+  - Switched to test on Xcode 12.0, disable ARM64 builds for Themis CocoaPods and Themis Carthage ([#721](https://github.com/cossacklabs/themis/pull/721), [#722](https://github.com/cossacklabs/themis/pull/722), [#732](https://github.com/cossacklabs/themis/pull/732)).
   - Updated Objective-C examples (iOS and macOS, Carthage and CocoaPods) to showcase usage of the newest Secure Cell API: generating symmetric keys and using Secure Cell with Passphrase ([#688](https://github.com/cossacklabs/themis/pull/688)) and to use latest Themis 0.13.2, 0.13.3 ([#701](https://github.com/cossacklabs/themis/pull/701), [#703](https://github.com/cossacklabs/themis/pull/703), [#706](https://github.com/cossacklabs/themis/pull/706), [#723](https://github.com/cossacklabs/themis/pull/723), [#724](https://github.com/cossacklabs/themis/pull/724), [#726](https://github.com/cossacklabs/themis/pull/726)).
   - `TSSession` initializer now returns an error (`nil`) when given incorrect key type ([#710](https://github.com/cossacklabs/themis/pull/710)).
 
@@ -46,7 +46,7 @@ _Code:_
 
 - **Swift**
 
-  - Switched to test on Xcode 12.0, disable ARM64 builds for Themis CocoaPods and Themis Carthage ([#721](https://github.com/cossacklabs/themis/pull/721), [#722](https://github.com/cossacklabs/themis/pull/722)).
+  - Switched to test on Xcode 12.0, disable ARM64 builds for Themis CocoaPods and Themis Carthage ([#721](https://github.com/cossacklabs/themis/pull/721), [#722](https://github.com/cossacklabs/themis/pull/722), [#732](https://github.com/cossacklabs/themis/pull/732)).
   - Updated Swift examples (iOS and macOS, Carthage and CocoaPods) to showcase usage of the newest Secure Cell API: generating symmetric keys and using Secure Cell with Passphrase ([#688](https://github.com/cossacklabs/themis/pull/688)) and to use latest Themis 0.13.2, 0.13.3 ([#701](https://github.com/cossacklabs/themis/pull/701), [#703](https://github.com/cossacklabs/themis/pull/703), [#706](https://github.com/cossacklabs/themis/pull/706)).
   - `TSSession` initializer now returns an error (`nil`) when given incorrect key type ([#710](https://github.com/cossacklabs/themis/pull/710)).
 

--- a/themis.podspec
+++ b/themis.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
     s.license = { :type => 'Apache 2.0'}
 
     s.source = { :git => "https://github.com/cossacklabs/themis.git", :tag => "#{s.version}" }
-  
+
     s.author = {'cossacklabs' => 'info@cossacklabs.com'}
 
     s.module_name = 'themis'
@@ -30,17 +30,17 @@ Pod::Spec.new do |s|
     #     # OpenSSL 1.1.1g
     #     so.dependency 'CLOpenSSL', '~> 1.1.107'
 
-    #     # Enable bitcode for OpenSSL in a very specific way, but it works, thanks to @deszip 
+    #     # Enable bitcode for OpenSSL in a very specific way, but it works, thanks to @deszip
     #     so.ios.pod_target_xcconfig = {
     #         'OTHER_CFLAGS[config=Debug]'                => '$(inherited) -fembed-bitcode-marker',
     #         'OTHER_CFLAGS[config=Release]'              => '$(inherited) -fembed-bitcode',
     #         'BITCODE_GENERATION_MODE[config=Release]'   => 'bitcode',
     #         'BITCODE_GENERATION_MODE[config=Debug]'     => 'bitcode-marker'
     #     }
-        
+
     #     # Xcode12, arm64 simulator issues https://stackoverflow.com/a/63955114
     #     # disable building for arm64 simulator for now
-        
+
     #     so.ios.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
     #     so.ios.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 
@@ -93,21 +93,21 @@ Pod::Spec.new do |s|
 
     # use `themis/themis-openssl` as separate target to use Themis with OpenSSL
     s.subspec 'themis-openssl' do |so|
-        # Enable bitcode for OpenSSL in a very specific way, but it works, thanks to @deszip 
+        # Enable bitcode for OpenSSL in a very specific way, but it works, thanks to @deszip
         so.ios.pod_target_xcconfig = {
             'OTHER_CFLAGS[config=Debug]'                => '$(inherited) -fembed-bitcode-marker',
             'OTHER_CFLAGS[config=Release]'              => '$(inherited) -fembed-bitcode',
             'BITCODE_GENERATION_MODE[config=Release]'   => 'bitcode',
             'BITCODE_GENERATION_MODE[config=Debug]'     => 'bitcode-marker'
         }
-        
+
         # Xcode12, arm64 simulator issues https://stackoverflow.com/a/63955114
         # disable building for arm64 simulator for now
-        
+
         so.ios.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
         so.ios.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-        
-        
+
+
         # TODO: due to error in symbols in GRKOpenSSLFramework 219 release, we've manually switched to 218
         # which doesn't sound like a good decision, so when GRKOpenSSLFramework will be updated –
         # please bring back correct dependency version

--- a/themis.podspec
+++ b/themis.podspec
@@ -101,12 +101,14 @@ Pod::Spec.new do |s|
             'BITCODE_GENERATION_MODE[config=Debug]'     => 'bitcode-marker'
         }
 
-        # Xcode12, arm64 simulator issues https://stackoverflow.com/a/63955114
-        # disable building for arm64 simulator for now
-
-        so.ios.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+        # As of version 1.0.2.20.1, GRKOpenSSLFramework binaries do not contain
+        # arm64 slices for iOS Simulator and macOS, and thus do not support
+        # Apple Silicon. Disable building Themis for Apple Silicon until
+        # GRKOpenSSLFramework gets proper arm64 support.
+        so.ios.pod_target_xcconfig  = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
         so.ios.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-
+        so.osx.pod_target_xcconfig  = { 'EXCLUDED_ARCHS' => 'arm64' }
+        so.osx.user_target_xcconfig = { 'EXCLUDED_ARCHS' => 'arm64' }
 
         # TODO: due to error in symbols in GRKOpenSSLFramework 219 release, we've manually switched to 218
         # which doesn't sound like a good decision, so when GRKOpenSSLFramework will be updated –


### PR DESCRIPTION
Since GRKOpenSSLFramework is a prebuilt binary pod, Themis is limited by the architectures included by GRKOpenSSLFramework's maintainer. Currently, as of v1.0.2.20.1, there is no support for Apple Silicon architectures: arm64 slices for macOS and iOS Simulator. While Themis can be built for those architectures, OpenSSL is not available there, making Themis unusable.

Instruct CocoaPods to disable building user applications for arm64 used on Apple Silicon when GRKOpenSSLFramework is used by Themis. This makes sure that the applications can still be compiled, archived, etc., but they will not support Apple Silicon.

Note that this does not affect arm64 for iOS devices, this is still supported. Also, other subspecs of Themis will support Apple Silicon, both the BoringSSL flavor (compiled on user machine) and CLOpenSSL (where we will provide arm64 support).

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] ~~Example projects and code samples are up-to-date~~ (we don't have macOS examples of CocoaPods)
- [X] Changelog is updated (in case of notable or breaking changes)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md

Required reviews:
- [x] @vixentael