### PR TITLE
Measure test coverage with GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,47 +1,15 @@
+# Starting with Themis 0.14 we don't have any need for this config anymore
+# since Themis has migrated away from CircleCI. However, until Themis 0.14
+# is released, CircleCI still runs nightly builds on the "stable" branch
+# and it requires the ".circleci/config.yml" file on the "master" branch.
+# Here's a minimal file contaning only required keys and doing no jobs.
+
 version: 2
 jobs:
-  x86_64:
+  sinecure:
     docker:
-      - image: cossacklabs/android-build:2019.01
-    environment:
-      # NIST STS tests tend to fail in Docker environment
-      NO_NIST_STS: 1
-      WITH_FATAL_WARNINGS: yes
-      SOTER_KDF_RUN_LONG_TESTS: yes
+      - image: scratch
     steps:
-      - run: sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get -y install libssl-dev ruby-dev lcov libc6-dbg
-      - run: sudo ln -sf /usr/bin/gcov-5 /usr/bin/gcov
-      - run: sudo gem install coveralls-lcov
-      - run: go get github.com/mattn/goveralls
-      - checkout
-      - run: git reset HEAD && git submodule sync && git submodule update --init
-      - run: make BUILD_PATH=cover_build COVERAGE=y prepare_tests_basic
-      - run: lcov --directory . --zerocounters
-      # run only if CIRCLE_PR_NUMBER variable is not set (it's not pull request and COVERALLS_TOKEN will be set via circleCI for non-PR build) and COVERALLS_TOKEN is set
-      # we should calculate coverage for gothemis and send report before sending coverage of main C part
-      - run: '[ -z "$CIRCLE_PR_NUMBER" ] && ! [ -z "$COVERALLS_TOKEN" ] && cd $HOME/go/src/$GOTHEMIS_IMPORT && $HOME/go/bin/goveralls -v -service=circle-ci -repotoken=$COVERALLS_TOKEN || true'
-      - run: cover_build/tests/soter_test
-      - run: cover_build/tests/themis_test
-      - run: lcov --directory . --capture --output-file coverage.info
-      - run: lcov --remove coverage.info 'tests/*' 'src/soter/openssl/*' '/usr/*' --output-file coverage.info
-      - run: lcov --list coverage.info
-      - run: coveralls-lcov -v --repo-token $COVERALLS_TOKEN coverage.info || true
 
 workflows:
   version: 2
-  tests:
-    jobs:
-      - x86_64
-  nightly:
-    # Apparently CircleCI does not have a "push" or "pull request" trigger
-    # so we have to have a separate workflow with the same job list.
-    triggers:
-      - schedule:
-          cron: "0 5 * * *"
-          filters:
-            branches:
-              only:
-                - master
-                - stable
-    jobs:
-      - x86_64

--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -318,3 +318,32 @@ jobs:
             /ERROR SUMMARY|(definitely|indirectly|possibly) lost/ { sum += $4 }
             END { if (sum > 0) { exit 1 } }
           ' valgrind-report.txt
+
+  coverage:
+    name: Unit test coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install system dependencies
+        run: |
+          sudo sh -c 'echo "DEBIAN_FRONTEND=noninteractive" >> /etc/environment'
+          sudo apt update
+          sudo apt install --yes gcc make libssl-dev lcov
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Build Themis Core
+        run: make prepare_tests_basic COVERAGE=y
+      - name: Reset lcov counters
+        run: lcov --directory . --zerocounters
+      - name: Run test suite
+        run: make test COVERAGE=y
+      - name: Prepare lcov data
+        run: |
+          lcov --output-file coverage.info --directory . --capture
+          # Do not include tests themselves as well as system headers
+          lcov --output-file coverage.info --remove coverage.info '*/tests/*' '/usr/*'
+          lcov --list coverage.info
+      - name: Submit results to Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./coverage.info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ _Infrastructure:_
 - `make deb` and `make rpm` with `ENGINE=boringssl` will now produce `libthemis-boringssl` packages with embedded BoringSSL ([#683](https://github.com/cossacklabs/themis/pull/683), [#686](https://github.com/cossacklabs/themis/pull/686)).
 - Build system and tests now respect the `PATH` settings ([#685](https://github.com/cossacklabs/themis/pull/685)).
 - Rename embedded BoringSSL symbols by default to avoid conflicts with system OpenSSL ([#702](https://github.com/cossacklabs/themis/pull/702)).
-- Started phasing out CircleCI in favour of GitHub Actions ([#709](https://github.com/cossacklabs/themis/pull/709)).
+- Started phasing out CircleCI in favour of GitHub Actions ([#709](https://github.com/cossacklabs/themis/pull/709), [#755](https://github.com/cossacklabs/themis/pull/755)).
 
 
 ## [0.13.6](https://github.com/cossacklabs/themis/releases/tag/0.13.6), November 23rd 2020


### PR DESCRIPTION
Migrate the coverage step from CircleCI to GitHub Actions. It's pretty easy: compile Themis with `gcov` instrumentation, run the tests, use `lcov` to extract coverage data, post results using official Action.

Compared to CircleCI, the difference is in how we exclude the `tests` directory. For some reason the version of lcov available on GitHub's runners handles relative paths slightly differently.

(Also, if I understand the docs correctly, Coveralls can (will?) post coverage results in pull requests, thanks to that action.)

### On CircleCI retirement

Now that GitHub Actions have stolen the last job CircleCI had, it's no longer necessary on the `master` branch. However, CircleCI is still running nightly builds on the `stable` branch so we can't turn it off just like that.

Due to the way CircleCI works, it needs to see the `.circleci/config.yml` file on the default branch of the repo (i.e., `master`). However, we don't need it to do anything. So put there the minimal valid config and let CircleCI rest. It had worked hard for us all these days, after all.

Once Themis 0.14 is out, GitHub Actions configuration will be applied to the `stable` branch, and only then CircleCI can be deconfigured and finally retired.

### On GoThemis coverage

Also note that these is no replacement for `goveralls` execution that is removed in this commit. It does not seem to be working right now, and no one knows when exactly it stopped working. Well, we can't replace it easily right now so GoThemis is in the same boat with other wrappers: that is, test coverage is collected only for Themis Core. Maybe future work on Themis 0.14 will add more coverage coverage before the release.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] Public API has proper documentation
- [X] Changelog is updated
- [x] `x86_64` job is marked optional in `master` branch settings

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md