### PR TITLE
Set timeouts on some CI jobs

### DIFF
--- a/.github/workflows/test-java.yaml
+++ b/.github/workflows/test-java.yaml
@@ -51,6 +51,9 @@ jobs:
           make all themis_jni
           sudo make install themis_jni_install
       - name: Build and test JavaThemis
+        # This step tends to randomly hang up. Use a shorter timeout here
+        # instead of the default 6-hour one.
+        timeout-minutes: 5
         # Set native library search path for Java explicitly since most
         # distribution-provided JVMs do not look there by default.
         run: |
@@ -66,11 +69,17 @@ jobs:
         with:
           submodules: true
       - name: Build Themis
+        # This step tends to randomly hang up. Use a shorter timeout here
+        # instead of the default 6-hour one.
+        timeout-minutes: 30
         run: ./gradlew --no-daemon :android:assembleDebug
       # This works reliably only in macOS runners which have HAXM available.
       # Ubuntu runners do not have KVM enabled, modern x86 emulators do not
       # work without KVM, and ARM emulator is abysmally slow.
       - name: Run test suite
+        # This step tends to randomly hang up. Use a shorter timeout here
+        # instead of the default 6-hour one.
+        timeout-minutes: 15
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 29

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -149,6 +149,9 @@ jobs:
 
       - name: Test examples (Secure Session)
         if: always()
+        # This step tends to randomly hang up. Use a shorter timeout here
+        # instead of the default 6-hour one.
+        timeout-minutes: 5
         run: |
           cd $GITHUB_WORKSPACE/docs/examples/python
 


### PR DESCRIPTION
Occasionally I get an email about some random job failing after running for 6 hours. I know that compute is free for Themis, but let's make our little contribution to the environment by not wasting computing power when we can avoid that. It's not like those tasks are mining BTC.

Android builds are notoriously prone to hanging up because the emulator has such amazing quality. Currently, the build step takes about 8 minutes on average while the testing step is about 4 minutes. New timeouts should provide some leeway while not being ridiculously large.

Java unit tests are something new: only recently I was greeted by [a build trace](https://github.com/cossacklabs/themis/runs/2243468294?check_suite_focus=true) in my email which looked like this:

    > Task :desktop:compileKotlin
    > Task :desktop:compileJava
    > Task :desktop:processResources NO-SOURCE
    > Task :desktop:classes
    > Task :desktop:inspectClassesForKotlinIC
    > Task :desktop:jar
    > Task :desktop:assemble
    > Task :desktop:compileTestKotlin
    > Task :desktop:compileTestJava
    > Task :desktop:processTestResources NO-SOURCE
    > Task :desktop:testClasses
    > Task :desktop:test

    [ and here it stoppped and did nothing for 5h 59m 11s ]

No idea what that was, but let's put a timeout there as well. Those jobs are just running unit tests locally, they should be quick.

Finally, occasionally I see Python examples for Secure Session to randomly hang up. It happens very rarely. I have no clue why. Maybe someone has an idea? In the meantime, that step should not go ahead and waste 6 hours if it decided it's time to take a nap.

## Checklist

- [X] Change is covered by automated tests (sure it is)
- [X] The [coding guidelines] are followed

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md