### PR TITLE
Cherry-picked  to stable: Use "ubuntu-20.04" for AFL fuzzing job (#790)

### DIFF
--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -199,14 +199,7 @@ jobs:
 
   fuzzing:
     name: AFL fuzzing
-    # TODO(ilammy, 2021-01-28): use "ubuntu-latest" once it works
-    # Currently "ubuntu-latest" means "ubuntu-18.04" but for some inexplicable
-    # reasons GitHub runners in the main repo treat it as "ubuntu-20.04" which
-    # does not seem to work yet (for this job). Pin the Ubuntu 18.04 version
-    # for now, but don't forget to update this once "ubuntu-latest" changes
-    # its meaning or starts working for this job.
-    # See: https://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       FUZZ_TIMEOUT: 30s
       THEMIS_DEFAULT_PBKDF2_ITERATIONS: 10


### PR DESCRIPTION
Cherry-picked ubuntu update from master to stable
_______
Some time ago I have pinned this job to "ubuntu-18.04" worker because
"ubuntu-20.04" was broken, now it's the reverse: package repos used in
"ubuntu-18.04" contain incompatible versions of 32- and 64-bit OpenSSL.

Switch to "ubuntu-20.04" now that it's actually functional. Don't use
"ubuntu-latest" because even God does not know what GitHub will use for
that label.

I have some desire to use vanilla Ubuntu 20.04 for this job to prevent
GitHub from breaking it again by piling up incompatible repositories
there again, but let's see how it rolls. (Using GitHub's images is
faster as they have most of our dependencies preinstalled.) It it breaks
again in the future -- I'm switching it to vanilla Docker image, I don't
care if it gets slower (Microsoft is paying for compute, after all).