### PR TITLE
Use new trait order in generated code

### DIFF
--- a/src/wrappers/themis/rust/libthemis-sys/src/lib.rs
+++ b/src/wrappers/themis/rust/libthemis-sys/src/lib.rs
@@ -211,7 +211,7 @@ extern "C" {
     ) -> themis_status_t;
 }
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum themis_key_kind {
     THEMIS_KEY_INVALID = 0,
     THEMIS_KEY_RSA_PRIVATE = 1,


### PR DESCRIPTION
Backport #758 onto `stable` to fix the build, as discovered in #770.

## Checklist

- [X] Change is covered by automated tests