### PR TITLE
Migrate to "afl++" from "afl"

### DIFF
--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -199,7 +199,14 @@ jobs:
 
   fuzzing:
     name: AFL fuzzing
-    runs-on: ubuntu-latest
+    # TODO(ilammy, 2021-01-28): use "ubuntu-latest" once it works
+    # Currently "ubuntu-latest" means "ubuntu-18.04" but for some inexplicable
+    # reasons GitHub runners in the main repo treat it as "ubuntu-20.04" which
+    # does not seem to work yet (for this job). Pin the Ubuntu 18.04 version
+    # for now, but don't forget to update this once "ubuntu-latest" changes
+    # its meaning or starts working for this job.
+    # See: https://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners
+    runs-on: ubuntu-18.04
     env:
       FUZZ_TIMEOUT: 30s
       THEMIS_DEFAULT_PBKDF2_ITERATIONS: 10
@@ -212,7 +219,7 @@ jobs:
           sudo dpkg --add-architecture i386
           sudo apt update
           sudo apt install --yes gcc make zip \
-              afl gcc-multilib libc6-dev:i386 \
+              afl++ gcc-multilib libc6-dev:i386 \
               libssl-dev:amd64 libssl-dev:i386
           # AFL needs proper core dumps to be available, write them to files
           sudo sh -c 'echo core > /proc/sys/kernel/core_pattern'

--- a/tools/afl/fuzzy.mk
+++ b/tools/afl/fuzzy.mk
@@ -17,6 +17,11 @@
 AFL_FUZZ ?= afl-fuzz
 AFL_CC   ?= afl-clang
 
+# TODO(ilammy, 2021-01-27): use afl++ toolchain if available
+# The above tools are compaible with the original "afl" which is currently
+# not maintained. Modern systems come with "afl++" that has mostly compatible
+# command-line and new instrumentation toolchain. We should use it if possible.
+
 FUZZ_PATH = tools/afl
 FUZZ_BIN_PATH = $(BIN_PATH)/afl
 FUZZ_SRC_PATH = $(FUZZ_PATH)/src


### PR DESCRIPTION
Following #769, backport #766 onto `stable` too to fix the build.

Ignore changes in CHANGELOG.md, there is no "Unreleased" section on the `stable` branch. It will get here in due time.

## Checklist

- [X] Change is covered by automated tests
  <sup>Oh why yes, it is covered.</sup>