### PR TITLE
Update Emscripten 2.0.9 => 2.0.13

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -75,8 +75,8 @@ jobs:
           cd $HOME
           git clone https://github.com/emscripten-core/emsdk.git
           cd $HOME/emsdk
-          ./emsdk install  2.0.9
-          ./emsdk activate 2.0.9
+          ./emsdk install  2.0.13
+          ./emsdk activate 2.0.13
       - name: Install PHP from PPA
         run: |
           sudo apt install --yes software-properties-common

--- a/.github/workflows/test-wasm.yaml
+++ b/.github/workflows/test-wasm.yaml
@@ -58,8 +58,8 @@ jobs:
           cd $HOME
           git clone https://github.com/emscripten-core/emsdk.git
           cd $HOME/emsdk
-          ./emsdk install  2.0.9
-          ./emsdk activate 2.0.9
+          ./emsdk install  2.0.13
+          ./emsdk activate 2.0.13
       - name: Check out code
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
There were some reports on the mailing list about HEAP* variables being broken in 2.0.10. Thankfully, the issue does not seem to reproduce (for anyone other than the reporter).

Some potentially interesting changes brought by the update:

- An upstream LLVM regression with global initializer linking has been fixed.
- Stop overriding CMake default flags based on build type.

Full release notes:
https://emscripten.org/docs/introducing_emscripten/release_notes.html

Nothing interesting, actually. Something interesting will be in the next release: more optimizations. For now, it's just a sanity check, making sure we're still compatible with the latest Emscripten toolchain.

Pinging @shadinua to ensure that internal publishing pipelines will use Emscripten 2.0.13 too.

## Checklist

- [X] Change is covered by automated tests