### PR TITLE
SPM support with XCF (#789)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 Changes that are currently in development and have not been released yet.
 
-
-## [0.13.6](https://github.com/cossacklabs/themis/releases/tag/0.13.6), November 23th 2020
 ## [0.13.7](https://github.com/cossacklabs/themis/releases/tag/0.13.7), April 28rd 2021
 
 **Hotfix for Apple platforms:**
@@ -20,6 +18,7 @@ _Code:_
   - Added script to generate xcframework for iOS, iOS Simulator and macOS ([#789](https://github.com/cossacklabs/themis/pull/789)).
   - Added Package.swift file for SPM ([#789](https://github.com/cossacklabs/themis/pull/789)).
 
+## [0.13.6](https://github.com/cossacklabs/themis/releases/tag/0.13.6), November 23th 2020
 
 **Hotfix for Apple platforms:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Changes that are currently in development and have not been released yet.
 
 
 ## [0.13.6](https://github.com/cossacklabs/themis/releases/tag/0.13.6), November 23th 2020
+## [0.13.7](https://github.com/cossacklabs/themis/releases/tag/0.13.7), April 28rd 2021
+
+**Hotfix for Apple platforms:**
+
+- `themis` is now packaged as xcframework. It is available in the release attached files section.
+- `themis` now supports SPM, its installation and usage are very straightforward, just add `themis` as SPM dependency.
+
+_Code:_
+
+- **Objective-C / Swift**
+
+  - Added script to generate xcframework for iOS, iOS Simulator and macOS ([#789](https://github.com/cossacklabs/themis/pull/789)).
+  - Added Package.swift file for SPM ([#789](https://github.com/cossacklabs/themis/pull/789)).
+
 
 **Hotfix for Apple platforms:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Changes that are currently in development and have not been released yet.
 
-## [0.13.7](https://github.com/cossacklabs/themis/releases/tag/0.13.7), April 28rd 2021
+## [0.13.7](https://github.com/cossacklabs/themis/releases/tag/0.13.7), April 28th 2021
 
 **Hotfix for Apple platforms:**
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "themis",
+    products: [
+        .library(
+            name: "themis",
+            targets: ["themis"]),
+    ],
+    // OpenSSL XCF is statically linked to Themis XCF, so no need to have it as a dependency
+    dependencies: [],
+    targets: [
+        .binaryTarget(name: "themis",
+                      // update version in URL path
+                      url: "https://github.com/cossacklabs/themis/releases/download/0.13.7/themis.xcframework.zip",
+                      // The scripts/create_xcframework.sh calculates the checksum when generating the XCF.
+                      // Alternatively, run from package directory:
+                      // swift package compute-checksum build/xcf_output/themis.xcframework.zip
+                      checksum: "9e7b42fa1b9c49a1e28ede9eb5e17340ea6a4e0f57de806db874cb22568bef96"),
+
+    ]
+)

--- a/Themis.xcodeproj/project.pbxproj
+++ b/Themis.xcodeproj/project.pbxproj
@@ -937,6 +937,8 @@
 			dependencies = (
 			);
 			name = "Themis (macOS)";
+			packageProductDependencies = (
+			);
 			productName = "Themis (macOS)";
 			productReference = 9F00E8D7223C197900EC1EF3 /* themis.framework */;
 			productType = "com.apple.product-type.framework";
@@ -954,6 +956,8 @@
 			dependencies = (
 			);
 			name = "Themis (iOS)";
+			packageProductDependencies = (
+			);
 			productName = Themis;
 			productReference = 9F4A24A1223A8D7F005CB63A /* themis.framework */;
 			productType = "com.apple.product-type.framework";
@@ -1067,6 +1071,8 @@
 				Base,
 			);
 			mainGroup = 738B81052239809D00A9947C;
+			packageReferences = (
+			);
 			productRefGroup = 738B81102239809D00A9947C /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -1476,7 +1482,7 @@
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1502,7 +1508,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.13.6;
+				MARKETING_VERSION = 0.13.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis;
 				PRODUCT_MODULE_NAME = themis;
 				PRODUCT_NAME = themis;
@@ -1518,7 +1524,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1544,7 +1550,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.13.6;
+				MARKETING_VERSION = 0.13.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis;
 				PRODUCT_MODULE_NAME = themis;
 				PRODUCT_NAME = themis;
@@ -1559,7 +1565,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1587,7 +1593,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.13.6;
+				MARKETING_VERSION = 0.13.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis;
 				PRODUCT_MODULE_NAME = themis;
 				PRODUCT_NAME = themis;
@@ -1607,7 +1613,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1635,7 +1641,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.13.6;
+				MARKETING_VERSION = 0.13.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis;
 				PRODUCT_MODULE_NAME = themis;
 				PRODUCT_NAME = themis;

--- a/scripts/create_xcframeworks.sh
+++ b/scripts/create_xcframeworks.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Shebang to explicitly use bash and not break on macOS boxes with zsh as default shell.
+#
+# This script generates Themis xcframework for iOS and macOS.
+# Run it from the repo root so the xcodebuild command finds Themis.xcodeproj
+
+set -eu # common flags to ensure that the shell does not ignore failures
+
+BUILD_PATH=${BUILD_PATH:-build}
+output_dir=$BUILD_PATH/xcf_output
+project_dir=$(pwd) #repo root where Themis.xcodeproj and Package.swift are
+
+# creating required xcframework structure
+mkdir -p $output_dir/archives
+mkdir -p $output_dir/iphoneos
+mkdir -p $output_dir/macosx
+
+# build the framework for iOS devices
+xcodebuild archive \
+-scheme "Themis (iOS)" \
+-destination="iOS" \
+-archivePath $output_dir/archives/ios.xcarchive \
+-derivedDataPath $output_dir/iphoneos \
+-sdk iphoneos \
+SKIP_INSTALL=NO \
+BUILD_LIBRARIES_FOR_DISTRIBUTION=YES
+
+# build the framework for iOS simulator
+xcodebuild archive \
+-scheme "Themis (iOS)" \
+-destination="iOS Simulator" \
+-archivePath $output_dir/archives/iossimulator.xcarchive \
+-derivedDataPath $output_dir/iphoneos \
+-sdk iphonesimulator \
+SKIP_INSTALL=NO \
+BUILD_LIBRARIES_FOR_DISTRIBUTION=YES
+
+# build the framework for macOS
+xcodebuild archive \
+-scheme "Themis (macOS)" \
+-destination="macOS" \
+-archivePath $output_dir/archives/macosx.xcarchive \
+-derivedDataPath $output_dir/macosx \
+-sdk macosx \
+SKIP_INSTALL=NO \
+BUILD_LIBRARIES_FOR_DISTRIBUTION=YES
+
+# gather separate frameworks into a single xcframework
+xcodebuild -create-xcframework \
+-framework $output_dir/archives/ios.xcarchive/Products/Library/Frameworks/themis.framework \
+-framework $output_dir/archives/iossimulator.xcarchive/Products/Library/Frameworks/themis.framework \
+-framework $output_dir/archives/macosx.xcarchive/Products/Library/Frameworks/themis.framework \
+-output $output_dir/themis.xcframework
+
+# deleting the artifacts
+rm -rf $output_dir/archives
+rm -rf $output_dir/iphoneos
+rm -rf $output_dir/macosx
+
+# zip the xcodeframework
+# SPM accepts binary targets only in zip format
+cd $output_dir
+zip -r themis.xcframework.zip themis.xcframework
+
+rm -rf themis.xcframework
+
+# calculate checksum from the directory with Package.swift
+# update the the checksum in Package.swift if that is a new release
+cd $project_dir
+echo "XCF Checksum:"
+swift package compute-checksum $output_dir/themis.xcframework.zip


### PR DESCRIPTION
Cherry-picked SPM support from master to release/0.13
___________
* add SPM support with XCF
* add swift SPM test project
* add macOS swift SPM example, updated iOS one
* updates per pr comments
* removed cl-openssl from Themis.xcodeproj + edits per pr comments + extra comments
* removed example projects
* updated xcodeproj version
* updated Package.swift
* updated changelog
* Update CHANGELOG.md
Co-authored-by: vixentael <vixentael@users.noreply.github.com>
Co-authored-by: vixentael <vixentael@users.noreply.github.com>
