### PR TITLE
Update zeroize to `1` (on stable)

### DIFF
--- a/src/wrappers/themis/rust/Cargo.toml
+++ b/src/wrappers/themis/rust/Cargo.toml
@@ -28,7 +28,7 @@ vendored = ["bindings/vendored"]
 
 [dependencies]
 bindings = { package = "libthemis-sys", path = "libthemis-sys", version = "0.13.0" }
-zeroize = "0.5.2"
+zeroize = "1"
 
 [dev-dependencies]
 base64 = "0.10.0"


### PR DESCRIPTION
Cherry-pick #799 onto **stable** to fix the build there as well.

What a waste of the 800 GET.

- [X] **task-list-completed** check completed