### PR TITLE
Test {Js,Wasm}Themis with Node.js v16

### DIFF
--- a/.github/workflows/test-nodejs.yaml
+++ b/.github/workflows/test-nodejs.yaml
@@ -31,9 +31,10 @@ jobs:
       matrix:
         node-version:
           - 8.x   # legacy
-          - 10.x  # old LTS
-          - 12.x  # current LTS
-          - 14.x  # current stable
+          - 10.x  # legacy
+          - 12.x  # old LTS
+          - 14.x  # current LTS
+          - 16.x  # current stable
       fail-fast: false
     steps:
       - name: Install system dependencies

--- a/.github/workflows/test-nodejs.yaml
+++ b/.github/workflows/test-nodejs.yaml
@@ -61,16 +61,23 @@ jobs:
   examples:
     name: Code examples
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version:
+          - 12.x  # old LTS
+          - 14.x  # current LTS
+          - 16.x  # current stable
+      fail-fast: false
     steps:
       - name: Install system dependencies
         run: |
           sudo sh -c 'echo "DEBIAN_FRONTEND=noninteractive" >> /etc/environment'
           sudo apt update
           sudo apt install --yes gcc make libssl-dev
-      - name: Install Node.js 10.x
+      - name: Install Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: ${{ matrix.node-version }}
       - name: Check out code
         uses: actions/checkout@v2
       - name: Install Themis Core

--- a/.github/workflows/test-wasm.yaml
+++ b/.github/workflows/test-wasm.yaml
@@ -37,9 +37,10 @@ jobs:
       matrix:
         node-version:
           - 8.x   # legacy
-          - 10.x  # old LTS
-          - 12.x  # current LTS
-          - 14.x  # current stable
+          - 10.x  # legacy
+          - 12.x  # old LTS
+          - 14.x  # current LTS
+          - 16.x  # current stable
       fail-fast: false
     steps:
       - name: Install system dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ _Code:_
 - **Node.js**
 
   - `SecureSession` constructor now throws an exception when given incorrect key type ([#698](https://github.com/cossacklabs/themis/pull/698)).
+  - Node.js v16 is now supported ([#801](https://github.com/cossacklabs/themis/pull/801)).
 
 - **Python**
 
@@ -142,6 +143,7 @@ _Code:_
 - **WebAssembly**
 
   - Updated Emscripten toolchain to the latest version ([#760](https://github.com/cossacklabs/themis/pull/760)).
+  - Node.js v16 is now supported ([#801](https://github.com/cossacklabs/themis/pull/801)).
 
 _Infrastructure:_
 


### PR DESCRIPTION
[Node.js v16 has been released yesterday][1], becoming the new "current" stable release track of Node.js. It's going to turn LTS in October 2021.

[1]: https://nodejs.org/en/about/releases/

Node.js v10 release is scheduled for EOL this April. However, we're still going to build and test our JavaScript stuff against it while it's still practical.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] Example projects and code samples are up-to-date
- [X] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
