### PR TITLE
Unbreak Criterion's HTML reports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,10 +133,10 @@ jobs:
       - run:
           name: Pack benchmark report
           command: |
-            cd benches/themis/target
+            cd target
             zip -r ../report.zip criterion
       - store_artifacts:
-          path: benches/themis/report.zip
+          path: report.zip
       - save_cache:
           key: rust
           paths:

--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -195,7 +195,7 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: Criterion report
-          path: benches/themis/target/criterion
+          path: target/criterion
 
   fuzzing:
     name: AFL fuzzing

--- a/benches/themis/Cargo.toml
+++ b/benches/themis/Cargo.toml
@@ -9,7 +9,7 @@ themis = { version = "0.13", path = "../../src/wrappers/themis/rust" }
 libthemis-sys = { version = "0.13", path = "../../src/wrappers/themis/rust/libthemis-sys" }
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = { version = "0.3.4", features = ["cargo_bench_support", "html_reports"]}
 
 [[bench]]
 name = "secure_cell_seal_master_key"


### PR DESCRIPTION
Backport #764 onto `stable` to unbreak nightly builds that run there.

Also added the same path update for CircleCI which is still running for the stable branch.

## Checklist

- [X] Change is covered by automated tests