### PR TITLE
Themis 0.13.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 Changes that are currently in development and have not been released yet.
 
+
+## [0.13.6](https://github.com/cossacklabs/themis/releases/tag/0.13.6), November 23th 2020
+
+**Hotfix for Apple platforms:**
+
+- `themis` pod is now restored to use *dynamic* linkage again
+- Resolved errors related to `@rpath` when using CocoaPods
+- Removed `arm64e` architecture slice from Carthage builds for iOS which prevented CocoaPods from functioning correctly
+
 _Code:_
 
 - **Objective-C / Swift**

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
 # OpenSSL 1.1.1h
-binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-iPhone.json" "1.1.10802"
-binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-MacOSX.json" "1.1.10802"
+binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-iPhone.json" == 1.1.10802
+binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-MacOSX.json" == 1.1.10802

--- a/Themis.xcodeproj/project.pbxproj
+++ b/Themis.xcodeproj/project.pbxproj
@@ -1476,7 +1476,7 @@
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1502,7 +1502,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.13.5;
+				MARKETING_VERSION = 0.13.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis;
 				PRODUCT_MODULE_NAME = themis;
 				PRODUCT_NAME = themis;
@@ -1518,7 +1518,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1544,7 +1544,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.13.5;
+				MARKETING_VERSION = 0.13.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis;
 				PRODUCT_MODULE_NAME = themis;
 				PRODUCT_NAME = themis;
@@ -1559,7 +1559,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1587,7 +1587,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.13.5;
+				MARKETING_VERSION = 0.13.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis;
 				PRODUCT_MODULE_NAME = themis;
 				PRODUCT_NAME = themis;
@@ -1607,7 +1607,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1635,7 +1635,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.13.5;
+				MARKETING_VERSION = 0.13.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis;
 				PRODUCT_MODULE_NAME = themis;
 				PRODUCT_NAME = themis;

--- a/themis.podspec
+++ b/themis.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name = "themis"
-    s.version = "0.13.4"
+    s.version = "0.13.6"
     s.summary = "Data security library for network communication and data storage for iOS and mac OS"
     s.description = "Themis is a convenient cryptographic library for data protection. It provides secure messaging with forward secrecy and secure data storage. Themis is aimed at modern development practices and has a unified API across 12 platforms, including iOS/macOS, Ruby, JavaScript, Python, and Java/Android."
     s.homepage = "https://cossacklabs.com"


### PR DESCRIPTION
Push out (yet another) hotfix for Apple platforms, now enabling back dynamic linkage for CocoaPods, resolving installation issues as well as weird errors about `@rpath` when trying to run compiled apps.

## Checklist

- [X] ~~Change is covered by automated tests~~ (yes, but...)
- [X] ~~Example projects and code samples are up-to-date~~ (examples are broken until after the release)
- [X] Changelog is updated