### PR TITLE
Migrate to "afl++" from "afl"

### DIFF
--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -212,7 +212,7 @@ jobs:
           sudo dpkg --add-architecture i386
           sudo apt update
           sudo apt install --yes gcc make zip \
-              afl gcc-multilib libc6-dev:i386 \
+              afl++ gcc-multilib libc6-dev:i386 \
               libssl-dev:amd64 libssl-dev:i386
           # AFL needs proper core dumps to be available, write them to files
           sudo sh -c 'echo core > /proc/sys/kernel/core_pattern'

--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -199,7 +199,14 @@ jobs:
 
   fuzzing:
     name: AFL fuzzing
-    runs-on: ubuntu-latest
+    # TODO(ilammy, 2021-01-28): use "ubuntu-latest" once it works
+    # Currently "ubuntu-latest" means "ubuntu-18.04" but for some inexplicable
+    # reasons GitHub runners in the main repo treat it as "ubuntu-20.04" which
+    # does not seem to work yet (for this job). Pin the Ubuntu 18.04 version
+    # for now, but don't forget to update this once "ubuntu-latest" changes
+    # its meaning or starts working for this job.
+    # See: https://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners
+    runs-on: ubuntu-18.04
     env:
       FUZZ_TIMEOUT: 30s
       THEMIS_DEFAULT_PBKDF2_ITERATIONS: 10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ _Infrastructure:_
 - Build system and tests now respect the `PATH` settings ([#685](https://github.com/cossacklabs/themis/pull/685)).
 - Rename embedded BoringSSL symbols by default to avoid conflicts with system OpenSSL ([#702](https://github.com/cossacklabs/themis/pull/702)).
 - Started phasing out CircleCI in favour of GitHub Actions ([#709](https://github.com/cossacklabs/themis/pull/709), [#755](https://github.com/cossacklabs/themis/pull/755)).
+- Themis is now fuzzed with `afl++` ([#766](https://github.com/cossacklabs/themis/pull/766)).
 
 
 ## [0.13.6](https://github.com/cossacklabs/themis/releases/tag/0.13.6), November 23rd 2020

--- a/tools/afl/fuzzy.mk
+++ b/tools/afl/fuzzy.mk
@@ -17,6 +17,11 @@
 AFL_FUZZ ?= afl-fuzz
 AFL_CC   ?= afl-clang
 
+# TODO(ilammy, 2021-01-27): use afl++ toolchain if available
+# The above tools are compaible with the original "afl" which is currently
+# not maintained. Modern systems come with "afl++" that has mostly compatible
+# command-line and new instrumentation toolchain. We should use it if possible.
+
 FUZZ_PATH = tools/afl
 FUZZ_BIN_PATH = $(BIN_PATH)/afl
 FUZZ_SRC_PATH = $(FUZZ_PATH)/src


### PR DESCRIPTION
The original [`afl`][1] has been abandoned and is not maintained since 2017. [`afl++`][2] is its successor. Since it's a fork, it has mostly compatible command line, and more features.

[1]: http://lcamtuf.coredump.cx/afl/
[2]: https://github.com/AFLplusplus/AFLplusplus

The original afl is currently being phased out from distributions. In particular, it's gone from whatever repo list GitHub Actions use, breaking our build. Migrate to afl++ instead.

Not all operating systems ship with afl++ though. For example, it's still not available in binary form on macOS via Homebrew. Therefore, don't jump the gun and don't update the Makefile to use afl++-only features. (However, it would be nice to use them if available.)

---

The timing could not have been better! GitHub Actions broke the build again... I guess it's the “upgrade January” for them.

I'm tired of this so this is the last PR that I submit or merge this week. If it's red then it's red.

## Checklist

- [X] Change is covered by automated tests
- [X] Changelog is updated (in case of notable or breaking changes)