### PR TITLE
Dynamic linkage for CocoaPods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 Changes that are currently in development and have not been released yet.
 
+_Code:_
+
+- **Objective-C / Swift**
+
+  - CocoaPods will now again link ObjCThemis *dynamically* into application ([#750](https://github.com/cossacklabs/themis/pull/750)).
+  - Carthage no longer builds `arm64e` architecture slice ([#750](https://github.com/cossacklabs/themis/pull/750)).
+  - Updated OpenSSL to the latest 1.1.1h-2 ([#750](https://github.com/cossacklabs/themis/pull/750)).
+
 
 ## [0.13.5](https://github.com/cossacklabs/themis/releases/tag/0.13.5), November 12th 2020
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
 # OpenSSL 1.1.1h
-binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-iPhone.json" ~> 1.1.10802
-binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-MacOSX.json" ~> 1.1.10802
+binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-iPhone.json" "1.1.10802"
+binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-MacOSX.json" "1.1.10802"

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
 # OpenSSL 1.1.1h
-binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-iPhone.json" ~> 1.1.10801
-binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-MacOSX.json" ~> 1.1.10801
+binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-iPhone.json" ~> 1.1.10802
+binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-MacOSX.json" ~> 1.1.10802

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-MacOSX.json" "1.1.10801"
-binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-iPhone.json" "1.1.10801"
+binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-MacOSX.json" "1.1.10802"
+binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-iPhone.json" "1.1.10802"

--- a/Themis.xcodeproj/project.pbxproj
+++ b/Themis.xcodeproj/project.pbxproj
@@ -1557,10 +1557,6 @@
 		9F4A24A7223A8D7F005CB63A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = (
-					"$(ARCHS_STANDARD)",
-					arm64e,
-				);
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 5;
@@ -1571,7 +1567,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = YES;
 				EXCLUDED_ARCHS = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 arm64e";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				EXPORTED_SYMBOLS_FILE = "$(PROJECT_DIR)/src/wrappers/themis/Obj-C/exported.symbols";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1609,10 +1605,6 @@
 		9F4A24A8223A8D7F005CB63A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = (
-					"$(ARCHS_STANDARD)",
-					arm64e,
-				);
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 5;
@@ -1623,7 +1615,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = YES;
 				EXCLUDED_ARCHS = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 arm64e";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				EXPORTED_SYMBOLS_FILE = "$(PROJECT_DIR)/src/wrappers/themis/Obj-C/exported.symbols";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/themis.podspec
+++ b/themis.podspec
@@ -17,10 +17,6 @@ Pod::Spec.new do |s|
     s.osx.deployment_target = '10.11'
     s.ios.frameworks = 'UIKit', 'Foundation'
 
-    # Tell CocoaPods that the frameworks we publish are "static frameworks".
-    # This ensures correct resolution of transitive dependencies.
-    s.static_framework = true
-
     # TODO(ilammy, 2020-03-02): resolve "pod spec lint" warnings due to dependencies
     # If you update dependencies, please check whether we can remove "--allow-warnings"
     # from podspec validation in .github/workflows/test-objc.yaml

--- a/themis.podspec
+++ b/themis.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
     # This variant uses the current stable, non-legacy version of OpenSSL.
     s.subspec 'openssl-1.1.1' do |so|
         # OpenSSL 1.1.1h
-        so.dependency 'CLOpenSSL', '~> 1.1.10801'
+        so.dependency 'CLOpenSSL', '~> 1.1.10802'
 
         # Enable bitcode for OpenSSL in a very specific way, but it works, thanks to @deszip
         so.ios.pod_target_xcconfig = {

--- a/themis.podspec
+++ b/themis.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
     # This variant uses the current stable, non-legacy version of OpenSSL.
     s.subspec 'openssl-1.1.1' do |so|
         # OpenSSL 1.1.1h
-        so.dependency 'CLOpenSSL', '~> 1.1.10802'
+        so.dependency 'CLOpenSSL', '1.1.10802'
 
         # Enable bitcode for OpenSSL in a very specific way, but it works, thanks to @deszip
         so.ios.pod_target_xcconfig = {


### PR DESCRIPTION
Update to latest CLOpenSSL 1.1.10802 which uses dynamic linkage (and removes some architecture slices for that).

Now that CLOpenSSL is using dynamic linkage, we can switch Themis back to using dynamic linkage too (as it was before). The `themis` pod will have to continue being a dynamic framework Pod to avoid breaking existing builds.

`arm64e` slice in binary dynamic frameworks causes issues with CocoaPods so it has been removed from CLOpenSSL starting with 1.1.10802. However, Carthage builds use Xcode project which still requires `arm64e`. Remove `arm64e` from the architectures list as it is not available now.

## Checklist

- [X] Change is covered by automated tests
- [X] Changelog is updated (in case of notable or breaking changes)