### PR TITLE
Update misc. links and READMEs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,5 +23,5 @@ If you'd like to participate in the core development more closely, [get in touch
 
 - Requests/bugfixes/queries should go through [GitHub Issues](https://github.com/cossacklabs/themis/issues)
 - To reach the developers, use [dev@cossacklabs.com](mailto:dev@cossacklabs.com).
-- See more information on contributing on our [Documentation Server/Contributing, contacts, assistance](https://docs.cossacklabs.com/pages/documentation-themis/#contributing-contacts-assistance).
+- See more information [on contributing](https://docs.cossacklabs.com/themis/community/contributing/) and [Themis community](https://docs.cossacklabs.com/themis/community/).
 - To talk to the business wing of Cossack Labs, drop us an email to [info@cossacklabs.com](mailto:info@cossacklabs.com).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,13 @@ Every commit that goes into the master branch is audited and reviewed by somebod
 
 ## "I'd like to help somehow, but don't know what will be useful. What should I do?"
 
-There's a Development [status page](https://docs.cossacklabs.com/pages/documentation-themis/#development-status), which displays what we're working on right now and what critical stuff is not there yet. If you'd like to take over any of those tasks, get in touch or just raise an issue and work on it. 
+If you're looking for something to contribute to and gain eternal respect,
+just pick the things in the [list of issues](https://github.com/cossacklabs/themis/issues)
+and let us know via [email](mailto:dev@cossacklabs.com),
+or raise a [new issue](https://github.com/cossacklabs/themis/issues)
+to make sure nobody's on it yet.
+
+Issues marked as ["enhancement"](https://github.com/cossacklabs/themis/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Aenhancement%20) are a great place to start.
 
 If you'd like to do independent parts (implement new procedures/objects, create a language wrapper or a set of examples for languages or architectures we don't have and don't even plan yet) — just go ahead and let us know when you finish. 
 

--- a/benches/themis/README.md
+++ b/benches/themis/README.md
@@ -19,7 +19,7 @@ You will need Rust toolchain installed to run benchmarks.
     ```
 
     If it doesn’t work (or this is your first time building Themis)
-    then you might need to [review the documentation](https://docs.cossacklabs.com/pages/documentation-themis/#building-and-installing).
+    then you might need to [review the documentation](https://docs.cossacklabs.com/themis/installation/).
 
     If it still doesn’t work, please [file an issue](https://github.com/cossacklabs/themis/issues/new?labels=bug,installation,core&template=bug_report.md&title=).
 

--- a/docs/examples/README.MD
+++ b/docs/examples/README.MD
@@ -1,12 +1,16 @@
 # Examples
 
-- **[Themis-Server](https://github.com/cossacklabs/themis/tree/master/docs/examples/Themis-server)**: examples for Secure Session and Secure Message, specifically tailored to talk to interactive [Themis Server](https://docs.cossacklabs.com/simulator/interactive/), available for most languages.
+- **[Themis Server](https://github.com/cossacklabs/themis/tree/master/docs/examples/Themis-server)**: examples for Secure Session and Secure Message, specifically tailored to talk to interactive [Themis Server](https://docs.cossacklabs.com/simulator/interactive/), available for most languages.
 
-- **Language-specific examples**: illustrate usage of Themis [Secure Cell](https://docs.cossacklabs.com/pages/secure-cell-cryptosystem/), [Secure Message](https://docs.cossacklabs.com/pages/secure-message-cryptosystem/), [Secure Session](https://docs.cossacklabs.com/pages/secure-session-cryptosystem/), [Secure Comparator](https://docs.cossacklabs.com/pages/secure-comparator-cryptosystem/).
+- **Language-specific examples**: illustrate usage of Themis
+  [Secure Cell](https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-cell/),
+  [Secure Message](https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-message/),
+  [Secure Session](https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-session/),
+  [Secure Comparator](https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-comparator/).
 
-## On Themis Server (Interactive Simulator)    
+## On Themis Server
 
-Read more about using [Themis Server (Interactive Simulator)](https://docs.cossacklabs.com/simulator/interactive/) in the [documentation](https://docs.cossacklabs.com/pages/using-themis-server/).
+Read more about using [Themis Server](https://docs.cossacklabs.com/simulator/interactive/) in the [documentation](https://docs.cossacklabs.com/themis/debugging/themis-server/).
 
 # Tutorials and sample apps
 

--- a/docs/examples/Themis-server/Obj-C/README.md
+++ b/docs/examples/Themis-server/Obj-C/README.md
@@ -1,6 +1,6 @@
-0. [Install Pods](https://docs.cossacklabs.com/pages/objective-c-howto/#installing-stable-version-from-cocoapods)
+0. [Install Pods](https://docs.cossacklabs.com/themis/languages/objc/installation/)
 1. Run the app (yes, it crashes on asserts – this is fine :)
-2. Open `AppDelegate` and choose a Client example for either SMessage ([Secure Message](https://docs.cossacklabs.com/pages/secure-message-cryptosystem/)) or SSession ([Secure Session](https://docs.cossacklabs.com/pages/secure-session-cryptosystem/)). Uncomment the necessary mode to start. 
+2. Open `AppDelegate` and choose a Client example for either SMessage ([Secure Message](https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-message/)) or SSession ([Secure Session](https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-session/)). Uncomment the necessary mode to start.
 
 
 ![appdelegate](pics/appdelegate.png)
@@ -8,7 +8,7 @@
 
 ## SecureSession mode
 
-Let's assume, you want to play with [Secure Session](https://docs.cossacklabs.com/pages/secure-session-cryptosystem/).
+Let's assume, you want to play with [Secure Session](https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-session/).
 
 3. Open `SSessionClient.m` file.
 
@@ -48,7 +48,7 @@ The idea is to let the Server know the Client's public key, and let the Client k
 
  
 9. Open [Themis Server](https://docs.cossacklabs.com/simulator/interactive/).  
-10. Log in with your existing Themis Server credentials or [register](https://docs.cossacklabs.com/pages/using-themis-server/#registration).  
+10. Log in with your existing Themis Server credentials or [register](https://docs.cossacklabs.com/themis/debugging/themis-server/#registration).
 
 >Note: The UI of Themis Server is gradually (albeit constantly) evolving. Don’t be surprised to see that some of the UI elements have changed their colour or that some buttons have moved around a little. The core functionality of Themis Server stays the same.  
 
@@ -89,4 +89,4 @@ Follow the same steps as described above, but do it for `SMessageClient` file :)
 
 ## Useful reading  
 
-To get most of Themis Server, read a [detailed explanation of how Themis Server Simulator works](https://docs.cossacklabs.com/pages/using-themis-server/).
+To get most of Themis Server, read a [detailed explanation of how Themis Server Simulator works](https://docs.cossacklabs.com/themis/debugging/themis-server/).

--- a/docs/examples/Themis-server/swift/README.md
+++ b/docs/examples/Themis-server/swift/README.md
@@ -1,8 +1,8 @@
 # How to use Themis Server with Swift     
 
-0. [Install Pods](https://docs.cossacklabs.com/pages/swift-howto/#installing-stable-version-from-cocoapods)
+0. [Install Pods](https://docs.cossacklabs.com/themis/languages/swift/installation/)
 1. Run the app (yes, it crashes on asserts – this is fine :)
-2. Open `AppDelegate` and choose a Client example for either SMessage ([Secure Message](https://docs.cossacklabs.com/pages/secure-message-cryptosystem/)) or SSession ([Secure Session](https://docs.cossacklabs.com/pages/secure-session-cryptosystem/)). Uncomment the necessary mode to start.     
+2. Open `AppDelegate` and choose a Client example for either SMessage ([Secure Message](https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-message/)) or SSession ([Secure Session](https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-session/)). Uncomment the necessary mode to start.
 
 
 ![appdelegate](pics/appdelegate.png)
@@ -10,7 +10,7 @@
 
 ## Secure Session mode   
 
-Let's assume, you want to play with [Secure Session](https://docs.cossacklabs.com/pages/secure-session-cryptosystem/).
+Let's assume, you want to play with [Secure Session](https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-session/).
 
 3. Open `SSessionClient` file.
 
@@ -50,7 +50,7 @@ The idea is to let the Server know the Client's public key, and let the Client k
 
  
 9. Open [Themis Server](https://docs.cossacklabs.com/simulator/interactive/).  
-10. Log in with your existing Themis Server credentials or [register](https://docs.cossacklabs.com/pages/using-themis-server/#registration). 
+10. Log in with your existing Themis Server credentials or [register](https://docs.cossacklabs.com/themis/debugging/themis-server/#registration).
 
 >Note: The UI of Themis Server is gradually (albeit constantly) evolving. Don’t be surprised to see that some of the UI elements have changed their colour or that some buttons have moved around a little. The core functionality of Themis Server stays the same.    
 
@@ -91,4 +91,4 @@ Follow the same steps as described above, but do it for `SMessageClient` file :)
 
 ## Useful reading  
 
-To get most of Themis Server, read a [detailed explanation of how Themis Server Simulator works](https://docs.cossacklabs.com/pages/using-themis-server/).
+To get most of Themis Server, read a [detailed explanation of how Themis Server Simulator works](https://docs.cossacklabs.com/themis/debugging/themis-server/).

--- a/docs/examples/Themis-server/swift/SwiftThemisServerExample/SwiftThemisServerExample/AppDelegate.swift
+++ b/docs/examples/Themis-server/swift/SwiftThemisServerExample/SwiftThemisServerExample/AppDelegate.swift
@@ -21,7 +21,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // https://docs.cossacklabs.com/simulator/interactive/
         // 
         // Read more how server simulator works
-        // https://docs.cossacklabs.com/pages/documentation-themis/#interactive-simulator-themis-server
+        // https://docs.cossacklabs.com/themis/debugging/themis-server/
         
         print(" ------------ running SMessage Client example ")
         SMessageClient().runSecureMessageCITest()

--- a/docs/examples/Themis-server/swift/SwiftThemisServerExample/SwiftThemisServerExample/SMessageClient.swift
+++ b/docs/examples/Themis-server/swift/SwiftThemisServerExample/SwiftThemisServerExample/SMessageClient.swift
@@ -14,7 +14,7 @@ final class SMessageClient {
     
     // ---------------------- IMPORTANT SETUP ---------------------------------------
     // Read how Themis Server works:
-    // https://docs.cossacklabs.com/pages/documentation-themis/#interactive-simulator-themis-server
+    // https://docs.cossacklabs.com/themis/debugging/themis-server/
     
     // You may NEED to re-generate all keys
     
@@ -150,7 +150,7 @@ final class SMessageClient {
 
     fileprivate func checkKeysNotEmpty() {
         // Read how Themis Server works:
-        // https://docs.cossacklabs.com/pages/documentation-themis/#interactive-simulator-themis-server
+        // https://docs.cossacklabs.com/themis/debugging/themis-server/
         
         
         assert(!(kUserId == "<user id>"), "Get user id from https://docs.cossacklabs.com/simulator/interactive/")

--- a/docs/examples/Themis-server/swift/SwiftThemisServerExample/SwiftThemisServerExample/SSessionClient.swift
+++ b/docs/examples/Themis-server/swift/SwiftThemisServerExample/SwiftThemisServerExample/SSessionClient.swift
@@ -46,7 +46,7 @@ final class SSessionClient {
     
     // ---------------------- IMPORTANT SETUP ---------------------------------------
     // Read how Themis Server works:
-    // https://docs.cossacklabs.com/pages/documentation-themis/#interactive-simulator-themis-server
+    // https://docs.cossacklabs.com/themis/debugging/themis-server/
     
     // You may NEED to re-generate all keys
     
@@ -256,7 +256,7 @@ final class SSessionClient {
     
     fileprivate func checkKeysNotEmpty() {
         // Read how Themis Server works:
-        // https://docs.cossacklabs.com/pages/documentation-themis/#interactive-simulator-themis-server
+        // https://docs.cossacklabs.com/themis/debugging/themis-server/
         
         
         assert(!(kUserId == "<user id>"), "Get user id from https://docs.cossacklabs.com/simulator/interactive/")

--- a/docs/examples/rust/README.md
+++ b/docs/examples/rust/README.md
@@ -3,13 +3,13 @@
 In this directory, we have some examples of Themis usage.
 
 * [**keygen**](keygen.rs) — a tool for generating ECDSA keys (usable by other examples).
-* [**secure_cell**](secure_cell.rs) — showcase of [Secure Cell](https://docs.cossacklabs.com/pages/secure-cell-cryptosystem/) API.
-* [**secure_compare**](secure_compare.rs) — zero-knowledge secret comparison based on [Secure Comparator](https://docs.cossacklabs.com/pages/secure-comparator-cryptosystem/).
-* <b>secure_message_*</b> — secure group chat implemented with [Secure Message](https://docs.cossacklabs.com/pages/secure-message-cryptosystem/)
+* [**secure_cell**](secure_cell.rs) — showcase of [Secure Cell](https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-cell/) API.
+* [**secure_compare**](secure_compare.rs) — zero-knowledge secret comparison based on [Secure Comparator](https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-comparator/).
+* <b>secure_message_*</b> — secure group chat implemented with [Secure Message](https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-message/)
   * [**secure_message_server**](secure_message_server.rs) — simple relay server.
   * [**secure_message_client_encrypt**](secure_message_client_encrypt.rs) — chat client which encrypts messages.
   * [**secure_message_client_verify**](secure_message_client_verify.rs) — chat client which signs and verifies messages.
-* <b>secure_session_echo_*</b> — an example of secure network communication with [Secure Session](https://docs.cossacklabs.com/pages/secure-session-cryptosystem/).
+* <b>secure_session_echo_*</b> — an example of secure network communication with [Secure Session](https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-session/).
   * [**secure_session_echo_client**](secure_session_echo_client.rs) — simple echo client using buffer-oriented API.
   * [**secure_session_echo_server**](secure_session_echo_server.rs) — simple echo server using callback API.
 

--- a/gothemis/cell/cell.go
+++ b/gothemis/cell/cell.go
@@ -44,7 +44,7 @@
 //
 // Read more about Secure Cell modes here:
 //
-// https://docs.cossacklabs.com/pages/secure-cell-cryptosystem/
+// https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-cell/
 package cell
 
 /*
@@ -191,7 +191,7 @@ var (
 	ErrMissingContext    = errors.NewWithCode(errors.InvalidParameter, "associated context is required in Context Imprint mode")
 	ErrOutOfMemory       = errors.NewWithCode(errors.NoMemory, "Secure Cell cannot allocate enough memory")
 	// Deprecated: Since 0.14. Use ErrOutOfMemory instead.
-	ErrOverflow          = ErrOutOfMemory
+	ErrOverflow = ErrOutOfMemory
 )
 
 // Secure Cell operation mode.

--- a/gothemis/cell/cell.go
+++ b/gothemis/cell/cell.go
@@ -191,7 +191,7 @@ var (
 	ErrMissingContext    = errors.NewWithCode(errors.InvalidParameter, "associated context is required in Context Imprint mode")
 	ErrOutOfMemory       = errors.NewWithCode(errors.NoMemory, "Secure Cell cannot allocate enough memory")
 	// Deprecated: Since 0.14. Use ErrOutOfMemory instead.
-	ErrOverflow = ErrOutOfMemory
+	ErrOverflow          = ErrOutOfMemory
 )
 
 // Secure Cell operation mode.

--- a/gothemis/cell/context_imprint.go
+++ b/gothemis/cell/context_imprint.go
@@ -47,7 +47,7 @@ import (
 //
 // Read more about Context Imprint mode here:
 //
-// https://docs.cossacklabs.com/pages/secure-cell-cryptosystem/#context-imprint-mode
+// https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-cell/#context-imprint-mode
 type SecureCellContextImprint struct {
 	key *keys.SymmetricKey
 }

--- a/gothemis/cell/seal.go
+++ b/gothemis/cell/seal.go
@@ -49,7 +49,7 @@ import (
 //
 // Read more about Seal mode here:
 //
-// https://docs.cossacklabs.com/pages/secure-cell-cryptosystem/#seal-mode
+// https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-cell/#seal-mode
 type SecureCellSeal struct {
 	key *keys.SymmetricKey
 }

--- a/gothemis/cell/seal_pw.go
+++ b/gothemis/cell/seal_pw.go
@@ -38,7 +38,7 @@ import (
 //
 // Read more about Seal mode here:
 //
-// https://docs.cossacklabs.com/pages/secure-cell-cryptosystem/#seal-mode
+// https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-cell/#seal-mode
 type SecureCellSealPassphrase struct {
 	passphrase string
 }

--- a/gothemis/cell/token_protect.go
+++ b/gothemis/cell/token_protect.go
@@ -54,7 +54,7 @@ import (
 //
 // Read more about Token Protect mode here:
 //
-// https://docs.cossacklabs.com/pages/secure-cell-cryptosystem/#token-protect-mode
+// https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-cell/#token-protect-mode
 type SecureCellTokenProtect struct {
 	key *keys.SymmetricKey
 }

--- a/src/wrappers/themis/Obj-C/objcthemis/scell.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell.h
@@ -83,4 +83,4 @@ NS_ASSUME_NONNULL_BEGIN
 NS_ASSUME_NONNULL_END
 
 /** @} */
-/** @} */
+/** @} */  

--- a/src/wrappers/themis/Obj-C/objcthemis/scell.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell.h
@@ -62,7 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Read more about Secure Cell modes:
  *
- * https://docs.cossacklabs.com/pages/secure-cell-cryptosystem/
+ * https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-cell/
  */
 @interface TSCell : NSObject
 
@@ -83,4 +83,4 @@ NS_ASSUME_NONNULL_BEGIN
 NS_ASSUME_NONNULL_END
 
 /** @} */
-/** @} */  
+/** @} */

--- a/src/wrappers/themis/Obj-C/objcthemis/scell_context_imprint.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_context_imprint.h
@@ -48,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Read more about Context Imprint mode:
  *
- * https://docs.cossacklabs.com/pages/secure-cell-cryptosystem/#context-imprint-mode
+ * https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-cell/#context-imprint-mode
  */
 @interface TSCellContextImprint : TSCell
 

--- a/src/wrappers/themis/Obj-C/objcthemis/scell_seal.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_seal.h
@@ -55,7 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Read more about Seal mode:
  *
- * https://docs.cossacklabs.com/pages/secure-cell-cryptosystem/#seal-mode
+ * https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-cell/#seal-mode
  */
 @interface TSCellSeal : TSCell
 

--- a/src/wrappers/themis/Obj-C/objcthemis/scell_token.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/scell_token.h
@@ -85,7 +85,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @note Read more about Token Protect mode:
  *
- * https://docs.cossacklabs.com/pages/secure-cell-cryptosystem/#token-protect-mode
+ * https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-cell/#token-protect-mode
  */
 @interface TSCellToken : TSCell
 

--- a/src/wrappers/themis/java/com/cossacklabs/themis/SecureCell.java
+++ b/src/wrappers/themis/java/com/cossacklabs/themis/SecureCell.java
@@ -103,13 +103,13 @@ import java.nio.charset.StandardCharsets;
  * For example, {@link SecureCell#SealWithKey(SymmetricKey)} constructs Secure Cell in Seal mode
  * using a symmetric key.
  * <p>
- * <a href="https://docs.cossacklabs.com/pages/secure-cell-cryptosystem/">Here you can learn more</a>
+ * <a href="https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-cell/">Here you can learn more</a>
  * about the underlying considerations, limitations, and features of each mode.
  *
  * @since JavaThemis 0.9
  */
 public class SecureCell {
-	
+
 	static {
 		System.loadLibrary("themis_jni");
 	}
@@ -142,7 +142,7 @@ public class SecureCell {
      * use passphrase API instead: {@link SecureCell#SealWithPassphrase(String)}.
      * <p>
      * You can read more about Seal mode
-     * <a href="https://docs.cossacklabs.com/pages/secure-cell-cryptosystem/#seal-mode">in documentation</a>.
+     * <a href="https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-cell/#seal-mode">in documentation</a>.
      *
      * @since JavaThemis 0.13
      */
@@ -358,7 +358,7 @@ public class SecureCell {
      * then use {@link SecureCell#TokenProtectWithKey(SymmetricKey)} to construct a Secure Cell.
      * <p>
      * You can read more about Token Protect mode
-     * <a href="https://docs.cossacklabs.com/pages/secure-cell-cryptosystem/#token-protect-mode">in documentation</a>.
+     * <a href="https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-cell/#token-protect-mode">in documentation</a>.
      *
      * @since JavaThemis 0.13
      */
@@ -512,7 +512,7 @@ public class SecureCell {
      * supply a different associated context for each encryption invocation with the same key.
      * <p>
      * You can read more about Context Imprint mode
-     * <a href="https://docs.cossacklabs.com/pages/secure-cell-cryptosystem/#context-imprint-mode">in documentation</a>.
+     * <a href="https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-cell/#context-imprint-mode">in documentation</a>.
      *
      * @since JavaThemis 0.13
      */
@@ -619,10 +619,10 @@ public class SecureCell {
 		if (mode < MODE_SEAL || mode > MODE_CONTEXT_IMPRINT) {
 			throw new InvalidArgumentException("invalid mode");
 		}
-		
+
 		this.mode = mode;
 	}
-	
+
 	/**
 	 * Creates new SecureCell with default master key in SEAL mode
 	 * @param default master key
@@ -634,7 +634,7 @@ public class SecureCell {
 	public SecureCell(byte[] key) {
 		this.key = key;
 	}
-	
+
 	/**
 	 * Creates new SecureCell with default master key in specified mode
 	 * @param default master key
@@ -654,7 +654,7 @@ public class SecureCell {
 		this(mode);
 		this.key = key;
 	}
-	
+
 	/**
 	 * Creates new SecureCell with default master password in SEAL mode
 	 * @param default master password
@@ -673,7 +673,7 @@ public class SecureCell {
 	public SecureCell(String password) {
 		this(password.getBytes(CHARSET));
 	}
-	
+
 	/**
 	 * Creates new SecureCell with default master password in specified mode
 	 * @param default master password
@@ -700,10 +700,10 @@ public class SecureCell {
 		this(mode);
 		this.key = password.getBytes(CHARSET);
 	}
-	
+
 	int mode = MODE_SEAL;
 	byte[] key;
-	
+
 	static final Charset CHARSET = StandardCharsets.UTF_16;
 
 	/** @deprecated since JavaThemis 0.13 */
@@ -716,7 +716,7 @@ public class SecureCell {
 	@Deprecated
 	public static final int MODE_CONTEXT_IMPRINT = 2;
 	static final int MODE_SEAL_PASSPHRASE = 3;
-	
+
 	static native byte[][] encrypt(byte[] key, byte[] context, byte[] data, int mode);
 	static native byte[] decrypt(byte[] key, byte[] context, byte[][] protectedData, int mode);
 
@@ -725,24 +725,24 @@ public class SecureCell {
 		if (null == key) {
 			throw new NullArgumentException("Master key was not provided");
 		}
-		
+
 		if (null == data) {
 			throw new NullArgumentException("Data was not provided");
 		}
-		
+
 		if (MODE_CONTEXT_IMPRINT == mode) {
 			// Context is mandatory for this mode
 			if (null == context) {
 				throw new NullArgumentException("Context is mandatory for context imprint mode");
 			}
 		}
-		
+
 		byte[][] protectedData = encrypt(key, context, data, mode);
-		
+
 		if (null == protectedData) {
 			throw new SecureCellException();
 		}
-		
+
 		return new SecureCellData(protectedData[0], protectedData[1]);
 	}
 
@@ -751,36 +751,36 @@ public class SecureCell {
 		if (null == key) {
 			throw new NullArgumentException("Master key was not provided");
 		}
-		
+
 		if (null == protectedData) {
 			throw new NullArgumentException("Protected data was not provided");
 		}
-		
+
 		if (MODE_CONTEXT_IMPRINT == mode) {
 			// Context is mandatory for this mode
 			if (null == context) {
 				throw new NullArgumentException("Context is mandatory for context imprint mode");
 			}
 		}
-		
+
 		if (null == protectedData.getProtectedData()) {
 			throw new InvalidArgumentException("protectedData");
 		}
-		
+
 		if (MODE_TOKEN_PROTECT == mode) {
 			if (null == protectedData.getAdditionalData()) {
 				throw new InvalidArgumentException("additionalData");
 			}
 		}
-		
+
 		byte[] data = decrypt(key, context, new byte[][]{protectedData.getProtectedData(), protectedData.getAdditionalData()}, mode);
 		if (null == data) {
 			throw new SecureCellException();
 		}
-		
+
 		return data;
 	}
-	
+
 	/**
 	 * Protects data with specified master key
 	 * @param master key to use for protecting data
@@ -797,7 +797,7 @@ public class SecureCell {
 	public SecureCellData protect(byte[] key, byte[] context, byte[] data) throws SecureCellException {
 		return protect(key, context, data, this.mode);
 	}
-	
+
 	/**
 	 * Protects data with default master key
 	 * @param context to which protected data will be bound (may be null)
@@ -813,7 +813,7 @@ public class SecureCell {
 	public SecureCellData protect(byte[] context, byte[] data) throws SecureCellException {
 		return this.protect(this.key, context, data);
 	}
-	
+
 	/**
 	 * Protects data with specified master password
 	 * @param master password to use for protecting data
@@ -833,7 +833,7 @@ public class SecureCell {
 	public SecureCellData protect(String password, String context, byte[] data) throws SecureCellException {
 		return this.protect(password.getBytes(CHARSET), context.getBytes(CHARSET), data);
 	}
-	
+
 	/**
 	 * Protects data with default master password
 	 * @param context to which protected data will be bound (may be null)
@@ -849,7 +849,7 @@ public class SecureCell {
 	public SecureCellData protect(String context, byte[] data) throws SecureCellException {
 		return this.protect(this.key, context.getBytes(CHARSET), data);
 	}
-	
+
 	/**
 	 * Decrypts and verifies protected data
 	 * @param master key
@@ -867,7 +867,7 @@ public class SecureCell {
 	public byte[] unprotect(byte[] key, byte[] context, SecureCellData protectedData) throws SecureCellException {
 		return unprotect(key, context, protectedData, this.mode);
 	}
-	
+
 	/**
 	 * Decrypts and verifies protected data with default master key
 	 * @param context to which protected data will is bound (may be null, must be same as provided in protect call)
@@ -884,7 +884,7 @@ public class SecureCell {
 	public byte[] unprotect(byte[] context, SecureCellData protectedData) throws SecureCellException {
 		return this.unprotect(this.key, context, protectedData);
 	}
-	
+
 	/**
 	 * Decrypts and verifies protected data
 	 * @param master password
@@ -905,7 +905,7 @@ public class SecureCell {
 	public byte[] unprotect(String password, String context, SecureCellData protectedData) throws SecureCellException {
 		return this.unprotect(password.getBytes(CHARSET), context.getBytes(CHARSET), protectedData);
 	}
-	
+
 	/**
 	 * Decrypts and verifies protected data with default master password
 	 * @param context to which protected data will is bound (may be null, must be same as provided in protect call)

--- a/src/wrappers/themis/java/com/cossacklabs/themis/SecureCell.java
+++ b/src/wrappers/themis/java/com/cossacklabs/themis/SecureCell.java
@@ -109,7 +109,7 @@ import java.nio.charset.StandardCharsets;
  * @since JavaThemis 0.9
  */
 public class SecureCell {
-
+	
 	static {
 		System.loadLibrary("themis_jni");
 	}
@@ -619,10 +619,10 @@ public class SecureCell {
 		if (mode < MODE_SEAL || mode > MODE_CONTEXT_IMPRINT) {
 			throw new InvalidArgumentException("invalid mode");
 		}
-
+		
 		this.mode = mode;
 	}
-
+	
 	/**
 	 * Creates new SecureCell with default master key in SEAL mode
 	 * @param default master key
@@ -634,7 +634,7 @@ public class SecureCell {
 	public SecureCell(byte[] key) {
 		this.key = key;
 	}
-
+	
 	/**
 	 * Creates new SecureCell with default master key in specified mode
 	 * @param default master key
@@ -654,7 +654,7 @@ public class SecureCell {
 		this(mode);
 		this.key = key;
 	}
-
+	
 	/**
 	 * Creates new SecureCell with default master password in SEAL mode
 	 * @param default master password
@@ -673,7 +673,7 @@ public class SecureCell {
 	public SecureCell(String password) {
 		this(password.getBytes(CHARSET));
 	}
-
+	
 	/**
 	 * Creates new SecureCell with default master password in specified mode
 	 * @param default master password
@@ -700,10 +700,10 @@ public class SecureCell {
 		this(mode);
 		this.key = password.getBytes(CHARSET);
 	}
-
+	
 	int mode = MODE_SEAL;
 	byte[] key;
-
+	
 	static final Charset CHARSET = StandardCharsets.UTF_16;
 
 	/** @deprecated since JavaThemis 0.13 */
@@ -716,7 +716,7 @@ public class SecureCell {
 	@Deprecated
 	public static final int MODE_CONTEXT_IMPRINT = 2;
 	static final int MODE_SEAL_PASSPHRASE = 3;
-
+	
 	static native byte[][] encrypt(byte[] key, byte[] context, byte[] data, int mode);
 	static native byte[] decrypt(byte[] key, byte[] context, byte[][] protectedData, int mode);
 
@@ -725,24 +725,24 @@ public class SecureCell {
 		if (null == key) {
 			throw new NullArgumentException("Master key was not provided");
 		}
-
+		
 		if (null == data) {
 			throw new NullArgumentException("Data was not provided");
 		}
-
+		
 		if (MODE_CONTEXT_IMPRINT == mode) {
 			// Context is mandatory for this mode
 			if (null == context) {
 				throw new NullArgumentException("Context is mandatory for context imprint mode");
 			}
 		}
-
+		
 		byte[][] protectedData = encrypt(key, context, data, mode);
-
+		
 		if (null == protectedData) {
 			throw new SecureCellException();
 		}
-
+		
 		return new SecureCellData(protectedData[0], protectedData[1]);
 	}
 
@@ -751,36 +751,36 @@ public class SecureCell {
 		if (null == key) {
 			throw new NullArgumentException("Master key was not provided");
 		}
-
+		
 		if (null == protectedData) {
 			throw new NullArgumentException("Protected data was not provided");
 		}
-
+		
 		if (MODE_CONTEXT_IMPRINT == mode) {
 			// Context is mandatory for this mode
 			if (null == context) {
 				throw new NullArgumentException("Context is mandatory for context imprint mode");
 			}
 		}
-
+		
 		if (null == protectedData.getProtectedData()) {
 			throw new InvalidArgumentException("protectedData");
 		}
-
+		
 		if (MODE_TOKEN_PROTECT == mode) {
 			if (null == protectedData.getAdditionalData()) {
 				throw new InvalidArgumentException("additionalData");
 			}
 		}
-
+		
 		byte[] data = decrypt(key, context, new byte[][]{protectedData.getProtectedData(), protectedData.getAdditionalData()}, mode);
 		if (null == data) {
 			throw new SecureCellException();
 		}
-
+		
 		return data;
 	}
-
+	
 	/**
 	 * Protects data with specified master key
 	 * @param master key to use for protecting data
@@ -797,7 +797,7 @@ public class SecureCell {
 	public SecureCellData protect(byte[] key, byte[] context, byte[] data) throws SecureCellException {
 		return protect(key, context, data, this.mode);
 	}
-
+	
 	/**
 	 * Protects data with default master key
 	 * @param context to which protected data will be bound (may be null)
@@ -813,7 +813,7 @@ public class SecureCell {
 	public SecureCellData protect(byte[] context, byte[] data) throws SecureCellException {
 		return this.protect(this.key, context, data);
 	}
-
+	
 	/**
 	 * Protects data with specified master password
 	 * @param master password to use for protecting data
@@ -833,7 +833,7 @@ public class SecureCell {
 	public SecureCellData protect(String password, String context, byte[] data) throws SecureCellException {
 		return this.protect(password.getBytes(CHARSET), context.getBytes(CHARSET), data);
 	}
-
+	
 	/**
 	 * Protects data with default master password
 	 * @param context to which protected data will be bound (may be null)
@@ -849,7 +849,7 @@ public class SecureCell {
 	public SecureCellData protect(String context, byte[] data) throws SecureCellException {
 		return this.protect(this.key, context.getBytes(CHARSET), data);
 	}
-
+	
 	/**
 	 * Decrypts and verifies protected data
 	 * @param master key
@@ -867,7 +867,7 @@ public class SecureCell {
 	public byte[] unprotect(byte[] key, byte[] context, SecureCellData protectedData) throws SecureCellException {
 		return unprotect(key, context, protectedData, this.mode);
 	}
-
+	
 	/**
 	 * Decrypts and verifies protected data with default master key
 	 * @param context to which protected data will is bound (may be null, must be same as provided in protect call)
@@ -884,7 +884,7 @@ public class SecureCell {
 	public byte[] unprotect(byte[] context, SecureCellData protectedData) throws SecureCellException {
 		return this.unprotect(this.key, context, protectedData);
 	}
-
+	
 	/**
 	 * Decrypts and verifies protected data
 	 * @param master password
@@ -905,7 +905,7 @@ public class SecureCell {
 	public byte[] unprotect(String password, String context, SecureCellData protectedData) throws SecureCellException {
 		return this.unprotect(password.getBytes(CHARSET), context.getBytes(CHARSET), protectedData);
 	}
-
+	
 	/**
 	 * Decrypts and verifies protected data with default master password
 	 * @param context to which protected data will is bound (may be null, must be same as provided in protect call)

--- a/src/wrappers/themis/jsthemis/README.md
+++ b/src/wrappers/themis/jsthemis/README.md
@@ -1,5 +1,9 @@
 # JsThemis
 
+[![npm][npm-badge]][npm]
+[![JsThemis][github-ci-badge]][github-ci]
+[![License][license-badge]][license]
+
 _Node.js_ wrapper for [Themis crypto library](https://github.com/cossacklabs/themis).
 
 Themis is a convenient cryptographic library for data protection. 
@@ -7,11 +11,21 @@ It provides secure messaging with forward secrecy and secure data storage. Themi
 
 By [Cossack Labs](https://www.cossacklabs.com/themis/).
 
-## Quickstart
+[npm]: https://www.npmjs.com/package/jsthemis
+[npm-badge]: https://img.shields.io/npm/v/jsthemis.svg
+[github-ci]: https://github.com/cossacklabs/themis/actions?query=workflow%3AJsThemis
+[github-ci-badge]: https://github.com/cossacklabs/themis/workflows/JsThemis/badge.svg
+[license]: LICENSE
+[license-badge]: https://img.shields.io/npm/l/jsthemis.svg
+
+## Getting started
 
 ### Installation
 
-Start by installing the latest version of JsThemis:
+JsThemis requires native Themis library to be installed.
+Please refer to the [installation instructions](https://docs.cossacklabs.com/themis/languages/nodejs/installation/).
+
+After that install the latest version of JsThemis:
 
 ```
 npm install jsthemis
@@ -29,13 +43,12 @@ That's it!
 
 Read the following resources to learn more:
 
-  - [How to use JsThemis with JavaScript](https://docs.cossacklabs.com/pages/nodejs-howto/).
-  - [How to build JsThemis from source code](https://docs.cossacklabs.com/pages/documentation-themis/#node-js-wrapper-installation).
-  - [General documentation for Themis library on Cossack Labs Documentation Server](https://docs.cossacklabs.com/products/themis/).
+  - [How to use JsThemis with JavaScript](https://docs.cossacklabs.com/themis/languages/nodejs/).
+  - [General documentation for Themis library on Cossack Labs Documentation Server](https://docs.cossacklabs.com/themis/).
 
 ### Additional resources  
-  - To get a better understanding of how to use Themis, try playing around with [Interactive Themis Server Simulator](https://docs.cossacklabs.com/simulator/interactive/).
-  - If WebAssembly would be a better match for your project, see [WasmThemis wrapper](https://github.com/cossacklabs/themis/tree/master/src/wrappers/themis/wasm).
+  - To get a better understanding of how to use Themis, try playing around with [Themis Server](https://docs.cossacklabs.com/simulator/interactive/).
+  - If WebAssembly would be a better match for your project, see [WasmThemis wrapper](https://www.npmjs.com/package/wasm-themis).
 
 ## Licensing
 

--- a/src/wrappers/themis/python/README.md
+++ b/src/wrappers/themis/python/README.md
@@ -7,10 +7,10 @@ Themis provides ready-made building components, which simplifies the usage of co
 
 [Themis]: https://github.com/cossacklabs/themis
 
-## Quickstart
+## Getting started
 
-PyThemis requires a native Themis library.
-Please refer to the [Quickstart guide] for the installation instructions.
+PyThemis requires native Themis library to be installed.
+Please refer to the [installation instructions][install].
 
 In-depth documentation can be found on our [Documentation Server].     
 Make sure to check out the [Examples].
@@ -20,8 +20,8 @@ TODO: refer to simulators, code samples, and tests here
 
 -->
 
-[Quickstart guide]: https://docs.cossacklabs.com/pages/python-howto/
-[Documentation Server]: https://docs.cossacklabs.com/products/themis/
+[install]: https://docs.cossacklabs.com/themis/languages/python/installation/
+[Documentation Server]: https://docs.cossacklabs.com/themis/
 [Examples]: /docs/examples/python
 
 

--- a/src/wrappers/themis/rust/README.md
+++ b/src/wrappers/themis/rust/README.md
@@ -1,4 +1,4 @@
-# Rust-Themis
+# RustThemis
 
 [![crates.io][crates-io-badge]][crates-io]
 [![CircleCI][circle-ci-badge]][circle-ci]

--- a/src/wrappers/themis/rust/README.md
+++ b/src/wrappers/themis/rust/README.md
@@ -19,23 +19,24 @@ Themis provides ready-made building components, which simplifies the usage of co
 
 ## Quickstart
 
-Rust-Themis requires a native Themis library.
-Please refer to the [Quickstart guide] for the installation instructions.
+RustThemis requires native Themis library to be installed.
+Please refer to the [installation instructions][install].
 
 See also:
-   
- - [In-depth documentation on our Documentation Server][Documentation Server],     
- - [Rust API documentation on Docs.rs][Docs.rs],     
- - [Changelog on GitHub][CHANGELOG].
+
+ - [In-depth documentation on our Documentation Server][Documentation Server]
+ - [RustThemis user guide][user guide]
+ - [RustThemis API documentation on Docs.rs][Docs.rs]
+ - [Changelog on GitHub][CHANGELOG]
 
 You can start experimenting with [Examples]
 or take a look at [Tests]
 to get a feeling of how Themis can be used.
 
-[Quickstart guide]: https://github.com/cossacklabs/themis/wiki/Rust-Howto
-[Wiki]: https://github.com/cossacklabs/themis/wiki
+[install]: https://docs.cossacklabs.com/themis/languages/rust/installation/
+[user guide]: https://docs.cossacklabs.com/themis/languages/rust/
 [Docs.rs]: https://docs.rs/themis
-[Documentation Server]: https://docs.cossacklabs.com/products/themis/
+[Documentation Server]: https://docs.cossacklabs.com/themis/
 [CHANGELOG]: /CHANGELOG.md
 [Examples]: /docs/examples/rust
 [Tests]: /tests/rust

--- a/src/wrappers/themis/rust/README.md
+++ b/src/wrappers/themis/rust/README.md
@@ -17,7 +17,7 @@ Themis provides ready-made building components, which simplifies the usage of co
 [license]: LICENSE
 [license-badge]: https://img.shields.io/crates/l/themis.svg
 
-## Quickstart
+## Getting started
 
 RustThemis requires native Themis library to be installed.
 Please refer to the [installation instructions][install].

--- a/src/wrappers/themis/rust/README.md
+++ b/src/wrappers/themis/rust/README.md
@@ -1,7 +1,7 @@
 # RustThemis
 
 [![crates.io][crates-io-badge]][crates-io]
-[![CircleCI][circle-ci-badge]][circle-ci]
+[![RustThemis][github-ci-badge]][github-ci]
 [![License][license-badge]][license]
 
 _Rust_ wrapper for [Themis] crypto library.
@@ -12,8 +12,8 @@ Themis provides ready-made building components, which simplifies the usage of co
 [Themis]: https://github.com/cossacklabs/themis
 [crates-io]: https://crates.io/crates/themis
 [crates-io-badge]: https://img.shields.io/crates/v/themis.svg
-[circle-ci]: https://circleci.com/gh/cossacklabs/themis/tree/master
-[circle-ci-badge]: https://circleci.com/gh/cossacklabs/themis/tree/master.svg?style=shield
+[github-ci]: https://github.com/cossacklabs/themis/actions?query=workflow%3ARustThemis
+[github-ci-badge]: https://github.com/cossacklabs/themis/workflows/RustThemis/badge.svg
 [license]: LICENSE
 [license-badge]: https://img.shields.io/crates/l/themis.svg
 

--- a/src/wrappers/themis/rust/src/keygen.rs
+++ b/src/wrappers/themis/rust/src/keygen.rs
@@ -24,7 +24,7 @@
 //!
 //! [`SecureMessage`]: ../secure_message/index.html
 //! [`SecureSession`]: ../secure_session/index.html
-//! [key-management]: https://github.com/cossacklabs/themis/wiki/Key-management
+//! [key-management]: https://docs.cossacklabs.com/themis/crypto-theory/key-management/
 //!
 //! # Examples
 //!

--- a/src/wrappers/themis/rust/src/keys.rs
+++ b/src/wrappers/themis/rust/src/keys.rs
@@ -552,7 +552,7 @@ fn try_get_key_kind(key: &KeyBytes) -> Result<KeyKind> {
 /// [our guidelines][key-management] for some advice on key management.
 ///
 /// [`SecureCell`]: ../secure_cell/index.html
-/// [key-management]: https://docs.cossacklabs.com/pages/documentation-themis/#key-management
+/// [key-management]: https://docs.cossacklabs.com/themis/crypto-theory/key-management/
 ///
 /// # Examples
 ///

--- a/src/wrappers/themis/rust/src/secure_cell.rs
+++ b/src/wrappers/themis/rust/src/secure_cell.rs
@@ -81,7 +81,7 @@
 //!
 //! The operation mode is selected via an appropriate method of a basic [`SecureCell`] object.
 //!
-//! [Here you can learn more](https://docs.cossacklabs.com/pages/secure-cell-cryptosystem/)
+//! [Here you can learn more](https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-cell/)
 //! about the underlying considerations, limitations, and features of each mode.
 //!
 //! [`SecureCell`]: struct.SecureCell.html
@@ -285,7 +285,7 @@ impl SecureCellWithPassphrase {
 /// [`SymmetricKey`]: ../keys/struct.SymmetricKey.html#method.new
 /// [`SecureCell::with_passphrase`]: struct.SecureCell.html#method.with_passphrase
 /// [`SecureCellSealWithPassphrase`]: struct.SecureCellSealWithPassphrase.html
-/// [1]: https://docs.cossacklabs.com/pages/secure-cell-cryptosystem/#seal-mode
+/// [1]: https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-cell/#seal-mode
 ///
 /// # Examples
 ///
@@ -622,7 +622,7 @@ impl SecureCellSeal {
 ///
 /// [`SecureCell::with_key`]: struct.SecureCell.html#method.with_key
 /// [`SecureCellSeal`]: struct.SecureCellSeal.html
-/// [1]: https://docs.cossacklabs.com/pages/secure-cell-cryptosystem/#seal-mode
+/// [1]: https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-cell/#seal-mode
 ///
 /// # Examples
 ///
@@ -1149,7 +1149,7 @@ fn decrypt_seal_with_passphrase(
 /// You can read more about Token Protect mode [in documentation][1].
 ///
 /// [`SymmetricKey`]: ../keys/struct.SymmetricKey.html#method.new
-/// [1]: https://docs.cossacklabs.com/pages/secure-cell-cryptosystem/#token-protect-mode
+/// [1]: https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-cell/#token-protect-mode
 ///
 /// # Examples
 ///
@@ -1662,7 +1662,7 @@ fn decrypt_token_protect(
 /// You can read more about Context Imprint mode [in documentation][1].
 ///
 /// [`SymmetricKey`]: ../keys/struct.SymmetricKey.html#method.new
-/// [1]: https://docs.cossacklabs.com/pages/secure-cell-cryptosystem/#context-imprint-mode
+/// [1]: https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-cell/#context-imprint-mode
 ///
 /// # Examples
 ///

--- a/src/wrappers/themis/rust/src/secure_message.rs
+++ b/src/wrappers/themis/rust/src/secure_message.rs
@@ -32,13 +32,13 @@
 //!     generated key (in RSA) or a key derived by ECDH (in ECDSA), via symmetric
 //!     algorithm with Secure Cell in seal mode (keys are 256 bits long).
 //!
-//! [Here you can read more][wiki] about cryptographic internals of Secure Messages.
+//! [Here you can read more][docs] about cryptographic internals of Secure Messages.
 //!
 //! [Secure Session]: ../secure_session/index.html
 //! [Sign]: struct.SecureSign.html
 //! [Verify]: struct.SecureVerify.html
 //! [Encrypt/Decrypt]: struct.SecureMessage.html
-//! [wiki]: https://github.com/cossacklabs/themis/wiki/Secure-Message-cryptosystem
+//! [docs]: https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-message/
 //!
 //! # Examples
 //!

--- a/src/wrappers/themis/wasm/README.md
+++ b/src/wrappers/themis/wasm/README.md
@@ -1,7 +1,7 @@
 # WasmThemis
 
 [![npm][npm-badge]][npm]
-[![CircleCI][circle-ci-badge]][circle-ci]
+[![WasmThemis][github-ci-badge]][github-ci]
 [![License][license-badge]][license]
 
 _WebAssembly_ wrapper for [Themis crypto library][themis].
@@ -11,12 +11,12 @@ Themis is a convenient cryptographic library for data protection. It provides se
 [themis]: https://github.com/cossacklabs/themis
 [npm]: https://www.npmjs.com/package/wasm-themis
 [npm-badge]: https://img.shields.io/npm/v/wasm-themis.svg
-[circle-ci]: https://circleci.com/gh/cossacklabs/themis/tree/master
-[circle-ci-badge]: https://circleci.com/gh/cossacklabs/themis/tree/master.svg?style=shield
+[github-ci]: https://github.com/cossacklabs/themis/actions?query=workflow%3AWasmThemis
+[github-ci-badge]: https://github.com/cossacklabs/themis/workflows/WasmThemis/badge.svg
 [license]: LICENSE
 [license-badge]: https://img.shields.io/npm/l/wasm-themis.svg
 
-## Quickstart
+## Getting started
 
 ### Installation
 
@@ -48,20 +48,20 @@ Success!
 Read the following resources to learn more:
 
   - [How to use WasmThemis with JavaScript][language-guide].
-  - [How to build WasmThemis from source code][build-instructions].
+  - [How to deploy apps using WasmThemis][deploy].
   - [General documentation for Themis library on Cossack Labs Documentation Server][docserver].
 
 ### Additional resources  
   - To get a better understanding of how to use Themis, try playing around with [Interactive Themis Server Simulator](https://docs.cossacklabs.com/simulator/interactive/).
-  - If Node.js wrapper would be a better match for your project, see [JsThemis](https://github.com/cossacklabs/themis/tree/master/src/wrappers/themis/jsthemis).
+  - If Node.js wrapper would be a better match for your project, see [JsThemis](https://www.npmjs.com/package/jsthemis).
 
 <!--
 TODO: refer code samples and tests here
 -->
 
-[language-guide]: https://docs.cossacklabs.com/pages/js-wasm-howto/
-[build-instructions]: https://docs.cossacklabs.com/pages/documentation-themis/#webassembly-wrapper-installation
-[docserver]: https://docs.cossacklabs.com/products/themis/
+[language-guide]: https://docs.cossacklabs.com/themis/languages/wasm/
+[deploy]: https://docs.cossacklabs.com/themis/languages/wasm/installation/
+[docserver]: https://docs.cossacklabs.com/themis/
 
 ## Licensing
 

--- a/tests/test.mk
+++ b/tests/test.mk
@@ -98,7 +98,7 @@ endif
 test_cpp:
 	@echo "------------------------------------------------------------"
 	@echo "Running themissp tests."
-	@echo "In case of errors, see https://docs.cossacklabs.com/pages/cpp-howto/"
+	@echo "In case of errors, see https://docs.cossacklabs.com/themis/languages/cpp/"
 	@echo "------------------------------------------------------------"
 	$(TEST_BIN_PATH)/themispp_test
 	@echo "------------------------------------------------------------"
@@ -107,7 +107,7 @@ test_php:
 ifdef PHP_VERSION
 	@echo "------------------------------------------------------------"
 	@echo "Running phpthemis tests."
-	@echo "In case of errors, see https://docs.cossacklabs.com/pages/php-howto/"
+	@echo "In case of errors, see https://docs.cossacklabs.com/themis/languages/php/"
 	@echo "------------------------------------------------------------"
 	$(TEST_BIN_PATH)/phpthemis_test.sh
 	@echo "------------------------------------------------------------"
@@ -118,7 +118,7 @@ test_python:
 ifneq ($(PYTHON3_VERSION),)
 	@echo "------------------------------------------------------------"
 	@echo "Running pythemis tests."
-	@echo "In case of errors, see https://docs.cossacklabs.com/pages/python-howto/"
+	@echo "In case of errors, see https://docs.cossacklabs.com/themis/languages/python/"
 	@echo "------------------------------------------------------------"
 	$(PYTHON3_TEST_SCRIPT)
 	@echo "------------------------------------------------------------"
@@ -131,7 +131,7 @@ test_ruby:
 ifdef RUBY_GEM_VERSION
 	@echo "------------------------------------------------------------"
 	@echo "Running rbthemis tests."
-	@echo "In case of errors, see https://docs.cossacklabs.com/pages/ruby-howto/"
+	@echo "In case of errors, see https://docs.cossacklabs.com/themis/languages/ruby/"
 	@echo "------------------------------------------------------------"
 	$(TEST_BIN_PATH)/rbthemis_test.sh
 	@echo "------------------------------------------------------------"
@@ -141,7 +141,7 @@ test_js:
 ifdef NPM_VERSION
 	@echo "------------------------------------------------------------"
 	@echo "Running jsthemis tests."
-	@echo "In case of errors, see https://docs.cossacklabs.com/pages/nodejs-howto/"
+	@echo "In case of errors, see https://docs.cossacklabs.com/themis/languages/nodejs/"
 	@echo "------------------------------------------------------------"
 	cd $(JSTHEMIS_SRC) && npm install && npm test
 	@echo "------------------------------------------------------------"
@@ -151,7 +151,7 @@ test_go:
 ifdef GO_VERSION
 	@echo "------------------------------------------------------------"
 	@echo "Running gothemis tests."
-	@echo "In case of errors, see https://docs.cossacklabs.com/pages/go-howto/"
+	@echo "In case of errors, see https://docs.cossacklabs.com/themis/languages/go/"
 	@echo "------------------------------------------------------------"
 	@go test -v $(GOTHEMIS_IMPORT)/...
 endif
@@ -160,7 +160,7 @@ test_rust:
 ifdef RUST_VERSION
 	@echo "------------------------------------------------------------"
 	@echo "Running rust-themis tests."
-	@echo "In case of errors, see https://docs.cossacklabs.com/pages/rust-howto/"
+	@echo "In case of errors, see https://docs.cossacklabs.com/themis/languages/rust/"
 	@echo "------------------------------------------------------------"
 	$(TEST_SRC_PATH)/rust/run_tests.sh
 	@echo "------------------------------------------------------------"

--- a/tools/afl/README.md
+++ b/tools/afl/README.md
@@ -36,7 +36,7 @@ That’s it.
 You don’t have to compile and install Themis,
 we’ll do it for you, in a special way.
 
-[build]: https://docs.cossacklabs.com/pages/documentation-themis/#building-and-installing
+[build]: https://docs.cossacklabs.com/themis/installation/
 
 ### Running fuzzing tests
 
@@ -252,8 +252,8 @@ in order to add a `${new_tool}` to fuzz test suite.
     input is a good place to fuzz.
     For example:
     key files,
-    [Secure Cell](https://docs.cossacklabs.com/pages/secure-cell-cryptosystem/) containers,
-    network packets received by [Secure Session](https://docs.cossacklabs.com/pages/secure-session-cryptosystem/),
+    [Secure Cell](https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-cell/) containers,
+    network packets received by [Secure Session](https://docs.cossacklabs.com/themis/crypto-theory/cryptosystems/secure-session/),
     etc.
 
   - Use `abort()` to check assertions.


### PR DESCRIPTION
- Update links to documentation server in Rust docs

  Themis wiki on GitHub has been deprecated. Let's point users to the proper, up-to-date documentation
  (starting with the next release, that is).

- Update links in RustThemis README as well

- Quickstart => Getting started

   Because we have moved away from that wording in the documentation.

- Capitalize as “RustThemis” without a dash

   Because that's how it's spelled in the documentation.

- Replace CircleCI badge with GitHub Actions

   CI has migrated to GitHub, let's update the badge to something actually indicative.