### PR TITLE
Remove TextEncoder polyfill (#779)

### DIFF
--- a/src/wrappers/themis/wasm/package-lock.json
+++ b/src/wrappers/themis/wasm/package-lock.json
@@ -263,11 +263,6 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
-    "fastestsmallesttextencoderdecoder": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.14.tgz",
-      "integrity": "sha512-ov+uDh4DMZHpZvcGwlCb9tfntaHwRI7SK+/6XkdXhksZLJcMoTJ20FZx3GvujnsGjMvJVQ71LkduEUEPwX1BvQ=="
-    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",

--- a/src/wrappers/themis/wasm/package.json
+++ b/src/wrappers/themis/wasm/package.json
@@ -22,9 +22,7 @@
     "url": "https://github.com/cossacklabs/themis/issues"
   },
   "homepage": "https://www.cossacklabs.com/themis/",
-  "dependencies": {
-    "fastestsmallesttextencoderdecoder": "^1.0.14"
-  },
+  "dependencies": {},
   "devDependencies": {
     "mocha": "^7.1.1"
   }

--- a/src/wrappers/themis/wasm/src/utils.js
+++ b/src/wrappers/themis/wasm/src/utils.js
@@ -18,7 +18,6 @@
  */
 
 const libthemis = require('./libthemis.js')
-const {TextEncoder} = require('fastestsmallesttextencoderdecoder')
 
 /**
  * Convert an object into a byte buffer.
@@ -35,10 +34,25 @@ module.exports.coerceToBytes = function(buffer) {
     throw new TypeError('type mismatch, expect "Uint8Array" or "ArrayBuffer"')
 }
 
-const utf8Encoder = new TextEncoder()
+function getTextEncoder() {
+    if (typeof window !== 'undefined' && window.TextEncoder) {
+        return new window.TextEncoder()
+    }
+
+    if (typeof TextEncoder !== 'undefined') {
+        return new TextEncoder()
+    }
+    
+    // we are using a browser which does not support TextEncoder or in a Node process which has TextEncoder
+    // available through the util package.
+    const NodeTextEncoder = require('util').TextEncoder
+    return new NodeTextEncoder()
+}
+
+const textEncoder = getTextEncoder()
 
 function stringToUTF8(str) {
-    return utf8Encoder.encode(str)
+    return textEncoder.encode(str)
 }
 
 /**


### PR DESCRIPTION
TextEncoder is supported in the all browsers for a long time and also in node.js. For some node.js versions it is only available through the util package.

We do not need to support browsers like IE11 because they do not support webassembly.

This PR works on all browsers which support TextEncoding. It also works on all node versions until v8.3.0

## Checklist

- [x] Change is covered by automated tests
- [x] Benchmark results are attached (if applicable)
- [x] The [coding guidelines] are followed
- [x] Public API has proper documentation
- [x] Example projects and code samples are up-to-date (in case of API changes)
- [x] Changelog is updated (in case of notable or breaking changes)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
