### PR TITLE
Use new trait order in generated code

### DIFF
--- a/src/wrappers/themis/rust/libthemis-sys/src/lib.rs
+++ b/src/wrappers/themis/rust/libthemis-sys/src/lib.rs
@@ -211,7 +211,7 @@ extern "C" {
     ) -> themis_status_t;
 }
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum themis_key_kind {
     THEMIS_KEY_INVALID = 0,
     THEMIS_KEY_RSA_PRIVATE = 1,


### PR DESCRIPTION
[Recent release of bindgen 0.56.0](https://github.com/rust-lang/rust-bindgen/blob/master/CHANGELOG.md#0560) resulted in a change in the order of the derived traits in the generated code. The changelog does not say anything about that, but I doubt this is considered a notable change. However, it breaks our build system which meticulously checks for any changes in the generated code compared to checked in version. It does this so that we don't miss any changes.

Well, the CI is going to be using bindgen 0.56.0 from now on, let's use the new trait order as well, whatever it is.

## Checklist

- [X] Change is covered by automated tests