### PR TITLE
Update to CLOpenSSL 1.1.10801

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ _Code:_
   - Switched to test on Xcode 12.0, disable ARM64 builds for Themis CocoaPods and Themis Carthage ([#721](https://github.com/cossacklabs/themis/pull/721), [#722](https://github.com/cossacklabs/themis/pull/722), [#732](https://github.com/cossacklabs/themis/pull/732), [#733](https://github.com/cossacklabs/themis/pull/733)).
   - Updated Objective-C examples (iOS and macOS, Carthage and CocoaPods) to showcase usage of the newest Secure Cell API: generating symmetric keys and using Secure Cell with Passphrase ([#688](https://github.com/cossacklabs/themis/pull/688)) and to use latest Themis 0.13.2, 0.13.3 ([#701](https://github.com/cossacklabs/themis/pull/701), [#703](https://github.com/cossacklabs/themis/pull/703), [#706](https://github.com/cossacklabs/themis/pull/706), [#723](https://github.com/cossacklabs/themis/pull/723), [#724](https://github.com/cossacklabs/themis/pull/724), [#726](https://github.com/cossacklabs/themis/pull/726)).
   - `TSSession` initializer now returns an error (`nil`) when given incorrect key type ([#710](https://github.com/cossacklabs/themis/pull/710)).
-  - CocoaPods will now link ObjCThemis statically into application ([#731](https://github.com/cossacklabs/themis/pull/731)).
+  - CocoaPods will now link ObjCThemis statically into application ([#731](https://github.com/cossacklabs/themis/pull/731), [#735](https://github.com/cossacklabs/themis/pull/735)).
+  - Updated OpenSSL to the latest 1.1.1h ([#735](https://github.com/cossacklabs/themis/pull/735)).
 
 - **PHP**
 
@@ -50,7 +51,8 @@ _Code:_
   - Switched to test on Xcode 12.0, disable ARM64 builds for Themis CocoaPods and Themis Carthage ([#721](https://github.com/cossacklabs/themis/pull/721), [#722](https://github.com/cossacklabs/themis/pull/722), [#732](https://github.com/cossacklabs/themis/pull/732), [#733](https://github.com/cossacklabs/themis/pull/733)).
   - Updated Swift examples (iOS and macOS, Carthage and CocoaPods) to showcase usage of the newest Secure Cell API: generating symmetric keys and using Secure Cell with Passphrase ([#688](https://github.com/cossacklabs/themis/pull/688)) and to use latest Themis 0.13.2, 0.13.3 ([#701](https://github.com/cossacklabs/themis/pull/701), [#703](https://github.com/cossacklabs/themis/pull/703), [#706](https://github.com/cossacklabs/themis/pull/706)).
   - `TSSession` initializer now returns an error (`nil`) when given incorrect key type ([#710](https://github.com/cossacklabs/themis/pull/710)).
-  - CocoaPods will now link SwiftThemis statically into application ([#731](https://github.com/cossacklabs/themis/pull/731)).
+  - CocoaPods will now link SwiftThemis statically into application ([#731](https://github.com/cossacklabs/themis/pull/731), [#735](https://github.com/cossacklabs/themis/pull/735)).
+  - Updated OpenSSL to the latest 1.1.1h ([#735](https://github.com/cossacklabs/themis/pull/735)).
 
 _Infrastructure:_
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
-# OpenSSL 1.1.1g
-binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-iPhone.json" ~> 1.1.107
-binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-MacOSX.json" ~> 1.1.107
+# OpenSSL 1.1.1h
+binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-iPhone.json" ~> 1.1.10801
+binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-MacOSX.json" ~> 1.1.10801

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-MacOSX.json" "1.1.107"
-binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-iPhone.json" "1.1.107"
+binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-MacOSX.json" "1.1.10801"
+binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-iPhone.json" "1.1.10801"

--- a/Themis.xcodeproj/project.pbxproj
+++ b/Themis.xcodeproj/project.pbxproj
@@ -1476,7 +1476,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				EXCLUDED_ARCHS = arm64;
 				EXPORTED_SYMBOLS_FILE = "$(PROJECT_DIR)/src/wrappers/themis/Obj-C/exported.symbols";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1519,7 +1518,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				EXCLUDED_ARCHS = arm64;
 				EXPORTED_SYMBOLS_FILE = "$(PROJECT_DIR)/src/wrappers/themis/Obj-C/exported.symbols";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/themis.podspec
+++ b/themis.podspec
@@ -29,8 +29,8 @@ Pod::Spec.new do |s|
     # Change openssl-1.1.1 to default when fix our openssl
     # This variant uses the current stable, non-legacy version of OpenSSL.
     s.subspec 'openssl-1.1.1' do |so|
-        # OpenSSL 1.1.1g
-        so.dependency 'CLOpenSSL', '~> 1.1.107'
+        # OpenSSL 1.1.1h
+        so.dependency 'CLOpenSSL', '~> 1.1.10801'
 
         # Enable bitcode for OpenSSL in a very specific way, but it works, thanks to @deszip
         so.ios.pod_target_xcconfig = {
@@ -40,10 +40,11 @@ Pod::Spec.new do |s|
             'BITCODE_GENERATION_MODE[config=Debug]'     => 'bitcode-marker'
         }
 
-        # Xcode12, arm64 simulator issues https://stackoverflow.com/a/63955114
-        # disable building for arm64 simulator for now
-
-        so.ios.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+        # As of version 1.1.10801, the framework produced by CLOpenSSL does not
+        # contain arm64 slice for iOS Simulator since it conflicts with arm64
+        # slice for the real iOS. Fixing this requires migration to XCFrameworks.
+        # See T1406 for current status of XCFrameworks.
+        so.ios.pod_target_xcconfig  = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
         so.ios.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 
         # We're building some C code here which uses includes as it pleases.

--- a/themis.podspec
+++ b/themis.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
     s.author = {'cossacklabs' => 'info@cossacklabs.com'}
 
     s.module_name = 'themis'
-    s.default_subspec = 'themis-openssl'
+    s.default_subspec = 'openssl-1.1.1'
 
     s.ios.deployment_target = '10.0'
     s.osx.deployment_target = '10.11'
@@ -25,8 +25,6 @@ Pod::Spec.new do |s|
     # If you update dependencies, please check whether we can remove "--allow-warnings"
     # from podspec validation in .github/workflows/test-objc.yaml
 
-    # TODO(vixentael, 11 oct 2020): as xcode12 introduces new arm64 architecture, our own openssl framework doesn't work yet
-    # Change openssl-1.1.1 to default when fix our openssl
     # This variant uses the current stable, non-legacy version of OpenSSL.
     s.subspec 'openssl-1.1.1' do |so|
         # OpenSSL 1.1.1h

--- a/themis.podspec
+++ b/themis.podspec
@@ -25,75 +25,73 @@ Pod::Spec.new do |s|
     # If you update dependencies, please check whether we can remove "--allow-warnings"
     # from podspec validation in .github/workflows/test-objc.yaml
 
-    # TODO(vixentael, 12 oct 2020): disable this podspec to prevent linting errors, until we fix it
+    # TODO(vixentael, 11 oct 2020): as xcode12 introduces new arm64 architecture, our own openssl framework doesn't work yet
+    # Change openssl-1.1.1 to default when fix our openssl
+    # This variant uses the current stable, non-legacy version of OpenSSL.
+    s.subspec 'openssl-1.1.1' do |so|
+        # OpenSSL 1.1.1g
+        so.dependency 'CLOpenSSL', '~> 1.1.107'
 
-    # # TODO(vixentael, 11 oct 2020): as xcode12 introduces new arm64 architecture, our own openssl framework doesn't work yet
-    # # Change openssl-1.1.1 to default when fix our openssl
-    # # This variant uses the current stable, non-legacy version of OpenSSL.
-    # s.subspec 'openssl-1.1.1' do |so|
-    #     # OpenSSL 1.1.1g
-    #     so.dependency 'CLOpenSSL', '~> 1.1.107'
+        # Enable bitcode for OpenSSL in a very specific way, but it works, thanks to @deszip
+        so.ios.pod_target_xcconfig = {
+            'OTHER_CFLAGS[config=Debug]'                => '$(inherited) -fembed-bitcode-marker',
+            'OTHER_CFLAGS[config=Release]'              => '$(inherited) -fembed-bitcode',
+            'BITCODE_GENERATION_MODE[config=Release]'   => 'bitcode',
+            'BITCODE_GENERATION_MODE[config=Debug]'     => 'bitcode-marker'
+        }
 
-    #     # Enable bitcode for OpenSSL in a very specific way, but it works, thanks to @deszip
-    #     so.ios.pod_target_xcconfig = {
-    #         'OTHER_CFLAGS[config=Debug]'                => '$(inherited) -fembed-bitcode-marker',
-    #         'OTHER_CFLAGS[config=Release]'              => '$(inherited) -fembed-bitcode',
-    #         'BITCODE_GENERATION_MODE[config=Release]'   => 'bitcode',
-    #         'BITCODE_GENERATION_MODE[config=Debug]'     => 'bitcode-marker'
-    #     }
+        # Xcode12, arm64 simulator issues https://stackoverflow.com/a/63955114
+        # disable building for arm64 simulator for now
 
-    #     # Xcode12, arm64 simulator issues https://stackoverflow.com/a/63955114
-    #     # disable building for arm64 simulator for now
+        so.ios.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+        so.ios.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 
-    #     so.ios.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-    #     so.ios.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+        # We're building some C code here which uses includes as it pleases.
+        # Allow this behavior, but we will have to control header mappings.
+        so.ios.xcconfig = {
+            'OTHER_CFLAGS' => '-DLIBRESSL',
+            'USE_HEADERMAP' => 'NO',
+            'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/themis/src" "${PODS_ROOT}/themis/src/wrappers/themis/Obj-C"',
+            'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES',
+        }
+        so.osx.xcconfig = {
+            'OTHER_CFLAGS' => '-DLIBRESSL',
+            'USE_HEADERMAP' => 'NO',
+            'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/themis/src" "${PODS_ROOT}/themis/src/wrappers/themis/Obj-C"',
+            'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES',
+        }
 
-    #     # We're building some C code here which uses includes as it pleases.
-    #     # Allow this behavior, but we will have to control header mappings.
-    #     so.ios.xcconfig = {
-    #         'OTHER_CFLAGS' => '-DLIBRESSL',
-    #         'USE_HEADERMAP' => 'NO',
-    #         'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/themis/src" "${PODS_ROOT}/themis/src/wrappers/themis/Obj-C"',
-    #         'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES',
-    #     }
-    #     so.osx.xcconfig = {
-    #         'OTHER_CFLAGS' => '-DLIBRESSL',
-    #         'USE_HEADERMAP' => 'NO',
-    #         'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/themis/src" "${PODS_ROOT}/themis/src/wrappers/themis/Obj-C"',
-    #         'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES',
-    #     }
-
-    #     # We need to do this weird subspec matryoshka because CocoaPods
-    #     # insists on compiling everything as if it were a modular framework.
-    #     # Unfortunately, Themis has a lot of #include "themis/something.h"
-    #     # which break in modular compilation. The "header_dir" fixes it up,
-    #     # but we must set it differently for ObjCThemis. Hence two subspecs.
-    #     # End users should use "themis/openssl-1.1.1" only, not these ones.
-    #     so.subspec 'core' do |ss|
-    #         ss.source_files = [
-    #             "src/themis/*.{c,h}",
-    #             "src/soter/*.{c,h}",
-    #             "src/soter/ed25519/*.{c,h}",
-    #             "src/soter/openssl/*.{c,h}",
-    #         ]
-    #         ss.header_dir = "src"
-    #         ss.header_mappings_dir = "src"
-    #         # Don't export Themis Core headers, make only ObjcThemis public.
-    #         ss.private_header_files = [
-    #             "src/themis/*.h",
-    #             "src/soter/*.h",
-    #             "src/soter/ed25519/*.h",
-    #             "src/soter/openssl/*.h",
-    #         ]
-    #     end
-    #     so.subspec 'objcwrapper' do |ss|
-    #         ss.dependency 'themis/openssl-1.1.1/core'
-    #         ss.source_files = "src/wrappers/themis/Obj-C/objcthemis/*.{m,h}"
-    #         ss.header_dir = "objcthemis"
-    #         ss.header_mappings_dir = "src/wrappers/themis/Obj-C/objcthemis"
-    #         ss.public_header_files = "src/wrappers/themis/Obj-C/objcthemis/*.h"
-    #     end
-    # end
+        # We need to do this weird subspec matryoshka because CocoaPods
+        # insists on compiling everything as if it were a modular framework.
+        # Unfortunately, Themis has a lot of #include "themis/something.h"
+        # which break in modular compilation. The "header_dir" fixes it up,
+        # but we must set it differently for ObjCThemis. Hence two subspecs.
+        # End users should use "themis/openssl-1.1.1" only, not these ones.
+        so.subspec 'core' do |ss|
+            ss.source_files = [
+                "src/themis/*.{c,h}",
+                "src/soter/*.{c,h}",
+                "src/soter/ed25519/*.{c,h}",
+                "src/soter/openssl/*.{c,h}",
+            ]
+            ss.header_dir = "src"
+            ss.header_mappings_dir = "src"
+            # Don't export Themis Core headers, make only ObjcThemis public.
+            ss.private_header_files = [
+                "src/themis/*.h",
+                "src/soter/*.h",
+                "src/soter/ed25519/*.h",
+                "src/soter/openssl/*.h",
+            ]
+        end
+        so.subspec 'objcwrapper' do |ss|
+            ss.dependency 'themis/openssl-1.1.1/core'
+            ss.source_files = "src/wrappers/themis/Obj-C/objcthemis/*.{m,h}"
+            ss.header_dir = "objcthemis"
+            ss.header_mappings_dir = "src/wrappers/themis/Obj-C/objcthemis"
+            ss.public_header_files = "src/wrappers/themis/Obj-C/objcthemis/*.h"
+        end
+    end
 
     # use `themis/themis-openssl` as separate target to use Themis with OpenSSL
     s.subspec 'themis-openssl' do |so|


### PR DESCRIPTION
Recently released [CLOpenSSL 1.1.10801](https://github.com/cossacklabs/openssl-apple/releases/tag/v1.1.10801) includes support for Apple Silicon for macOS. Update both Carthage and CocoaPods to use this version to support Apple Silicon. (Note though that iOS Simulator builds are *not* supported on Apple Silicon. Yet.)

Another important change is that CLOpenSSL for CocoaPods now distributes a *static framework*. This finally unifies CocoaPods with Carthage in that respect. This move also makes it much easier to deploy apps that use Themis, removing multiple possible failure point in dynamic framework usage.

This PR changes the default of CocoaPods to CLOpenSSL, back from the changes introduced by 0.13.xx hotfixes. The subspecs are:

- `themis` — the default, alias for `themis/openssl-1.1.1` now
- `themis/openssl-1.1.1` — uses OpenSSL 1.1.1h provided by [CLOpenSSL](https://github.com/cossacklabs/openssl-apple)
  - full static build
  - Apple Silicon supported on macOS
  - Apple Silicon **not supported** for iOS Simulator
  - this is the new default
- `themis/themis-openssl` — uses OpenSSL 1.0.2u provided by [GRKOpenSSLFramework](https://github.com/levigroker/GRKOpenSSLFramework)
  - Themis linked statically, OpenSSL linked dynamically
  - Apple Silicon **not supported**
  - this was the previous default from 0.13 and earlier
- `themis/themis-boringssl` — uses outdated BoringSSL provided by [Google](https://cocoapods.org/pods/BoringSSL)
  - Themis linked statically, BoringSSL linked dynamically
  - Apple Silicon supported on macOS and iOS Simulator

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] Public API has proper documentation
- [X] ~~Example projects and code samples are up-to-date~~ (no, they stay the same until 0.14 release)
- [X] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md

Required review:
- [x] @vixentael