### PR TITLE
Update code style checking job to Ubuntu 20.04

### DIFF
--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -35,8 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     # GitHub's host contains way too much crap in /etc/apt/sources.list
     # which causes package conflicts in clang-format-8 and clang-tidy-8
-    # installation. Run this job in a pristine Ubuntu 19.10 container.
-    container: ubuntu:19.10
+    # installation. Run this job in a pristine Ubuntu 20.04 container.
+    container: ubuntu:20.04
     steps:
       - name: Install system dependencies
         run: |


### PR DESCRIPTION
One of the GitHub Actions jobs is using a pristine Ubuntu container because whatever is provided by GitHub Actions runners causes conflicts when some of the packages are installed. That container has been using Ubuntu 19.10.

[Ubuntu 19.10 "Eoan Ermine" has reached end of life on 2020-07-17](https://lists.ubuntu.com/archives/ubuntu-announce/2020-July/000258.html). Normally EOL only means that the distribution stops receiving updates after that date. However, eventually it gets purged from the mainline repositories as well. This is exactly what has happened recently, and since then the builds are all red because they are not able to install packages for a missing distribution.

Upgrade to Ubuntu 20.04 LTS "Focal Focca". This should last us at least until 2030 or something. Or well, until GitHub becomes more attentive to whatever stuff they put in their `sources.list`.

## Checklist

- [X] Change is covered by automated tests
- [X] ~~Changelog is updated~~ (don't think we need this, the packages are all the same)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
