### PR TITLE
Unbreak Criterion's HTML reports

### DIFF
--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -195,7 +195,7 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: Criterion report
-          path: benches/themis/target/criterion
+          path: target/criterion
 
   fuzzing:
     name: AFL fuzzing

--- a/benches/themis/Cargo.toml
+++ b/benches/themis/Cargo.toml
@@ -9,7 +9,7 @@ themis = { version = "0.13", path = "../../src/wrappers/themis/rust" }
 libthemis-sys = { version = "0.13", path = "../../src/wrappers/themis/rust/libthemis-sys" }
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = { version = "0.3.4", features = ["cargo_bench_support", "html_reports"]}
 
 [[bench]]
 name = "secure_cell_seal_master_key"


### PR DESCRIPTION
Our benchmarking harness has decided that it's time for some INNOVATION and for starters released a version which has disabled generation of HTML reports by default, changed their location from current directory to the proper shared target directory, and strongly suggests migrating away from running benchmarks with `cargo bench` in favor of their own `cargo criterion`.

<sub>At least they have a [changelog](https://github.com/bheisler/criterion.rs/blob/master/CHANGELOG.md). It does not yet contain an entry for 0.3.4 released about 15 hours ago, but that's something.</sub>

Well, okay, that's a fine rabbit to chase later, but for now let's at least unbreak our build by adapting to the new reality.

## Checklist

- [X] Change is covered by automated tests
- [X] Benchmark results are attached (should be)