### PR TITLE
Run examples only with Python 3

### DIFF
--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -52,11 +52,7 @@ jobs:
     name: Code examples
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        python: [python3]
       fail-fast: false
-    env:
-      PYTHON: ${{ matrix.python }}
     services:
       postgres:
         image: postgres
@@ -97,15 +93,15 @@ jobs:
           cd $GITHUB_WORKSPACE/docs/examples/python
 
           echo "Secure Cell: showcase"
-          $PYTHON scell_test.py
+          python3 scell_test.py
           echo
 
           echo "Secure Cell: PostgreSQL"
-          $PYTHON scell_test_postgres.py
+          python3 scell_test_postgres.py
           echo
 
           echo "Secure Cell: XML processing"
-          $PYTHON scell_xml_format-preserving_encryption.py
+          python3 scell_xml_format-preserving_encryption.py
           diff -q example_data/test.xml decoded_data.xml
           echo
 
@@ -115,39 +111,39 @@ jobs:
           cd $GITHUB_WORKSPACE/docs/examples/python
 
           echo "Generating keys..."
-          $PYTHON skeygen_test.py private.key public.key
+          python3 skeygen_test.py private.key public.key
           echo
 
           echo "Secure Message: sockets: encryption"
-          $PYTHON smessage_test_server.py &
+          python3 smessage_test_server.py &
           sleep 1 # give server time to start
-          $PYTHON smessage_test_client.py
+          python3 smessage_test_client.py
           echo
 
           echo "Secure Message: sockets: sign/verify"
-          $PYTHON smessage_sv_test_server.py &
+          python3 smessage_sv_test_server.py &
           sleep 1 # give server time to start
-          $PYTHON smessage_sv_test_client.py
+          python3 smessage_sv_test_client.py
           echo
 
           echo "Secure Message: Twisted"
-          $PYTHON smessage_test_twisted.py &
+          python3 smessage_test_twisted.py &
           sleep 2 # give server time to start
-          $PYTHON smessage_test_client.py
+          python3 smessage_test_client.py
           kill -SIGTERM $!
           echo
 
           echo "Secure Message: Tornado"
-          $PYTHON smessage_test_tornado_server.py &
+          python3 smessage_test_tornado_server.py &
           sleep 1 # give server time to start
-          $PYTHON smessage_test_tornado_client.py
+          python3 smessage_test_tornado_client.py
           kill -SIGTERM $!
           echo
 
           echo "Secure Message: RabbitMQ"
-          $PYTHON smessage_test_rabbitMQ_server.py &
+          python3 smessage_test_rabbitMQ_server.py &
           sleep 1 # give server time to start
-          $PYTHON smessage_test_rabbitMQ_client.py
+          python3 smessage_test_rabbitMQ_client.py
           kill -SIGTERM $!
           echo
 
@@ -157,29 +153,29 @@ jobs:
           cd $GITHUB_WORKSPACE/docs/examples/python
 
           echo "Secure Session: sockets"
-          $PYTHON ssession_test_server.py &
+          python3 ssession_test_server.py &
           sleep 1 # give server time to start
-          $PYTHON ssession_test_client.py
+          python3 ssession_test_client.py
           echo
 
           echo "Secure Session: Twisted"
-          $PYTHON ssession_test_twisted.py &
+          python3 ssession_test_twisted.py &
           sleep 1 # give server time to start
-          $PYTHON ssession_test_client.py
+          python3 ssession_test_client.py
           kill -SIGTERM $!
           echo
 
           echo "Secure Session: Tornado"
-          $PYTHON ssession_test_tornado_server.py &
+          python3 ssession_test_tornado_server.py &
           sleep 1 # give server time to start
-          $PYTHON ssession_test_tornado_client.py
+          python3 ssession_test_tornado_client.py
           kill -SIGTERM $!
           echo
 
           echo "Secure Session: RabbitMQ"
-          $PYTHON ssession_rabbitMQ_server_test.py &
+          python3 ssession_rabbitMQ_server_test.py &
           sleep 1 # give server time to start
-          $PYTHON ssession_rabbitMQ_client_test.py
+          python3 ssession_rabbitMQ_client_test.py
           kill -SIGTERM $!
           echo
 
@@ -188,9 +184,9 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/docs/examples/python
 
-          $PYTHON scomparator_test_server.py | tee server-output.txt &
+          python3 scomparator_test_server.py | tee server-output.txt &
           sleep 1 # give server time to start
-          $PYTHON scomparator_test_client.py | tee client-output.txt
+          python3 scomparator_test_client.py | tee client-output.txt
           test "$(cat server-output.txt)" = "match"
           test "$(cat client-output.txt)" = "match"
 
@@ -201,5 +197,5 @@ jobs:
           # Since these require manual configuration, we just check the syntax.
           # Though it doesn't guarantee much: enjoy dynamic scripting languages.
           rm -f *.pyc
-          $PYTHON -m py_compile smessage_client.py
-          $PYTHON -m py_compile ssession_client.py
+          python3 -m py_compile smessage_client.py
+          python3 -m py_compile ssession_client.py

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -77,12 +77,10 @@ jobs:
           sudo sh -c 'echo "DEBIAN_FRONTEND=noninteractive" >> /etc/environment'
           sudo apt update
           sudo apt install --yes gcc make libssl-dev \
-            python  python-pip  python-setuptools \
             python3 python3-pip python3-setuptools \
             libpq-dev
       - name: Install Python modules
         run: |
-          sudo pip2 install tornado twisted psycopg2 pika
           sudo pip3 install tornado twisted psycopg2 pika
       - name: Check out code
         uses: actions/checkout@v2


### PR DESCRIPTION
**pip** has dropped support for Python 2 [some time ago](https://pip.pypa.io/en/stable/development/release-process/#python-2-support) – a version of Python that has been EOL for about a year now. [Themis does not support Python 2](https://github.com/cossacklabs/themis/blob/master/CHANGELOG.md#0.13.0-drop-python-2) officially, yet we're still test with it as long as it's practical.

Well, it stopped being practical for this CI job because Ubuntu has removed `python-pip` package from their repos. Remove all lines which install Python 2 testing environment.

For quite some time we have been running this job only with Python 3. Now that Python 2 environment installation has been removed, it no longer makes sense to pretend that we'll enable it back. Just run everything with `python3`.

<sub>Damn you, CI. Can there be a week where *nothing* breaks? Gotta keep running to say in one place, it seems.</sub>

## Checklist

- [X] Change is covered by automated tests