### PR TITLE
Use correct Javadoc syntax

### DIFF
--- a/src/wrappers/themis/java/com/cossacklabs/themis/KeypairGenerator.java
+++ b/src/wrappers/themis/java/com/cossacklabs/themis/KeypairGenerator.java
@@ -46,7 +46,7 @@ public abstract class KeypairGenerator {
 	
 	/**
 	 * Generates new keypair
-	 * @param key type (EC or RSA)
+	 * @param keyType type of the keypair to generate (EC or RSA)
 	 * @return new Keypair
 	 * @throws KeyGenerationException when cannot generate a keypair
 	 * @throws InvalidArgumentException when keyType is invalid

--- a/src/wrappers/themis/java/com/cossacklabs/themis/SecureCell.java
+++ b/src/wrappers/themis/java/com/cossacklabs/themis/SecureCell.java
@@ -602,7 +602,7 @@ public class SecureCell {
 
 	/**
 	 * Creates new SecureCell in specified mode
-	 * @param SecureCell mode
+	 * @param mode SecureCell mode
 	 * @throws InvalidArgumentException when unsupported mode is specified
 	 * @deprecated since JavaThemis 0.13
 	 * <p>
@@ -625,7 +625,7 @@ public class SecureCell {
 	
 	/**
 	 * Creates new SecureCell with default master key in SEAL mode
-	 * @param default master key
+	 * @param key master key
 	 * @deprecated since JavaThemis 0.13
 	 * <p>
 	 * Use {@link #SealWithKey(byte[])} instead.
@@ -637,8 +637,8 @@ public class SecureCell {
 	
 	/**
 	 * Creates new SecureCell with default master key in specified mode
-	 * @param default master key
-	 * @param SecureCell mode
+	 * @param key master key
+	 * @param mode SecureCell mode
 	 * @throws InvalidArgumentException when unsupported mode is specified
 	 * @deprecated since JavaThemis 0.13
 	 * <p>
@@ -657,7 +657,7 @@ public class SecureCell {
 	
 	/**
 	 * Creates new SecureCell with default master password in SEAL mode
-	 * @param default master password
+	 * @param password master password
 	 * @deprecated since JavaThemis 0.13
 	 * <p>
 	 * This method is <strong>not secure</strong> when used with short passphrases or passwords.
@@ -676,8 +676,8 @@ public class SecureCell {
 	
 	/**
 	 * Creates new SecureCell with default master password in specified mode
-	 * @param default master password
-	 * @param SecureCell mode
+	 * @param password master password
+	 * @param mode Secure Cell mode
 	 * @throws InvalidArgumentException when unsupported mode is specified
 	 * @deprecated since JavaThemis 0.13
 	 * <p>
@@ -783,7 +783,7 @@ public class SecureCell {
 	
 	/**
 	 * Protects data with specified master key
-	 * @param master key to use for protecting data
+	 * @param key master key to use for protecting data
 	 * @param context to which protected data will be bound (may be null)
 	 * @param data to protect
 	 * @return SecureCellData with protected data
@@ -816,7 +816,7 @@ public class SecureCell {
 	
 	/**
 	 * Protects data with specified master password
-	 * @param master password to use for protecting data
+	 * @param password master password to use for protecting data
 	 * @param context to which protected data will be bound (may be null)
 	 * @param data to protect
 	 * @return SecureCellData with protected data
@@ -852,7 +852,7 @@ public class SecureCell {
 	
 	/**
 	 * Decrypts and verifies protected data
-	 * @param master key
+	 * @param key master key
 	 * @param context to which protected data will is bound (may be null, must be same as provided in protect call)
 	 * @param protectedData to verify
 	 * @return original data
@@ -887,7 +887,7 @@ public class SecureCell {
 	
 	/**
 	 * Decrypts and verifies protected data
-	 * @param master password
+	 * @param password master password
 	 * @param context to which protected data will is bound (may be null, must be same as provided in protect call)
 	 * @param protectedData to verify
 	 * @return original data

--- a/src/wrappers/themis/java/com/cossacklabs/themis/SecureCellData.java
+++ b/src/wrappers/themis/java/com/cossacklabs/themis/SecureCellData.java
@@ -28,8 +28,8 @@ public class SecureCellData {
 	
 	/**
 	 * Creates new SecureCellData
-	 * @param actual protected data
-	 * @param auxiliary data
+	 * @param protectedData actual protected data
+	 * @param additionalData auxiliary data
 	 */
 	public SecureCellData(byte[] protectedData, byte[] additionalData) {
 		this.protectedData = protectedData;
@@ -65,6 +65,7 @@ public class SecureCellData {
 	 * <p>
 	 * This method is equivalent to {@link #getProtectedData()}.
 	 * You are not expected to use it directly, it exists for improved Kotlin API.
+	 * @return protected data.
 	 */
 	public @NotNull byte[] component1() {
 		return this.protectedData;
@@ -75,6 +76,7 @@ public class SecureCellData {
 	 * <p>
 	 * This method is equivalent to {@link #getAdditionalData()}.
 	 * You are not expected to use it directly, it exists for improved Kotlin API.
+	 * @return auxiliary data (may be null).
 	 */
 	public @NotNull byte[] component2() {
 		return this.additionalData;

--- a/src/wrappers/themis/java/com/cossacklabs/themis/SecureMessage.java
+++ b/src/wrappers/themis/java/com/cossacklabs/themis/SecureMessage.java
@@ -30,7 +30,7 @@ public class SecureMessage {
 	
 	/**
 	 * Creates new SecureMessage with specified PrivateKey
-	 * @param your own PrivateKey
+	 * @param privateKey your own PrivateKey
 	 * @throws NullArgumentException when privateKey is null
 	 */
 	public SecureMessage(PrivateKey privateKey) {
@@ -44,7 +44,7 @@ public class SecureMessage {
 
 	/**
 	 * Creates new SecureMessage with default peer PublicKey (can be used only for signature verification)
-	 * @param default peer PublicKey
+	 * @param peerPublicKey peer PublicKey
 	 * @throws NullArgumentException when peerPublicKey is null
 	 */
 	public SecureMessage(PublicKey peerPublicKey) {
@@ -58,8 +58,8 @@ public class SecureMessage {
 	
 	/**
 	 * Creates new SecureMessage with specified PrivateKey and default peer PublicKey
-	 * @param your own PrivateKey
-	 * @param default peer PublicKey
+	 * @param privateKey your own PrivateKey
+	 * @param peerPublicKey peer PublicKey
 	 * @throws NullArgumentException when privateKey or peerPublicKey is null
 	 */
 	public SecureMessage(PrivateKey privateKey, PublicKey peerPublicKey) {
@@ -84,8 +84,8 @@ public class SecureMessage {
 
 	/**
 	 * Wraps message for peer
-	 * @param message to wrap
-	 * @param receiver's PublicKey
+	 * @param message message to wrap
+	 * @param peerPublicKey receiver's PublicKey
 	 * @return wrapped message
 	 * @throws NullArgumentException when message or peerPublicKey is null
 	 * @throws SecureMessageWrapException when cannot wrap message
@@ -111,7 +111,7 @@ public class SecureMessage {
 	
 	/**
 	 * Wraps message for default peer
-	 * @param message to wrap
+	 * @param message message to wrap
 	 * @return wrapped message
 	 * @throws NullArgumentException when message or default peer PublicKey is null
 	 * @throws SecureMessageWrapException when cannot wrap message
@@ -122,8 +122,8 @@ public class SecureMessage {
 	
 	/**
 	 * Unwraps message from peer
-	 * @param wrapped message
-	 * @param sender's PublicKey
+	 * @param message wrapped message
+	 * @param peerPublicKey sender's PublicKey
 	 * @return unwrapped message
 	 * @throws NullArgumentException when message or peerPublicKey is null
 	 * @throws SecureMessageWrapException when cannot unwrap message
@@ -149,7 +149,7 @@ public class SecureMessage {
 	
 	/**
 	 * Unwraps message from default peer
-	 * @param wrapped message
+	 * @param message wrapped message
 	 * @return unwrapped message
 	 * @throws NullArgumentException when message or default peer PublicKey is null
 	 * @throws SecureMessageWrapException when cannot unwrap message
@@ -160,7 +160,7 @@ public class SecureMessage {
 
 	/**
 	 * Signs message
-	 * @param message to sign
+	 * @param message message to sign
 	 * @return signed message
 	 * @throws NullArgumentException when message or default peer PublicKey is null
 	 * @throws SecureMessageWrapException when cannot wrap message
@@ -186,8 +186,8 @@ public class SecureMessage {
 
 	/**
 	 * Verifies signed message from peer
-	 * @param signed message
-	 * @param sender's PublicKey
+	 * @param message signed message
+	 * @param peerPublicKey sender's PublicKey
 	 * @return verified message
 	 * @throws NullArgumentException when message or peerPublicKey is null
 	 * @throws SecureMessageWrapException when cannot verify message
@@ -213,7 +213,7 @@ public class SecureMessage {
 
 	/**
 	 * Verifies message from default peer
-	 * @param signed message
+	 * @param message signed message
 	 * @return verified message
 	 * @throws NullArgumentException when message or default peer PublicKey is null
 	 * @throws SecureMessageWrapException when cannot verify message

--- a/src/wrappers/themis/java/com/cossacklabs/themis/SecureSession.java
+++ b/src/wrappers/themis/java/com/cossacklabs/themis/SecureSession.java
@@ -105,9 +105,9 @@ public class SecureSession {
 	
 	/**
 	 * Creates new SecureSession
-	 * @param your id
-	 * @param your sign PrivateKey
-	 * @param callbacks implementation
+	 * @param id your id
+	 * @param signPrivateKey your sign PrivateKey
+	 * @param callbacks callbacks implementation
 	 * @throws NullArgumentException if `id` is null
 	 * @throws InvalidArgumentException if `id` is empty
 	 * @throws RuntimeException when cannot create session
@@ -131,9 +131,9 @@ public class SecureSession {
 	
 	/**
 	 * Creates new SecureSession
-	 * @param your id
-	 * @param your sign PrivateKey
-	 * @param callbacks implementation
+	 * @param id your id
+	 * @param signPrivateKey your sign PrivateKey
+	 * @param callbacks callbacks implementation
 	 * @throws NullArgumentException if `id` is null
 	 * @throws InvalidArgumentException if `id` is empty
 	 * @throws RuntimeException when cannot create session
@@ -169,7 +169,7 @@ public class SecureSession {
 	
 	/**
 	 * Wraps outgoing data
-	 * @param data to wrap
+	 * @param data data to wrap
 	 * @return wrapped data
 	 * @throws IllegalStateException is the session is already closed
 	 * @throws SecureSessionException when cannot wrap data
@@ -195,7 +195,7 @@ public class SecureSession {
 	
 	/**
 	 * Unwraps incoming data
-	 * @param wrapped data
+	 * @param wrappedData wrapped data
 	 * @return unwrapped data
 	 * @throws IllegalStateException is the session is already closed
 	 * @throws SecureSessionException when cannot unwrap data
@@ -303,8 +303,8 @@ public class SecureSession {
 	
 	/**
 	 * Restores previously saved session
-	 * @param saved session state
-	 * @param callbacks implementation
+	 * @param state saved session state
+	 * @param callbacks callbacks implementation
 	 * @return restored SecureSession
 	 * @throws SecureSessionException when cannot restore session
 	 * @deprecated since JavaThemis 0.13

--- a/src/wrappers/themis/java/com/cossacklabs/themis/SecureSession.java
+++ b/src/wrappers/themis/java/com/cossacklabs/themis/SecureSession.java
@@ -34,15 +34,35 @@ public class SecureSession {
 	 * SecureSession state
 	 */
 	public enum State {
-		IDLE, /** < session was just created */
-		NEGOTIATING, /** < key agreement is in progress. No data exchange possible yet. */
-		ESTABLISHED /** < session is secured. Possible to exchange data securely. */
+		/**
+		 * Initial state for newly created Secure Session.
+		 */
+		IDLE,
+		/**
+		 * Key agreement is in progress. Data exchange is not possible yet.
+		 */
+		NEGOTIATING,
+		/**
+		 * Secure Session is established. You may exchange data securely now.
+		 */
+		ESTABLISHED
 	}
 	
 	public enum SessionDataType {
-		NO_DATA, /** < no output data */
-		PROTOCOL_DATA, /** < output is an internal protocol message. Needs to be sent to your peer.*/
-		USER_DATA; /** < output is decrypted user data. It should be handled according to your application flow.*/
+		/**
+		 * No output data.
+		 */
+		NO_DATA,
+		/**
+		 * Output is a Secure Session protocol message.
+		 * Send this data to your peer as is.
+		 */
+		PROTOCOL_DATA,
+		/**
+		 * Output is decrypted user data.
+		 * Pass it to the application for processing.
+		 */
+		USER_DATA;
 
 		public static SessionDataType fromByte(byte src) throws SecureSessionException {
 			switch (src) {


### PR DESCRIPTION
While tinkering with publishing of AndroidThemis I have found out that Javadoc generator yells at me with a ton of errors like

    src/wrappers/themis/java/com/cossacklabs/themis/KeypairGenerator.java:49: error: @param name not found
             * @param key type (EC or RSA)

    [...]

    src/wrappers/themis/java/com/cossacklabs/themis/SecureSession.java:38: error: malformed HTML
                    NEGOTIATING, /** < key agreement is in progress. No data exchange possible yet. */
                                     ^
    36 errors
    36 warnings

    > Task :android:generateJavadoc FAILED

when I do

    ./gradlew :android:generateJavadoc

which is a part of publication process.

Well, this won't fly for proper publication so let's fix it. At least, make the Javadoc generator happy at first.

Make sure that all `@param` lines have an actual parameter name followed by its description. I make no effort to make it “good”, only making it correct. Improving quality of API documentation – ideally across all wrappers – is a project for another day.

Similarly, Javadoc does not support “inline” syntax for items like Doxygen-flavor documentation comments do. Just add full-fledged comments for enum variants.

## Checklist

- [X] Change is covered by automated tests
- [X] Public API has proper documentation