### PR TITLE
Maven publishing for desktop JavaThemis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,13 +79,29 @@ _Code:_
 - **Java / Kotlin**
 
   - `SecureMessage#sign()` output is a bit smaller now ([#777](https://github.com/cossacklabs/themis/pull/777)).
-  - JavaThemis for **Android** is now published in the Maven Central repository ([#786](https://github.com/cossacklabs/themis/pull/786)).
+  - JavaThemis is now published in the Maven Central repository ([#786](https://github.com/cossacklabs/themis/pull/786), [#788](https://github.com/cossacklabs/themis/pull/788)).
 
     Add the Maven Central repository to your `build.gradle`:
 
     ```groovy
     repositories {
         mavenCentral()
+    }
+    ```
+
+    For Android, use this dependency:
+
+    ```groovy
+    dependencies {
+        implementation 'com.cossacklabs.com:themis:0.14.0'
+    }
+    ```
+
+    For desktop systems use this one:
+
+    ```groovy
+    dependencies {
+        implementation 'com.cossacklabs.com:java-themis:0.14.0'
     }
     ```
 
@@ -136,7 +152,7 @@ _Infrastructure:_
 - Started phasing out CircleCI in favour of GitHub Actions ([#709](https://github.com/cossacklabs/themis/pull/709), [#755](https://github.com/cossacklabs/themis/pull/755)).
 - Themis is now fuzzed with `afl++` ([#766](https://github.com/cossacklabs/themis/pull/766)).
 - Secure Message is now covered with fuzz testing ([#762](https://github.com/cossacklabs/themis/pull/762)).
-- JavaThemis for **Android** is now published in the Maven Central repository ([#786](https://github.com/cossacklabs/themis/pull/786)).
+- JavaThemis is now published in the Maven Central repository ([#786](https://github.com/cossacklabs/themis/pull/786), [#788](https://github.com/cossacklabs/themis/pull/788)).
 
 
 ## [0.13.6](https://github.com/cossacklabs/themis/releases/tag/0.13.6), November 23rd 2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@ _Code:_
 - **Java / Kotlin**
 
   - `SecureMessage#sign()` output is a bit smaller now ([#777](https://github.com/cossacklabs/themis/pull/777)).
-  - JavaThemis is now published in the Maven Central repository ([#786](https://github.com/cossacklabs/themis/pull/786), [#788](https://github.com/cossacklabs/themis/pull/788)).
+  - JavaThemis for Android and desktop Java is now published in the Maven Central repository ([#786](https://github.com/cossacklabs/themis/pull/786), [#788](https://github.com/cossacklabs/themis/pull/788)).
 
     Add the Maven Central repository to your `build.gradle`:
 
@@ -152,7 +152,7 @@ _Infrastructure:_
 - Started phasing out CircleCI in favour of GitHub Actions ([#709](https://github.com/cossacklabs/themis/pull/709), [#755](https://github.com/cossacklabs/themis/pull/755)).
 - Themis is now fuzzed with `afl++` ([#766](https://github.com/cossacklabs/themis/pull/766)).
 - Secure Message is now covered with fuzz testing ([#762](https://github.com/cossacklabs/themis/pull/762)).
-- JavaThemis is now published in the Maven Central repository ([#786](https://github.com/cossacklabs/themis/pull/786), [#788](https://github.com/cossacklabs/themis/pull/788)).
+- JavaThemis for Android and desktop Java is now published in the Maven Central repository ([#786](https://github.com/cossacklabs/themis/pull/786), [#788](https://github.com/cossacklabs/themis/pull/788)).
 
 
 ## [0.13.6](https://github.com/cossacklabs/themis/releases/tag/0.13.6), November 23rd 2020

--- a/src/wrappers/themis/android/build.gradle
+++ b/src/wrappers/themis/android/build.gradle
@@ -9,11 +9,6 @@ buildscript {
         // on this Gradle version until it breaks or we *need* an upgrade:
         classpath 'com.android.tools.build:gradle:3.2.1'
 
-        // Two necessary plugins for uploading .aar to bintray
-        // from: https://android.jlelse.eu/how-to-distribute-android-library-in-a-convenient-way-d43fb68304a7
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.1'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
-
         // Kotlin plugin for Android
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }

--- a/src/wrappers/themis/java/build.gradle
+++ b/src/wrappers/themis/java/build.gradle
@@ -56,3 +56,36 @@ compileTestJava {
     options.deprecation = true // log deprecated API usage
     options.encoding = "ASCII" // allow only ASCII in source code
 }
+
+// Publishing on Maven Central requires packages with Java source code and Javadocs.
+// Note that "archiveClassifier" values are important for Maven Central.
+
+task generateSourceJar(type: Jar) {
+    description = 'Assembles a JAR with Java source code'
+    archiveClassifier = 'sources'
+    from sourceSets.main.java.srcDirs
+    // "You cannot place a Planck generator container within another Planck generator,
+    // as it will cause a graviton harmonics chain reaction whose end cannot be determined."
+    // No, seriously, sometimes Gradle eats much more glue than it usually does.
+    // When packing the current directory -- sourceSets.main.java.srcDirs --
+    // into a JAR, it will just go ahead and pack the "build" directory too,
+    // along the very JAR it's currently constructing. RIP disk space.
+    excludes = ['build']
+}
+
+task generateJavadoc(type: Javadoc) {
+    description = 'Generates Javadocs from the source code'
+    source = sourceSets.main.java.srcDirs
+    title = 'Themis API Reference'
+    // Javadoc chokes on non-Java files so exclude non-sources from the source dir.
+    excludes = ['build', 'build.gradle']
+    // Make runtime dependencies available to Javadoc (important for annotations)
+    classpath = project.sourceSets.main.runtimeClasspath
+}
+
+task generateJavadocJar(type: Jar) {
+    description = 'Assembles a JAR with Javadocs'
+    archiveClassifier = 'javadoc'
+    from generateJavadoc.destinationDir
+    dependsOn 'generateJavadoc'
+}

--- a/src/wrappers/themis/java/build.gradle
+++ b/src/wrappers/themis/java/build.gradle
@@ -89,3 +89,72 @@ task generateJavadocJar(type: Jar) {
     from generateJavadoc.destinationDir
     dependsOn 'generateJavadoc'
 }
+
+// Maven Central distribution
+
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+
+publishing {
+    publications {
+        Production(MavenPublication) {
+            from components.java
+            artifact generateSourceJar
+            artifact generateJavadocJar
+            groupId 'com.cossacklabs.com'
+            artifactId 'java-themis'
+            version javaThemisVersion
+            pom {
+                name = 'JavaThemis'
+                description = 'Cross-platform high-level cryptographic library for mobile, web, and server platforms'
+                url = 'https://www.cossacklabs.com/themis/'
+                licenses {
+                    license {
+                        name = 'Apache License, Version 2.0'
+                        url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+                developers {
+                    developer {
+                        name = 'Cossack Labs'
+                        email = 'dev@cossacklabs.com'
+                        organization = 'Cossack Labs'
+                        organizationUrl = 'https://www.cossacklabs.com'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:git://github.com/cossacklabs/themis.git'
+                    developerConnection = 'scm:git:ssh://github.com:cossacklabs/themis.git'
+                    url = 'https://github.com/cossacklabs/themis'
+                }
+            }
+        }
+    }
+    repositories {
+        maven {
+            url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
+            credentials {
+                // Use API tokens instead of actual username and password
+                // https://oss.sonatype.org/#profile;User%20Token
+                username System.getenv('OSSRH_USERNAME')
+                password System.getenv('OSSRH_PASSWORD')
+            }
+        }
+    }
+}
+
+// Credentials for signing should be set in "~/.gradle/gradle.properties" file.
+// (The global one in your home directory, NOT the one in the project root.)
+//
+//     signing.gnupg.executable=gpg
+//     signing.gnupg.keyName=...
+//     signing.gnupg.passphrase=...
+//
+// Yes, only in that file. Because Gradle says so.
+//
+// https://docs.gradle.org/current/userguide/signing_plugin.html#example_configure_the_gnupgsignatory
+signing {
+    required { gradle.taskGraph.hasTask("publish") }
+    useGpgCmd()
+    sign publishing.publications.Production
+}


### PR DESCRIPTION
Let's put JavaThemis for desktop systems into Maven Central as well.

Note that this includes only the Java part of the library – a JAR with JVM bytecode. JavaThemis also needs a JNI library, which you will have to install separately, as appropriate for your system. See docs:

https://docs.cossacklabs.com/themis/languages/java/installation-desktop/

Also note that we are publishing under the same "weird" groupId: `com.cossacklabs.com`, because that's what we have used in the past, and that's our groupId prefix on Maven Central.

Since the artifactId `themis` is already taken by JavaThemis for Android, desktop systems will use `java-themis`. Hopefully, this will not be too confusing for the users. **If you want a different one**, like `desktop-themis` or whatever – speak now or forever hold your peace.

```groovy
repositories {
    mavenCentral()
}

dependencies {
    // Add JavaThemis as runtime dependency of your application.
    // Always pin the latest version, you can find it here:
    // https://search.maven.org/artifact/com.cossacklabs.com/java-themis
    implementation 'com.cossacklabs.com:java-themis:0.13.1'
}
```

## Checklist

- [X] ~~Change is covered by automated tests~~ (not really, but at least you're sure it does not break builds)
- [X] The [coding guidelines] are followed
- [X] ~~Example projects and code samples are up-to-date~~ (will do later)
- [X] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md