### PR TITLE
Fix flaky Secure Comparator test

### DIFF
--- a/tests/themis/themis_secure_comparator.c
+++ b/tests/themis/themis_secure_comparator.c
@@ -127,7 +127,7 @@ static void secure_comparator_api_test(void)
 {
     /* setup */
     themis_status_t themis_status;
-    secret_length = rand_int(MAX_SECRET_SIZE);
+    secret_length = rand_int(MAX_SECRET_SIZE - 1) + 1;
     if (SOTER_SUCCESS != soter_rand(secret, secret_length)) {
         testsuite_fail_if(true, "soter_rand failed");
         return;


### PR DESCRIPTION
Make sure that `secret_length` is in [2, MAX_SECRET_SIZE) range, disallowing it to be just 1 byte.

(`rand_int()` generates non-zero integers.)

If `secret_length` is exactly 1 byte then the following call below:

https://github.com/cossacklabs/themis/blob/e323abb2470cc759ea4dd90f9f2985ffce9449f1/tests/themis/themis_secure_comparator.c#L220-L222

will fail as the appended secret cannot have zero length.

Naturally, this happens rarely. But often enough to pop up in nightly tests running on my branch which got me curious.

```
[14:11]  secure_comparator_api_test:#11  "secure_comparator_destroy: destroy alice"  pass
[14:12]  secure_comparator_api_test:#12  "secure_comparator_append_secret failed"  FAIL
!    Type:      fail-if
!    Condition: condition
!    File:      tests/themis/themis_secure_comparator.c
!    Line:      222

--> 12 check(s), 11 ok, 1 failed (8.33%)

== Entering suite #15, "secure comparator: security test" ==

[15:1]  secure_comparator_security_test:#1  "compare result no match"  pass

--> 1 check(s), 1 ok, 0 failed (0.00%)

==> 291 check(s) in 15 suite(s) finished after 2.00 second(s),
    290 succeeded, 1 failed (0.34%)

[FAILURE]
```

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md