### PR TITLE
Test MSYS2 build and packaging 

### DIFF
--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -347,3 +347,53 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./coverage.info
+
+  msys2:
+    name: MSYS2 environment
+    runs-on: windows-latest
+    env:
+      SOTER_KDF_RUN_LONG_TESTS: yes
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - name: Install MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          install: >-
+            base-devel tar git gcc make
+            libopenssl>=1.1.1
+            openssl-devel>=1.1.1
+            mingw-w64-x86_64-nsis
+      # Git, I know you're only trying to help, but MSYS can work with
+      # UNIX line endings just fine. In fact, "makepkg" *requires* them.
+      # So don't be smart: just fetch the files as they are.
+      - name: Use UNIX line endings
+        shell: bash
+        run: git config --global core.autocrlf input
+      - name: Check out code
+        uses: actions/checkout@v2
+      # TODO: if there are users of the BoringSSL flavor on Windows,
+      # we should be testing that one as well
+      - name: Build Themis Core
+        run: make prepare_tests_basic
+      - name: Run test suite
+        run: make test
+      # TODO: it would be nice to test the installer too
+      - name: Build Themis installer
+        run: make nsis_installer
+      - name: Build Themis packages
+        run: makepkg -p PKGBUILD.MSYS2
+      - name: Install Themis packages
+        run: pacman -U --noconfirm themis-*.pkg.*
+      - name: Try building examples
+        run: |
+          cd $GITHUB_WORKSPACE/docs/examples/c/session_buffer_test
+          echo "Secure Session: buffer interface"
+          cc -o session_buffer_test session_buffer_test.c -lthemis
+          ./session_buffer_test
+
+          cd $GITHUB_WORKSPACE/docs/examples/c/ssession_test
+          echo "Secure Session: socket interface"
+          cc -o session_test client.c server.c session_test.c -lthemis -pthread
+          ./session_test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,7 @@ _Infrastructure:_
 - Themis is now fuzzed with `afl++` ([#766](https://github.com/cossacklabs/themis/pull/766)).
 - Secure Message is now covered with fuzz testing ([#762](https://github.com/cossacklabs/themis/pull/762)).
 - JavaThemis for Android and desktop Java is now published in the Maven Central repository ([#786](https://github.com/cossacklabs/themis/pull/786), [#788](https://github.com/cossacklabs/themis/pull/788)).
+- MSYS2 builds for Windows are now checked by CI ([#791](https://github.com/cossacklabs/themis/pull/791)).
 
 
 ## [0.13.6](https://github.com/cossacklabs/themis/releases/tag/0.13.6), November 23rd 2020

--- a/PKGBUILD.MSYS2
+++ b/PKGBUILD.MSYS2
@@ -17,9 +17,9 @@ depends=('libopenssl>=1.1.1')
 makedepends=('tar' 'gcc' 'make' 'openssl-devel>=1.1.1')
 
 source=("https://github.com/cossacklabs/themis/archive/$pkgver.tar.gz")
-sha256sums=('ee5c4be360401094dc5429035e1499912b3ccc10e93f71d0c2578934a5b2c81f')
-sha1sums=('418d71b0d3dd1ffff93ef025908bacb99d4c4aa4')
-md5sums=('afc3ac4e7d6c6db59e4e2f059a4fc973')
+sha256sums=('4dbe8faff569b8992ee091a207367604db468648503e5e6679a4c89e0918d525')
+sha1sums=('21372309e4e3d714bd637bce1e931e9be39a765f')
+md5sums=('623383678c6e73651a31b38cadcab441')
 # TODO: verify package signature
 
 # Unfortunately, bsdtar cannot handle symlinks on MSYS2 [1] so we have to use


### PR DESCRIPTION
The documentation claims that we regularly test MSYS2 packaging but actually never do. Start doing that.

Since MSYS2 is *very* different from Linux/macOS, make a separate task for it so that we can override the shell to MSYS2 shell. While we're at it, test everything that we have:

  - plain build in MSYS2 environment and runnin unit tests
  - building and installing packages, then testing the examples
  - building NSIS installer

Unfortunately, I don't really have a good idea of how to test the NSIS installer, which will probably require a Visual Studio project or something like that. But it would be cool to check if it works too.

Also, to avoid spending more time on this than necessary, test only OpenSSL builds with system packages provided by MSYS2, don't test building BoringSSL and appropriate Themis flavor.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] Example projects and code samples are up-to-date
- [X] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
