### PR TITLE
Merge "release/0.13" into "stable"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@
 Changes that are currently in development and have not been released yet.
 
 
+## [0.13.4](https://github.com/cossacklabs/themis/releases/tag/0.13.4), October 29th 2020
+
+**Hotfix for Apple platforms:**
+
+- Improved Apple Silicon support (arm64 builds for macOS with Xcode 12.2 beta)
+- Resolved issues with stable Xcode 12 support (disabled arm64 builds for iOS Simulator)
+- Updated OpenSSL to the latest 1.1.1h
+- CocoaPods is now using OpenSSL 1.1.1h by default (again)
+- CocoaPods and Carthage now both produce full-static builds of Themis, resolving critical issues with App Store deployment (see [#715](https://github.com/cossacklabs/themis/issues/715))
+
+_Code:_
+
+- **Objective-C / Swift**
+
+  - Switched to test on Xcode 12.0, disable ARM64 builds for Themis CocoaPods and Themis Carthage ([#721](https://github.com/cossacklabs/themis/pull/721), [#722](https://github.com/cossacklabs/themis/pull/722), [#732](https://github.com/cossacklabs/themis/pull/732), [#733](https://github.com/cossacklabs/themis/pull/733)).
+  - CocoaPods will now link ObjCThemis statically into application ([#731](https://github.com/cossacklabs/themis/pull/731), [#735](https://github.com/cossacklabs/themis/pull/735)).
+  - Updated OpenSSL to the latest 1.1.1h ([#735](https://github.com/cossacklabs/themis/pull/735)).
+
+
 ## [0.13.3](https://github.com/cossacklabs/themis/releases/tag/0.13.3), October 12th 2020
 
 **Hotfix for Themis CocoaPods and Xcode12:**

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
-# OpenSSL 1.1.1g
-binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-iPhone.json" ~> 1.1.107
-binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-MacOSX.json" ~> 1.1.107
+# OpenSSL 1.1.1h
+binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-iPhone.json" ~> 1.1.10801
+binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-MacOSX.json" ~> 1.1.10801

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-MacOSX.json" "1.1.107"
-binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-iPhone.json" "1.1.107"
+binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-MacOSX.json" "1.1.10801"
+binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-iPhone.json" "1.1.10801"

--- a/Themis.xcodeproj/project.pbxproj
+++ b/Themis.xcodeproj/project.pbxproj
@@ -1401,8 +1401,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1460,8 +1460,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SUPPORTS_MACCATALYST = NO;
@@ -1478,7 +1478,7 @@
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1504,7 +1504,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.13.2;
+				MARKETING_VERSION = 0.13.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis;
 				PRODUCT_MODULE_NAME = themis;
 				PRODUCT_NAME = themis;
@@ -1520,7 +1520,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1546,7 +1546,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.13.2;
+				MARKETING_VERSION = 0.13.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis;
 				PRODUCT_MODULE_NAME = themis;
 				PRODUCT_NAME = themis;
@@ -1565,13 +1565,15 @@
 				);
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = YES;
+				EXCLUDED_ARCHS = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 arm64e";
 				EXPORTED_SYMBOLS_FILE = "$(PROJECT_DIR)/src/wrappers/themis/Obj-C/exported.symbols";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1591,7 +1593,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.13.2;
+				MARKETING_VERSION = 0.13.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis;
 				PRODUCT_MODULE_NAME = themis;
 				PRODUCT_NAME = themis;
@@ -1615,13 +1617,15 @@
 				);
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = YES;
+				EXCLUDED_ARCHS = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 arm64e";
 				EXPORTED_SYMBOLS_FILE = "$(PROJECT_DIR)/src/wrappers/themis/Obj-C/exported.symbols";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1641,7 +1645,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.13.2;
+				MARKETING_VERSION = 0.13.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis;
 				PRODUCT_MODULE_NAME = themis;
 				PRODUCT_NAME = themis;

--- a/themis.podspec
+++ b/themis.podspec
@@ -1,113 +1,117 @@
 Pod::Spec.new do |s|
     s.name = "themis"
-    s.version = "0.13.3"
+    s.version = "0.13.4"
     s.summary = "Data security library for network communication and data storage for iOS and mac OS"
     s.description = "Themis is a convenient cryptographic library for data protection. It provides secure messaging with forward secrecy and secure data storage. Themis is aimed at modern development practices and has a unified API across 12 platforms, including iOS/macOS, Ruby, JavaScript, Python, and Java/Android."
     s.homepage = "https://cossacklabs.com"
     s.license = { :type => 'Apache 2.0'}
 
     s.source = { :git => "https://github.com/cossacklabs/themis.git", :tag => "#{s.version}" }
-  
+
     s.author = {'cossacklabs' => 'info@cossacklabs.com'}
 
     s.module_name = 'themis'
-    s.default_subspec = 'themis-openssl'
+    s.default_subspec = 'openssl-1.1.1'
 
     s.ios.deployment_target = '10.0'
     s.osx.deployment_target = '10.11'
     s.ios.frameworks = 'UIKit', 'Foundation'
 
+    # Tell CocoaPods that the frameworks we publish are "static frameworks".
+    # This ensures correct resolution of transitive dependencies.
+    s.static_framework = true
+
     # TODO(ilammy, 2020-03-02): resolve "pod spec lint" warnings due to dependencies
     # If you update dependencies, please check whether we can remove "--allow-warnings"
     # from podspec validation in .github/workflows/test-objc.yaml
 
-    # TODO(vixentael, 12 oct 2020): disable this podspec to prevent linting errors, until we fix it
+    # This variant uses the current stable, non-legacy version of OpenSSL.
+    s.subspec 'openssl-1.1.1' do |so|
+        # OpenSSL 1.1.1h
+        so.dependency 'CLOpenSSL', '~> 1.1.10801'
 
-    # # TODO(vixentael, 11 oct 2020): as xcode12 introduces new arm64 architecture, our own openssl framework doesn't work yet
-    # # Change openssl-1.1.1 to default when fix our openssl
-    # # This variant uses the current stable, non-legacy version of OpenSSL.
-    # s.subspec 'openssl-1.1.1' do |so|
-    #     # OpenSSL 1.1.1g
-    #     so.dependency 'CLOpenSSL', '~> 1.1.107'
-
-    #     # Enable bitcode for OpenSSL in a very specific way, but it works, thanks to @deszip 
-    #     so.ios.pod_target_xcconfig = {
-    #         'OTHER_CFLAGS[config=Debug]'                => '$(inherited) -fembed-bitcode-marker',
-    #         'OTHER_CFLAGS[config=Release]'              => '$(inherited) -fembed-bitcode',
-    #         'BITCODE_GENERATION_MODE[config=Release]'   => 'bitcode',
-    #         'BITCODE_GENERATION_MODE[config=Debug]'     => 'bitcode-marker'
-    #     }
-        
-    #     # Xcode12, arm64 simulator issues https://stackoverflow.com/a/63955114
-    #     # disable building for arm64 simulator for now
-        
-    #     so.ios.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-    #     so.ios.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-
-    #     # We're building some C code here which uses includes as it pleases.
-    #     # Allow this behavior, but we will have to control header mappings.
-    #     so.ios.xcconfig = {
-    #         'OTHER_CFLAGS' => '-DLIBRESSL',
-    #         'USE_HEADERMAP' => 'NO',
-    #         'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/themis/src" "${PODS_ROOT}/themis/src/wrappers/themis/Obj-C"',
-    #         'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES',
-    #     }
-    #     so.osx.xcconfig = {
-    #         'OTHER_CFLAGS' => '-DLIBRESSL',
-    #         'USE_HEADERMAP' => 'NO',
-    #         'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/themis/src" "${PODS_ROOT}/themis/src/wrappers/themis/Obj-C"',
-    #         'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES',
-    #     }
-
-    #     # We need to do this weird subspec matryoshka because CocoaPods
-    #     # insists on compiling everything as if it were a modular framework.
-    #     # Unfortunately, Themis has a lot of #include "themis/something.h"
-    #     # which break in modular compilation. The "header_dir" fixes it up,
-    #     # but we must set it differently for ObjCThemis. Hence two subspecs.
-    #     # End users should use "themis/openssl-1.1.1" only, not these ones.
-    #     so.subspec 'core' do |ss|
-    #         ss.source_files = [
-    #             "src/themis/*.{c,h}",
-    #             "src/soter/*.{c,h}",
-    #             "src/soter/ed25519/*.{c,h}",
-    #             "src/soter/openssl/*.{c,h}",
-    #         ]
-    #         ss.header_dir = "src"
-    #         ss.header_mappings_dir = "src"
-    #         # Don't export Themis Core headers, make only ObjcThemis public.
-    #         ss.private_header_files = [
-    #             "src/themis/*.h",
-    #             "src/soter/*.h",
-    #             "src/soter/ed25519/*.h",
-    #             "src/soter/openssl/*.h",
-    #         ]
-    #     end
-    #     so.subspec 'objcwrapper' do |ss|
-    #         ss.dependency 'themis/openssl-1.1.1/core'
-    #         ss.source_files = "src/wrappers/themis/Obj-C/objcthemis/*.{m,h}"
-    #         ss.header_dir = "objcthemis"
-    #         ss.header_mappings_dir = "src/wrappers/themis/Obj-C/objcthemis"
-    #         ss.public_header_files = "src/wrappers/themis/Obj-C/objcthemis/*.h"
-    #     end
-    # end
-
-    # use `themis/themis-openssl` as separate target to use Themis with OpenSSL
-    s.subspec 'themis-openssl' do |so|
-        # Enable bitcode for OpenSSL in a very specific way, but it works, thanks to @deszip 
+        # Enable bitcode for OpenSSL in a very specific way, but it works, thanks to @deszip
         so.ios.pod_target_xcconfig = {
             'OTHER_CFLAGS[config=Debug]'                => '$(inherited) -fembed-bitcode-marker',
             'OTHER_CFLAGS[config=Release]'              => '$(inherited) -fembed-bitcode',
             'BITCODE_GENERATION_MODE[config=Release]'   => 'bitcode',
             'BITCODE_GENERATION_MODE[config=Debug]'     => 'bitcode-marker'
         }
-        
-        # Xcode12, arm64 simulator issues https://stackoverflow.com/a/63955114
-        # disable building for arm64 simulator for now
-        
-        so.ios.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+
+        # As of version 1.1.10801, the framework produced by CLOpenSSL does not
+        # contain arm64 slice for iOS Simulator since it conflicts with arm64
+        # slice for the real iOS. Fixing this requires migration to XCFrameworks.
+        # See T1406 for current status of XCFrameworks.
+        so.ios.pod_target_xcconfig  = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
         so.ios.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-        
-        
+
+        # We're building some C code here which uses includes as it pleases.
+        # Allow this behavior, but we will have to control header mappings.
+        so.ios.xcconfig = {
+            'OTHER_CFLAGS' => '-DLIBRESSL',
+            'USE_HEADERMAP' => 'NO',
+            'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/themis/src" "${PODS_ROOT}/themis/src/wrappers/themis/Obj-C"',
+            'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES',
+        }
+        so.osx.xcconfig = {
+            'OTHER_CFLAGS' => '-DLIBRESSL',
+            'USE_HEADERMAP' => 'NO',
+            'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/themis/src" "${PODS_ROOT}/themis/src/wrappers/themis/Obj-C"',
+            'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES',
+        }
+
+        # We need to do this weird subspec matryoshka because CocoaPods
+        # insists on compiling everything as if it were a modular framework.
+        # Unfortunately, Themis has a lot of #include "themis/something.h"
+        # which break in modular compilation. The "header_dir" fixes it up,
+        # but we must set it differently for ObjCThemis. Hence two subspecs.
+        # End users should use "themis/openssl-1.1.1" only, not these ones.
+        so.subspec 'core' do |ss|
+            ss.source_files = [
+                "src/themis/*.{c,h}",
+                "src/soter/*.{c,h}",
+                "src/soter/ed25519/*.{c,h}",
+                "src/soter/openssl/*.{c,h}",
+            ]
+            ss.header_dir = "src"
+            ss.header_mappings_dir = "src"
+            # Don't export Themis Core headers, make only ObjcThemis public.
+            ss.private_header_files = [
+                "src/themis/*.h",
+                "src/soter/*.h",
+                "src/soter/ed25519/*.h",
+                "src/soter/openssl/*.h",
+            ]
+        end
+        so.subspec 'objcwrapper' do |ss|
+            ss.dependency 'themis/openssl-1.1.1/core'
+            ss.source_files = "src/wrappers/themis/Obj-C/objcthemis/*.{m,h}"
+            ss.header_dir = "objcthemis"
+            ss.header_mappings_dir = "src/wrappers/themis/Obj-C/objcthemis"
+            ss.public_header_files = "src/wrappers/themis/Obj-C/objcthemis/*.h"
+        end
+    end
+
+    # use `themis/themis-openssl` as separate target to use Themis with OpenSSL
+    s.subspec 'themis-openssl' do |so|
+        # Enable bitcode for OpenSSL in a very specific way, but it works, thanks to @deszip
+        #so.ios.pod_target_xcconfig = {'ENABLE_BITCODE' => 'YES' }
+        so.ios.pod_target_xcconfig = {
+            'OTHER_CFLAGS[config=Debug]'                => '$(inherited) -fembed-bitcode-marker',
+            'OTHER_CFLAGS[config=Release]'              => '$(inherited) -fembed-bitcode',
+            'BITCODE_GENERATION_MODE[config=Release]'   => 'bitcode',
+            'BITCODE_GENERATION_MODE[config=Debug]'     => 'bitcode-marker'
+        }
+
+        # As of version 1.0.2.20.1, GRKOpenSSLFramework binaries do not contain
+        # arm64 slices for iOS Simulator and macOS, and thus do not support
+        # Apple Silicon. Disable building Themis for Apple Silicon until
+        # GRKOpenSSLFramework gets proper arm64 support.
+        so.ios.pod_target_xcconfig  = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+        so.ios.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+        so.osx.pod_target_xcconfig  = { 'EXCLUDED_ARCHS' => 'arm64' }
+        so.osx.user_target_xcconfig = { 'EXCLUDED_ARCHS' => 'arm64' }
+
         # TODO: due to error in symbols in GRKOpenSSLFramework 219 release, we've manually switched to 218
         # which doesn't sound like a good decision, so when GRKOpenSSLFramework will be updated –
         # please bring back correct dependency version


### PR DESCRIPTION
Now that Themis 0.13.4 is out, let's merge the changes from the current supported 0.13.x series into `stable`.

## Checklist

- [X] Change is covered by automated tests
- [X] Changelog is updated
- [x] ⚠️ Push the merge manually from the command-line

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
