### PR TITLE
Themis 0.13.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 Changes that are currently in development and have not been released yet.
 
+
+## [0.13.4](https://github.com/cossacklabs/themis/releases/tag/0.13.4), October 29th 2020
+
+**Hotfix for Apple platforms:**
+
+- Improved Apple Silicon support (arm64 builds for macOS with Xcode 12.2 beta)
+- Resolved issues with stable Xcode 12 support (disabled arm64 builds for iOS Simulator)
+- Updated OpenSSL to the latest 1.1.1h
+- CocoaPods is now using OpenSSL 1.1.1h by default (again)
+- CocoaPods and Carthage now both produce full-static builds of Themis, resolving critical issues with App Store deployment
+
 _Code:_
 
 - **Objective-C**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Changes that are currently in development and have not been released yet.
 - Resolved issues with stable Xcode 12 support (disabled arm64 builds for iOS Simulator)
 - Updated OpenSSL to the latest 1.1.1h
 - CocoaPods is now using OpenSSL 1.1.1h by default (again)
-- CocoaPods and Carthage now both produce full-static builds of Themis, resolving critical issues with App Store deployment
+- CocoaPods and Carthage now both produce full-static builds of Themis, resolving critical issues with App Store deployment (see [#715](https://github.com/cossacklabs/themis/issues/715))
 
 _Code:_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,16 +17,10 @@ Changes that are currently in development and have not been released yet.
 
 _Code:_
 
-- **Objective-C**
+- **Objective-C / Swift**
 
   - Switched to test on Xcode 12.0, disable ARM64 builds for Themis CocoaPods and Themis Carthage ([#721](https://github.com/cossacklabs/themis/pull/721), [#722](https://github.com/cossacklabs/themis/pull/722), [#732](https://github.com/cossacklabs/themis/pull/732), [#733](https://github.com/cossacklabs/themis/pull/733)).
   - CocoaPods will now link ObjCThemis statically into application ([#731](https://github.com/cossacklabs/themis/pull/731), [#735](https://github.com/cossacklabs/themis/pull/735)).
-  - Updated OpenSSL to the latest 1.1.1h ([#735](https://github.com/cossacklabs/themis/pull/735)).
-
-- **Swift**
-
-  - Switched to test on Xcode 12.0, disable ARM64 builds for Themis CocoaPods and Themis Carthage ([#721](https://github.com/cossacklabs/themis/pull/721), [#722](https://github.com/cossacklabs/themis/pull/722), [#732](https://github.com/cossacklabs/themis/pull/732), [#733](https://github.com/cossacklabs/themis/pull/733)).
-  - CocoaPods will now link SwiftThemis statically into application ([#731](https://github.com/cossacklabs/themis/pull/731), [#735](https://github.com/cossacklabs/themis/pull/735)).
   - Updated OpenSSL to the latest 1.1.1h ([#735](https://github.com/cossacklabs/themis/pull/735)).
 
 

--- a/Themis.xcodeproj/project.pbxproj
+++ b/Themis.xcodeproj/project.pbxproj
@@ -1478,7 +1478,7 @@
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1504,7 +1504,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.13.2;
+				MARKETING_VERSION = 0.13.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis;
 				PRODUCT_MODULE_NAME = themis;
 				PRODUCT_NAME = themis;
@@ -1520,7 +1520,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1546,7 +1546,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.13.2;
+				MARKETING_VERSION = 0.13.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis;
 				PRODUCT_MODULE_NAME = themis;
 				PRODUCT_NAME = themis;
@@ -1565,7 +1565,7 @@
 				);
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1593,7 +1593,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.13.2;
+				MARKETING_VERSION = 0.13.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis;
 				PRODUCT_MODULE_NAME = themis;
 				PRODUCT_NAME = themis;
@@ -1617,7 +1617,7 @@
 				);
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1645,7 +1645,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.13.2;
+				MARKETING_VERSION = 0.13.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis;
 				PRODUCT_MODULE_NAME = themis;
 				PRODUCT_NAME = themis;

--- a/themis.podspec
+++ b/themis.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name = "themis"
-    s.version = "0.13.3"
+    s.version = "0.13.4"
     s.summary = "Data security library for network communication and data storage for iOS and mac OS"
     s.description = "Themis is a convenient cryptographic library for data protection. It provides secure messaging with forward secrecy and secure data storage. Themis is aimed at modern development practices and has a unified API across 12 platforms, including iOS/macOS, Ruby, JavaScript, Python, and Java/Android."
     s.homepage = "https://cossacklabs.com"


### PR DESCRIPTION
Cut the next hotfix for Apple platforms, updating the OpenSSL dependency which should resolve most of the newly found issues with Apple Silicon support and deploying applications to the App Store.

@vixentael, please review the changelog updates and other things.

I've already cherry-picked all those changes from master into `release/0.13` and tested them. I've also merged CI changes from `stable` with fixes for Xcode 12 support and non-Apple builds. Carthage and CocoaPods configurations should be the same as in `master`, except for version updates performed in this PR.

Running the CI tests is going to take a while, since there are a lot of pushes pending. I think we might be able to merge this today(ish)—maybe at 26:23 😂 However, I'd expect the proper GitHub release to be performed tomorrow, after testing the published version on devices, so I'm dating it with October 29th in the changelog.

Provisional `0.13.4` tag has been already pushed to the repository to allow CocoaPods spec linting. It points to the tip of this PR. After this PR is merged, I'll update the tag to the proper commit and sign it. (As per the release process.)

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] ~~Example projects and code samples are up-to-date~~ (this will be done in a separate PR)
- [x] Changelog is updated (mark after review)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md