### PR TITLE
Fix code signing issues on macOS with Xcode 12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ _Code:_
   - Updated Objective-C examples (iOS and macOS, Carthage and CocoaPods) to showcase usage of the newest Secure Cell API: generating symmetric keys and using Secure Cell with Passphrase ([#688](https://github.com/cossacklabs/themis/pull/688)) and to use latest Themis 0.13.4 ([#701](https://github.com/cossacklabs/themis/pull/701), [#703](https://github.com/cossacklabs/themis/pull/703), [#706](https://github.com/cossacklabs/themis/pull/706), [#723](https://github.com/cossacklabs/themis/pull/723), [#724](https://github.com/cossacklabs/themis/pull/724), [#726](https://github.com/cossacklabs/themis/pull/726), [#740](https://github.com/cossacklabs/themis/pull/740)).
   - `TSSession` initializer now returns an error (`nil`) when given incorrect key type ([#710](https://github.com/cossacklabs/themis/pull/710)).
   - Improved compatibility with Xcode 12 ([#742](https://github.com/cossacklabs/themis/pull/742)).
+  - Fixed code signing issues on macOS with Xcode 12 ([#744](https://github.com/cossacklabs/themis/pull/744)).
 
 - **PHP**
 
@@ -49,6 +50,7 @@ _Code:_
   - Updated Swift examples (iOS and macOS, Carthage and CocoaPods) to showcase usage of the newest Secure Cell API: generating symmetric keys and using Secure Cell with Passphrase ([#688](https://github.com/cossacklabs/themis/pull/688)) and to use latest Themis 0.13.4 ([#701](https://github.com/cossacklabs/themis/pull/701), [#703](https://github.com/cossacklabs/themis/pull/703), [#706](https://github.com/cossacklabs/themis/pull/706), [#740](https://github.com/cossacklabs/themis/pull/740)).
   - `TSSession` initializer now returns an error (`nil`) when given incorrect key type ([#710](https://github.com/cossacklabs/themis/pull/710)).
   - Improved compatibility with Xcode 12 ([#742](https://github.com/cossacklabs/themis/pull/742)).
+  - Fixed code signing issues on macOS with Xcode 12 ([#744](https://github.com/cossacklabs/themis/pull/744)).
 
 _Infrastructure:_
 

--- a/Themis.xcodeproj/project.pbxproj
+++ b/Themis.xcodeproj/project.pbxproj
@@ -1375,7 +1375,6 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 4;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				ENABLE_BITCODE = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
@@ -1442,7 +1441,6 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 4;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_BITCODE = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
@@ -1544,6 +1542,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_BITCODE = YES;
 				EXCLUDED_ARCHS = "";
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 arm64e";
 				EXPORTED_SYMBOLS_FILE = "$(PROJECT_DIR)/src/wrappers/themis/Obj-C/exported.symbols";
@@ -1583,6 +1582,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_BITCODE = YES;
 				EXCLUDED_ARCHS = "";
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 arm64e";
 				EXPORTED_SYMBOLS_FILE = "$(PROJECT_DIR)/src/wrappers/themis/Obj-C/exported.symbols";
@@ -1614,7 +1614,6 @@
 		9F70B2C5241D0FEC009CB629 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/Mac",
@@ -1637,7 +1636,6 @@
 		9F70B2C6241D0FEC009CB629 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/Mac",
@@ -1772,7 +1770,6 @@
 		9F70B32F2420E176009CB629 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/Mac",
@@ -1795,7 +1792,6 @@
 		9F70B3302420E176009CB629 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/Mac",


### PR DESCRIPTION
It turned out that enabling Bitcode *project-wide* is a bad idea because for some reason it causes code signing issues when preparing macOS apps for distribution.

Not only this glorious technology breaks iOS apps at times, the advent of Apple Silicon seems to be making macOS and iOS really compatible. I'd say, bug-to-bug compatible!

So... if Bitcode metastasizes into macOS builds, the apps exhibit similar symptoms: everything seems to be fine, the app and its build lead their normal life, right until the developer attempts to prepare the app for distribution. Then it suddenly fails to code sign with the following informative dialog:

<img width="1312" alt="Screenshot 2020-11-11 at 16 54 56" src="https://user-images.githubusercontent.com/1256587/98826710-bbaa3b00-243e-11eb-9709-60e9b7654c76.png">

and the following errors hidden deeply in logs (Show Logs, then look at the end of IDEDistributionPipeline.log):

    Running /usr/bin/codesign '-vvv' '--force' '--sign' '3356BDE5BC1F1235571602E373E6BA16B748CDF3' [...]
    [...].app/Contents/Frameworks/themis.framework/Versions/A: replacing existing signature
    [...].app/Contents/Frameworks/themis.framework/Versions/A: code object is not signed at all
    /usr/bin/codesign exited with 1

Well, that's enlightening!

Anyway. Once there is no mention of Bitcode whatsoever in the build settings of macOS target for Themis framework, the applications can be signed and everything seems to be okay.

Remove `ENABLE_BITCODE` setting from all macOS targets, leave it only for iOS targets. The framework is built with YES (but of course!) and the tests are built with NO, because the tests are bundles and they are not compatible with Bitcode (and they are not capable of using it anyway).

*Of course, we learn about this only with Xcode 12.2 RC which supports Apple Silicon architecture. After all, it's a long-standing Apple tradition to change something up in code signing every 18 months, just to keep the developers sharp.*

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] Changelog is updated (in case of notable or breaking changes)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md