### PR TITLE
Decrease limit for KDF execution time in test

### DIFF
--- a/src/wrappers/themis/wasm/test/test.js
+++ b/src/wrappers/themis/wasm/test/test.js
@@ -236,7 +236,7 @@ describe('wasm-themis', function() {
             // Passphrase API uses KDF so it can be quite slow.
             // Mocha uses default threshold of 75 ms which is not enough.
             this.slow(1500) // milliseconds
-            const bottomLimit = 200
+            const bottomLimit = 100
 
             it('encrypts without context', function() {
                 let cell = themis.SecureCellSeal.withPassphrase(passphrase1)


### PR DESCRIPTION
Executing `emmake make test_wasm` failed for me locally with emsdk `2.0.13`.
This PR should be more  a small discussion whether this test really makes sense if it is platform dependant.

## Checklist

- [x] Change is covered by automated tests
- [x] Benchmark results are attached (if applicable)
- [x] The [coding guidelines] are followed
- [x] Public API has proper documentation
- [x] Example projects and code samples are up-to-date (in case of API changes)
- [x] Changelog is updated (in case of notable or breaking changes)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
