### PR TITLE
Update zeroize to `1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@ _Code:_
 - **Rust**
 
   - Dropped `libthemis-src` crate support and removed the `vendored` feature. RustThemis wrapper now requires Themis Core to be installed in the system ([#691](https://github.com/cossacklabs/themis/pull/691)).
+  - Updated `zeroize` depedency to 1.x version. Rust 1.47 or newer is now required ([#799](https://github.com/cossacklabs/themis/pull/799)).
 
 - **Swift**
 

--- a/src/wrappers/themis/rust/Cargo.toml
+++ b/src/wrappers/themis/rust/Cargo.toml
@@ -25,7 +25,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 bindings = { package = "libthemis-sys", path = "libthemis-sys", version = "0.13.0" }
-zeroize = "0.5.2"
+zeroize = "1"
 
 [dev-dependencies]
 base64 = "0.10.0"


### PR DESCRIPTION
This is the only dependency of RustThemis and they have managed to break even that 🤦

Some bright maintainer head over there thought that it would be a great idea to just yank all 0.x versions from crates.io, breaking our build. (Since RustThemis is a library, we're not using Cargo.lock. If a dependency is yanked, we can't build our stuff.)

Well, thanks for not breaking the API in 1.x at least. You're still better than the Tokio team.

Note that zeroize requires reasonably new stable version of Rust toolchain. With 0.5.2 this has been 1.31, now it's 1.47. (The current stable version is 1.51. RustThemis tracks that version.)

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] Public API has proper documentation
- [X] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md