### PR TITLE
Use environment files in GitHub Actions

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -58,7 +58,7 @@ jobs:
           # to be set via shell profile. GitHub Actions do not load profile
           # so we have to tweak the path manually here.
           sudo usermod -a -G rvm $(id -nu)
-          echo "::add-path::/usr/share/rvm/bin"
+          echo "/usr/share/rvm/bin" >> "$GITHUB_PATH"
       - name: Install stable Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/test-objc.yaml
+++ b/.github/workflows/test-objc.yaml
@@ -189,7 +189,7 @@ jobs:
           # allow modified podspec to be published, and issues a warning
           # if the source is anything but a release tag. For regular builds
           # we allow warnings with this extra flag:
-          echo "::set-env name=ALLOW_WARNINGS::--allow-warnings"
+          echo "ALLOW_WARNINGS=--allow-warnings" >> "$GITHUB_ENV"
       - name: Syntax check
         run: pod spec lint $ALLOW_WARNINGS --quick
       - name: Lint podspec

--- a/.github/workflows/test-ruby.yaml
+++ b/.github/workflows/test-ruby.yaml
@@ -46,7 +46,7 @@ jobs:
           # to be set via shell profile. GitHub Actions do not load profile
           # so we have to tweak the path manually here.
           sudo usermod -a -G rvm $(id -nu)
-          echo "::add-path::/usr/share/rvm/bin"
+          echo "/usr/share/rvm/bin" >> "$GITHUB_PATH"
       - name: Check out code
         uses: actions/checkout@v2
       - name: Prepare Themis Core


### PR DESCRIPTION
GitHub Actions have deprecated `set-env` and `add-path` commands due to [a security vulnerability][1]. The grace period for migration has expired around a week ago and now they cause hard errors instead of warnings. Replace `set-env` and `add-path` usage with recommended [environment files approach][2], fixing the build errors.

[1]: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
[2]: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files

## Checklist

- [X] Change is covered by automated tests