### PR TITLE
Fix buffer and integer overflows in Secure Message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ _Code:_
 
     </details>
 
+  - Fixed multiple buffer overflows in Secure Message ([#763](https://github.com/cossacklabs/themis/pull/763)).
+
 - **Go**
 
   - Error `ErrOverflow` is now deprecated in favor of `ErrOutOfMemory`, new error types were added ([#711](https://github.com/cossacklabs/themis/pull/711)).

--- a/src/themis/secure_message.c
+++ b/src/themis/secure_message.c
@@ -114,7 +114,6 @@ themis_status_t themis_secure_message_decrypt(const uint8_t* private_key,
 
     themis_secure_message_hdr_t* message_hdr = (themis_secure_message_hdr_t*)encrypted_message;
     THEMIS_CHECK_PARAM(IS_THEMIS_SECURE_MESSAGE_ENCRYPTED(message_hdr->message_type));
-    THEMIS_CHECK_PARAM(encrypted_message_length >= THEMIS_SECURE_MESSAGE_LENGTH(message_hdr));
 
     themis_secure_message_decrypter_t* ctx = NULL;
     ctx = themis_secure_message_decrypter_init(private_key, private_key_length, public_key, public_key_length);
@@ -168,7 +167,6 @@ themis_status_t themis_secure_message_verify(const uint8_t* public_key,
 
     themis_secure_message_hdr_t* message_hdr = (themis_secure_message_hdr_t*)signed_message;
     THEMIS_CHECK_PARAM(IS_THEMIS_SECURE_MESSAGE_SIGNED(message_hdr->message_type));
-    THEMIS_CHECK_PARAM(signed_message_length >= THEMIS_SECURE_MESSAGE_LENGTH(message_hdr));
 
     themis_secure_message_verifier_t* ctx = NULL;
     ctx = themis_secure_message_verifier_init(public_key, public_key_length);
@@ -257,7 +255,6 @@ themis_status_t themis_secure_message_unwrap(const uint8_t* private_key,
     themis_secure_message_hdr_t* message_hdr = (themis_secure_message_hdr_t*)wrapped_message;
     THEMIS_CHECK_PARAM(IS_THEMIS_SECURE_MESSAGE_SIGNED(message_hdr->message_type)
                        || IS_THEMIS_SECURE_MESSAGE_ENCRYPTED(message_hdr->message_type));
-    THEMIS_CHECK_PARAM(wrapped_message_length >= THEMIS_SECURE_MESSAGE_LENGTH(message_hdr));
     if (IS_THEMIS_SECURE_MESSAGE_SIGNED(message_hdr->message_type)) {
         themis_secure_message_verifier_t* ctx = NULL;
         ctx = themis_secure_message_verifier_init(public_key, public_key_length);

--- a/src/themis/secure_message.c
+++ b/src/themis/secure_message.c
@@ -105,7 +105,7 @@ themis_status_t themis_secure_message_decrypt(const uint8_t* private_key,
                                               size_t* message_length)
 {
     THEMIS_CHECK_PARAM(encrypted_message != NULL);
-    THEMIS_CHECK_PARAM(encrypted_message_length != 0);
+    THEMIS_CHECK_PARAM(encrypted_message_length >= sizeof(themis_secure_message_hdr_t));
     THEMIS_CHECK_PARAM(message_length != NULL);
     THEMIS_CHECK_PARAM(valid_private_key(private_key, private_key_length));
     THEMIS_CHECK_PARAM(valid_public_key(public_key, public_key_length));
@@ -162,7 +162,7 @@ themis_status_t themis_secure_message_verify(const uint8_t* public_key,
                                              size_t* message_length)
 {
     THEMIS_CHECK_PARAM(signed_message != NULL);
-    THEMIS_CHECK_PARAM(signed_message_length != 0);
+    THEMIS_CHECK_PARAM(signed_message_length >= sizeof(themis_secure_message_hdr_t));
     THEMIS_CHECK_PARAM(message_length != NULL);
     THEMIS_CHECK_PARAM(valid_public_key(public_key, public_key_length));
 
@@ -252,7 +252,7 @@ themis_status_t themis_secure_message_unwrap(const uint8_t* private_key,
     THEMIS_CHECK_PARAM(public_key != NULL);
     THEMIS_CHECK_PARAM(public_key_length != 0);
     THEMIS_CHECK_PARAM(wrapped_message != NULL);
-    THEMIS_CHECK_PARAM(wrapped_message_length != 0);
+    THEMIS_CHECK_PARAM(wrapped_message_length >= sizeof(themis_secure_message_hdr_t));
     THEMIS_CHECK_PARAM(message_length != NULL);
     themis_secure_message_hdr_t* message_hdr = (themis_secure_message_hdr_t*)wrapped_message;
     THEMIS_CHECK_PARAM(IS_THEMIS_SECURE_MESSAGE_SIGNED(message_hdr->message_type)

--- a/src/themis/secure_message_wrapper.c
+++ b/src/themis/secure_message_wrapper.c
@@ -142,7 +142,9 @@ themis_status_t themis_secure_message_verifier_proceed(themis_secure_message_ver
                                                        size_t* message_length)
 {
     THEMIS_CHECK(ctx != NULL);
-    THEMIS_CHECK(wrapped_message != NULL && wrapped_message_length != 0 && message_length != NULL);
+    THEMIS_CHECK(wrapped_message != NULL)
+    THEMIS_CHECK(wrapped_message_length >= sizeof(themis_secure_signed_message_hdr_t));
+    THEMIS_CHECK(message_length != NULL);
     themis_secure_signed_message_hdr_t* msg = (themis_secure_signed_message_hdr_t*)wrapped_message;
     if (((msg->message_hdr.message_type == THEMIS_SECURE_MESSAGE_RSA_SIGNED
           && soter_verify_get_alg_id(ctx->verify_ctx) != SOTER_SIGN_rsa_pss_pkcs8)

--- a/src/themis/secure_message_wrapper.c
+++ b/src/themis/secure_message_wrapper.c
@@ -146,12 +146,16 @@ themis_status_t themis_secure_message_verifier_proceed(themis_secure_message_ver
     THEMIS_CHECK(wrapped_message_length >= sizeof(themis_secure_signed_message_hdr_t));
     THEMIS_CHECK(message_length != NULL);
     themis_secure_signed_message_hdr_t* msg = (themis_secure_signed_message_hdr_t*)wrapped_message;
-    if (((msg->message_hdr.message_type == THEMIS_SECURE_MESSAGE_RSA_SIGNED
-          && soter_verify_get_alg_id(ctx->verify_ctx) != SOTER_SIGN_rsa_pss_pkcs8)
-         || (msg->message_hdr.message_type == THEMIS_SECURE_MESSAGE_EC_SIGNED
-             && soter_verify_get_alg_id(ctx->verify_ctx) != SOTER_SIGN_ecdsa_none_pkcs8))
-        || (msg->message_hdr.message_length + msg->signature_length + sizeof(themis_secure_message_hdr_t)
-            > wrapped_message_length)) {
+    if (msg->message_hdr.message_type == THEMIS_SECURE_MESSAGE_RSA_SIGNED
+        && soter_verify_get_alg_id(ctx->verify_ctx) != SOTER_SIGN_rsa_pss_pkcs8) {
+        return THEMIS_INVALID_PARAMETER;
+    }
+    if (msg->message_hdr.message_type == THEMIS_SECURE_MESSAGE_EC_SIGNED
+        && soter_verify_get_alg_id(ctx->verify_ctx) != SOTER_SIGN_ecdsa_none_pkcs8) {
+        return THEMIS_INVALID_PARAMETER;
+    }
+    if (msg->message_hdr.message_length + msg->signature_length + sizeof(themis_secure_message_hdr_t)
+        > wrapped_message_length) {
         return THEMIS_INVALID_PARAMETER;
     }
     if (message == NULL || (*message_length) < msg->message_hdr.message_length) {

--- a/src/themis/secure_message_wrapper.c
+++ b/src/themis/secure_message_wrapper.c
@@ -176,7 +176,7 @@ themis_status_t themis_secure_message_verifier_proceed(themis_secure_message_ver
      * have based on the information encoded in the header. This is necessary for Themis
      * to be able to verify all those overlong Secure Messages produced in the past.
      */
-    if (msg->message_hdr.message_length + msg->signature_length + sizeof(themis_secure_message_hdr_t)
+    if (msg->message_hdr.message_length + msg->signature_length + sizeof(themis_secure_signed_message_hdr_t)
         > wrapped_message_length) {
         return THEMIS_INVALID_PARAMETER;
     }

--- a/src/themis/secure_message_wrapper.c
+++ b/src/themis/secure_message_wrapper.c
@@ -150,7 +150,7 @@ themis_status_t themis_secure_message_verifier_proceed(themis_secure_message_ver
           && soter_verify_get_alg_id(ctx->verify_ctx) != SOTER_SIGN_rsa_pss_pkcs8)
          || (msg->message_hdr.message_type == THEMIS_SECURE_MESSAGE_EC_SIGNED
              && soter_verify_get_alg_id(ctx->verify_ctx) != SOTER_SIGN_ecdsa_none_pkcs8))
-        && (msg->message_hdr.message_length + msg->signature_length + sizeof(themis_secure_message_hdr_t)
+        || (msg->message_hdr.message_length + msg->signature_length + sizeof(themis_secure_message_hdr_t)
             > wrapped_message_length)) {
         return THEMIS_INVALID_PARAMETER;
     }

--- a/src/themis/secure_message_wrapper.c
+++ b/src/themis/secure_message_wrapper.c
@@ -336,6 +336,15 @@ themis_status_t themis_secure_message_rsa_decrypter_proceed(themis_secure_messag
                        == THEMIS_SECURE_MESSAGE_RSA_ENCRYPTED);
     THEMIS_CHECK_PARAM(((const themis_secure_encrypted_message_hdr_t*)wrapped_message)->message_hdr.message_length
                        == wrapped_message_length);
+    /*
+     * Make sure the code below does not trigger an underflow if the header is corrupted.
+     * The subtraction subexpression does not underflow because of the check we made before.
+     * (And yes, this code needs cleanup. I intentionally leave it ugly.)
+     */
+    if ((wrapped_message_length - sizeof(themis_secure_rsa_encrypted_message_hdr_t))
+        < ((const themis_secure_rsa_encrypted_message_hdr_t*)wrapped_message)->encrypted_passwd_length) {
+        return THEMIS_FAIL;
+    }
     size_t ml = 0;
     THEMIS_CHECK(
         themis_secure_cell_decrypt_seal((const uint8_t*)"123",

--- a/src/themis/secure_message_wrapper.h
+++ b/src/themis/secure_message_wrapper.h
@@ -43,8 +43,6 @@ struct themis_secure_message_hdr_type {
 };
 typedef struct themis_secure_message_hdr_type themis_secure_message_hdr_t;
 
-#define THEMIS_SECURE_MESSAGE_LENGTH(hdr) ((hdr)->message_length)
-
 struct themis_secure_signed_message_hdr_type {
     themis_secure_message_hdr_t message_hdr;
     uint32_t signature_length;


### PR DESCRIPTION
Fix or work around issues in Secure Message implementation found by fuzzers from #762.

The details of the changes are documented in commit messages. I won't repeat them in the cover letter since they are too technical and too tied to the changes themselves. Have fun with review!

Turns out that fuzzing is actually useful for cryptography code written in C, who would have guessed? Well, most of those issues could have been avoided in a more safe language, but Themis Core is written in C for a reason. A different code style could have also reduced the probability of those issues, but we have what we have.

The changes here are *not* a rewrite, or refactoring, or anything. This is a quickly hacked patch to fix some glaring issues and make the build with fuzzers green. Though, it would not hurt to get to that at some point in the future, I believe.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] Public API has proper documentation
- [X] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md