### PR TITLE
Fix warnings from Clippy

### DIFF
--- a/tests/rust/secure_session.rs
+++ b/tests/rust/secure_session.rs
@@ -660,14 +660,14 @@ fn panic_in_status_change() {
 // MockTransport implementation
 //
 
-type GetPublicKeyForID = Box<dyn FnMut(&[u8]) -> Option<EcdsaPublicKey>>;
+type GetPublicKeyForId = Box<dyn FnMut(&[u8]) -> Option<EcdsaPublicKey>>;
 type SendData = Box<dyn FnMut(&[u8]) -> Result<usize, TransportError>>;
 type ReceiveData = Box<dyn FnMut(&mut [u8]) -> Result<usize, TransportError>>;
 type StateChanged = Box<dyn FnMut(SecureSessionState)>;
 
 #[derive(Default)]
 struct MockTransport {
-    impl_get_public_key_for_id: Option<GetPublicKeyForID>,
+    impl_get_public_key_for_id: Option<GetPublicKeyForId>,
     impl_send_data: Option<SendData>,
     impl_receive_data: Option<ReceiveData>,
     impl_state_changed: Option<StateChanged>,


### PR DESCRIPTION
Recently released Rust 1.51 includes new Clippy with new warnings:

    error: name `GetPublicKeyForID` contains a capitalized acronym
       --> src/wrappers/themis/rust/tests/secure_session.rs:663:6
        |
    663 | type GetPublicKeyForID = Box<dyn FnMut(&[u8]) -> Option<EcdsaPublicKey>>;
        |      ^^^^^^^^^^^^^^^^^ help: consider making the acronym lowercase, except the initial letter: `GetPublicKeyForId`
        |
        = note: `-D clippy::upper-case-acronyms` implied by `-D warnings`
        = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#upper_case_acronyms

    error: aborting due to previous error

~~Shut up, Clippy, I name my types however I want to!~~

I mean, yes, sure, O Wise Stationery, I will immediately rename the entity as prescribed and will refrain from such practice any further.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md