### PR TITLE
Build Themis + BoringSSL with Xcode

### DIFF
--- a/.github/workflows/test-objc.yaml
+++ b/.github/workflows/test-objc.yaml
@@ -117,6 +117,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+        with:
+          submodules: true
       - name: Pull Carthage dependencies
         run: carthage bootstrap
       - name: Run unit tests (Swift 4, macOS)
@@ -156,6 +158,26 @@ jobs:
             -derivedDataPath DerivedData  \
             -project Themis.xcodeproj \
             -scheme "Test Themis (Swift 5, iOS)" \
+            -sdk iphonesimulator \
+            -destination "platform=iOS Simulator,name=${TEST_IPHONE}" \
+            test
+      - name: Run unit tests (BoringSSL, Swift 5, macOS)
+        if: always()
+        run: |
+          rm -rf DerivedData
+          xcodebuild \
+            -derivedDataPath DerivedData  \
+            -project Themis.xcodeproj \
+            -scheme "Test Themis (BoringSSL, Swift 5, macOS)" \
+            test
+      - name: Run unit tests (BoringSSL, Swift 5, iOS Simulator)
+        if: always()
+        run: |
+          rm -rf DerivedData
+          xcodebuild \
+            -derivedDataPath DerivedData  \
+            -project Themis.xcodeproj \
+            -scheme "Test Themis (BoringSSL, Swift 5, iOS)" \
             -sdk iphonesimulator \
             -destination "platform=iOS Simulator,name=${TEST_IPHONE}" \
             test

--- a/Themis.xcodeproj/project.pbxproj
+++ b/Themis.xcodeproj/project.pbxproj
@@ -4887,6 +4887,12 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"BORINGSSL=1",
+					"CRYPTO_ENGINE_PATH=boringssl",
+					"SOTER_BORINGSSL_DISABLE_XTS=1",
+					"$(inherited)",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/include",
 					"$(PROJECT_DIR)/src",
@@ -4927,6 +4933,12 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"BORINGSSL=1",
+					"CRYPTO_ENGINE_PATH=boringssl",
+					"SOTER_BORINGSSL_DISABLE_XTS=1",
+					"$(inherited)",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/include",
 					"$(PROJECT_DIR)/src",
@@ -4965,6 +4977,12 @@
 					"$(PROJECT_DIR)/Carthage/Build/Mac",
 				);
 				FRAMEWORK_VERSION = A;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"BORINGSSL=1",
+					"CRYPTO_ENGINE_PATH=boringssl",
+					"SOTER_BORINGSSL_DISABLE_XTS=1",
+					"$(inherited)",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/include",
 					"$(PROJECT_DIR)/src",
@@ -5002,6 +5020,12 @@
 					"$(PROJECT_DIR)/Carthage/Build/Mac",
 				);
 				FRAMEWORK_VERSION = A;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"BORINGSSL=1",
+					"CRYPTO_ENGINE_PATH=boringssl",
+					"SOTER_BORINGSSL_DISABLE_XTS=1",
+					"$(inherited)",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/include",
 					"$(PROJECT_DIR)/src",

--- a/Themis.xcodeproj/project.pbxproj
+++ b/Themis.xcodeproj/project.pbxproj
@@ -752,24 +752,8 @@
 		9F52B03D263D30430025EB78 /* soter_hmac.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2353223A73B1005CB63A /* soter_hmac.c */; };
 		9F52B03E263D30430025EB78 /* soter_kdf.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2357223A73B1005CB63A /* soter_kdf.c */; };
 		9F52B03F263D30430025EB78 /* soter_sign.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2351223A73B1005CB63A /* soter_sign.c */; };
-		9F52B040263D30430025EB78 /* soter_asym_cipher.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A238F223A7426005CB63A /* soter_asym_cipher.c */; };
-		9F52B041263D30430025EB78 /* soter_asym_ka.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2388223A7425005CB63A /* soter_asym_ka.c */; };
-		9F52B042263D30430025EB78 /* soter_ec_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2392223A7426005CB63A /* soter_ec_key.c */; };
-		9F52B043263D30430025EB78 /* soter_ecdsa_common.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2387223A7425005CB63A /* soter_ecdsa_common.c */; };
-		9F52B044263D30430025EB78 /* soter_hash.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2390223A7426005CB63A /* soter_hash.c */; };
-		9F52B045263D30430025EB78 /* soter_rand.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A238E223A7426005CB63A /* soter_rand.c */; };
 		9F52B046263D30430025EB78 /* soter_ec_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F874AB122CCB0D100E8DECA /* soter_ec_key.c */; };
 		9F52B047263D30430025EB78 /* secure_cell_seal_passphrase.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F6B385423D9D11600EA5D1B /* secure_cell_seal_passphrase.c */; };
-		9F52B048263D30430025EB78 /* soter_rsa_common.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2386223A7425005CB63A /* soter_rsa_common.c */; };
-		9F52B049263D30430025EB78 /* soter_rsa_key_pair_gen.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A238A223A7425005CB63A /* soter_rsa_key_pair_gen.c */; };
-		9F52B04A263D30430025EB78 /* soter_rsa_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2385223A7425005CB63A /* soter_rsa_key.c */; };
-		9F52B04B263D30430025EB78 /* soter_kdf.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F33485723B38D9B00368291 /* soter_kdf.c */; };
-		9F52B04C263D30430025EB78 /* soter_wipe.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F98F32722CCEB0E008E14E6 /* soter_wipe.c */; };
-		9F52B04D263D30430025EB78 /* soter_sign_ecdsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2389223A7425005CB63A /* soter_sign_ecdsa.c */; };
-		9F52B04E263D30430025EB78 /* soter_sign_rsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A238C223A7425005CB63A /* soter_sign_rsa.c */; };
-		9F52B04F263D30430025EB78 /* soter_sym.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2394223A7426005CB63A /* soter_sym.c */; };
-		9F52B050263D30430025EB78 /* soter_verify_ecdsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2393223A7426005CB63A /* soter_verify_ecdsa.c */; };
-		9F52B051263D30430025EB78 /* soter_verify_rsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A238D223A7426005CB63A /* soter_verify_rsa.c */; };
 		9F52B052263D30430025EB78 /* fe_0.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B3223A745B005CB63A /* fe_0.c */; };
 		9F52B053263D30430025EB78 /* fe_1.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23CF223A745C005CB63A /* fe_1.c */; };
 		9F52B054263D30430025EB78 /* soter_rsa_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F874AB222CCB0D100E8DECA /* soter_rsa_key.c */; };
@@ -851,24 +835,8 @@
 		9F52B0B8263D310F0025EB78 /* soter_hmac.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2353223A73B1005CB63A /* soter_hmac.c */; };
 		9F52B0B9263D310F0025EB78 /* soter_kdf.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2357223A73B1005CB63A /* soter_kdf.c */; };
 		9F52B0BA263D310F0025EB78 /* soter_sign.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2351223A73B1005CB63A /* soter_sign.c */; };
-		9F52B0BB263D310F0025EB78 /* soter_asym_cipher.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A238F223A7426005CB63A /* soter_asym_cipher.c */; };
-		9F52B0BC263D310F0025EB78 /* soter_asym_ka.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2388223A7425005CB63A /* soter_asym_ka.c */; };
-		9F52B0BD263D310F0025EB78 /* soter_ec_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2392223A7426005CB63A /* soter_ec_key.c */; };
-		9F52B0BE263D310F0025EB78 /* soter_ecdsa_common.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2387223A7425005CB63A /* soter_ecdsa_common.c */; };
-		9F52B0BF263D310F0025EB78 /* soter_hash.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2390223A7426005CB63A /* soter_hash.c */; };
-		9F52B0C0263D310F0025EB78 /* soter_rand.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A238E223A7426005CB63A /* soter_rand.c */; };
 		9F52B0C1263D310F0025EB78 /* soter_ec_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F874AB122CCB0D100E8DECA /* soter_ec_key.c */; };
 		9F52B0C2263D310F0025EB78 /* secure_cell_seal_passphrase.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F6B385423D9D11600EA5D1B /* secure_cell_seal_passphrase.c */; };
-		9F52B0C3263D310F0025EB78 /* soter_rsa_common.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2386223A7425005CB63A /* soter_rsa_common.c */; };
-		9F52B0C4263D310F0025EB78 /* soter_rsa_key_pair_gen.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A238A223A7425005CB63A /* soter_rsa_key_pair_gen.c */; };
-		9F52B0C5263D310F0025EB78 /* soter_rsa_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2385223A7425005CB63A /* soter_rsa_key.c */; };
-		9F52B0C6263D310F0025EB78 /* soter_kdf.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F33485723B38D9B00368291 /* soter_kdf.c */; };
-		9F52B0C7263D310F0025EB78 /* soter_wipe.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F98F32722CCEB0E008E14E6 /* soter_wipe.c */; };
-		9F52B0C8263D310F0025EB78 /* soter_sign_ecdsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2389223A7425005CB63A /* soter_sign_ecdsa.c */; };
-		9F52B0C9263D310F0025EB78 /* soter_sign_rsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A238C223A7425005CB63A /* soter_sign_rsa.c */; };
-		9F52B0CA263D310F0025EB78 /* soter_sym.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2394223A7426005CB63A /* soter_sym.c */; };
-		9F52B0CB263D310F0025EB78 /* soter_verify_ecdsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2393223A7426005CB63A /* soter_verify_ecdsa.c */; };
-		9F52B0CC263D310F0025EB78 /* soter_verify_rsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A238D223A7426005CB63A /* soter_verify_rsa.c */; };
 		9F52B0CD263D310F0025EB78 /* ge_p2_to_p3.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B2223A745A005CB63A /* ge_p2_to_p3.c */; };
 		9F52B0CE263D310F0025EB78 /* ge_p3_0.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23BB223A745B005CB63A /* ge_p3_0.c */; };
 		9F52B0CF263D310F0025EB78 /* soter_rsa_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F874AB222CCB0D100E8DECA /* soter_rsa_key.c */; };
@@ -922,6 +890,38 @@
 		9F52B0FF263D310F0025EB78 /* ssession_transport_interface.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24B2223A8FA7005CB63A /* ssession_transport_interface.m */; };
 		9F52B100263D310F0025EB78 /* ssession.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24BA223A8FA8005CB63A /* ssession.m */; };
 		9F52B102263D310F0025EB78 /* openssl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E940223C1AFA00EC1EF3 /* openssl.framework */; };
+		9F52B138263D32F30025EB78 /* soter_asym_cipher.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B017263D2F840025EB78 /* soter_asym_cipher.c */; };
+		9F52B139263D32F30025EB78 /* soter_asym_ka.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B020263D2F850025EB78 /* soter_asym_ka.c */; };
+		9F52B13A263D32F30025EB78 /* soter_ec_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B01E263D2F850025EB78 /* soter_ec_key.c */; };
+		9F52B13B263D32F30025EB78 /* soter_ecdsa_common.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B012263D2F840025EB78 /* soter_ecdsa_common.c */; };
+		9F52B13C263D32F30025EB78 /* soter_hash.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B011263D2F840025EB78 /* soter_hash.c */; };
+		9F52B13D263D32F30025EB78 /* soter_kdf.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B018263D2F840025EB78 /* soter_kdf.c */; };
+		9F52B13E263D32F30025EB78 /* soter_rand.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B00F263D2F840025EB78 /* soter_rand.c */; };
+		9F52B13F263D32F30025EB78 /* soter_rsa_common.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B016263D2F840025EB78 /* soter_rsa_common.c */; };
+		9F52B140263D32F30025EB78 /* soter_rsa_key_pair_gen.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B01C263D2F850025EB78 /* soter_rsa_key_pair_gen.c */; };
+		9F52B141263D32F30025EB78 /* soter_rsa_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B01A263D2F850025EB78 /* soter_rsa_key.c */; };
+		9F52B142263D32F30025EB78 /* soter_sign_ecdsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B00E263D2F840025EB78 /* soter_sign_ecdsa.c */; };
+		9F52B143263D32F30025EB78 /* soter_sign_rsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B01F263D2F850025EB78 /* soter_sign_rsa.c */; };
+		9F52B144263D32F30025EB78 /* soter_sym.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B010263D2F840025EB78 /* soter_sym.c */; };
+		9F52B145263D32F30025EB78 /* soter_verify_ecdsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B01D263D2F850025EB78 /* soter_verify_ecdsa.c */; };
+		9F52B146263D32F30025EB78 /* soter_verify_rsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B014263D2F840025EB78 /* soter_verify_rsa.c */; };
+		9F52B147263D32F30025EB78 /* soter_wipe.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B015263D2F840025EB78 /* soter_wipe.c */; };
+		9F52B15A263D33290025EB78 /* soter_asym_cipher.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B017263D2F840025EB78 /* soter_asym_cipher.c */; };
+		9F52B15B263D33290025EB78 /* soter_asym_ka.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B020263D2F850025EB78 /* soter_asym_ka.c */; };
+		9F52B15C263D33290025EB78 /* soter_ec_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B01E263D2F850025EB78 /* soter_ec_key.c */; };
+		9F52B15D263D33290025EB78 /* soter_ecdsa_common.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B012263D2F840025EB78 /* soter_ecdsa_common.c */; };
+		9F52B15E263D33290025EB78 /* soter_hash.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B011263D2F840025EB78 /* soter_hash.c */; };
+		9F52B15F263D33290025EB78 /* soter_kdf.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B018263D2F840025EB78 /* soter_kdf.c */; };
+		9F52B160263D33290025EB78 /* soter_rand.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B00F263D2F840025EB78 /* soter_rand.c */; };
+		9F52B161263D33290025EB78 /* soter_rsa_common.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B016263D2F840025EB78 /* soter_rsa_common.c */; };
+		9F52B162263D33290025EB78 /* soter_rsa_key_pair_gen.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B01C263D2F850025EB78 /* soter_rsa_key_pair_gen.c */; };
+		9F52B163263D33290025EB78 /* soter_rsa_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B01A263D2F850025EB78 /* soter_rsa_key.c */; };
+		9F52B164263D33290025EB78 /* soter_sign_ecdsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B00E263D2F840025EB78 /* soter_sign_ecdsa.c */; };
+		9F52B165263D33290025EB78 /* soter_sign_rsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B01F263D2F850025EB78 /* soter_sign_rsa.c */; };
+		9F52B166263D33290025EB78 /* soter_sym.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B010263D2F840025EB78 /* soter_sym.c */; };
+		9F52B167263D33290025EB78 /* soter_verify_ecdsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B01D263D2F850025EB78 /* soter_verify_ecdsa.c */; };
+		9F52B168263D33290025EB78 /* soter_verify_rsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B014263D2F840025EB78 /* soter_verify_rsa.c */; };
+		9F52B169263D33290025EB78 /* soter_wipe.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B015263D2F840025EB78 /* soter_wipe.c */; };
 		9F6B385523D9D11600EA5D1B /* secure_cell_seal_passphrase.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F6B385423D9D11600EA5D1B /* secure_cell_seal_passphrase.c */; };
 		9F6B385623D9D11600EA5D1B /* secure_cell_seal_passphrase.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F6B385423D9D11600EA5D1B /* secure_cell_seal_passphrase.c */; };
 		9F70B2C1241D0FEC009CB629 /* themis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E8D7223C197900EC1EF3 /* themis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -3512,6 +3512,22 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9F52B138263D32F30025EB78 /* soter_asym_cipher.c in Sources */,
+				9F52B139263D32F30025EB78 /* soter_asym_ka.c in Sources */,
+				9F52B13A263D32F30025EB78 /* soter_ec_key.c in Sources */,
+				9F52B13B263D32F30025EB78 /* soter_ecdsa_common.c in Sources */,
+				9F52B13C263D32F30025EB78 /* soter_hash.c in Sources */,
+				9F52B13D263D32F30025EB78 /* soter_kdf.c in Sources */,
+				9F52B13E263D32F30025EB78 /* soter_rand.c in Sources */,
+				9F52B13F263D32F30025EB78 /* soter_rsa_common.c in Sources */,
+				9F52B140263D32F30025EB78 /* soter_rsa_key_pair_gen.c in Sources */,
+				9F52B141263D32F30025EB78 /* soter_rsa_key.c in Sources */,
+				9F52B142263D32F30025EB78 /* soter_sign_ecdsa.c in Sources */,
+				9F52B143263D32F30025EB78 /* soter_sign_rsa.c in Sources */,
+				9F52B144263D32F30025EB78 /* soter_sym.c in Sources */,
+				9F52B145263D32F30025EB78 /* soter_verify_ecdsa.c in Sources */,
+				9F52B146263D32F30025EB78 /* soter_verify_rsa.c in Sources */,
+				9F52B147263D32F30025EB78 /* soter_wipe.c in Sources */,
 				9F52B030263D30430025EB78 /* secure_cell.c in Sources */,
 				9F52B031263D30430025EB78 /* secure_comparator.c in Sources */,
 				9F52B032263D30430025EB78 /* secure_keygen.c in Sources */,
@@ -3528,24 +3544,8 @@
 				9F52B03D263D30430025EB78 /* soter_hmac.c in Sources */,
 				9F52B03E263D30430025EB78 /* soter_kdf.c in Sources */,
 				9F52B03F263D30430025EB78 /* soter_sign.c in Sources */,
-				9F52B040263D30430025EB78 /* soter_asym_cipher.c in Sources */,
-				9F52B041263D30430025EB78 /* soter_asym_ka.c in Sources */,
-				9F52B042263D30430025EB78 /* soter_ec_key.c in Sources */,
-				9F52B043263D30430025EB78 /* soter_ecdsa_common.c in Sources */,
-				9F52B044263D30430025EB78 /* soter_hash.c in Sources */,
-				9F52B045263D30430025EB78 /* soter_rand.c in Sources */,
 				9F52B046263D30430025EB78 /* soter_ec_key.c in Sources */,
 				9F52B047263D30430025EB78 /* secure_cell_seal_passphrase.c in Sources */,
-				9F52B048263D30430025EB78 /* soter_rsa_common.c in Sources */,
-				9F52B049263D30430025EB78 /* soter_rsa_key_pair_gen.c in Sources */,
-				9F52B04A263D30430025EB78 /* soter_rsa_key.c in Sources */,
-				9F52B04B263D30430025EB78 /* soter_kdf.c in Sources */,
-				9F52B04C263D30430025EB78 /* soter_wipe.c in Sources */,
-				9F52B04D263D30430025EB78 /* soter_sign_ecdsa.c in Sources */,
-				9F52B04E263D30430025EB78 /* soter_sign_rsa.c in Sources */,
-				9F52B04F263D30430025EB78 /* soter_sym.c in Sources */,
-				9F52B050263D30430025EB78 /* soter_verify_ecdsa.c in Sources */,
-				9F52B051263D30430025EB78 /* soter_verify_rsa.c in Sources */,
 				9F52B052263D30430025EB78 /* fe_0.c in Sources */,
 				9F52B053263D30430025EB78 /* fe_1.c in Sources */,
 				9F52B054263D30430025EB78 /* soter_rsa_key.c in Sources */,
@@ -3605,6 +3605,22 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9F52B15A263D33290025EB78 /* soter_asym_cipher.c in Sources */,
+				9F52B15B263D33290025EB78 /* soter_asym_ka.c in Sources */,
+				9F52B15C263D33290025EB78 /* soter_ec_key.c in Sources */,
+				9F52B15D263D33290025EB78 /* soter_ecdsa_common.c in Sources */,
+				9F52B15E263D33290025EB78 /* soter_hash.c in Sources */,
+				9F52B15F263D33290025EB78 /* soter_kdf.c in Sources */,
+				9F52B160263D33290025EB78 /* soter_rand.c in Sources */,
+				9F52B161263D33290025EB78 /* soter_rsa_common.c in Sources */,
+				9F52B162263D33290025EB78 /* soter_rsa_key_pair_gen.c in Sources */,
+				9F52B163263D33290025EB78 /* soter_rsa_key.c in Sources */,
+				9F52B164263D33290025EB78 /* soter_sign_ecdsa.c in Sources */,
+				9F52B165263D33290025EB78 /* soter_sign_rsa.c in Sources */,
+				9F52B166263D33290025EB78 /* soter_sym.c in Sources */,
+				9F52B167263D33290025EB78 /* soter_verify_ecdsa.c in Sources */,
+				9F52B168263D33290025EB78 /* soter_verify_rsa.c in Sources */,
+				9F52B169263D33290025EB78 /* soter_wipe.c in Sources */,
 				9F52B0AB263D310F0025EB78 /* secure_cell.c in Sources */,
 				9F52B0AC263D310F0025EB78 /* secure_comparator.c in Sources */,
 				9F52B0AD263D310F0025EB78 /* secure_keygen.c in Sources */,
@@ -3621,24 +3637,8 @@
 				9F52B0B8263D310F0025EB78 /* soter_hmac.c in Sources */,
 				9F52B0B9263D310F0025EB78 /* soter_kdf.c in Sources */,
 				9F52B0BA263D310F0025EB78 /* soter_sign.c in Sources */,
-				9F52B0BB263D310F0025EB78 /* soter_asym_cipher.c in Sources */,
-				9F52B0BC263D310F0025EB78 /* soter_asym_ka.c in Sources */,
-				9F52B0BD263D310F0025EB78 /* soter_ec_key.c in Sources */,
-				9F52B0BE263D310F0025EB78 /* soter_ecdsa_common.c in Sources */,
-				9F52B0BF263D310F0025EB78 /* soter_hash.c in Sources */,
-				9F52B0C0263D310F0025EB78 /* soter_rand.c in Sources */,
 				9F52B0C1263D310F0025EB78 /* soter_ec_key.c in Sources */,
 				9F52B0C2263D310F0025EB78 /* secure_cell_seal_passphrase.c in Sources */,
-				9F52B0C3263D310F0025EB78 /* soter_rsa_common.c in Sources */,
-				9F52B0C4263D310F0025EB78 /* soter_rsa_key_pair_gen.c in Sources */,
-				9F52B0C5263D310F0025EB78 /* soter_rsa_key.c in Sources */,
-				9F52B0C6263D310F0025EB78 /* soter_kdf.c in Sources */,
-				9F52B0C7263D310F0025EB78 /* soter_wipe.c in Sources */,
-				9F52B0C8263D310F0025EB78 /* soter_sign_ecdsa.c in Sources */,
-				9F52B0C9263D310F0025EB78 /* soter_sign_rsa.c in Sources */,
-				9F52B0CA263D310F0025EB78 /* soter_sym.c in Sources */,
-				9F52B0CB263D310F0025EB78 /* soter_verify_ecdsa.c in Sources */,
-				9F52B0CC263D310F0025EB78 /* soter_verify_rsa.c in Sources */,
 				9F52B0CD263D310F0025EB78 /* ge_p2_to_p3.c in Sources */,
 				9F52B0CE263D310F0025EB78 /* ge_p3_0.c in Sources */,
 				9F52B0CF263D310F0025EB78 /* soter_rsa_key.c in Sources */,

--- a/Themis.xcodeproj/project.pbxproj
+++ b/Themis.xcodeproj/project.pbxproj
@@ -806,7 +806,6 @@
 		9F52B083263D30430025EB78 /* scell_seal.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24B0223A8FA7005CB63A /* scell_seal.m */; };
 		9F52B084263D30430025EB78 /* skeygen.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24B7223A8FA8005CB63A /* skeygen.m */; };
 		9F52B085263D30430025EB78 /* scomparator.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24B6223A8FA8005CB63A /* scomparator.m */; };
-		9F52B087263D30430025EB78 /* openssl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FBD853C223BFB5E009EAEB3 /* openssl.framework */; };
 		9F52B09E263D310F0025EB78 /* themis.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F0BBCE824E6FC810073CA52 /* themis.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9F52B09F263D310F0025EB78 /* objcthemis.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A24B5223A8FA8005CB63A /* objcthemis.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9F52B0A0263D310F0025EB78 /* scell_context_imprint.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A24B9223A8FA8005CB63A /* scell_context_imprint.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -889,7 +888,6 @@
 		9F52B0FE263D310F0025EB78 /* smessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24B8223A8FA8005CB63A /* smessage.m */; };
 		9F52B0FF263D310F0025EB78 /* ssession_transport_interface.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24B2223A8FA7005CB63A /* ssession_transport_interface.m */; };
 		9F52B100263D310F0025EB78 /* ssession.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24BA223A8FA8005CB63A /* ssession.m */; };
-		9F52B102263D310F0025EB78 /* openssl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E940223C1AFA00EC1EF3 /* openssl.framework */; };
 		9F52B138263D32F30025EB78 /* soter_asym_cipher.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B017263D2F840025EB78 /* soter_asym_cipher.c */; };
 		9F52B139263D32F30025EB78 /* soter_asym_ka.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B020263D2F850025EB78 /* soter_asym_ka.c */; };
 		9F52B13A263D32F30025EB78 /* soter_ec_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B01E263D2F850025EB78 /* soter_ec_key.c */; };
@@ -922,6 +920,8 @@
 		9F52B167263D33290025EB78 /* soter_verify_ecdsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B01D263D2F850025EB78 /* soter_verify_ecdsa.c */; };
 		9F52B168263D33290025EB78 /* soter_verify_rsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B014263D2F840025EB78 /* soter_verify_rsa.c */; };
 		9F52B169263D33290025EB78 /* soter_wipe.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B015263D2F840025EB78 /* soter_wipe.c */; };
+		9F52B170263D35120025EB78 /* libboringssl.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F56693F25546397005CF297 /* libboringssl.a */; };
+		9F52B173263D35270025EB78 /* libboringssl.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F56694F255463B5005CF297 /* libboringssl.a */; };
 		9F6B385523D9D11600EA5D1B /* secure_cell_seal_passphrase.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F6B385423D9D11600EA5D1B /* secure_cell_seal_passphrase.c */; };
 		9F6B385623D9D11600EA5D1B /* secure_cell_seal_passphrase.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F6B385423D9D11600EA5D1B /* secure_cell_seal_passphrase.c */; };
 		9F70B2C1241D0FEC009CB629 /* themis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E8D7223C197900EC1EF3 /* themis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -1264,6 +1264,20 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		9F52B171263D35180025EB78 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 738B81062239809D00A9947C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9F56693E25546397005CF297;
+			remoteInfo = "BoringSSL (iOS)";
+		};
+		9F52B174263D352D0025EB78 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 738B81062239809D00A9947C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9F56694E255463B5005CF297;
+			remoteInfo = "BoringSSL (macOS)";
+		};
 		9F70B2C2241D0FEC009CB629 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 738B81062239809D00A9947C /* Project object */;
@@ -2038,7 +2052,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9F52B087263D30430025EB78 /* openssl.framework in Frameworks */,
+				9F52B170263D35120025EB78 /* libboringssl.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2046,7 +2060,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9F52B102263D310F0025EB78 /* openssl.framework in Frameworks */,
+				9F52B173263D35270025EB78 /* libboringssl.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3131,6 +3145,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				9F52B172263D35180025EB78 /* PBXTargetDependency */,
 			);
 			name = "Themis (iOS) - BoringSSL";
 			productName = Themis;
@@ -3148,6 +3163,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				9F52B175263D352D0025EB78 /* PBXTargetDependency */,
 			);
 			name = "Themis (macOS) - BoringSSL";
 			productName = "Themis (macOS)";
@@ -4573,6 +4589,16 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		9F52B172263D35180025EB78 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9F56693E25546397005CF297 /* BoringSSL (iOS) */;
+			targetProxy = 9F52B171263D35180025EB78 /* PBXContainerItemProxy */;
+		};
+		9F52B175263D352D0025EB78 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9F56694E255463B5005CF297 /* BoringSSL (macOS) */;
+			targetProxy = 9F52B174263D352D0025EB78 /* PBXContainerItemProxy */;
+		};
 		9F70B2C3241D0FEC009CB629 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 9F00E8D6223C197900EC1EF3 /* Themis (macOS) */;

--- a/Themis.xcodeproj/project.pbxproj
+++ b/Themis.xcodeproj/project.pbxproj
@@ -724,6 +724,204 @@
 		9F4A2621223ABEF2005CB63A /* secure_session.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2438223A74AF005CB63A /* secure_session.c */; };
 		9F4A2622223ABEF2005CB63A /* sym_enc_message.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2431223A74AF005CB63A /* sym_enc_message.c */; };
 		9F4F7C57C0E7986C44CFAE37 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		9F52B023263D30430025EB78 /* themis.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F0BBCE824E6FC810073CA52 /* themis.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F52B024263D30430025EB78 /* objcthemis.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A24B5223A8FA8005CB63A /* objcthemis.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F52B025263D30430025EB78 /* scell_context_imprint.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A24B9223A8FA8005CB63A /* scell_context_imprint.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F52B026263D30430025EB78 /* scell_seal.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A24BC223A8FA8005CB63A /* scell_seal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F52B027263D30430025EB78 /* scell_token.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A24C3223A8FA8005CB63A /* scell_token.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F52B028263D30430025EB78 /* scell.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A24B3223A8FA7005CB63A /* scell.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F52B029263D30430025EB78 /* scomparator.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A24C0223A8FA8005CB63A /* scomparator.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F52B02A263D30430025EB78 /* serror.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A24BB223A8FA8005CB63A /* serror.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F52B02B263D30430025EB78 /* skeygen.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A24C1223A8FA8005CB63A /* skeygen.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F52B02C263D30430025EB78 /* smessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A24C2223A8FA8005CB63A /* smessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F52B02D263D30430025EB78 /* ssession_transport_interface.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A24BF223A8FA8005CB63A /* ssession_transport_interface.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F52B02E263D30430025EB78 /* ssession.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A24B1223A8FA7005CB63A /* ssession.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F52B030263D30430025EB78 /* secure_cell.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A241E223A74AE005CB63A /* secure_cell.c */; };
+		9F52B031263D30430025EB78 /* secure_comparator.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2432223A74AF005CB63A /* secure_comparator.c */; };
+		9F52B032263D30430025EB78 /* secure_keygen.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2427223A74AE005CB63A /* secure_keygen.c */; };
+		9F52B033263D30430025EB78 /* secure_message_wrapper.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2422223A74AE005CB63A /* secure_message_wrapper.c */; };
+		9F52B034263D30430025EB78 /* secure_message.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2437223A74AF005CB63A /* secure_message.c */; };
+		9F52B035263D30430025EB78 /* secure_session_message.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2435223A74AF005CB63A /* secure_session_message.c */; };
+		9F52B036263D30430025EB78 /* secure_session_peer.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2429223A74AF005CB63A /* secure_session_peer.c */; };
+		9F52B037263D30430025EB78 /* secure_session_serialize.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2425223A74AE005CB63A /* secure_session_serialize.c */; };
+		9F52B038263D30430025EB78 /* secure_session_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A242E223A74AF005CB63A /* secure_session_utils.c */; };
+		9F52B039263D30430025EB78 /* secure_session.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2438223A74AF005CB63A /* secure_session.c */; };
+		9F52B03A263D30430025EB78 /* sym_enc_message.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2431223A74AF005CB63A /* sym_enc_message.c */; };
+		9F52B03B263D30430025EB78 /* soter_container.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2348223A73B0005CB63A /* soter_container.c */; };
+		9F52B03C263D30430025EB78 /* soter_crc32.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A234D223A73B0005CB63A /* soter_crc32.c */; };
+		9F52B03D263D30430025EB78 /* soter_hmac.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2353223A73B1005CB63A /* soter_hmac.c */; };
+		9F52B03E263D30430025EB78 /* soter_kdf.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2357223A73B1005CB63A /* soter_kdf.c */; };
+		9F52B03F263D30430025EB78 /* soter_sign.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2351223A73B1005CB63A /* soter_sign.c */; };
+		9F52B040263D30430025EB78 /* soter_asym_cipher.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A238F223A7426005CB63A /* soter_asym_cipher.c */; };
+		9F52B041263D30430025EB78 /* soter_asym_ka.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2388223A7425005CB63A /* soter_asym_ka.c */; };
+		9F52B042263D30430025EB78 /* soter_ec_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2392223A7426005CB63A /* soter_ec_key.c */; };
+		9F52B043263D30430025EB78 /* soter_ecdsa_common.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2387223A7425005CB63A /* soter_ecdsa_common.c */; };
+		9F52B044263D30430025EB78 /* soter_hash.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2390223A7426005CB63A /* soter_hash.c */; };
+		9F52B045263D30430025EB78 /* soter_rand.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A238E223A7426005CB63A /* soter_rand.c */; };
+		9F52B046263D30430025EB78 /* soter_ec_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F874AB122CCB0D100E8DECA /* soter_ec_key.c */; };
+		9F52B047263D30430025EB78 /* secure_cell_seal_passphrase.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F6B385423D9D11600EA5D1B /* secure_cell_seal_passphrase.c */; };
+		9F52B048263D30430025EB78 /* soter_rsa_common.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2386223A7425005CB63A /* soter_rsa_common.c */; };
+		9F52B049263D30430025EB78 /* soter_rsa_key_pair_gen.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A238A223A7425005CB63A /* soter_rsa_key_pair_gen.c */; };
+		9F52B04A263D30430025EB78 /* soter_rsa_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2385223A7425005CB63A /* soter_rsa_key.c */; };
+		9F52B04B263D30430025EB78 /* soter_kdf.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F33485723B38D9B00368291 /* soter_kdf.c */; };
+		9F52B04C263D30430025EB78 /* soter_wipe.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F98F32722CCEB0E008E14E6 /* soter_wipe.c */; };
+		9F52B04D263D30430025EB78 /* soter_sign_ecdsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2389223A7425005CB63A /* soter_sign_ecdsa.c */; };
+		9F52B04E263D30430025EB78 /* soter_sign_rsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A238C223A7425005CB63A /* soter_sign_rsa.c */; };
+		9F52B04F263D30430025EB78 /* soter_sym.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2394223A7426005CB63A /* soter_sym.c */; };
+		9F52B050263D30430025EB78 /* soter_verify_ecdsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2393223A7426005CB63A /* soter_verify_ecdsa.c */; };
+		9F52B051263D30430025EB78 /* soter_verify_rsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A238D223A7426005CB63A /* soter_verify_rsa.c */; };
+		9F52B052263D30430025EB78 /* fe_0.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B3223A745B005CB63A /* fe_0.c */; };
+		9F52B053263D30430025EB78 /* fe_1.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23CF223A745C005CB63A /* fe_1.c */; };
+		9F52B054263D30430025EB78 /* soter_rsa_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F874AB222CCB0D100E8DECA /* soter_rsa_key.c */; };
+		9F52B055263D30430025EB78 /* fe_add.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B1223A745A005CB63A /* fe_add.c */; };
+		9F52B056263D30430025EB78 /* fe_cmov.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23A8223A745A005CB63A /* fe_cmov.c */; };
+		9F52B057263D30430025EB78 /* fe_copy.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B6223A745B005CB63A /* fe_copy.c */; };
+		9F52B058263D30430025EB78 /* fe_frombytes.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23AC223A745A005CB63A /* fe_frombytes.c */; };
+		9F52B059263D30430025EB78 /* fe_invert.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23D3223A745D005CB63A /* fe_invert.c */; };
+		9F52B05A263D30430025EB78 /* fe_isnegative.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23BE223A745B005CB63A /* fe_isnegative.c */; };
+		9F52B05B263D30430025EB78 /* fe_isnonzero.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B9223A745B005CB63A /* fe_isnonzero.c */; };
+		9F52B05C263D30430025EB78 /* fe_mul.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23D1223A745C005CB63A /* fe_mul.c */; };
+		9F52B05D263D30430025EB78 /* fe_neg.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23BC223A745B005CB63A /* fe_neg.c */; };
+		9F52B05E263D30430025EB78 /* fe_pow22523.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23DD223A745D005CB63A /* fe_pow22523.c */; };
+		9F52B05F263D30430025EB78 /* fe_sq.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23E0223A745D005CB63A /* fe_sq.c */; };
+		9F52B060263D30430025EB78 /* fe_sq2.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B8223A745B005CB63A /* fe_sq2.c */; };
+		9F52B061263D30430025EB78 /* fe_sub.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23A9223A745A005CB63A /* fe_sub.c */; };
+		9F52B062263D30430025EB78 /* fe_tobytes.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23D2223A745D005CB63A /* fe_tobytes.c */; };
+		9F52B063263D30430025EB78 /* ge_add.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23DA223A745D005CB63A /* ge_add.c */; };
+		9F52B064263D30430025EB78 /* ge_cmp.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23C0223A745B005CB63A /* ge_cmp.c */; };
+		9F52B065263D30430025EB78 /* ge_double_scalarmult.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23BA223A745B005CB63A /* ge_double_scalarmult.c */; };
+		9F52B066263D30430025EB78 /* ge_frombytes_no_negate.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23D5223A745D005CB63A /* ge_frombytes_no_negate.c */; };
+		9F52B067263D30430025EB78 /* ge_frombytes.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23A7223A745A005CB63A /* ge_frombytes.c */; };
+		9F52B068263D30430025EB78 /* ge_madd.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23DB223A745D005CB63A /* ge_madd.c */; };
+		9F52B069263D30430025EB78 /* ge_msub.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23C6223A745C005CB63A /* ge_msub.c */; };
+		9F52B06A263D30430025EB78 /* ge_p1p1_to_p2.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23CC223A745C005CB63A /* ge_p1p1_to_p2.c */; };
+		9F52B06B263D30430025EB78 /* ge_p1p1_to_p3.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23DC223A745D005CB63A /* ge_p1p1_to_p3.c */; };
+		9F52B06C263D30430025EB78 /* ge_p2_0.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23D7223A745D005CB63A /* ge_p2_0.c */; };
+		9F52B06D263D30430025EB78 /* ge_p2_dbl.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B4223A745B005CB63A /* ge_p2_dbl.c */; };
+		9F52B06E263D30430025EB78 /* ge_p2_to_p3.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B2223A745A005CB63A /* ge_p2_to_p3.c */; };
+		9F52B06F263D30430025EB78 /* ge_p3_0.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23BB223A745B005CB63A /* ge_p3_0.c */; };
+		9F52B070263D30430025EB78 /* ge_p3_dbl.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B0223A745A005CB63A /* ge_p3_dbl.c */; };
+		9F52B071263D30430025EB78 /* ge_p3_sub.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23AA223A745A005CB63A /* ge_p3_sub.c */; };
+		9F52B072263D30430025EB78 /* ge_p3_to_cached.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B7223A745B005CB63A /* ge_p3_to_cached.c */; };
+		9F52B073263D30430025EB78 /* ge_p3_to_p2.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23C7223A745C005CB63A /* ge_p3_to_p2.c */; };
+		9F52B074263D30430025EB78 /* ge_p3_tobytes.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23C9223A745C005CB63A /* ge_p3_tobytes.c */; };
+		9F52B075263D30430025EB78 /* ge_precomp_0.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23BF223A745B005CB63A /* ge_precomp_0.c */; };
+		9F52B076263D30430025EB78 /* ge_scalarmult_base.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23DF223A745D005CB63A /* ge_scalarmult_base.c */; };
+		9F52B077263D30430025EB78 /* ge_scalarmult.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23E1223A745E005CB63A /* ge_scalarmult.c */; };
+		9F52B078263D30430025EB78 /* ge_sub.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B5223A745B005CB63A /* ge_sub.c */; };
+		9F52B079263D30430025EB78 /* ge_tobytes.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23AD223A745A005CB63A /* ge_tobytes.c */; };
+		9F52B07A263D30430025EB78 /* gen_rand_32.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23D8223A745D005CB63A /* gen_rand_32.c */; };
+		9F52B07B263D30430025EB78 /* sc_muladd.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23CE223A745C005CB63A /* sc_muladd.c */; };
+		9F52B07C263D30430025EB78 /* sc_reduce.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23C2223A745B005CB63A /* sc_reduce.c */; };
+		9F52B07D263D30430025EB78 /* scell.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24BE223A8FA8005CB63A /* scell.m */; };
+		9F52B07E263D30430025EB78 /* ssession_transport_interface.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24B2223A8FA7005CB63A /* ssession_transport_interface.m */; };
+		9F52B07F263D30430025EB78 /* smessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24B8223A8FA8005CB63A /* smessage.m */; };
+		9F52B080263D30430025EB78 /* ssession.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24BA223A8FA8005CB63A /* ssession.m */; };
+		9F52B081263D30430025EB78 /* scell_token.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24BD223A8FA8005CB63A /* scell_token.m */; };
+		9F52B082263D30430025EB78 /* scell_context_imprint.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24B4223A8FA8005CB63A /* scell_context_imprint.m */; };
+		9F52B083263D30430025EB78 /* scell_seal.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24B0223A8FA7005CB63A /* scell_seal.m */; };
+		9F52B084263D30430025EB78 /* skeygen.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24B7223A8FA8005CB63A /* skeygen.m */; };
+		9F52B085263D30430025EB78 /* scomparator.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24B6223A8FA8005CB63A /* scomparator.m */; };
+		9F52B087263D30430025EB78 /* openssl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FBD853C223BFB5E009EAEB3 /* openssl.framework */; };
+		9F52B09E263D310F0025EB78 /* themis.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F0BBCE824E6FC810073CA52 /* themis.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F52B09F263D310F0025EB78 /* objcthemis.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A24B5223A8FA8005CB63A /* objcthemis.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F52B0A0263D310F0025EB78 /* scell_context_imprint.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A24B9223A8FA8005CB63A /* scell_context_imprint.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F52B0A1263D310F0025EB78 /* scell_seal.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A24BC223A8FA8005CB63A /* scell_seal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F52B0A2263D310F0025EB78 /* scell_token.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A24C3223A8FA8005CB63A /* scell_token.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F52B0A3263D310F0025EB78 /* scell.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A24B3223A8FA7005CB63A /* scell.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F52B0A4263D310F0025EB78 /* scomparator.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A24C0223A8FA8005CB63A /* scomparator.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F52B0A5263D310F0025EB78 /* serror.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A24BB223A8FA8005CB63A /* serror.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F52B0A6263D310F0025EB78 /* skeygen.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A24C1223A8FA8005CB63A /* skeygen.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F52B0A7263D310F0025EB78 /* smessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A24C2223A8FA8005CB63A /* smessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F52B0A8263D310F0025EB78 /* ssession_transport_interface.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A24BF223A8FA8005CB63A /* ssession_transport_interface.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F52B0A9263D310F0025EB78 /* ssession.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A24B1223A8FA7005CB63A /* ssession.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F52B0AB263D310F0025EB78 /* secure_cell.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A241E223A74AE005CB63A /* secure_cell.c */; };
+		9F52B0AC263D310F0025EB78 /* secure_comparator.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2432223A74AF005CB63A /* secure_comparator.c */; };
+		9F52B0AD263D310F0025EB78 /* secure_keygen.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2427223A74AE005CB63A /* secure_keygen.c */; };
+		9F52B0AE263D310F0025EB78 /* secure_message_wrapper.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2422223A74AE005CB63A /* secure_message_wrapper.c */; };
+		9F52B0AF263D310F0025EB78 /* secure_message.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2437223A74AF005CB63A /* secure_message.c */; };
+		9F52B0B0263D310F0025EB78 /* secure_session_message.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2435223A74AF005CB63A /* secure_session_message.c */; };
+		9F52B0B1263D310F0025EB78 /* secure_session_peer.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2429223A74AF005CB63A /* secure_session_peer.c */; };
+		9F52B0B2263D310F0025EB78 /* secure_session_serialize.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2425223A74AE005CB63A /* secure_session_serialize.c */; };
+		9F52B0B3263D310F0025EB78 /* secure_session_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A242E223A74AF005CB63A /* secure_session_utils.c */; };
+		9F52B0B4263D310F0025EB78 /* secure_session.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2438223A74AF005CB63A /* secure_session.c */; };
+		9F52B0B5263D310F0025EB78 /* sym_enc_message.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2431223A74AF005CB63A /* sym_enc_message.c */; };
+		9F52B0B6263D310F0025EB78 /* soter_container.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2348223A73B0005CB63A /* soter_container.c */; };
+		9F52B0B7263D310F0025EB78 /* soter_crc32.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A234D223A73B0005CB63A /* soter_crc32.c */; };
+		9F52B0B8263D310F0025EB78 /* soter_hmac.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2353223A73B1005CB63A /* soter_hmac.c */; };
+		9F52B0B9263D310F0025EB78 /* soter_kdf.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2357223A73B1005CB63A /* soter_kdf.c */; };
+		9F52B0BA263D310F0025EB78 /* soter_sign.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2351223A73B1005CB63A /* soter_sign.c */; };
+		9F52B0BB263D310F0025EB78 /* soter_asym_cipher.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A238F223A7426005CB63A /* soter_asym_cipher.c */; };
+		9F52B0BC263D310F0025EB78 /* soter_asym_ka.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2388223A7425005CB63A /* soter_asym_ka.c */; };
+		9F52B0BD263D310F0025EB78 /* soter_ec_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2392223A7426005CB63A /* soter_ec_key.c */; };
+		9F52B0BE263D310F0025EB78 /* soter_ecdsa_common.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2387223A7425005CB63A /* soter_ecdsa_common.c */; };
+		9F52B0BF263D310F0025EB78 /* soter_hash.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2390223A7426005CB63A /* soter_hash.c */; };
+		9F52B0C0263D310F0025EB78 /* soter_rand.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A238E223A7426005CB63A /* soter_rand.c */; };
+		9F52B0C1263D310F0025EB78 /* soter_ec_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F874AB122CCB0D100E8DECA /* soter_ec_key.c */; };
+		9F52B0C2263D310F0025EB78 /* secure_cell_seal_passphrase.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F6B385423D9D11600EA5D1B /* secure_cell_seal_passphrase.c */; };
+		9F52B0C3263D310F0025EB78 /* soter_rsa_common.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2386223A7425005CB63A /* soter_rsa_common.c */; };
+		9F52B0C4263D310F0025EB78 /* soter_rsa_key_pair_gen.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A238A223A7425005CB63A /* soter_rsa_key_pair_gen.c */; };
+		9F52B0C5263D310F0025EB78 /* soter_rsa_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2385223A7425005CB63A /* soter_rsa_key.c */; };
+		9F52B0C6263D310F0025EB78 /* soter_kdf.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F33485723B38D9B00368291 /* soter_kdf.c */; };
+		9F52B0C7263D310F0025EB78 /* soter_wipe.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F98F32722CCEB0E008E14E6 /* soter_wipe.c */; };
+		9F52B0C8263D310F0025EB78 /* soter_sign_ecdsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2389223A7425005CB63A /* soter_sign_ecdsa.c */; };
+		9F52B0C9263D310F0025EB78 /* soter_sign_rsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A238C223A7425005CB63A /* soter_sign_rsa.c */; };
+		9F52B0CA263D310F0025EB78 /* soter_sym.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2394223A7426005CB63A /* soter_sym.c */; };
+		9F52B0CB263D310F0025EB78 /* soter_verify_ecdsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2393223A7426005CB63A /* soter_verify_ecdsa.c */; };
+		9F52B0CC263D310F0025EB78 /* soter_verify_rsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A238D223A7426005CB63A /* soter_verify_rsa.c */; };
+		9F52B0CD263D310F0025EB78 /* ge_p2_to_p3.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B2223A745A005CB63A /* ge_p2_to_p3.c */; };
+		9F52B0CE263D310F0025EB78 /* ge_p3_0.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23BB223A745B005CB63A /* ge_p3_0.c */; };
+		9F52B0CF263D310F0025EB78 /* soter_rsa_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F874AB222CCB0D100E8DECA /* soter_rsa_key.c */; };
+		9F52B0D0263D310F0025EB78 /* ge_p3_dbl.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B0223A745A005CB63A /* ge_p3_dbl.c */; };
+		9F52B0D1263D310F0025EB78 /* ge_p3_sub.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23AA223A745A005CB63A /* ge_p3_sub.c */; };
+		9F52B0D2263D310F0025EB78 /* ge_p3_to_cached.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B7223A745B005CB63A /* ge_p3_to_cached.c */; };
+		9F52B0D3263D310F0025EB78 /* ge_p3_to_p2.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23C7223A745C005CB63A /* ge_p3_to_p2.c */; };
+		9F52B0D4263D310F0025EB78 /* ge_p3_tobytes.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23C9223A745C005CB63A /* ge_p3_tobytes.c */; };
+		9F52B0D5263D310F0025EB78 /* ge_precomp_0.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23BF223A745B005CB63A /* ge_precomp_0.c */; };
+		9F52B0D6263D310F0025EB78 /* ge_scalarmult_base.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23DF223A745D005CB63A /* ge_scalarmult_base.c */; };
+		9F52B0D7263D310F0025EB78 /* ge_scalarmult.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23E1223A745E005CB63A /* ge_scalarmult.c */; };
+		9F52B0D8263D310F0025EB78 /* ge_sub.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B5223A745B005CB63A /* ge_sub.c */; };
+		9F52B0D9263D310F0025EB78 /* ge_tobytes.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23AD223A745A005CB63A /* ge_tobytes.c */; };
+		9F52B0DA263D310F0025EB78 /* gen_rand_32.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23D8223A745D005CB63A /* gen_rand_32.c */; };
+		9F52B0DB263D310F0025EB78 /* sc_muladd.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23CE223A745C005CB63A /* sc_muladd.c */; };
+		9F52B0DC263D310F0025EB78 /* sc_reduce.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23C2223A745B005CB63A /* sc_reduce.c */; };
+		9F52B0DD263D310F0025EB78 /* ge_cmp.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23C0223A745B005CB63A /* ge_cmp.c */; };
+		9F52B0DE263D310F0025EB78 /* ge_double_scalarmult.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23BA223A745B005CB63A /* ge_double_scalarmult.c */; };
+		9F52B0DF263D310F0025EB78 /* ge_frombytes_no_negate.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23D5223A745D005CB63A /* ge_frombytes_no_negate.c */; };
+		9F52B0E0263D310F0025EB78 /* ge_frombytes.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23A7223A745A005CB63A /* ge_frombytes.c */; };
+		9F52B0E1263D310F0025EB78 /* ge_madd.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23DB223A745D005CB63A /* ge_madd.c */; };
+		9F52B0E2263D310F0025EB78 /* ge_msub.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23C6223A745C005CB63A /* ge_msub.c */; };
+		9F52B0E3263D310F0025EB78 /* ge_p1p1_to_p2.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23CC223A745C005CB63A /* ge_p1p1_to_p2.c */; };
+		9F52B0E4263D310F0025EB78 /* ge_p1p1_to_p3.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23DC223A745D005CB63A /* ge_p1p1_to_p3.c */; };
+		9F52B0E5263D310F0025EB78 /* ge_p2_0.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23D7223A745D005CB63A /* ge_p2_0.c */; };
+		9F52B0E6263D310F0025EB78 /* ge_p2_dbl.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B4223A745B005CB63A /* ge_p2_dbl.c */; };
+		9F52B0E7263D310F0025EB78 /* fe_0.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B3223A745B005CB63A /* fe_0.c */; };
+		9F52B0E8263D310F0025EB78 /* fe_1.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23CF223A745C005CB63A /* fe_1.c */; };
+		9F52B0E9263D310F0025EB78 /* fe_add.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B1223A745A005CB63A /* fe_add.c */; };
+		9F52B0EA263D310F0025EB78 /* fe_cmov.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23A8223A745A005CB63A /* fe_cmov.c */; };
+		9F52B0EB263D310F0025EB78 /* fe_copy.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B6223A745B005CB63A /* fe_copy.c */; };
+		9F52B0EC263D310F0025EB78 /* fe_frombytes.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23AC223A745A005CB63A /* fe_frombytes.c */; };
+		9F52B0ED263D310F0025EB78 /* fe_invert.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23D3223A745D005CB63A /* fe_invert.c */; };
+		9F52B0EE263D310F0025EB78 /* fe_isnegative.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23BE223A745B005CB63A /* fe_isnegative.c */; };
+		9F52B0EF263D310F0025EB78 /* fe_isnonzero.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B9223A745B005CB63A /* fe_isnonzero.c */; };
+		9F52B0F0263D310F0025EB78 /* fe_mul.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23D1223A745C005CB63A /* fe_mul.c */; };
+		9F52B0F1263D310F0025EB78 /* fe_neg.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23BC223A745B005CB63A /* fe_neg.c */; };
+		9F52B0F2263D310F0025EB78 /* fe_pow22523.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23DD223A745D005CB63A /* fe_pow22523.c */; };
+		9F52B0F3263D310F0025EB78 /* fe_sq.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23E0223A745D005CB63A /* fe_sq.c */; };
+		9F52B0F4263D310F0025EB78 /* fe_sq2.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23B8223A745B005CB63A /* fe_sq2.c */; };
+		9F52B0F5263D310F0025EB78 /* fe_sub.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23A9223A745A005CB63A /* fe_sub.c */; };
+		9F52B0F6263D310F0025EB78 /* fe_tobytes.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23D2223A745D005CB63A /* fe_tobytes.c */; };
+		9F52B0F7263D310F0025EB78 /* ge_add.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A23DA223A745D005CB63A /* ge_add.c */; };
+		9F52B0F8263D310F0025EB78 /* scell_context_imprint.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24B4223A8FA8005CB63A /* scell_context_imprint.m */; };
+		9F52B0F9263D310F0025EB78 /* scell_seal.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24B0223A8FA7005CB63A /* scell_seal.m */; };
+		9F52B0FA263D310F0025EB78 /* scell_token.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24BD223A8FA8005CB63A /* scell_token.m */; };
+		9F52B0FB263D310F0025EB78 /* scell.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24BE223A8FA8005CB63A /* scell.m */; };
+		9F52B0FC263D310F0025EB78 /* scomparator.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24B6223A8FA8005CB63A /* scomparator.m */; };
+		9F52B0FD263D310F0025EB78 /* skeygen.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24B7223A8FA8005CB63A /* skeygen.m */; };
+		9F52B0FE263D310F0025EB78 /* smessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24B8223A8FA8005CB63A /* smessage.m */; };
+		9F52B0FF263D310F0025EB78 /* ssession_transport_interface.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24B2223A8FA7005CB63A /* ssession_transport_interface.m */; };
+		9F52B100263D310F0025EB78 /* ssession.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A24BA223A8FA8005CB63A /* ssession.m */; };
+		9F52B102263D310F0025EB78 /* openssl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E940223C1AFA00EC1EF3 /* openssl.framework */; };
 		9F6B385523D9D11600EA5D1B /* secure_cell_seal_passphrase.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F6B385423D9D11600EA5D1B /* secure_cell_seal_passphrase.c */; };
 		9F6B385623D9D11600EA5D1B /* secure_cell_seal_passphrase.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F6B385423D9D11600EA5D1B /* secure_cell_seal_passphrase.c */; };
 		9F70B2C1241D0FEC009CB629 /* themis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E8D7223C197900EC1EF3 /* themis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -1698,6 +1896,8 @@
 		9F52B01E263D2F850025EB78 /* soter_ec_key.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = soter_ec_key.c; path = src/soter/boringssl/soter_ec_key.c; sourceTree = "<group>"; };
 		9F52B01F263D2F850025EB78 /* soter_sign_rsa.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = soter_sign_rsa.c; path = src/soter/boringssl/soter_sign_rsa.c; sourceTree = "<group>"; };
 		9F52B020263D2F850025EB78 /* soter_asym_ka.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = soter_asym_ka.c; path = src/soter/boringssl/soter_asym_ka.c; sourceTree = "<group>"; };
+		9F52B08B263D30430025EB78 /* themis.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = themis.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9F52B106263D310F0025EB78 /* themis.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = themis.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9F56693F25546397005CF297 /* libboringssl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libboringssl.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		9F56694F255463B5005CF297 /* libboringssl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libboringssl.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		9F6B385423D9D11600EA5D1B /* secure_cell_seal_passphrase.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = secure_cell_seal_passphrase.c; path = src/themis/secure_cell_seal_passphrase.c; sourceTree = "<group>"; };
@@ -1831,6 +2031,22 @@
 			buildActionMask = 2147483647;
 			files = (
 				9FBD853D223BFB5E009EAEB3 /* openssl.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9F52B086263D30430025EB78 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9F52B087263D30430025EB78 /* openssl.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9F52B101263D310F0025EB78 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9F52B102263D310F0025EB78 /* openssl.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2336,6 +2552,8 @@
 				9F70B3312420E176009CB629 /* Test Themis (Swift 4, macOS).xctest */,
 				9F56693F25546397005CF297 /* libboringssl.a */,
 				9F56694F255463B5005CF297 /* libboringssl.a */,
+				9F52B08B263D30430025EB78 /* themis.framework */,
+				9F52B106263D310F0025EB78 /* themis.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2784,6 +3002,44 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		9F52B022263D30430025EB78 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9F52B023263D30430025EB78 /* themis.h in Headers */,
+				9F52B024263D30430025EB78 /* objcthemis.h in Headers */,
+				9F52B025263D30430025EB78 /* scell_context_imprint.h in Headers */,
+				9F52B026263D30430025EB78 /* scell_seal.h in Headers */,
+				9F52B027263D30430025EB78 /* scell_token.h in Headers */,
+				9F52B028263D30430025EB78 /* scell.h in Headers */,
+				9F52B029263D30430025EB78 /* scomparator.h in Headers */,
+				9F52B02A263D30430025EB78 /* serror.h in Headers */,
+				9F52B02B263D30430025EB78 /* skeygen.h in Headers */,
+				9F52B02C263D30430025EB78 /* smessage.h in Headers */,
+				9F52B02D263D30430025EB78 /* ssession_transport_interface.h in Headers */,
+				9F52B02E263D30430025EB78 /* ssession.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9F52B09D263D310F0025EB78 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9F52B09E263D310F0025EB78 /* themis.h in Headers */,
+				9F52B09F263D310F0025EB78 /* objcthemis.h in Headers */,
+				9F52B0A0263D310F0025EB78 /* scell_context_imprint.h in Headers */,
+				9F52B0A1263D310F0025EB78 /* scell_seal.h in Headers */,
+				9F52B0A2263D310F0025EB78 /* scell_token.h in Headers */,
+				9F52B0A3263D310F0025EB78 /* scell.h in Headers */,
+				9F52B0A4263D310F0025EB78 /* scomparator.h in Headers */,
+				9F52B0A5263D310F0025EB78 /* serror.h in Headers */,
+				9F52B0A6263D310F0025EB78 /* skeygen.h in Headers */,
+				9F52B0A7263D310F0025EB78 /* smessage.h in Headers */,
+				9F52B0A8263D310F0025EB78 /* ssession_transport_interface.h in Headers */,
+				9F52B0A9263D310F0025EB78 /* ssession.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9F56694B255463B5005CF297 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -2862,6 +3118,40 @@
 			name = "Themis (iOS)";
 			productName = Themis;
 			productReference = 9F4A24A1223A8D7F005CB63A /* themis.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		9F52B021263D30430025EB78 /* Themis (iOS) - BoringSSL */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9F52B088263D30430025EB78 /* Build configuration list for PBXNativeTarget "Themis (iOS) - BoringSSL" */;
+			buildPhases = (
+				9F52B022263D30430025EB78 /* Headers */,
+				9F52B02F263D30430025EB78 /* Sources */,
+				9F52B086263D30430025EB78 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Themis (iOS) - BoringSSL";
+			productName = Themis;
+			productReference = 9F52B08B263D30430025EB78 /* themis.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		9F52B09C263D310F0025EB78 /* Themis (macOS) - BoringSSL */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9F52B103263D310F0025EB78 /* Build configuration list for PBXNativeTarget "Themis (macOS) - BoringSSL" */;
+			buildPhases = (
+				9F52B09D263D310F0025EB78 /* Headers */,
+				9F52B0AA263D310F0025EB78 /* Sources */,
+				9F52B101263D310F0025EB78 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Themis (macOS) - BoringSSL";
+			productName = "Themis (macOS)";
+			productReference = 9F52B106263D310F0025EB78 /* themis.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		9F56693E25546397005CF297 /* BoringSSL (iOS) */ = {
@@ -3018,7 +3308,9 @@
 			projectRoot = "";
 			targets = (
 				9F4A24A0223A8D7F005CB63A /* Themis (iOS) */,
+				9F52B021263D30430025EB78 /* Themis (iOS) - BoringSSL */,
 				9F00E8D6223C197900EC1EF3 /* Themis (macOS) */,
+				9F52B09C263D310F0025EB78 /* Themis (macOS) - BoringSSL */,
 				9F70B3032420E16E009CB629 /* Test Themis (Swift 4, iOS) */,
 				9F70B31B2420E176009CB629 /* Test Themis (Swift 4, macOS) */,
 				9F70B2E6241D17A3009CB629 /* Test Themis (Swift 5, iOS) */,
@@ -3213,6 +3505,192 @@
 				9F4A24C4223A8FA9005CB63A /* scell_seal.m in Sources */,
 				9F4A24CB223A8FA9005CB63A /* skeygen.m in Sources */,
 				9F4A24CA223A8FA9005CB63A /* scomparator.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9F52B02F263D30430025EB78 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9F52B030263D30430025EB78 /* secure_cell.c in Sources */,
+				9F52B031263D30430025EB78 /* secure_comparator.c in Sources */,
+				9F52B032263D30430025EB78 /* secure_keygen.c in Sources */,
+				9F52B033263D30430025EB78 /* secure_message_wrapper.c in Sources */,
+				9F52B034263D30430025EB78 /* secure_message.c in Sources */,
+				9F52B035263D30430025EB78 /* secure_session_message.c in Sources */,
+				9F52B036263D30430025EB78 /* secure_session_peer.c in Sources */,
+				9F52B037263D30430025EB78 /* secure_session_serialize.c in Sources */,
+				9F52B038263D30430025EB78 /* secure_session_utils.c in Sources */,
+				9F52B039263D30430025EB78 /* secure_session.c in Sources */,
+				9F52B03A263D30430025EB78 /* sym_enc_message.c in Sources */,
+				9F52B03B263D30430025EB78 /* soter_container.c in Sources */,
+				9F52B03C263D30430025EB78 /* soter_crc32.c in Sources */,
+				9F52B03D263D30430025EB78 /* soter_hmac.c in Sources */,
+				9F52B03E263D30430025EB78 /* soter_kdf.c in Sources */,
+				9F52B03F263D30430025EB78 /* soter_sign.c in Sources */,
+				9F52B040263D30430025EB78 /* soter_asym_cipher.c in Sources */,
+				9F52B041263D30430025EB78 /* soter_asym_ka.c in Sources */,
+				9F52B042263D30430025EB78 /* soter_ec_key.c in Sources */,
+				9F52B043263D30430025EB78 /* soter_ecdsa_common.c in Sources */,
+				9F52B044263D30430025EB78 /* soter_hash.c in Sources */,
+				9F52B045263D30430025EB78 /* soter_rand.c in Sources */,
+				9F52B046263D30430025EB78 /* soter_ec_key.c in Sources */,
+				9F52B047263D30430025EB78 /* secure_cell_seal_passphrase.c in Sources */,
+				9F52B048263D30430025EB78 /* soter_rsa_common.c in Sources */,
+				9F52B049263D30430025EB78 /* soter_rsa_key_pair_gen.c in Sources */,
+				9F52B04A263D30430025EB78 /* soter_rsa_key.c in Sources */,
+				9F52B04B263D30430025EB78 /* soter_kdf.c in Sources */,
+				9F52B04C263D30430025EB78 /* soter_wipe.c in Sources */,
+				9F52B04D263D30430025EB78 /* soter_sign_ecdsa.c in Sources */,
+				9F52B04E263D30430025EB78 /* soter_sign_rsa.c in Sources */,
+				9F52B04F263D30430025EB78 /* soter_sym.c in Sources */,
+				9F52B050263D30430025EB78 /* soter_verify_ecdsa.c in Sources */,
+				9F52B051263D30430025EB78 /* soter_verify_rsa.c in Sources */,
+				9F52B052263D30430025EB78 /* fe_0.c in Sources */,
+				9F52B053263D30430025EB78 /* fe_1.c in Sources */,
+				9F52B054263D30430025EB78 /* soter_rsa_key.c in Sources */,
+				9F52B055263D30430025EB78 /* fe_add.c in Sources */,
+				9F52B056263D30430025EB78 /* fe_cmov.c in Sources */,
+				9F52B057263D30430025EB78 /* fe_copy.c in Sources */,
+				9F52B058263D30430025EB78 /* fe_frombytes.c in Sources */,
+				9F52B059263D30430025EB78 /* fe_invert.c in Sources */,
+				9F52B05A263D30430025EB78 /* fe_isnegative.c in Sources */,
+				9F52B05B263D30430025EB78 /* fe_isnonzero.c in Sources */,
+				9F52B05C263D30430025EB78 /* fe_mul.c in Sources */,
+				9F52B05D263D30430025EB78 /* fe_neg.c in Sources */,
+				9F52B05E263D30430025EB78 /* fe_pow22523.c in Sources */,
+				9F52B05F263D30430025EB78 /* fe_sq.c in Sources */,
+				9F52B060263D30430025EB78 /* fe_sq2.c in Sources */,
+				9F52B061263D30430025EB78 /* fe_sub.c in Sources */,
+				9F52B062263D30430025EB78 /* fe_tobytes.c in Sources */,
+				9F52B063263D30430025EB78 /* ge_add.c in Sources */,
+				9F52B064263D30430025EB78 /* ge_cmp.c in Sources */,
+				9F52B065263D30430025EB78 /* ge_double_scalarmult.c in Sources */,
+				9F52B066263D30430025EB78 /* ge_frombytes_no_negate.c in Sources */,
+				9F52B067263D30430025EB78 /* ge_frombytes.c in Sources */,
+				9F52B068263D30430025EB78 /* ge_madd.c in Sources */,
+				9F52B069263D30430025EB78 /* ge_msub.c in Sources */,
+				9F52B06A263D30430025EB78 /* ge_p1p1_to_p2.c in Sources */,
+				9F52B06B263D30430025EB78 /* ge_p1p1_to_p3.c in Sources */,
+				9F52B06C263D30430025EB78 /* ge_p2_0.c in Sources */,
+				9F52B06D263D30430025EB78 /* ge_p2_dbl.c in Sources */,
+				9F52B06E263D30430025EB78 /* ge_p2_to_p3.c in Sources */,
+				9F52B06F263D30430025EB78 /* ge_p3_0.c in Sources */,
+				9F52B070263D30430025EB78 /* ge_p3_dbl.c in Sources */,
+				9F52B071263D30430025EB78 /* ge_p3_sub.c in Sources */,
+				9F52B072263D30430025EB78 /* ge_p3_to_cached.c in Sources */,
+				9F52B073263D30430025EB78 /* ge_p3_to_p2.c in Sources */,
+				9F52B074263D30430025EB78 /* ge_p3_tobytes.c in Sources */,
+				9F52B075263D30430025EB78 /* ge_precomp_0.c in Sources */,
+				9F52B076263D30430025EB78 /* ge_scalarmult_base.c in Sources */,
+				9F52B077263D30430025EB78 /* ge_scalarmult.c in Sources */,
+				9F52B078263D30430025EB78 /* ge_sub.c in Sources */,
+				9F52B079263D30430025EB78 /* ge_tobytes.c in Sources */,
+				9F52B07A263D30430025EB78 /* gen_rand_32.c in Sources */,
+				9F52B07B263D30430025EB78 /* sc_muladd.c in Sources */,
+				9F52B07C263D30430025EB78 /* sc_reduce.c in Sources */,
+				9F52B07D263D30430025EB78 /* scell.m in Sources */,
+				9F52B07E263D30430025EB78 /* ssession_transport_interface.m in Sources */,
+				9F52B07F263D30430025EB78 /* smessage.m in Sources */,
+				9F52B080263D30430025EB78 /* ssession.m in Sources */,
+				9F52B081263D30430025EB78 /* scell_token.m in Sources */,
+				9F52B082263D30430025EB78 /* scell_context_imprint.m in Sources */,
+				9F52B083263D30430025EB78 /* scell_seal.m in Sources */,
+				9F52B084263D30430025EB78 /* skeygen.m in Sources */,
+				9F52B085263D30430025EB78 /* scomparator.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9F52B0AA263D310F0025EB78 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9F52B0AB263D310F0025EB78 /* secure_cell.c in Sources */,
+				9F52B0AC263D310F0025EB78 /* secure_comparator.c in Sources */,
+				9F52B0AD263D310F0025EB78 /* secure_keygen.c in Sources */,
+				9F52B0AE263D310F0025EB78 /* secure_message_wrapper.c in Sources */,
+				9F52B0AF263D310F0025EB78 /* secure_message.c in Sources */,
+				9F52B0B0263D310F0025EB78 /* secure_session_message.c in Sources */,
+				9F52B0B1263D310F0025EB78 /* secure_session_peer.c in Sources */,
+				9F52B0B2263D310F0025EB78 /* secure_session_serialize.c in Sources */,
+				9F52B0B3263D310F0025EB78 /* secure_session_utils.c in Sources */,
+				9F52B0B4263D310F0025EB78 /* secure_session.c in Sources */,
+				9F52B0B5263D310F0025EB78 /* sym_enc_message.c in Sources */,
+				9F52B0B6263D310F0025EB78 /* soter_container.c in Sources */,
+				9F52B0B7263D310F0025EB78 /* soter_crc32.c in Sources */,
+				9F52B0B8263D310F0025EB78 /* soter_hmac.c in Sources */,
+				9F52B0B9263D310F0025EB78 /* soter_kdf.c in Sources */,
+				9F52B0BA263D310F0025EB78 /* soter_sign.c in Sources */,
+				9F52B0BB263D310F0025EB78 /* soter_asym_cipher.c in Sources */,
+				9F52B0BC263D310F0025EB78 /* soter_asym_ka.c in Sources */,
+				9F52B0BD263D310F0025EB78 /* soter_ec_key.c in Sources */,
+				9F52B0BE263D310F0025EB78 /* soter_ecdsa_common.c in Sources */,
+				9F52B0BF263D310F0025EB78 /* soter_hash.c in Sources */,
+				9F52B0C0263D310F0025EB78 /* soter_rand.c in Sources */,
+				9F52B0C1263D310F0025EB78 /* soter_ec_key.c in Sources */,
+				9F52B0C2263D310F0025EB78 /* secure_cell_seal_passphrase.c in Sources */,
+				9F52B0C3263D310F0025EB78 /* soter_rsa_common.c in Sources */,
+				9F52B0C4263D310F0025EB78 /* soter_rsa_key_pair_gen.c in Sources */,
+				9F52B0C5263D310F0025EB78 /* soter_rsa_key.c in Sources */,
+				9F52B0C6263D310F0025EB78 /* soter_kdf.c in Sources */,
+				9F52B0C7263D310F0025EB78 /* soter_wipe.c in Sources */,
+				9F52B0C8263D310F0025EB78 /* soter_sign_ecdsa.c in Sources */,
+				9F52B0C9263D310F0025EB78 /* soter_sign_rsa.c in Sources */,
+				9F52B0CA263D310F0025EB78 /* soter_sym.c in Sources */,
+				9F52B0CB263D310F0025EB78 /* soter_verify_ecdsa.c in Sources */,
+				9F52B0CC263D310F0025EB78 /* soter_verify_rsa.c in Sources */,
+				9F52B0CD263D310F0025EB78 /* ge_p2_to_p3.c in Sources */,
+				9F52B0CE263D310F0025EB78 /* ge_p3_0.c in Sources */,
+				9F52B0CF263D310F0025EB78 /* soter_rsa_key.c in Sources */,
+				9F52B0D0263D310F0025EB78 /* ge_p3_dbl.c in Sources */,
+				9F52B0D1263D310F0025EB78 /* ge_p3_sub.c in Sources */,
+				9F52B0D2263D310F0025EB78 /* ge_p3_to_cached.c in Sources */,
+				9F52B0D3263D310F0025EB78 /* ge_p3_to_p2.c in Sources */,
+				9F52B0D4263D310F0025EB78 /* ge_p3_tobytes.c in Sources */,
+				9F52B0D5263D310F0025EB78 /* ge_precomp_0.c in Sources */,
+				9F52B0D6263D310F0025EB78 /* ge_scalarmult_base.c in Sources */,
+				9F52B0D7263D310F0025EB78 /* ge_scalarmult.c in Sources */,
+				9F52B0D8263D310F0025EB78 /* ge_sub.c in Sources */,
+				9F52B0D9263D310F0025EB78 /* ge_tobytes.c in Sources */,
+				9F52B0DA263D310F0025EB78 /* gen_rand_32.c in Sources */,
+				9F52B0DB263D310F0025EB78 /* sc_muladd.c in Sources */,
+				9F52B0DC263D310F0025EB78 /* sc_reduce.c in Sources */,
+				9F52B0DD263D310F0025EB78 /* ge_cmp.c in Sources */,
+				9F52B0DE263D310F0025EB78 /* ge_double_scalarmult.c in Sources */,
+				9F52B0DF263D310F0025EB78 /* ge_frombytes_no_negate.c in Sources */,
+				9F52B0E0263D310F0025EB78 /* ge_frombytes.c in Sources */,
+				9F52B0E1263D310F0025EB78 /* ge_madd.c in Sources */,
+				9F52B0E2263D310F0025EB78 /* ge_msub.c in Sources */,
+				9F52B0E3263D310F0025EB78 /* ge_p1p1_to_p2.c in Sources */,
+				9F52B0E4263D310F0025EB78 /* ge_p1p1_to_p3.c in Sources */,
+				9F52B0E5263D310F0025EB78 /* ge_p2_0.c in Sources */,
+				9F52B0E6263D310F0025EB78 /* ge_p2_dbl.c in Sources */,
+				9F52B0E7263D310F0025EB78 /* fe_0.c in Sources */,
+				9F52B0E8263D310F0025EB78 /* fe_1.c in Sources */,
+				9F52B0E9263D310F0025EB78 /* fe_add.c in Sources */,
+				9F52B0EA263D310F0025EB78 /* fe_cmov.c in Sources */,
+				9F52B0EB263D310F0025EB78 /* fe_copy.c in Sources */,
+				9F52B0EC263D310F0025EB78 /* fe_frombytes.c in Sources */,
+				9F52B0ED263D310F0025EB78 /* fe_invert.c in Sources */,
+				9F52B0EE263D310F0025EB78 /* fe_isnegative.c in Sources */,
+				9F52B0EF263D310F0025EB78 /* fe_isnonzero.c in Sources */,
+				9F52B0F0263D310F0025EB78 /* fe_mul.c in Sources */,
+				9F52B0F1263D310F0025EB78 /* fe_neg.c in Sources */,
+				9F52B0F2263D310F0025EB78 /* fe_pow22523.c in Sources */,
+				9F52B0F3263D310F0025EB78 /* fe_sq.c in Sources */,
+				9F52B0F4263D310F0025EB78 /* fe_sq2.c in Sources */,
+				9F52B0F5263D310F0025EB78 /* fe_sub.c in Sources */,
+				9F52B0F6263D310F0025EB78 /* fe_tobytes.c in Sources */,
+				9F52B0F7263D310F0025EB78 /* ge_add.c in Sources */,
+				9F52B0F8263D310F0025EB78 /* scell_context_imprint.m in Sources */,
+				9F52B0F9263D310F0025EB78 /* scell_seal.m in Sources */,
+				9F52B0FA263D310F0025EB78 /* scell_token.m in Sources */,
+				9F52B0FB263D310F0025EB78 /* scell.m in Sources */,
+				9F52B0FC263D310F0025EB78 /* scomparator.m in Sources */,
+				9F52B0FD263D310F0025EB78 /* skeygen.m in Sources */,
+				9F52B0FE263D310F0025EB78 /* smessage.m in Sources */,
+				9F52B0FF263D310F0025EB78 /* ssession_transport_interface.m in Sources */,
+				9F52B100263D310F0025EB78 /* ssession.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4393,6 +4871,156 @@
 			};
 			name = Release;
 		};
+		9F52B089263D30430025EB78 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = 7;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_BITCODE = YES;
+				EXCLUDED_ARCHS = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
+				EXPORTED_SYMBOLS_FILE = "$(PROJECT_DIR)/src/wrappers/themis/Obj-C/exported.symbols";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/include",
+					"$(PROJECT_DIR)/src",
+					"$(PROJECT_DIR)/src/wrappers/themis/Obj-C",
+				);
+				INFOPLIST_FILE = "src/wrappers/themis/Obj-c/Themis/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 0.13.7;
+				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis;
+				PRODUCT_MODULE_NAME = themis;
+				PRODUCT_NAME = themis;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				WARNING_CFLAGS = "-Wno-documentation";
+			};
+			name = Debug;
+		};
+		9F52B08A263D30430025EB78 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = 7;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_BITCODE = YES;
+				EXCLUDED_ARCHS = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
+				EXPORTED_SYMBOLS_FILE = "$(PROJECT_DIR)/src/wrappers/themis/Obj-C/exported.symbols";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/include",
+					"$(PROJECT_DIR)/src",
+					"$(PROJECT_DIR)/src/wrappers/themis/Obj-C",
+				);
+				INFOPLIST_FILE = "src/wrappers/themis/Obj-c/Themis/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 0.13.7;
+				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis;
+				PRODUCT_MODULE_NAME = themis;
+				PRODUCT_NAME = themis;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				WARNING_CFLAGS = "-Wno-documentation";
+			};
+			name = Release;
+		};
+		9F52B104263D310F0025EB78 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = 7;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				EXPORTED_SYMBOLS_FILE = "$(PROJECT_DIR)/src/wrappers/themis/Obj-C/exported.symbols";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
+				FRAMEWORK_VERSION = A;
+				HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/include",
+					"$(PROJECT_DIR)/src",
+					"$(PROJECT_DIR)/src/wrappers/themis/Obj-C",
+				);
+				INFOPLIST_FILE = "src/wrappers/themis/Obj-c/Themis/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 0.13.7;
+				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis;
+				PRODUCT_MODULE_NAME = themis;
+				PRODUCT_NAME = themis;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				WARNING_CFLAGS = "-Wno-documentation";
+			};
+			name = Debug;
+		};
+		9F52B105263D310F0025EB78 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = 7;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				EXPORTED_SYMBOLS_FILE = "$(PROJECT_DIR)/src/wrappers/themis/Obj-C/exported.symbols";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
+				FRAMEWORK_VERSION = A;
+				HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/include",
+					"$(PROJECT_DIR)/src",
+					"$(PROJECT_DIR)/src/wrappers/themis/Obj-C",
+				);
+				INFOPLIST_FILE = "src/wrappers/themis/Obj-c/Themis/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 0.13.7;
+				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis;
+				PRODUCT_MODULE_NAME = themis;
+				PRODUCT_NAME = themis;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				WARNING_CFLAGS = "-Wno-documentation";
+			};
+			name = Release;
+		};
 		9F56694625546397005CF297 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -4737,6 +5365,24 @@
 			buildConfigurations = (
 				9F4A24A7223A8D7F005CB63A /* Debug */,
 				9F4A24A8223A8D7F005CB63A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9F52B088263D30430025EB78 /* Build configuration list for PBXNativeTarget "Themis (iOS) - BoringSSL" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9F52B089263D30430025EB78 /* Debug */,
+				9F52B08A263D30430025EB78 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9F52B103263D310F0025EB78 /* Build configuration list for PBXNativeTarget "Themis (macOS) - BoringSSL" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9F52B104263D310F0025EB78 /* Debug */,
+				9F52B105263D310F0025EB78 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Themis.xcodeproj/project.pbxproj
+++ b/Themis.xcodeproj/project.pbxproj
@@ -930,10 +930,6 @@
 		9F52B1B0263D3CA00025EB78 /* SecureMessageTestsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CB241D1042009CB629 /* SecureMessageTestsSwift.swift */; };
 		9F52B1B1263D3CA00025EB78 /* SecureMessageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CE241D1043009CB629 /* SecureMessageTests.m */; };
 		9F52B1B2263D3CA00025EB78 /* SecureCellTestsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CF241D1043009CB629 /* SecureCellTestsSwift.swift */; };
-		9F52B1B4263D3CA00025EB78 /* themis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F4A24A1223A8D7F005CB63A /* themis.framework */; };
-		9F52B1B5263D3CA00025EB78 /* openssl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FBD853C223BFB5E009EAEB3 /* openssl.framework */; };
-		9F52B1B7263D3CA00025EB78 /* themis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F4A24A1223A8D7F005CB63A /* themis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		9F52B1B8263D3CA00025EB78 /* openssl.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9FBD853C223BFB5E009EAEB3 /* openssl.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F52B1CE263D3CA60025EB78 /* objthemis-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F70B2C9241D1042009CB629 /* objthemis-Bridging-Header.h */; };
 		9F52B1CF263D3CA60025EB78 /* StaticKeys.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F70B2CC241D1043009CB629 /* StaticKeys.h */; };
 		9F52B1D1263D3CA60025EB78 /* SecureCellTestsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CF241D1043009CB629 /* SecureCellTestsSwift.swift */; };
@@ -942,10 +938,10 @@
 		9F52B1D4263D3CA60025EB78 /* SecureComparatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2C7241D1042009CB629 /* SecureComparatorTests.m */; };
 		9F52B1D5263D3CA60025EB78 /* SecureComparatorTestsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CA241D1042009CB629 /* SecureComparatorTestsSwift.swift */; };
 		9F52B1D6263D3CA60025EB78 /* SecureMessageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CE241D1043009CB629 /* SecureMessageTests.m */; };
-		9F52B1D8263D3CA60025EB78 /* openssl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E940223C1AFA00EC1EF3 /* openssl.framework */; };
-		9F52B1D9263D3CA60025EB78 /* themis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E8D7223C197900EC1EF3 /* themis.framework */; };
-		9F52B1DB263D3CA60025EB78 /* themis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E8D7223C197900EC1EF3 /* themis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		9F52B1DC263D3CA60025EB78 /* openssl.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E940223C1AFA00EC1EF3 /* openssl.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9F52B202263D3E240025EB78 /* themis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F52B08B263D30430025EB78 /* themis.framework */; };
+		9F52B203263D3E2C0025EB78 /* themis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F52B08B263D30430025EB78 /* themis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9F52B20C263D3E420025EB78 /* themis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F52B106263D310F0025EB78 /* themis.framework */; };
+		9F52B20D263D3E480025EB78 /* themis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F52B106263D310F0025EB78 /* themis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F6B385523D9D11600EA5D1B /* secure_cell_seal_passphrase.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F6B385423D9D11600EA5D1B /* secure_cell_seal_passphrase.c */; };
 		9F6B385623D9D11600EA5D1B /* secure_cell_seal_passphrase.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F6B385423D9D11600EA5D1B /* secure_cell_seal_passphrase.c */; };
 		9F70B2C1241D0FEC009CB629 /* themis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E8D7223C197900EC1EF3 /* themis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -1302,19 +1298,19 @@
 			remoteGlobalIDString = 9F56694E255463B5005CF297;
 			remoteInfo = "BoringSSL (macOS)";
 		};
-		9F52B1A8263D3CA00025EB78 /* PBXContainerItemProxy */ = {
+		9F52B200263D3DED0025EB78 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 738B81062239809D00A9947C /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 9F4A24A0223A8D7F005CB63A;
-			remoteInfo = "Themis (iOS)";
+			remoteGlobalIDString = 9F52B021263D30430025EB78;
+			remoteInfo = "Themis (iOS) - BoringSSL";
 		};
-		9F52B1CC263D3CA60025EB78 /* PBXContainerItemProxy */ = {
+		9F52B20A263D3E3B0025EB78 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 738B81062239809D00A9947C /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 9F00E8D6223C197900EC1EF3;
-			remoteInfo = "Themis (macOS)";
+			remoteGlobalIDString = 9F52B09C263D310F0025EB78;
+			remoteInfo = "Themis (macOS) - BoringSSL";
 		};
 		9F70B2C2241D0FEC009CB629 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -1353,8 +1349,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				9F52B1B7263D3CA00025EB78 /* themis.framework in Embed Frameworks */,
-				9F52B1B8263D3CA00025EB78 /* openssl.framework in Embed Frameworks */,
+				9F52B203263D3E2C0025EB78 /* themis.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1365,8 +1360,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				9F52B1DB263D3CA60025EB78 /* themis.framework in Embed Frameworks */,
-				9F52B1DC263D3CA60025EB78 /* openssl.framework in Embed Frameworks */,
+				9F52B20D263D3E480025EB78 /* themis.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2134,8 +2128,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9F52B1B4263D3CA00025EB78 /* themis.framework in Frameworks */,
-				9F52B1B5263D3CA00025EB78 /* openssl.framework in Frameworks */,
+				9F52B202263D3E240025EB78 /* themis.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2143,8 +2136,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9F52B1D8263D3CA60025EB78 /* openssl.framework in Frameworks */,
-				9F52B1D9263D3CA60025EB78 /* themis.framework in Frameworks */,
+				9F52B20C263D3E420025EB78 /* themis.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3288,7 +3280,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				9F52B1A7263D3CA00025EB78 /* PBXTargetDependency */,
+				9F52B201263D3DED0025EB78 /* PBXTargetDependency */,
 			);
 			name = "Test Themis (BoringSSL, Swift 5, iOS)";
 			productName = "Test Themis (iOS)";
@@ -3307,7 +3299,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				9F52B1CB263D3CA60025EB78 /* PBXTargetDependency */,
+				9F52B20B263D3E3B0025EB78 /* PBXTargetDependency */,
 			);
 			name = "Test Themis (BoringSSL, Swift 5, macOS)";
 			productName = "Test Themis (macOS)";
@@ -4771,15 +4763,15 @@
 			target = 9F56694E255463B5005CF297 /* BoringSSL (macOS) */;
 			targetProxy = 9F52B174263D352D0025EB78 /* PBXContainerItemProxy */;
 		};
-		9F52B1A7263D3CA00025EB78 /* PBXTargetDependency */ = {
+		9F52B201263D3DED0025EB78 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 9F4A24A0223A8D7F005CB63A /* Themis (iOS) */;
-			targetProxy = 9F52B1A8263D3CA00025EB78 /* PBXContainerItemProxy */;
+			target = 9F52B021263D30430025EB78 /* Themis (iOS) - BoringSSL */;
+			targetProxy = 9F52B200263D3DED0025EB78 /* PBXContainerItemProxy */;
 		};
-		9F52B1CB263D3CA60025EB78 /* PBXTargetDependency */ = {
+		9F52B20B263D3E3B0025EB78 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 9F00E8D6223C197900EC1EF3 /* Themis (macOS) */;
-			targetProxy = 9F52B1CC263D3CA60025EB78 /* PBXContainerItemProxy */;
+			target = 9F52B09C263D310F0025EB78 /* Themis (macOS) - BoringSSL */;
+			targetProxy = 9F52B20A263D3E3B0025EB78 /* PBXContainerItemProxy */;
 		};
 		9F70B2C3241D0FEC009CB629 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Themis.xcodeproj/project.pbxproj
+++ b/Themis.xcodeproj/project.pbxproj
@@ -922,6 +922,30 @@
 		9F52B169263D33290025EB78 /* soter_wipe.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F52B015263D2F840025EB78 /* soter_wipe.c */; };
 		9F52B170263D35120025EB78 /* libboringssl.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F56693F25546397005CF297 /* libboringssl.a */; };
 		9F52B173263D35270025EB78 /* libboringssl.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F56694F255463B5005CF297 /* libboringssl.a */; };
+		9F52B1AA263D3CA00025EB78 /* objthemis-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F70B2C9241D1042009CB629 /* objthemis-Bridging-Header.h */; };
+		9F52B1AB263D3CA00025EB78 /* StaticKeys.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F70B2CC241D1043009CB629 /* StaticKeys.h */; };
+		9F52B1AD263D3CA00025EB78 /* SecureComparatorTestsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CA241D1042009CB629 /* SecureComparatorTestsSwift.swift */; };
+		9F52B1AE263D3CA00025EB78 /* SecureComparatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2C7241D1042009CB629 /* SecureComparatorTests.m */; };
+		9F52B1AF263D3CA00025EB78 /* SecureCellTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2C8241D1042009CB629 /* SecureCellTests.m */; };
+		9F52B1B0263D3CA00025EB78 /* SecureMessageTestsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CB241D1042009CB629 /* SecureMessageTestsSwift.swift */; };
+		9F52B1B1263D3CA00025EB78 /* SecureMessageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CE241D1043009CB629 /* SecureMessageTests.m */; };
+		9F52B1B2263D3CA00025EB78 /* SecureCellTestsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CF241D1043009CB629 /* SecureCellTestsSwift.swift */; };
+		9F52B1B4263D3CA00025EB78 /* themis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F4A24A1223A8D7F005CB63A /* themis.framework */; };
+		9F52B1B5263D3CA00025EB78 /* openssl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FBD853C223BFB5E009EAEB3 /* openssl.framework */; };
+		9F52B1B7263D3CA00025EB78 /* themis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F4A24A1223A8D7F005CB63A /* themis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9F52B1B8263D3CA00025EB78 /* openssl.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9FBD853C223BFB5E009EAEB3 /* openssl.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9F52B1CE263D3CA60025EB78 /* objthemis-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F70B2C9241D1042009CB629 /* objthemis-Bridging-Header.h */; };
+		9F52B1CF263D3CA60025EB78 /* StaticKeys.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F70B2CC241D1043009CB629 /* StaticKeys.h */; };
+		9F52B1D1263D3CA60025EB78 /* SecureCellTestsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CF241D1043009CB629 /* SecureCellTestsSwift.swift */; };
+		9F52B1D2263D3CA60025EB78 /* SecureMessageTestsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CB241D1042009CB629 /* SecureMessageTestsSwift.swift */; };
+		9F52B1D3263D3CA60025EB78 /* SecureCellTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2C8241D1042009CB629 /* SecureCellTests.m */; };
+		9F52B1D4263D3CA60025EB78 /* SecureComparatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2C7241D1042009CB629 /* SecureComparatorTests.m */; };
+		9F52B1D5263D3CA60025EB78 /* SecureComparatorTestsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CA241D1042009CB629 /* SecureComparatorTestsSwift.swift */; };
+		9F52B1D6263D3CA60025EB78 /* SecureMessageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CE241D1043009CB629 /* SecureMessageTests.m */; };
+		9F52B1D8263D3CA60025EB78 /* openssl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E940223C1AFA00EC1EF3 /* openssl.framework */; };
+		9F52B1D9263D3CA60025EB78 /* themis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E8D7223C197900EC1EF3 /* themis.framework */; };
+		9F52B1DB263D3CA60025EB78 /* themis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E8D7223C197900EC1EF3 /* themis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9F52B1DC263D3CA60025EB78 /* openssl.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E940223C1AFA00EC1EF3 /* openssl.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F6B385523D9D11600EA5D1B /* secure_cell_seal_passphrase.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F6B385423D9D11600EA5D1B /* secure_cell_seal_passphrase.c */; };
 		9F6B385623D9D11600EA5D1B /* secure_cell_seal_passphrase.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F6B385423D9D11600EA5D1B /* secure_cell_seal_passphrase.c */; };
 		9F70B2C1241D0FEC009CB629 /* themis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E8D7223C197900EC1EF3 /* themis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -1278,6 +1302,20 @@
 			remoteGlobalIDString = 9F56694E255463B5005CF297;
 			remoteInfo = "BoringSSL (macOS)";
 		};
+		9F52B1A8263D3CA00025EB78 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 738B81062239809D00A9947C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9F4A24A0223A8D7F005CB63A;
+			remoteInfo = "Themis (iOS)";
+		};
+		9F52B1CC263D3CA60025EB78 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 738B81062239809D00A9947C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9F00E8D6223C197900EC1EF3;
+			remoteInfo = "Themis (macOS)";
+		};
 		9F70B2C2241D0FEC009CB629 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 738B81062239809D00A9947C /* Project object */;
@@ -1309,6 +1347,30 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		9F52B1B6263D3CA00025EB78 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				9F52B1B7263D3CA00025EB78 /* themis.framework in Embed Frameworks */,
+				9F52B1B8263D3CA00025EB78 /* openssl.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9F52B1DA263D3CA60025EB78 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				9F52B1DB263D3CA60025EB78 /* themis.framework in Embed Frameworks */,
+				9F52B1DC263D3CA60025EB78 /* openssl.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9F56693D25546397005CF297 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1912,6 +1974,10 @@
 		9F52B020263D2F850025EB78 /* soter_asym_ka.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = soter_asym_ka.c; path = src/soter/boringssl/soter_asym_ka.c; sourceTree = "<group>"; };
 		9F52B08B263D30430025EB78 /* themis.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = themis.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9F52B106263D310F0025EB78 /* themis.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = themis.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9F52B1BC263D3CA00025EB78 /* Test Themis (BoringSSL, Swift 5, iOS).xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Test Themis (BoringSSL, Swift 5, iOS).xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9F52B1BD263D3CA10025EB78 /* Test Themis (Swift 5, iOS) copy-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Test Themis (Swift 5, iOS) copy-Info.plist"; path = "/Users/ilammy/Documents/dev/cossacklabs/themis/Test Themis (Swift 5, iOS) copy-Info.plist"; sourceTree = "<absolute>"; };
+		9F52B1E0263D3CA60025EB78 /* Test Themis (BoringSSL, Swift 5, macOS).xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Test Themis (BoringSSL, Swift 5, macOS).xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9F52B1E1263D3CA70025EB78 /* Test Themis (Swift 5, macOS) copy-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Test Themis (Swift 5, macOS) copy-Info.plist"; path = "/Users/ilammy/Documents/dev/cossacklabs/themis/Test Themis (Swift 5, macOS) copy-Info.plist"; sourceTree = "<absolute>"; };
 		9F56693F25546397005CF297 /* libboringssl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libboringssl.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		9F56694F255463B5005CF297 /* libboringssl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libboringssl.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		9F6B385423D9D11600EA5D1B /* secure_cell_seal_passphrase.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = secure_cell_seal_passphrase.c; path = src/themis/secure_cell_seal_passphrase.c; sourceTree = "<group>"; };
@@ -2061,6 +2127,24 @@
 			buildActionMask = 2147483647;
 			files = (
 				9F52B173263D35270025EB78 /* libboringssl.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9F52B1B3263D3CA00025EB78 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9F52B1B4263D3CA00025EB78 /* themis.framework in Frameworks */,
+				9F52B1B5263D3CA00025EB78 /* openssl.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9F52B1D7263D3CA60025EB78 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9F52B1D8263D3CA60025EB78 /* openssl.framework in Frameworks */,
+				9F52B1D9263D3CA60025EB78 /* themis.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2552,6 +2636,8 @@
 				9F70B2B7241D0FA9009CB629 /* Tests */,
 				738B81102239809D00A9947C /* Products */,
 				9F4A2476223A885F005CB63A /* Frameworks */,
+				9F52B1BD263D3CA10025EB78 /* Test Themis (Swift 5, iOS) copy-Info.plist */,
+				9F52B1E1263D3CA70025EB78 /* Test Themis (Swift 5, macOS) copy-Info.plist */,
 			);
 			sourceTree = "<group>";
 		};
@@ -2568,6 +2654,8 @@
 				9F56694F255463B5005CF297 /* libboringssl.a */,
 				9F52B08B263D30430025EB78 /* themis.framework */,
 				9F52B106263D310F0025EB78 /* themis.framework */,
+				9F52B1BC263D3CA00025EB78 /* Test Themis (BoringSSL, Swift 5, iOS).xctest */,
+				9F52B1E0263D3CA60025EB78 /* Test Themis (BoringSSL, Swift 5, macOS).xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -3054,6 +3142,24 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		9F52B1A9263D3CA00025EB78 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9F52B1AA263D3CA00025EB78 /* objthemis-Bridging-Header.h in Headers */,
+				9F52B1AB263D3CA00025EB78 /* StaticKeys.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9F52B1CD263D3CA60025EB78 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9F52B1CE263D3CA60025EB78 /* objthemis-Bridging-Header.h in Headers */,
+				9F52B1CF263D3CA60025EB78 /* StaticKeys.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9F56694B255463B5005CF297 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -3169,6 +3275,44 @@
 			productName = "Themis (macOS)";
 			productReference = 9F52B106263D310F0025EB78 /* themis.framework */;
 			productType = "com.apple.product-type.framework";
+		};
+		9F52B1A6263D3CA00025EB78 /* Test Themis (BoringSSL, Swift 5, iOS) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9F52B1B9263D3CA00025EB78 /* Build configuration list for PBXNativeTarget "Test Themis (BoringSSL, Swift 5, iOS)" */;
+			buildPhases = (
+				9F52B1A9263D3CA00025EB78 /* Headers */,
+				9F52B1AC263D3CA00025EB78 /* Sources */,
+				9F52B1B3263D3CA00025EB78 /* Frameworks */,
+				9F52B1B6263D3CA00025EB78 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				9F52B1A7263D3CA00025EB78 /* PBXTargetDependency */,
+			);
+			name = "Test Themis (BoringSSL, Swift 5, iOS)";
+			productName = "Test Themis (iOS)";
+			productReference = 9F52B1BC263D3CA00025EB78 /* Test Themis (BoringSSL, Swift 5, iOS).xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		9F52B1CA263D3CA60025EB78 /* Test Themis (BoringSSL, Swift 5, macOS) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9F52B1DD263D3CA60025EB78 /* Build configuration list for PBXNativeTarget "Test Themis (BoringSSL, Swift 5, macOS)" */;
+			buildPhases = (
+				9F52B1CD263D3CA60025EB78 /* Headers */,
+				9F52B1D0263D3CA60025EB78 /* Sources */,
+				9F52B1D7263D3CA60025EB78 /* Frameworks */,
+				9F52B1DA263D3CA60025EB78 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				9F52B1CB263D3CA60025EB78 /* PBXTargetDependency */,
+			);
+			name = "Test Themis (BoringSSL, Swift 5, macOS)";
+			productName = "Test Themis (macOS)";
+			productReference = 9F52B1E0263D3CA60025EB78 /* Test Themis (BoringSSL, Swift 5, macOS).xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		9F56693E25546397005CF297 /* BoringSSL (iOS) */ = {
 			isa = PBXNativeTarget;
@@ -3331,6 +3475,8 @@
 				9F70B31B2420E176009CB629 /* Test Themis (Swift 4, macOS) */,
 				9F70B2E6241D17A3009CB629 /* Test Themis (Swift 5, iOS) */,
 				9F70B2BB241D0FEC009CB629 /* Test Themis (Swift 5, macOS) */,
+				9F52B1A6263D3CA00025EB78 /* Test Themis (BoringSSL, Swift 5, iOS) */,
+				9F52B1CA263D3CA60025EB78 /* Test Themis (BoringSSL, Swift 5, macOS) */,
 				9F56693E25546397005CF297 /* BoringSSL (iOS) */,
 				9F56694E255463B5005CF297 /* BoringSSL (macOS) */,
 			);
@@ -3707,6 +3853,32 @@
 				9F52B0FE263D310F0025EB78 /* smessage.m in Sources */,
 				9F52B0FF263D310F0025EB78 /* ssession_transport_interface.m in Sources */,
 				9F52B100263D310F0025EB78 /* ssession.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9F52B1AC263D3CA00025EB78 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9F52B1AD263D3CA00025EB78 /* SecureComparatorTestsSwift.swift in Sources */,
+				9F52B1AE263D3CA00025EB78 /* SecureComparatorTests.m in Sources */,
+				9F52B1AF263D3CA00025EB78 /* SecureCellTests.m in Sources */,
+				9F52B1B0263D3CA00025EB78 /* SecureMessageTestsSwift.swift in Sources */,
+				9F52B1B1263D3CA00025EB78 /* SecureMessageTests.m in Sources */,
+				9F52B1B2263D3CA00025EB78 /* SecureCellTestsSwift.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9F52B1D0263D3CA60025EB78 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9F52B1D1263D3CA60025EB78 /* SecureCellTestsSwift.swift in Sources */,
+				9F52B1D2263D3CA60025EB78 /* SecureMessageTestsSwift.swift in Sources */,
+				9F52B1D3263D3CA60025EB78 /* SecureCellTests.m in Sources */,
+				9F52B1D4263D3CA60025EB78 /* SecureComparatorTests.m in Sources */,
+				9F52B1D5263D3CA60025EB78 /* SecureComparatorTestsSwift.swift in Sources */,
+				9F52B1D6263D3CA60025EB78 /* SecureMessageTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4599,6 +4771,16 @@
 			target = 9F56694E255463B5005CF297 /* BoringSSL (macOS) */;
 			targetProxy = 9F52B174263D352D0025EB78 /* PBXContainerItemProxy */;
 		};
+		9F52B1A7263D3CA00025EB78 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9F4A24A0223A8D7F005CB63A /* Themis (iOS) */;
+			targetProxy = 9F52B1A8263D3CA00025EB78 /* PBXContainerItemProxy */;
+		};
+		9F52B1CB263D3CA60025EB78 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9F00E8D6223C197900EC1EF3 /* Themis (macOS) */;
+			targetProxy = 9F52B1CC263D3CA60025EB78 /* PBXContainerItemProxy */;
+		};
 		9F70B2C3241D0FEC009CB629 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 9F00E8D6223C197900EC1EF3 /* Themis (macOS) */;
@@ -5075,6 +5257,98 @@
 			};
 			name = Release;
 		};
+		9F52B1BA263D3CA00025EB78 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_BITCODE = NO;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = tests/objcthemis/objthemis/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis.tests;
+				PRODUCT_MODULE_NAME = themis_test;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_OBJC_BRIDGING_HEADER = "tests/objcthemis/objthemis/objthemis-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		9F52B1BB263D3CA00025EB78 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_BITCODE = NO;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = tests/objcthemis/objthemis/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis.tests;
+				PRODUCT_MODULE_NAME = themis_test;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_OBJC_BRIDGING_HEADER = "tests/objcthemis/objthemis/objthemis-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		9F52B1DE263D3CA60025EB78 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
+				INFOPLIST_FILE = tests/objcthemis/objthemis/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis.tests;
+				PRODUCT_MODULE_NAME = themis_test;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_OBJC_BRIDGING_HEADER = "tests/objcthemis/objthemis/objthemis-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		9F52B1DF263D3CA60025EB78 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
+				INFOPLIST_FILE = tests/objcthemis/objthemis/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis.tests;
+				PRODUCT_MODULE_NAME = themis_test;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_OBJC_BRIDGING_HEADER = "tests/objcthemis/objthemis/objthemis-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 		9F56694625546397005CF297 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -5437,6 +5711,24 @@
 			buildConfigurations = (
 				9F52B104263D310F0025EB78 /* Debug */,
 				9F52B105263D310F0025EB78 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9F52B1B9263D3CA00025EB78 /* Build configuration list for PBXNativeTarget "Test Themis (BoringSSL, Swift 5, iOS)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9F52B1BA263D3CA00025EB78 /* Debug */,
+				9F52B1BB263D3CA00025EB78 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9F52B1DD263D3CA60025EB78 /* Build configuration list for PBXNativeTarget "Test Themis (BoringSSL, Swift 5, macOS)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9F52B1DE263D3CA60025EB78 /* Debug */,
+				9F52B1DF263D3CA60025EB78 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Themis.xcodeproj/project.pbxproj
+++ b/Themis.xcodeproj/project.pbxproj
@@ -4891,6 +4891,7 @@
 					"$(PROJECT_DIR)/include",
 					"$(PROJECT_DIR)/src",
 					"$(PROJECT_DIR)/src/wrappers/themis/Obj-C",
+					"$(PROJECT_DIR)/third_party/boringssl/src/include",
 				);
 				INFOPLIST_FILE = "src/wrappers/themis/Obj-c/Themis/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -4930,6 +4931,7 @@
 					"$(PROJECT_DIR)/include",
 					"$(PROJECT_DIR)/src",
 					"$(PROJECT_DIR)/src/wrappers/themis/Obj-C",
+					"$(PROJECT_DIR)/third_party/boringssl/src/include",
 				);
 				INFOPLIST_FILE = "src/wrappers/themis/Obj-c/Themis/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -4967,6 +4969,7 @@
 					"$(PROJECT_DIR)/include",
 					"$(PROJECT_DIR)/src",
 					"$(PROJECT_DIR)/src/wrappers/themis/Obj-C",
+					"$(PROJECT_DIR)/third_party/boringssl/src/include",
 				);
 				INFOPLIST_FILE = "src/wrappers/themis/Obj-c/Themis/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -5003,6 +5006,7 @@
 					"$(PROJECT_DIR)/include",
 					"$(PROJECT_DIR)/src",
 					"$(PROJECT_DIR)/src/wrappers/themis/Obj-C",
+					"$(PROJECT_DIR)/third_party/boringssl/src/include",
 				);
 				INFOPLIST_FILE = "src/wrappers/themis/Obj-c/Themis/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";

--- a/Themis.xcodeproj/project.pbxproj
+++ b/Themis.xcodeproj/project.pbxproj
@@ -7,15 +7,15 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		001FFF61CD680060AB1BED0D /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		001FFF61CD680060AB1BED0D /* (null) in Sources */ = {isa = PBXBuildFile; };
 		00715282C8D28EECA6F225B6 /* x509_trs.c in Sources */ = {isa = PBXBuildFile; fileRef = 8565B956EDD92173990B7013 /* x509_trs.c */; };
 		00AE00AF9782ABEFBEB8C0F6 /* d1_srtp.cc in Sources */ = {isa = PBXBuildFile; fileRef = 8D003C2E052B7FE57735E052 /* d1_srtp.cc */; };
 		0105639509A1E43307959913 /* by_dir.c in Sources */ = {isa = PBXBuildFile; fileRef = 1258860B218CC3CF285F880F /* by_dir.c */; };
-		018EE780A8CB28AD5B4CA010 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		01FD716BC1C0188B0FD2E195 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		018EE780A8CB28AD5B4CA010 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		01FD716BC1C0188B0FD2E195 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		024F05BA3E89737F5B8905B3 /* v3_crld.c in Sources */ = {isa = PBXBuildFile; fileRef = D55F718790190C6021095A6C /* v3_crld.c */; };
-		02B1DE2F13C9F69176A71B4F /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		02E9439882A4864DC0A34FD8 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		02B1DE2F13C9F69176A71B4F /* (null) in Sources */ = {isa = PBXBuildFile; };
+		02E9439882A4864DC0A34FD8 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		0311F71392BA5E50F8D89C86 /* handshake_server.cc in Sources */ = {isa = PBXBuildFile; fileRef = 276EE70F4BD22BE0C7344F6C /* handshake_server.cc */; };
 		032DFFEA6DC8762237E58BCF /* thread_win.c in Sources */ = {isa = PBXBuildFile; fileRef = 90E0C8F68FBDD6C0027A96D9 /* thread_win.c */; };
 		033E7B691361C0563121D276 /* x_pubkey.c in Sources */ = {isa = PBXBuildFile; fileRef = 9359FB9D669D5BEC261292D9 /* x_pubkey.c */; };
@@ -27,7 +27,7 @@
 		060D0CC9C82D307DB91587E8 /* cbb.c in Sources */ = {isa = PBXBuildFile; fileRef = 3A72594CE11062A04E626323 /* cbb.c */; };
 		06165E0601EA2690FED3A972 /* x_x509a.c in Sources */ = {isa = PBXBuildFile; fileRef = 8B0289DA9C8571E91054CA26 /* x_x509a.c */; };
 		06DC3AF26A72FD9500BC090A /* err.c in Sources */ = {isa = PBXBuildFile; fileRef = 622A8739543801456BBDA66F /* err.c */; };
-		073E8E037F4B1FA8E8AA792A /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		073E8E037F4B1FA8E8AA792A /* (null) in Sources */ = {isa = PBXBuildFile; };
 		088F268D54BF1F51BFCB6797 /* hkdf.c in Sources */ = {isa = PBXBuildFile; fileRef = 5E6AC366157705E772E21A34 /* hkdf.c */; };
 		08D40297FD1469BD103FA948 /* ec_derive.c in Sources */ = {isa = PBXBuildFile; fileRef = 944E25D4E83DBE736299E6ED /* ec_derive.c */; };
 		08E64D37D36AA5BE136B7BE5 /* p256_beeu-x86_64-asm.S in Sources */ = {isa = PBXBuildFile; fileRef = 6E41B560C4081194F69C3316 /* p256_beeu-x86_64-asm.S */; };
@@ -36,14 +36,14 @@
 		096C05CC593347391F7FEE25 /* x_info.c in Sources */ = {isa = PBXBuildFile; fileRef = 74F314353358212AE8751B2A /* x_info.c */; };
 		09BCE64A01F6D9DE5F5D96B2 /* x509_vpm.c in Sources */ = {isa = PBXBuildFile; fileRef = 0E1D1E8E85B1918FD2BE3A17 /* x509_vpm.c */; };
 		09C557690316A27CDB0927F2 /* ssl_session.cc in Sources */ = {isa = PBXBuildFile; fileRef = 518752FF816A5A9E7D03A298 /* ssl_session.cc */; };
-		09F6309C8A751C081A905241 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		0A070B34055F7410505B91C5 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		09F6309C8A751C081A905241 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		0A070B34055F7410505B91C5 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		0BD030730CDDD5182590D989 /* ghashv8-armx32.S in Sources */ = {isa = PBXBuildFile; fileRef = EA60E9F16FF71A769C05B9C8 /* ghashv8-armx32.S */; };
-		0C2A90442F6AE21923566AAD /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		0C2A90442F6AE21923566AAD /* (null) in Sources */ = {isa = PBXBuildFile; };
 		0C2FD3E68BBCA41075C4D05F /* a_d2i_fp.c in Sources */ = {isa = PBXBuildFile; fileRef = 1767CD47FB8219FDB1938182 /* a_d2i_fp.c */; };
 		0D00EC09894950934444C46E /* dsa_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = 92F57D1743D65892A41DDD97 /* dsa_asn1.c */; };
-		0D50B00714063FCB2B1E905B /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		0D5474C3710E25C05CFDC341 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		0D50B00714063FCB2B1E905B /* (null) in Sources */ = {isa = PBXBuildFile; };
+		0D5474C3710E25C05CFDC341 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		0DBE90F642DDB7FBF8DF4B97 /* siphash.c in Sources */ = {isa = PBXBuildFile; fileRef = 2F2BE92783B72A2F21B0E093 /* siphash.c */; };
 		0E03E4E20AE0601C7744CBC7 /* tasn_new.c in Sources */ = {isa = PBXBuildFile; fileRef = 35D7984E610B3D60BE049E02 /* tasn_new.c */; };
 		0E1886DDC4A2166CCFC16D62 /* evp_ctx.c in Sources */ = {isa = PBXBuildFile; fileRef = 069B84410555410235C3E9E4 /* evp_ctx.c */; };
@@ -62,7 +62,7 @@
 		12A489DE124D74A6AC03EF18 /* ssl_privkey.cc in Sources */ = {isa = PBXBuildFile; fileRef = 71DA2CDD3FD692B3E4CC7729 /* ssl_privkey.cc */; };
 		138E79FD192E94A4BE5632F8 /* pem_xaux.c in Sources */ = {isa = PBXBuildFile; fileRef = 6EE258C0E242CFEA4D755541 /* pem_xaux.c */; };
 		139247A43A57EF89DAC4D57E /* handshake.cc in Sources */ = {isa = PBXBuildFile; fileRef = 71331EC04EF2810329EA1BD8 /* handshake.cc */; };
-		13CDB180FC581E77C30A514C /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		13CDB180FC581E77C30A514C /* (null) in Sources */ = {isa = PBXBuildFile; };
 		144EF6FD89E0A9EA30C7B25A /* poly1305_arm.c in Sources */ = {isa = PBXBuildFile; fileRef = 53CD3B797EDE1C8C499CD16E /* poly1305_arm.c */; };
 		1490B1C310AE4A72E877472A /* bio.c in Sources */ = {isa = PBXBuildFile; fileRef = 4F02F875BF1F552B7332D939 /* bio.c */; };
 		14AD218BC21F4020DCA3A3FB /* s3_both.cc in Sources */ = {isa = PBXBuildFile; fileRef = 655553F23840F5CBB0E5B8B5 /* s3_both.cc */; };
@@ -73,47 +73,47 @@
 		16B888F8C99F76400DB869CE /* refcount_c11.c in Sources */ = {isa = PBXBuildFile; fileRef = 0280A3D732820375556EC136 /* refcount_c11.c */; };
 		16D7B151CC13E8126C2FC15B /* armv8-mont.S in Sources */ = {isa = PBXBuildFile; fileRef = 48D1F629BA07F82DC8B45DB0 /* armv8-mont.S */; };
 		179FADB12273584C21F43604 /* pem_pk8.c in Sources */ = {isa = PBXBuildFile; fileRef = 87F7E9647ED80A0905AC51C1 /* pem_pk8.c */; };
-		17FAEB9CF96F6C6124570875 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		182FBDF3338C6AB3DB980B81 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		17FAEB9CF96F6C6124570875 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		182FBDF3338C6AB3DB980B81 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		18CB07C402C175BE2F27ED54 /* chacha-x86.S in Sources */ = {isa = PBXBuildFile; fileRef = 189C3D0F63876DA24A3F8D58 /* chacha-x86.S */; };
 		191B80362FB79DF2F2EC1ED6 /* curve25519.c in Sources */ = {isa = PBXBuildFile; fileRef = 8108DF0E1E0A6D8CBFF11998 /* curve25519.c */; };
 		19384D96D28B58F540950974 /* a_bitstr.c in Sources */ = {isa = PBXBuildFile; fileRef = F00A02AAA9B71BB161525E01 /* a_bitstr.c */; };
 		19639C10001923A610ABC903 /* handshake_client.cc in Sources */ = {isa = PBXBuildFile; fileRef = AF493028D7E2A9296D8241AA /* handshake_client.cc */; };
 		1980B4175AA9FA0973E84A40 /* x_info.c in Sources */ = {isa = PBXBuildFile; fileRef = 74F314353358212AE8751B2A /* x_info.c */; };
 		19C26049146C253C29B1A45E /* tls13_server.cc in Sources */ = {isa = PBXBuildFile; fileRef = C23D55306C0AE1551049E48A /* tls13_server.cc */; };
-		1A0A47D591B9170BB55062E2 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		1A35E909190D77B387D6D494 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		1A3DC31F84BE6A287333A953 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		1AE53F7F2E3AB77A0F5F450F /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		1B056733A5A9A484A11940D9 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		1B2F22BB5A8A37DAFC323E14 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		1A0A47D591B9170BB55062E2 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		1A35E909190D77B387D6D494 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		1A3DC31F84BE6A287333A953 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		1AE53F7F2E3AB77A0F5F450F /* (null) in Sources */ = {isa = PBXBuildFile; };
+		1B056733A5A9A484A11940D9 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		1B2F22BB5A8A37DAFC323E14 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		1B4392EA9268B2C1A5282CA4 /* chacha-armv4.S in Sources */ = {isa = PBXBuildFile; fileRef = 769AE91218729C8A31265046 /* chacha-armv4.S */; };
-		1B9681A5F4DC9D329A06A371 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		1B9681A5F4DC9D329A06A371 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		1C0B67DA571A504E2340EE72 /* md5-x86_64.S in Sources */ = {isa = PBXBuildFile; fileRef = 0749151FB22F9562B88AAE89 /* md5-x86_64.S */; };
 		1C15C46324109498A4BC8996 /* params.c in Sources */ = {isa = PBXBuildFile; fileRef = 71FE59DD329237B9FFF000BA /* params.c */; };
 		1C67FDB3E86BA6915861BA6D /* pmbtoken.c in Sources */ = {isa = PBXBuildFile; fileRef = 9313CF758A0348A8FA3759AC /* pmbtoken.c */; };
 		1CD6028458FBF0416EC76B0E /* cmac.c in Sources */ = {isa = PBXBuildFile; fileRef = 79DC230DE6DE77EC7FE7EEDF /* cmac.c */; };
-		1D21296AB535D863B04BBF87 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		1D21296AB535D863B04BBF87 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		1D276CB5CED4C14ECF6A339C /* a_type.c in Sources */ = {isa = PBXBuildFile; fileRef = 08370EFE6E5E67DC2D897F6B /* a_type.c */; };
-		1D5741C158B018BE59AF03B1 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		1D5741C158B018BE59AF03B1 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		1D683711B22881657AFE2F38 /* fd.c in Sources */ = {isa = PBXBuildFile; fileRef = 7FFCF8CA42EF6F7FA3646DFE /* fd.c */; };
 		1D87BB81898EA45D0B475B4D /* digest_extra.c in Sources */ = {isa = PBXBuildFile; fileRef = 378778FC6BD1CC062C411F7F /* digest_extra.c */; };
 		1DA4841A92F2B6AE66C675E0 /* voprf.c in Sources */ = {isa = PBXBuildFile; fileRef = 9DAF449D0061FFBF2F43A81F /* voprf.c */; };
 		1DCA26A470420AFCFEDFFD05 /* v3_genn.c in Sources */ = {isa = PBXBuildFile; fileRef = 4B4EE9CD9AE016AF4425E1F1 /* v3_genn.c */; };
-		1EB65ECE376ED7A56F2D04B6 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		1EB65ECE376ED7A56F2D04B6 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		1ED96538E54E862F880AE3AF /* aesni-x86.S in Sources */ = {isa = PBXBuildFile; fileRef = 52709FD043287F666526E35F /* aesni-x86.S */; };
 		1F13F800F43120139B33948C /* a_type.c in Sources */ = {isa = PBXBuildFile; fileRef = 08370EFE6E5E67DC2D897F6B /* a_type.c */; };
-		1F1A92281E36C34D5FFA90D5 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		1F1A92281E36C34D5FFA90D5 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		1F1AF31A94C152B12D12D651 /* conf.c in Sources */ = {isa = PBXBuildFile; fileRef = 70E1093198E23200A5FD6181 /* conf.c */; };
-		1F360DF1D4BDD0058151DB57 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		1F360DF1D4BDD0058151DB57 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		2018938AC730ED63E22690E1 /* asn1_par.c in Sources */ = {isa = PBXBuildFile; fileRef = 614BD318E9D622DC7A79CA00 /* asn1_par.c */; };
 		20B994D7F92B4EB2BD995EDC /* ssl_cipher.cc in Sources */ = {isa = PBXBuildFile; fileRef = B1335F2CD6708EAAC7DCE6AE /* ssl_cipher.cc */; };
-		20FC40501C8BAF025F461FEB /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		214B29C73CFC2F40325D98F0 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		216B09FADAC7DC1D8F90FD53 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		20FC40501C8BAF025F461FEB /* (null) in Sources */ = {isa = PBXBuildFile; };
+		214B29C73CFC2F40325D98F0 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		216B09FADAC7DC1D8F90FD53 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		222B1AF606E755465F23A038 /* pcy_node.c in Sources */ = {isa = PBXBuildFile; fileRef = 31498604FF0AF2E19071A302 /* pcy_node.c */; };
-		22CB9C82519B308F61574066 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		22D04738EF9B0F20B59B0595 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		22CB9C82519B308F61574066 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		22D04738EF9B0F20B59B0595 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		240F52513D8C09B304F9DB91 /* x509_d2.c in Sources */ = {isa = PBXBuildFile; fileRef = 57267DFA1DBC96BBF2D79360 /* x509_d2.c */; };
 		24A0C953BC2309B1BF8DBD0A /* v3_ncons.c in Sources */ = {isa = PBXBuildFile; fileRef = 388B50675A22B5705B4EB3B9 /* v3_ncons.c */; };
 		24DBB28178224B84ECBAFEB3 /* trampoline-armv8.S in Sources */ = {isa = PBXBuildFile; fileRef = 8822800239BC5753B234DD94 /* trampoline-armv8.S */; };
@@ -125,33 +125,33 @@
 		2758FF6D7CB6E6F97E65AE76 /* a_utf8.c in Sources */ = {isa = PBXBuildFile; fileRef = 33D151529FF09F98CE101C54 /* a_utf8.c */; };
 		27D067932D878D8FB57A2B21 /* x509_lu.c in Sources */ = {isa = PBXBuildFile; fileRef = 3E0D3549980F9749B037C49A /* x509_lu.c */; };
 		28570EB1BB5C6DFF27200E8E /* d1_both.cc in Sources */ = {isa = PBXBuildFile; fileRef = 39BA416547F7588F0937E644 /* d1_both.cc */; };
-		28CACE988565726CB0AAC899 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		28CACE988565726CB0AAC899 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		28D4A7D9A1D7CCC3968057AD /* x_pkey.c in Sources */ = {isa = PBXBuildFile; fileRef = 11CBF80145331DAD232B46DA /* x_pkey.c */; };
 		28FB10256A4E58B949BCEE52 /* hexdump.c in Sources */ = {isa = PBXBuildFile; fileRef = 9DCCA41CD887DC31F56A481E /* hexdump.c */; };
-		28FCFD58B68E73098C15D5AD /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		2929048DF8A07F61D10C0DDE /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		28FCFD58B68E73098C15D5AD /* (null) in Sources */ = {isa = PBXBuildFile; };
+		2929048DF8A07F61D10C0DDE /* (null) in Sources */ = {isa = PBXBuildFile; };
 		2994B6EFC9387420E6D9FD55 /* poly1305_vec.c in Sources */ = {isa = PBXBuildFile; fileRef = 622DBF359D8430487A68FEC0 /* poly1305_vec.c */; };
 		29B207B6DCEAD605F75354C0 /* x509_att.c in Sources */ = {isa = PBXBuildFile; fileRef = 227257FE24F35DBF96618204 /* x509_att.c */; };
 		29B9AD3D368A8120B5735151 /* e_rc2.c in Sources */ = {isa = PBXBuildFile; fileRef = 955EDFD13CF1326AB347D0AE /* e_rc2.c */; };
 		2A0F53E700049A5BF08DD2C7 /* tls13_both.cc in Sources */ = {isa = PBXBuildFile; fileRef = 669A5FA948E3F5341D97AA40 /* tls13_both.cc */; };
-		2AE3AB381A44D9C4130E4771 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		2B190A07927823BD6A88EDED /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		2BD7704FACC59AC8028B0FB9 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		2BDD978A1B7B0ADF80EBA66E /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		2AE3AB381A44D9C4130E4771 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		2B190A07927823BD6A88EDED /* (null) in Sources */ = {isa = PBXBuildFile; };
+		2BD7704FACC59AC8028B0FB9 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		2BDD978A1B7B0ADF80EBA66E /* (null) in Sources */ = {isa = PBXBuildFile; };
 		2BF6418F0D717D3EF71AA816 /* ssl_cert.cc in Sources */ = {isa = PBXBuildFile; fileRef = 543D272EA33AC52256BAF7CB /* ssl_cert.cc */; };
-		2BF6E7EDC845E7C95D8DC2CD /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		2BF6E7EDC845E7C95D8DC2CD /* (null) in Sources */ = {isa = PBXBuildFile; };
 		2C274B276A69A742ABB3DB94 /* bn_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = 40489B408C550104B165EBE1 /* bn_asn1.c */; };
 		2C2C53049B407B3122357326 /* pkcs8.c in Sources */ = {isa = PBXBuildFile; fileRef = 61A12AF57A4EF06C81A24522 /* pkcs8.c */; };
-		2C3651FA89368A30368F6BE6 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		2C3651FA89368A30368F6BE6 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		2C709FD7C352E84FBAF0BF1F /* tasn_typ.c in Sources */ = {isa = PBXBuildFile; fileRef = C56561387502ACD084C07F37 /* tasn_typ.c */; };
-		2C8528A68D987921D607D2C2 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		2C8528A68D987921D607D2C2 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		2CA5AE6D970AF0E8AB6D07BF /* fuchsia.c in Sources */ = {isa = PBXBuildFile; fileRef = 9A95045F93F8CB0DD158DEDD /* fuchsia.c */; };
 		2CA657B68D19D78AC1942A0F /* hpke.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F009525BAD3D69CA6CFDAD5 /* hpke.c */; };
-		2D9BC916CCA11F0412B07977 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		2E06848746D3CF2378264BF7 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		2D9BC916CCA11F0412B07977 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		2E06848746D3CF2378264BF7 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		2E5384DDBE16EB255768A210 /* x509_txt.c in Sources */ = {isa = PBXBuildFile; fileRef = 6E48EAC687DE0A94C1801B53 /* x509_txt.c */; };
 		2E5EAE1B7A7D0D45BA710078 /* aesv8-armx64.S in Sources */ = {isa = PBXBuildFile; fileRef = 30B2FFAAB2758A27C881CAE7 /* aesv8-armx64.S */; };
-		2E8E2ACFA325740F188C9E55 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		2E8E2ACFA325740F188C9E55 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		2EB49619612512892AD605FB /* a_strnid.c in Sources */ = {isa = PBXBuildFile; fileRef = 445D99E3F2D2E23044127878 /* a_strnid.c */; };
 		2EBAF6190B7424E734014DA9 /* x509cset.c in Sources */ = {isa = PBXBuildFile; fileRef = 77F3FBF88BF0BC0574369136 /* x509cset.c */; };
 		2F4BCD604E48C619A391B3D9 /* rsa_pss.c in Sources */ = {isa = PBXBuildFile; fileRef = 65C257F11F97056D16E27186 /* rsa_pss.c */; };
@@ -165,49 +165,49 @@
 		31C881AE5900EBFA70B28753 /* tls13_server.cc in Sources */ = {isa = PBXBuildFile; fileRef = C23D55306C0AE1551049E48A /* tls13_server.cc */; };
 		31C9D274CF4F0DBAEF9F39B3 /* tls_method.cc in Sources */ = {isa = PBXBuildFile; fileRef = 4A3C15FEB510C3395FD5F590 /* tls_method.cc */; };
 		31F58B3DBC91D7B481EF4129 /* rsa_print.c in Sources */ = {isa = PBXBuildFile; fileRef = 17087C55C2D10CBCEC2E39FA /* rsa_print.c */; };
-		32593A65C4F530BE1268EF1A /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		32593A65C4F530BE1268EF1A /* (null) in Sources */ = {isa = PBXBuildFile; };
 		3397D7EF47B95D6F2154BD1C /* sha512-586.S in Sources */ = {isa = PBXBuildFile; fileRef = 9F142DDDEA16A89F0696B0F2 /* sha512-586.S */; };
 		33A94EAC740E05A8E252FFE3 /* x509_txt.c in Sources */ = {isa = PBXBuildFile; fileRef = 6E48EAC687DE0A94C1801B53 /* x509_txt.c */; };
 		33C3A3BEF250652DB7C1E077 /* v3_akey.c in Sources */ = {isa = PBXBuildFile; fileRef = 91D520844D49ADC49E1A70B8 /* v3_akey.c */; };
 		33FECDFE6D8337B419550ED8 /* tasn_new.c in Sources */ = {isa = PBXBuildFile; fileRef = 35D7984E610B3D60BE049E02 /* tasn_new.c */; };
 		3456532B5861C3A786DD8B29 /* sha256-x86_64.S in Sources */ = {isa = PBXBuildFile; fileRef = 027F768B3C4092F2B0C34908 /* sha256-x86_64.S */; };
-		34DE553C2D20341704AC578E /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		34DE553C2D20341704AC578E /* (null) in Sources */ = {isa = PBXBuildFile; };
 		34EF6E1D5766601F554D801B /* v3_bcons.c in Sources */ = {isa = PBXBuildFile; fileRef = 8C211BF17B97C47DA931555C /* v3_bcons.c */; };
-		35027C9AD29018ECAE82F534 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		350D48872BA6A21FB03FDE43 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		35027C9AD29018ECAE82F534 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		350D48872BA6A21FB03FDE43 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		35F6D695DD128F0B6B0A45AC /* cpu-intel.c in Sources */ = {isa = PBXBuildFile; fileRef = 9DCF1E1E5903FDED6A994244 /* cpu-intel.c */; };
 		3626796056891CA565E6C6DC /* f_string.c in Sources */ = {isa = PBXBuildFile; fileRef = 90D4F156E8AD3C01289C17BB /* f_string.c */; };
 		368314A7053477550907E262 /* ssl_cert.cc in Sources */ = {isa = PBXBuildFile; fileRef = 543D272EA33AC52256BAF7CB /* ssl_cert.cc */; };
-		36D1BF7258C8F63A02C805A1 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		37138F894C392FCCD2E5D2D7 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		36D1BF7258C8F63A02C805A1 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		37138F894C392FCCD2E5D2D7 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		37DEAC5E4AAB5A2067706DE0 /* x_algor.c in Sources */ = {isa = PBXBuildFile; fileRef = 46D49BABD342EDF458E0E9A9 /* x_algor.c */; };
 		37F89306301A708503B2DB65 /* evp.c in Sources */ = {isa = PBXBuildFile; fileRef = 6E780F87E2AC3F150B4C81A5 /* evp.c */; };
-		37FA26F137AD90C616390DB0 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		38715C899B30DC431377C5DD /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		37FA26F137AD90C616390DB0 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		38715C899B30DC431377C5DD /* (null) in Sources */ = {isa = PBXBuildFile; };
 		3894D173AFA2B9B448755408 /* dtls_method.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1AFDA9EF121DF0DE240A7DD1 /* dtls_method.cc */; };
 		38DB939878EE6ED6A3C7F0ED /* s3_lib.cc in Sources */ = {isa = PBXBuildFile; fileRef = AFA5053EB14A930FA4E9C564 /* s3_lib.cc */; };
 		391D9244F399652F949A0335 /* x509_obj.c in Sources */ = {isa = PBXBuildFile; fileRef = 2F1683BF1D2C3DEE3E455130 /* x509_obj.c */; };
 		394795CF0C2CB04AD57A6D66 /* p_ec_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = 4914822D1328CA2EC4B64178 /* p_ec_asn1.c */; };
-		397A455350C69A71E1B39C04 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		3984A7A9719C0B3E0991C566 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		397A455350C69A71E1B39C04 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		3984A7A9719C0B3E0991C566 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		39B190D834034671D3F982E2 /* ghashv8-armx64.S in Sources */ = {isa = PBXBuildFile; fileRef = 2F250883B7FF6BB34D64D55D /* ghashv8-armx64.S */; };
 		3A0A3562156B7A0BA0F5644B /* i2d_pr.c in Sources */ = {isa = PBXBuildFile; fileRef = 93A271CB1989BA640C107747 /* i2d_pr.c */; };
-		3A770C70133081AF5414A38C /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		3A9294BD816B3EE92E692347 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		3A9F8998B0164D80AE443187 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		3B3559D64CAE11BAEB967F5C /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		3A770C70133081AF5414A38C /* (null) in Sources */ = {isa = PBXBuildFile; };
+		3A9294BD816B3EE92E692347 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		3A9F8998B0164D80AE443187 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		3B3559D64CAE11BAEB967F5C /* (null) in Sources */ = {isa = PBXBuildFile; };
 		3B98B242EE8FED9C2357FF33 /* fips_shared_support.c in Sources */ = {isa = PBXBuildFile; fileRef = 2148ED7084B556A740E18E14 /* fips_shared_support.c */; };
 		3C480BDB1160546C05437187 /* x509_def.c in Sources */ = {isa = PBXBuildFile; fileRef = 7EF28BEB6BACDA2EC13AD181 /* x509_def.c */; };
 		3C5F4E5A78C0926AA97BAE96 /* ssl_file.cc in Sources */ = {isa = PBXBuildFile; fileRef = 40834C452855B97F603F1D4B /* ssl_file.cc */; };
-		3CDE08A38BE71A60768C48A8 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		3D2D405AB38A2176506B6349 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		3CDE08A38BE71A60768C48A8 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		3D2D405AB38A2176506B6349 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		3DBF7CA212F416B23DF648A7 /* hrss.c in Sources */ = {isa = PBXBuildFile; fileRef = 4DD75B725C8C6AFF73377FE1 /* hrss.c */; };
 		3DC73056D9228CA48EBF4760 /* thread_win.c in Sources */ = {isa = PBXBuildFile; fileRef = 90E0C8F68FBDD6C0027A96D9 /* thread_win.c */; };
 		3DCCE4B4FE49BD88311FF8D6 /* ec_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = 239801E138F254CB7FE9C0E0 /* ec_asn1.c */; };
-		3E066F3097D645D88C5806BE /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		3E066F3097D645D88C5806BE /* (null) in Sources */ = {isa = PBXBuildFile; };
 		3E3880B37A3D71734426B2E9 /* ecdsa_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = 91B76BAD835175216ADD4C06 /* ecdsa_asn1.c */; };
-		3EF35E5C96674A4ACFF6A716 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		3F8441722F1EEC03840F7EFC /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		3EF35E5C96674A4ACFF6A716 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		3F8441722F1EEC03840F7EFC /* (null) in Sources */ = {isa = PBXBuildFile; };
 		3FAA454A53BE0861A4847415 /* s3_both.cc in Sources */ = {isa = PBXBuildFile; fileRef = 655553F23840F5CBB0E5B8B5 /* s3_both.cc */; };
 		40356BAF72410D5F750305A8 /* pcy_node.c in Sources */ = {isa = PBXBuildFile; fileRef = 31498604FF0AF2E19071A302 /* pcy_node.c */; };
 		405514699746E072B04A2BBA /* deterministic.c in Sources */ = {isa = PBXBuildFile; fileRef = 8C9E5D24B8DFD460712F74E4 /* deterministic.c */; };
@@ -217,28 +217,28 @@
 		420D27CD619DAAFFDF44D4E8 /* aesv8-armx32.S in Sources */ = {isa = PBXBuildFile; fileRef = CF42E16B19B6562EC64825AE /* aesv8-armx32.S */; };
 		421D3EC0A012595A26B4304E /* a_int.c in Sources */ = {isa = PBXBuildFile; fileRef = 80BDCBB23AD2A536C6556FAD /* a_int.c */; };
 		423A6457F66546235105535F /* t_x509.c in Sources */ = {isa = PBXBuildFile; fileRef = 9B3979357642B5C047A03E2A /* t_x509.c */; };
-		42487C57C6AE4E10A5E8469A /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		42487C57C6AE4E10A5E8469A /* (null) in Sources */ = {isa = PBXBuildFile; };
 		42A21580843AEB221326DA8C /* mem.c in Sources */ = {isa = PBXBuildFile; fileRef = 20A84B6FBED4B872F9262B57 /* mem.c */; };
 		42BC5AD263DF1168346714B3 /* a_bitstr.c in Sources */ = {isa = PBXBuildFile; fileRef = F00A02AAA9B71BB161525E01 /* a_bitstr.c */; };
 		42EDAA65CD9B985BE3402D26 /* vpaes-armv8.S in Sources */ = {isa = PBXBuildFile; fileRef = C1ABC536FB3F8634D74F7F7A /* vpaes-armv8.S */; };
 		43BD1B3E2D4FA605511EA00D /* a_time.c in Sources */ = {isa = PBXBuildFile; fileRef = 6378CA82DCEBFDCD843679F7 /* a_time.c */; };
-		43E11138FAAE2EFDF81CB7BA /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		43E11138FAAE2EFDF81CB7BA /* (null) in Sources */ = {isa = PBXBuildFile; };
 		4439B8CBC9FB621E48207EFF /* x_algor.c in Sources */ = {isa = PBXBuildFile; fileRef = 46D49BABD342EDF458E0E9A9 /* x_algor.c */; };
-		444AA334E305003BE74A51D2 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		444AA334E305003BE74A51D2 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		446C00C0F41061D9BF76C394 /* ssl_x509.cc in Sources */ = {isa = PBXBuildFile; fileRef = 64425DFB7D789748463000D0 /* ssl_x509.cc */; };
 		447FA09D58B5797F9B818404 /* x_req.c in Sources */ = {isa = PBXBuildFile; fileRef = 16E7DC716B9C1642C99EEE04 /* x_req.c */; };
 		44BE7C603E62D741249477F5 /* ssl_cipher.cc in Sources */ = {isa = PBXBuildFile; fileRef = B1335F2CD6708EAAC7DCE6AE /* ssl_cipher.cc */; };
 		44BEAA60861BB732D7A798C8 /* poly1305.c in Sources */ = {isa = PBXBuildFile; fileRef = E148698EAD73CBF38CDCC4FD /* poly1305.c */; };
 		4516FF8423AB52A88EBFC4C2 /* a_print.c in Sources */ = {isa = PBXBuildFile; fileRef = 8CE7FBEA00AECF0D990D28A7 /* a_print.c */; };
-		456E33C768281D3288C063B3 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		456E33C768281D3288C063B3 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		4572D50BBFD7E084ECAFDDB7 /* ssl_aead_ctx.cc in Sources */ = {isa = PBXBuildFile; fileRef = E8C6715C179FA3D4A3A06275 /* ssl_aead_ctx.cc */; };
 		45BB564067C692E2D0D97591 /* x509_cmp.c in Sources */ = {isa = PBXBuildFile; fileRef = 411D9C112D2BEC83F1FBED52 /* x509_cmp.c */; };
 		45C4DE5A562890B07F773E35 /* ecdh_extra.c in Sources */ = {isa = PBXBuildFile; fileRef = CD857B10E68746228A73FBFD /* ecdh_extra.c */; };
 		45CCD52A6E328D1F0CD72BD2 /* p_ed25519.c in Sources */ = {isa = PBXBuildFile; fileRef = 8EC52C5890A368A58BB4BF7B /* p_ed25519.c */; };
 		469B4F8E536AC8AD48936208 /* e_rc2.c in Sources */ = {isa = PBXBuildFile; fileRef = 955EDFD13CF1326AB347D0AE /* e_rc2.c */; };
-		46C0B1AAFEF103C3D5964EB0 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		46C0B1AAFEF103C3D5964EB0 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		46D0984532B8FE15B3CD1701 /* v3_skey.c in Sources */ = {isa = PBXBuildFile; fileRef = 5B0C6774ECB344A044A82C59 /* v3_skey.c */; };
-		46D22A4C867C9D7FEFD23BB2 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		46D22A4C867C9D7FEFD23BB2 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		46F328459D680AD4ED974EDC /* lhash.c in Sources */ = {isa = PBXBuildFile; fileRef = F5177B300FA2E27C15E382AE /* lhash.c */; };
 		474665271D3FF955A998E51A /* cpu-aarch64-win.c in Sources */ = {isa = PBXBuildFile; fileRef = E75DDABF68BE969F6986D0A8 /* cpu-aarch64-win.c */; };
 		47CFFF8878492818244DA596 /* ghash-x86_64.S in Sources */ = {isa = PBXBuildFile; fileRef = 35EAC9D27DBC3694463F71F8 /* ghash-x86_64.S */; };
@@ -246,55 +246,55 @@
 		485BE7E2F14D05AF48D3EA68 /* p_x25519.c in Sources */ = {isa = PBXBuildFile; fileRef = E91BA244589DB9AC0F9E7226 /* p_x25519.c */; };
 		48B8D48BABE257F119C5B8AD /* v3_pci.c in Sources */ = {isa = PBXBuildFile; fileRef = 6A1172B7A0C810A62762D6AE /* v3_pci.c */; };
 		48C7A9529F305EA08C57B754 /* digestsign.c in Sources */ = {isa = PBXBuildFile; fileRef = E548BC5EDC591F42C0DFD9FD /* digestsign.c */; };
-		48DF38FC21952CA55EBD4D9A /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		490D770E24C9CED82390B52D /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		493D8D46A818F4902A549D67 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		48DF38FC21952CA55EBD4D9A /* (null) in Sources */ = {isa = PBXBuildFile; };
+		490D770E24C9CED82390B52D /* (null) in Sources */ = {isa = PBXBuildFile; };
+		493D8D46A818F4902A549D67 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		4941E30C646DE0CF2CFDA124 /* pkcs7.c in Sources */ = {isa = PBXBuildFile; fileRef = 09BD3B60DB67ED53C9DEB8AF /* pkcs7.c */; };
 		4953DE55CFE049D0797533C5 /* thread.c in Sources */ = {isa = PBXBuildFile; fileRef = B34936067433B64D020E129C /* thread.c */; };
-		4960656D84CFCF2BECFA388F /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		4960656D84CFCF2BECFA388F /* (null) in Sources */ = {isa = PBXBuildFile; };
 		49791BF7B8C19D7881F60B41 /* thread_none.c in Sources */ = {isa = PBXBuildFile; fileRef = F639021AB01EBF66298D3937 /* thread_none.c */; };
-		49AC091FF369E6B9AB2F98E0 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		49EDACA726ED8487F4D0AEFD /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		49AC091FF369E6B9AB2F98E0 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		49EDACA726ED8487F4D0AEFD /* (null) in Sources */ = {isa = PBXBuildFile; };
 		4A1F5A665A1842D861F7175F /* cpu-arm-linux.c in Sources */ = {isa = PBXBuildFile; fileRef = 4C0ED393FA85526282634662 /* cpu-arm-linux.c */; };
-		4A3D988F1505B9BA9DEDE3BE /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		4A8347CEFB33ED5AF117812D /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		4A3D988F1505B9BA9DEDE3BE /* (null) in Sources */ = {isa = PBXBuildFile; };
+		4A8347CEFB33ED5AF117812D /* (null) in Sources */ = {isa = PBXBuildFile; };
 		4B2FCACD5B4D88212F190D42 /* fips_shared_support.c in Sources */ = {isa = PBXBuildFile; fileRef = 2148ED7084B556A740E18E14 /* fips_shared_support.c */; };
 		4B6DC412BA68E1539B03A239 /* dsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 88D3C1AEF8FD1320EE422AE3 /* dsa.c */; };
 		4B99A3A8FFE572AAC216B484 /* x_x509.c in Sources */ = {isa = PBXBuildFile; fileRef = B6F0D491D2E8A0ECABA855B2 /* x_x509.c */; };
-		4B9E0CFEDC29B3E5F38004B0 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		4B9E0CFEDC29B3E5F38004B0 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		4BC4520C7CAF9B35BAA18864 /* d1_pkt.cc in Sources */ = {isa = PBXBuildFile; fileRef = 8A4734E09CA210E631D7EFE1 /* d1_pkt.cc */; };
 		4BE3B931E8DFC72E24077BA1 /* rsa_print.c in Sources */ = {isa = PBXBuildFile; fileRef = 17087C55C2D10CBCEC2E39FA /* rsa_print.c */; };
 		4C8480633726B50280F36FAD /* ssl_asn1.cc in Sources */ = {isa = PBXBuildFile; fileRef = EDF96D02C1748A9976CC8803 /* ssl_asn1.cc */; };
-		4D2FA827533D7910A9EE2008 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		4D2FA827533D7910A9EE2008 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		4D91233F729E3FF653043128 /* obj.c in Sources */ = {isa = PBXBuildFile; fileRef = 4AC445F076CA03A291762953 /* obj.c */; };
 		4DBEB11609C74754FEE64F5B /* pkcs7_x509.c in Sources */ = {isa = PBXBuildFile; fileRef = 36ECED028C795E6C35C4CEB6 /* pkcs7_x509.c */; };
-		4E2C7E4C5DF42EFDDC649C50 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		4E3D2D46C2CC12154F2F4FF7 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		4E2C7E4C5DF42EFDDC649C50 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		4E3D2D46C2CC12154F2F4FF7 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		4E95B7544EF866AFFA43694F /* a_dup.c in Sources */ = {isa = PBXBuildFile; fileRef = 102AF1D55456151F508A7C4A /* a_dup.c */; };
 		4F7BE1E590DE5784850851E2 /* v3_ncons.c in Sources */ = {isa = PBXBuildFile; fileRef = 388B50675A22B5705B4EB3B9 /* v3_ncons.c */; };
 		4FA31F447362D34ACD1EC7D0 /* x_val.c in Sources */ = {isa = PBXBuildFile; fileRef = 342E05C9EBC2F2E072B5B69E /* x_val.c */; };
 		501902A3E86557DC2D68AEB4 /* a_mbstr.c in Sources */ = {isa = PBXBuildFile; fileRef = 98BCE20CFFDAD2A77F39498C /* a_mbstr.c */; };
-		50F30C481E8769D0161B970E /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		50F30C481E8769D0161B970E /* (null) in Sources */ = {isa = PBXBuildFile; };
 		51370471CFBE01E41916195B /* crypto.c in Sources */ = {isa = PBXBuildFile; fileRef = 148E127C993451F865C25E20 /* crypto.c */; };
 		51F85A37A1EBA47CE92AD3E4 /* p_x25519_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = 9A38C7098396BFBF857BBE8D /* p_x25519_asn1.c */; };
 		522B600D017263A112636779 /* sha256-armv4.S in Sources */ = {isa = PBXBuildFile; fileRef = F35F00B76815E45A436C8D8D /* sha256-armv4.S */; };
 		5275EB4E76A952AE1C6CC7BF /* time_support.c in Sources */ = {isa = PBXBuildFile; fileRef = 87FE78FEDADDD59E21059F01 /* time_support.c */; };
-		5292E4A72BC733B86DFF57D0 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		5292E4A72BC733B86DFF57D0 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		52B63B709D1901958DF63070 /* spake25519.c in Sources */ = {isa = PBXBuildFile; fileRef = 3ED2034F44739EF4CB2FBC88 /* spake25519.c */; };
 		53114229AEEDA81126376A50 /* hexdump.c in Sources */ = {isa = PBXBuildFile; fileRef = 9DCCA41CD887DC31F56A481E /* hexdump.c */; };
 		538E3329C097151B2D64B34D /* v3_prn.c in Sources */ = {isa = PBXBuildFile; fileRef = 74E902B3917408E045951319 /* v3_prn.c */; };
-		53E2A7313DD580871DDD42E9 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		5423581175FF15B4B16848F8 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		53E2A7313DD580871DDD42E9 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		5423581175FF15B4B16848F8 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		543C532F482A5095DC98CB4D /* trust_token.c in Sources */ = {isa = PBXBuildFile; fileRef = 6E4DCE5480FADFDA683118CC /* trust_token.c */; };
 		54567797C98571ECC3D0D69B /* x509_v3.c in Sources */ = {isa = PBXBuildFile; fileRef = 59A0CA2D4382EB7BD0461DB2 /* x509_v3.c */; };
-		54A2C6692A2B5364C634FA1B /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		54A2C6692A2B5364C634FA1B /* (null) in Sources */ = {isa = PBXBuildFile; };
 		54B174B8B4DA528ABE8D0C9A /* a_verify.c in Sources */ = {isa = PBXBuildFile; fileRef = DB52E49149BF2604FA35EB62 /* a_verify.c */; };
 		551ABA10C6BC9D984218A7F9 /* v3_ocsp.c in Sources */ = {isa = PBXBuildFile; fileRef = 3F6093D305A339C78F82B3CC /* v3_ocsp.c */; };
 		552EA7B19868371525C9048C /* v3_int.c in Sources */ = {isa = PBXBuildFile; fileRef = AF3FCF964D54F9365D5BC031 /* v3_int.c */; };
 		553BA595BE6BDC421C3BF372 /* p_ed25519_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = 315F65543860FC3FCF71C55B /* p_ed25519_asn1.c */; };
 		55557B89BC5DEFAC9313E916 /* rdrand-x86_64.S in Sources */ = {isa = PBXBuildFile; fileRef = 79DA264908929F17D6DC09BD /* rdrand-x86_64.S */; };
-		55CBCCDEF6ED579B53A97062 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		55DE436455A20282EA080F0E /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		55CBCCDEF6ED579B53A97062 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		55DE436455A20282EA080F0E /* (null) in Sources */ = {isa = PBXBuildFile; };
 		5607EF3B3AE3BC160AB0FD8B /* p5_pbev2.c in Sources */ = {isa = PBXBuildFile; fileRef = 7811B9D6494A5AB21BEBBA0D /* p5_pbev2.c */; };
 		560C1799145B24EB8D627145 /* t_crl.c in Sources */ = {isa = PBXBuildFile; fileRef = 3FA51A3AD44830372D0BECD3 /* t_crl.c */; };
 		56582FC351B0A72F8FD83254 /* p5_pbev2.c in Sources */ = {isa = PBXBuildFile; fileRef = 7811B9D6494A5AB21BEBBA0D /* p5_pbev2.c */; };
@@ -308,106 +308,106 @@
 		58D1060092D5AC27F5B8FC22 /* pem_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 6151C1E83346838803639A94 /* pem_lib.c */; };
 		58E259AFBB4203107D655A2B /* conf.c in Sources */ = {isa = PBXBuildFile; fileRef = 70E1093198E23200A5FD6181 /* conf.c */; };
 		590120FA54BA9053073FB8AE /* v3_akeya.c in Sources */ = {isa = PBXBuildFile; fileRef = 6578E1A9125E1BBD3D0D1AB7 /* v3_akeya.c */; };
-		5A00C7ECB0E8C51F71AC2D5F /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		5A00C7ECB0E8C51F71AC2D5F /* (null) in Sources */ = {isa = PBXBuildFile; };
 		5A68F278C83E03C27E4F59FE /* poly1305_vec.c in Sources */ = {isa = PBXBuildFile; fileRef = 622DBF359D8430487A68FEC0 /* poly1305_vec.c */; };
 		5A8CCBD6596671C5C4BC87E8 /* pkcs8.c in Sources */ = {isa = PBXBuildFile; fileRef = 61A12AF57A4EF06C81A24522 /* pkcs8.c */; };
 		5AC270CB716F5A8E7DF6E444 /* v3_enum.c in Sources */ = {isa = PBXBuildFile; fileRef = 781039BE709E9A484FD9F050 /* v3_enum.c */; };
 		5AC289EE050211529E599F1D /* ghash-neon-armv8.S in Sources */ = {isa = PBXBuildFile; fileRef = 2F9796240DCF3D61199E86EC /* ghash-neon-armv8.S */; };
 		5AC89FE8FD81768934684584 /* v3_cpols.c in Sources */ = {isa = PBXBuildFile; fileRef = 5717D37A1D32B48E5812E828 /* v3_cpols.c */; };
-		5AE3DFB922177CD825C9ED47 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		5B57F1D55E09C49C0CBABE78 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		5B61FB4F6034E4BD6E02484F /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		5AE3DFB922177CD825C9ED47 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		5B57F1D55E09C49C0CBABE78 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		5B61FB4F6034E4BD6E02484F /* (null) in Sources */ = {isa = PBXBuildFile; };
 		5BF29FCAF510954F36095AFC /* a_bool.c in Sources */ = {isa = PBXBuildFile; fileRef = 9E4FEEECAFDF9195F8699F07 /* a_bool.c */; };
 		5C1533FB5915EF474F0C9F04 /* d1_pkt.cc in Sources */ = {isa = PBXBuildFile; fileRef = 8A4734E09CA210E631D7EFE1 /* d1_pkt.cc */; };
-		5C2A8AF6C9D550C6E7DAC5AD /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		5C2A8AF6C9D550C6E7DAC5AD /* (null) in Sources */ = {isa = PBXBuildFile; };
 		5D047520D3CBCA2836A89E7F /* aesni-gcm-x86_64.S in Sources */ = {isa = PBXBuildFile; fileRef = 3ADEE369D8265CF897BC7A37 /* aesni-gcm-x86_64.S */; };
 		5D21C660FBFD82E6B657F3EC /* x509_vfy.c in Sources */ = {isa = PBXBuildFile; fileRef = FCCD00B7DD60035AE898B96C /* x509_vfy.c */; };
-		5DE9FFEDA770485C44AC2F87 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		5DE9FFEDA770485C44AC2F87 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		5E5E88CF4DC520F135FA4F4E /* ghash-x86.S in Sources */ = {isa = PBXBuildFile; fileRef = C949CF6DF8CD6FBE2BA8CA03 /* ghash-x86.S */; };
 		5E6749E98C7A1075DEC25EC4 /* p_rsa_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = 8BB0887EC587795C7DD1B950 /* p_rsa_asn1.c */; };
-		5E7792314B7C17B62B1A6B4F /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		5E7792314B7C17B62B1A6B4F /* (null) in Sources */ = {isa = PBXBuildFile; };
 		5EA328A587DFC756B4F9CDED /* ssl_buffer.cc in Sources */ = {isa = PBXBuildFile; fileRef = D23FE1D8C732A8F9A04112CC /* ssl_buffer.cc */; };
 		5ED7AD3DB16D35D0101DB942 /* cipher_extra.c in Sources */ = {isa = PBXBuildFile; fileRef = 224C7B79EB507B9A4BF0463D /* cipher_extra.c */; };
 		5F2030D63CAFF29CD2A5D654 /* a_enum.c in Sources */ = {isa = PBXBuildFile; fileRef = 7086FCF8C238C1E4EBB9309D /* a_enum.c */; };
-		5F49B1A0D5F7D4A85D6E5BBD /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		5F9BCDC1BB148BFEC29401A5 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		5FEAA33F60E349DA4444D0C7 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		5FF3598E55179C29119EEB11 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		5F49B1A0D5F7D4A85D6E5BBD /* (null) in Sources */ = {isa = PBXBuildFile; };
+		5F9BCDC1BB148BFEC29401A5 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		5FEAA33F60E349DA4444D0C7 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		5FF3598E55179C29119EEB11 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		6073EA74BCDBE2D38B089C86 /* trampoline-armv4.S in Sources */ = {isa = PBXBuildFile; fileRef = 10539F57503AD1B16A2BF020 /* trampoline-armv4.S */; };
 		610B729CA0DE45C00CFE8DCD /* p_rsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 8DF59799E5E2E83C681B2AD7 /* p_rsa.c */; };
-		611F877467789981E7106926 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		611F877467789981E7106926 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		6121586FC73892B5F3C6E6C3 /* cpu-aarch64-win.c in Sources */ = {isa = PBXBuildFile; fileRef = E75DDABF68BE969F6986D0A8 /* cpu-aarch64-win.c */; };
-		614484A9C160DE7F9FD30C21 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		6149F66CA7F650F243709CA0 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		614484A9C160DE7F9FD30C21 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		6149F66CA7F650F243709CA0 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		615A04E503D26D9CA20B545C /* ssl_transcript.cc in Sources */ = {isa = PBXBuildFile; fileRef = 7CB75E0504CCE1BD0096B202 /* ssl_transcript.cc */; };
-		617923A6BF1E4A36340DC0B6 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		617923A6BF1E4A36340DC0B6 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		6183EF7C0D72DC782A8CD0DE /* asn_pack.c in Sources */ = {isa = PBXBuildFile; fileRef = 6CCAD94536C6ED18C16CF7E3 /* asn_pack.c */; };
 		61865DAA98383EB21BC51D7E /* s3_lib.cc in Sources */ = {isa = PBXBuildFile; fileRef = AFA5053EB14A930FA4E9C564 /* s3_lib.cc */; };
 		61C4C63527B0310956789DFE /* dsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 88D3C1AEF8FD1320EE422AE3 /* dsa.c */; };
 		61DCDDEDD2EE5739C1EEB5B0 /* file.c in Sources */ = {isa = PBXBuildFile; fileRef = 29A7FB9838437DC90845D5E5 /* file.c */; };
 		6221517A2809A46FAAF20682 /* evp_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = 6C50D8F5606EE11D0BAF5E36 /* evp_asn1.c */; };
 		6276B92793073248507326E1 /* chacha.c in Sources */ = {isa = PBXBuildFile; fileRef = 8C8483FACDA514EE7D64C0F7 /* chacha.c */; };
-		62D8E1E782AFE9FDAC5EDD39 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		62D8E1E782AFE9FDAC5EDD39 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		62E32C3A26D03BF57AD753E5 /* e_aesgcmsiv.c in Sources */ = {isa = PBXBuildFile; fileRef = 37C89F7FA949492FD92B4918 /* e_aesgcmsiv.c */; };
-		631DB9BB33207274E88BBC41 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		631DB9BB33207274E88BBC41 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		63525A82AFCAC5F65ADC194A /* t_req.c in Sources */ = {isa = PBXBuildFile; fileRef = 6BBFB313860596FE96663ECB /* t_req.c */; };
 		6361852F6BE0C8CAE88C870C /* by_file.c in Sources */ = {isa = PBXBuildFile; fileRef = 6A983710429FB7C7B105ED74 /* by_file.c */; };
 		6386DA78F58EB664959B40F5 /* ssl_key_share.cc in Sources */ = {isa = PBXBuildFile; fileRef = 109CE71D6B7BD4CCF2922F6E /* ssl_key_share.cc */; };
 		64480168FCE48AE30D8AACD6 /* e_null.c in Sources */ = {isa = PBXBuildFile; fileRef = 1662F915750875363FF82D11 /* e_null.c */; };
-		6493313DD7E7C00257339FE2 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		6493313DD7E7C00257339FE2 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		64E0FCDADBA293615E4E0ACB /* sign.c in Sources */ = {isa = PBXBuildFile; fileRef = 943FE87362A65AF78C86D6D7 /* sign.c */; };
 		65E2B382BBDCBF734B68D6BB /* cpu-arm.c in Sources */ = {isa = PBXBuildFile; fileRef = DC28CBD0B5058B7463F60F2D /* cpu-arm.c */; };
 		66394A9F95D38CDD74AAF595 /* mem.c in Sources */ = {isa = PBXBuildFile; fileRef = 20A84B6FBED4B872F9262B57 /* mem.c */; };
 		672AC86CB3C593704E697530 /* p_ec.c in Sources */ = {isa = PBXBuildFile; fileRef = 59921E0EBF5DE6FF6444AB33 /* p_ec.c */; };
-		67C0A6CF7887D47BBC235F0E /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		67C0A6CF7887D47BBC235F0E /* (null) in Sources */ = {isa = PBXBuildFile; };
 		67CEB7830BA42D523C4C423C /* v3_prn.c in Sources */ = {isa = PBXBuildFile; fileRef = 74E902B3917408E045951319 /* v3_prn.c */; };
 		67E1331485153DD40B26DFD6 /* tls_record.cc in Sources */ = {isa = PBXBuildFile; fileRef = D9D20FB06463526438913D28 /* tls_record.cc */; };
 		686298E16BA3CB5FDD38C1E2 /* v3_pcia.c in Sources */ = {isa = PBXBuildFile; fileRef = 91A0A8696759B64EC82EA8DC /* v3_pcia.c */; };
 		68D83C97C6F7515048DD9332 /* cpu-arm.c in Sources */ = {isa = PBXBuildFile; fileRef = DC28CBD0B5058B7463F60F2D /* cpu-arm.c */; };
-		68E069C9F4EA00503869D4F1 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		68E069C9F4EA00503869D4F1 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		691AC841BBF7FC0C82A5A3C6 /* pem_pkey.c in Sources */ = {isa = PBXBuildFile; fileRef = EFDDCE5DB28C1E3A5BAEE28A /* pem_pkey.c */; };
 		692E1F167655A684D6F62111 /* pkcs8_x509.c in Sources */ = {isa = PBXBuildFile; fileRef = 800D1B99751682F24DC6BCDF /* pkcs8_x509.c */; };
 		69325C0ED38D89FDC4A3DEB4 /* thread_pthread.c in Sources */ = {isa = PBXBuildFile; fileRef = 9618195051F731FED87604C4 /* thread_pthread.c */; };
 		69AC94E133967CD8205A8199 /* x509rset.c in Sources */ = {isa = PBXBuildFile; fileRef = 11FC0D577EB9AC61C9413503 /* x509rset.c */; };
 		6A210B9C768DCE43332F0EFA /* x_sig.c in Sources */ = {isa = PBXBuildFile; fileRef = 71A7CFA18E5FEDB346744D27 /* x_sig.c */; };
-		6A34E90A533DD74CAC154E61 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		6A34E90A533DD74CAC154E61 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		6A432E72CB6862149CC65FEC /* aesni-x86_64.S in Sources */ = {isa = PBXBuildFile; fileRef = 3A4BC7880B6D48002C90A211 /* aesni-x86_64.S */; };
 		6A648134677FDF8569103138 /* x_exten.c in Sources */ = {isa = PBXBuildFile; fileRef = 1CE277743B6A1901F40B2F9C /* x_exten.c */; };
 		6A71667C78F13F00F7154680 /* pcy_tree.c in Sources */ = {isa = PBXBuildFile; fileRef = 2B86F692353610B2666B8230 /* pcy_tree.c */; };
 		6B0C8B25C5B5B2DC34F49EBF /* encrypted_client_hello.cc in Sources */ = {isa = PBXBuildFile; fileRef = 78827B2C5E783A656A2D98CA /* encrypted_client_hello.cc */; };
 		6B651A9030D9B750BDC5D776 /* pem_info.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A66F0379BBAA59EDDED6E9 /* pem_info.c */; };
-		6B79D106C41F11E999FA195B /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		6B79D106C41F11E999FA195B /* (null) in Sources */ = {isa = PBXBuildFile; };
 		6B7FC8C237F6D1C4FC36A13E /* v3_ia5.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D28B55C96DB5A30AA5950C4 /* v3_ia5.c */; };
 		6C1FA6B2C6F981F75D2D1B4E /* obj_xref.c in Sources */ = {isa = PBXBuildFile; fileRef = B24FEABC9A2EDA5791D9C54E /* obj_xref.c */; };
 		6C4A31172030E6227586268D /* p_ed25519.c in Sources */ = {isa = PBXBuildFile; fileRef = 8EC52C5890A368A58BB4BF7B /* p_ed25519.c */; };
-		6C56639C3F24DA5935B90026 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		6C56639C3F24DA5935B90026 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		6C8273E0FEEE84389466CCC3 /* x_val.c in Sources */ = {isa = PBXBuildFile; fileRef = 342E05C9EBC2F2E072B5B69E /* x_val.c */; };
 		6CBB7E62C3C092A21B3D1074 /* v3_alt.c in Sources */ = {isa = PBXBuildFile; fileRef = 0E517017FF0C070A675CD744 /* v3_alt.c */; };
 		6D6B11D40EF0CEBA94AB178C /* ghash-neon-armv8.S in Sources */ = {isa = PBXBuildFile; fileRef = 5E0BC97DA3735203D9D5C048 /* ghash-neon-armv8.S */; };
-		6DA8046AA88A71BB57435465 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		6DA8046AA88A71BB57435465 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		6DC5DCACCA06708CBD05E78C /* chacha20_poly1305_x86_64.S in Sources */ = {isa = PBXBuildFile; fileRef = 1E43AAB939593DB582313755 /* chacha20_poly1305_x86_64.S */; };
-		6DF4D3D48656F19734F61F56 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		6EED196FFE03C2358C1F246E /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		6DF4D3D48656F19734F61F56 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		6EED196FFE03C2358C1F246E /* (null) in Sources */ = {isa = PBXBuildFile; };
 		6F017B3EEF66825B5E1D4E66 /* ssl_session.cc in Sources */ = {isa = PBXBuildFile; fileRef = 518752FF816A5A9E7D03A298 /* ssl_session.cc */; };
 		6F4E1BB3F5FF49DA19CEFE81 /* x_crl.c in Sources */ = {isa = PBXBuildFile; fileRef = 3E83F0A6E5DFCBCAD5B0BFE7 /* x_crl.c */; };
 		6FB7B050C763B1DD9118EAB3 /* v3_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 06268D1C3A20585C7D38BFC7 /* v3_lib.c */; };
 		6FDBD31631FBFA23733AD7B3 /* cipher_extra.c in Sources */ = {isa = PBXBuildFile; fileRef = 224C7B79EB507B9A4BF0463D /* cipher_extra.c */; };
 		70044FD74C83892F36B98A34 /* x_all.c in Sources */ = {isa = PBXBuildFile; fileRef = 691D09F70E11969560013B0E /* x_all.c */; };
-		7049D19A94F392F6AD0C1A84 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		7049D19A94F392F6AD0C1A84 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		70B53B388C0F5B25315EF0B8 /* a_print.c in Sources */ = {isa = PBXBuildFile; fileRef = 8CE7FBEA00AECF0D990D28A7 /* a_print.c */; };
-		70BD3667CEE5029D0FEAED00 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		70BD3667CEE5029D0FEAED00 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		70DB23F8F84828CDCCEB6DB8 /* armv8-mont.S in Sources */ = {isa = PBXBuildFile; fileRef = EE56A5B2B53EB6A894438E56 /* armv8-mont.S */; };
 		70E4BB109AE70408403B2C25 /* x509_req.c in Sources */ = {isa = PBXBuildFile; fileRef = 02A51C17489D420A71D7AC85 /* x509_req.c */; };
 		71358BCE4C175CA5C3966BCC /* pkcs8_x509.c in Sources */ = {isa = PBXBuildFile; fileRef = 800D1B99751682F24DC6BCDF /* pkcs8_x509.c */; };
-		72A9DFEBAE2B1F83E01EE6E5 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		72A9DFEBAE2B1F83E01EE6E5 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		72AA683592AB306D1ED3A429 /* err.c in Sources */ = {isa = PBXBuildFile; fileRef = 622A8739543801456BBDA66F /* err.c */; };
 		7312A0C0A29ABB720642307B /* handshake_client.cc in Sources */ = {isa = PBXBuildFile; fileRef = AF493028D7E2A9296D8241AA /* handshake_client.cc */; };
 		731C2901ADEAFFEED5B210D5 /* deterministic.c in Sources */ = {isa = PBXBuildFile; fileRef = 8C9E5D24B8DFD460712F74E4 /* deterministic.c */; };
 		731FD849B4BCAA8F2757E0AF /* ghashv8-armx64.S in Sources */ = {isa = PBXBuildFile; fileRef = E91CA1068AA898116E483642 /* ghashv8-armx64.S */; };
 		73DDE8CAC60142D82B7A916D /* a_gentm.c in Sources */ = {isa = PBXBuildFile; fileRef = 02648893B99FA192BF18C7D9 /* a_gentm.c */; };
-		73FDBABF4CAF49E46CFFBEB6 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		7447267EAF54E1AD1C16A643 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		75567E14AF9EF4DA0B0FDF27 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		73FDBABF4CAF49E46CFFBEB6 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		7447267EAF54E1AD1C16A643 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		75567E14AF9EF4DA0B0FDF27 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		75E2B9A0866F05032B3B1DA0 /* pcy_data.c in Sources */ = {isa = PBXBuildFile; fileRef = 682966D322E4528C1E925810 /* pcy_data.c */; };
 		764E30F2348FA53D138894FF /* x509.c in Sources */ = {isa = PBXBuildFile; fileRef = 21E124D303337F706E63497E /* x509.c */; };
 		770D956C87AA78100DE88E07 /* v3_conf.c in Sources */ = {isa = PBXBuildFile; fileRef = 5CA60B2BE5AA67EAD75774BC /* v3_conf.c */; };
@@ -417,65 +417,65 @@
 		7802CEB5C4A643F9F1B292C1 /* pem_xaux.c in Sources */ = {isa = PBXBuildFile; fileRef = 6EE258C0E242CFEA4D755541 /* pem_xaux.c */; };
 		780B6E12FC8E03D57D61723E /* md5-586.S in Sources */ = {isa = PBXBuildFile; fileRef = 46EEFBE0EB930750E2CFF81D /* md5-586.S */; };
 		782B8822241296B00DECB037 /* ecdh_extra.c in Sources */ = {isa = PBXBuildFile; fileRef = CD857B10E68746228A73FBFD /* ecdh_extra.c */; };
-		78802AA1FEA8ABFB6D59DE77 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		78802AA1FEA8ABFB6D59DE77 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		789E5134B2AC9B1B79D93D08 /* x86_64-mont5.S in Sources */ = {isa = PBXBuildFile; fileRef = 7FB570A33D00E615CCD35D7B /* x86_64-mont5.S */; };
-		78F51793DEAFED77BE3233EA /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		78F51793DEAFED77BE3233EA /* (null) in Sources */ = {isa = PBXBuildFile; };
 		7A4FD7979ECB9946E1997C14 /* scrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 7F7F9267CEC47A4AC5F1B7F3 /* scrypt.c */; };
 		7AFAA1AECDF6DDEC4097C52E /* a_strex.c in Sources */ = {isa = PBXBuildFile; fileRef = 74B99B2B1BAD90A9D0CDE516 /* a_strex.c */; };
 		7B7B7C967A3C786D7FCAC0A0 /* pbkdf.c in Sources */ = {isa = PBXBuildFile; fileRef = E00FBF8254DB6F121322C7CF /* pbkdf.c */; };
 		7BC5D63A800D91C835A3970B /* pmbtoken.c in Sources */ = {isa = PBXBuildFile; fileRef = 9313CF758A0348A8FA3759AC /* pmbtoken.c */; };
-		7BD1391024EC420052658E16 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		7BD1391024EC420052658E16 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		7CB46C708808AC0F8E81619C /* tasn_utl.c in Sources */ = {isa = PBXBuildFile; fileRef = 93DBD9B95A237CF23D20BC51 /* tasn_utl.c */; };
 		7CB4B8BE5A3C25B461CA085B /* p_dsa_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = 4EBA6DA9BA0E52AB8839B4C8 /* p_dsa_asn1.c */; };
 		7CBCF716FB421DFDA8227CDD /* a_utctm.c in Sources */ = {isa = PBXBuildFile; fileRef = B87489135780021DBBBBFB12 /* a_utctm.c */; };
 		7D1145A9BD06831CDF78BBB0 /* evp_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = 6C50D8F5606EE11D0BAF5E36 /* evp_asn1.c */; };
 		7D71D54C78887AD48F87B8E7 /* a_time.c in Sources */ = {isa = PBXBuildFile; fileRef = 6378CA82DCEBFDCD843679F7 /* a_time.c */; };
 		7DEAA0154B3ABB053C34C73E /* evp.c in Sources */ = {isa = PBXBuildFile; fileRef = 6E780F87E2AC3F150B4C81A5 /* evp.c */; };
-		7E0F98E988386FAA5E824DDB /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		7E20134EBC2B4947A30004C4 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		7E0F98E988386FAA5E824DDB /* (null) in Sources */ = {isa = PBXBuildFile; };
+		7E20134EBC2B4947A30004C4 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		7E26C12E1A36549E863E6EAC /* bn_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = 40489B408C550104B165EBE1 /* bn_asn1.c */; };
 		7F3A626AC7CF798EF7F1271C /* tasn_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 043E65BAE8B2FBA273C538C5 /* tasn_dec.c */; };
 		7F78EDE186C7E0FB4AD46684 /* t1_lib.cc in Sources */ = {isa = PBXBuildFile; fileRef = D30DCB120336217B0543EA79 /* t1_lib.cc */; };
 		8067F325C92ECDA794664B5C /* tls13_enc.cc in Sources */ = {isa = PBXBuildFile; fileRef = 2296BEA874A895EA1BDBB436 /* tls13_enc.cc */; };
 		8069537DAB696C83153B599B /* lhash.c in Sources */ = {isa = PBXBuildFile; fileRef = F5177B300FA2E27C15E382AE /* lhash.c */; };
-		81047581B0DA4B73D9F10125 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		81047581B0DA4B73D9F10125 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		814B1614A75802258A403753 /* v3_bcons.c in Sources */ = {isa = PBXBuildFile; fileRef = 8C211BF17B97C47DA931555C /* v3_bcons.c */; };
 		82050A9790ED9ADE271ECAFC /* x_x509.c in Sources */ = {isa = PBXBuildFile; fileRef = B6F0D491D2E8A0ECABA855B2 /* x_x509.c */; };
 		825774580BB7F2A382AAD09E /* sha1-x86_64.S in Sources */ = {isa = PBXBuildFile; fileRef = 637A88650AF52ACE8BF41414 /* sha1-x86_64.S */; };
-		8296213B2F86071A1ED7354D /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		8296213B2F86071A1ED7354D /* (null) in Sources */ = {isa = PBXBuildFile; };
 		832FE03A89802FE386EBF0F1 /* handoff.cc in Sources */ = {isa = PBXBuildFile; fileRef = A1E597219C43F5D8F0A42190 /* handoff.cc */; };
 		83C66B6FB625F79BFCA6C2B5 /* rc4.c in Sources */ = {isa = PBXBuildFile; fileRef = 431AF269F1D171958CC80769 /* rc4.c */; };
-		841572601AA102E4C449A9EB /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		841572601AA102E4C449A9EB /* (null) in Sources */ = {isa = PBXBuildFile; };
 		847828B5B3C19D7A2E5B39BC /* pem_x509.c in Sources */ = {isa = PBXBuildFile; fileRef = 65727C46B0B529DE60D49461 /* pem_x509.c */; };
 		84D6362DDD4080066485B85D /* convert.c in Sources */ = {isa = PBXBuildFile; fileRef = 78A26D24578B17CE601F4891 /* convert.c */; };
 		85045BE92AFB139FCAC8249A /* x509_obj.c in Sources */ = {isa = PBXBuildFile; fileRef = 2F1683BF1D2C3DEE3E455130 /* x509_obj.c */; };
-		852540E7992C41D1BB4FD105 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		852540E7992C41D1BB4FD105 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		85A53370CC739414EB84E441 /* asn1_gen.c in Sources */ = {isa = PBXBuildFile; fileRef = 0A2124CD3818E07F4D8B4EC8 /* asn1_gen.c */; };
 		86C5499ECF7DA29DA7C5A37F /* d1_lib.cc in Sources */ = {isa = PBXBuildFile; fileRef = 0B2480E96418AA722F4B1533 /* d1_lib.cc */; };
 		881A096DA629D3EBDC3767DB /* x_sig.c in Sources */ = {isa = PBXBuildFile; fileRef = 71A7CFA18E5FEDB346744D27 /* x_sig.c */; };
-		88303405FDD6FCF337579C3E /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		88AF7FC3A0C54C93EE4ACA53 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		89075C2301FBB614BC720312 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		88303405FDD6FCF337579C3E /* (null) in Sources */ = {isa = PBXBuildFile; };
+		88AF7FC3A0C54C93EE4ACA53 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		89075C2301FBB614BC720312 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		8996DCADA8AB563D99284225 /* v3_extku.c in Sources */ = {isa = PBXBuildFile; fileRef = 65A65C51BC92DDC624E888B9 /* v3_extku.c */; };
-		89EF79990902B227BEA7C84C /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		89EF79990902B227BEA7C84C /* (null) in Sources */ = {isa = PBXBuildFile; };
 		8A0D14C91DDB12CCD8B9BE86 /* armv4-mont.S in Sources */ = {isa = PBXBuildFile; fileRef = 4F5E8B814FB7E4CD267C6AD7 /* armv4-mont.S */; };
-		8A5421446B7788EDFC876DB0 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		8A7F36618F9B88D0017ADC63 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		8A5421446B7788EDFC876DB0 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		8A7F36618F9B88D0017ADC63 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		8BAB26C2356DD938AF5A6EE2 /* a_bool.c in Sources */ = {isa = PBXBuildFile; fileRef = 9E4FEEECAFDF9195F8699F07 /* a_bool.c */; };
 		8BC0D733242F08D9361432C5 /* v3_pci.c in Sources */ = {isa = PBXBuildFile; fileRef = 6A1172B7A0C810A62762D6AE /* v3_pci.c */; };
 		8BE244C7944822ACCE0E34A5 /* evp_ctx.c in Sources */ = {isa = PBXBuildFile; fileRef = 069B84410555410235C3E9E4 /* evp_ctx.c */; };
-		8C6143C18F6A436CFF0E604F /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		8C6143C18F6A436CFF0E604F /* (null) in Sources */ = {isa = PBXBuildFile; };
 		8CAAC0AE0671B4F73DD36E76 /* ber.c in Sources */ = {isa = PBXBuildFile; fileRef = 1F462B8738F23CC847F3629B /* ber.c */; };
 		8CFF6B25CDACD61D6D607DAD /* v3_info.c in Sources */ = {isa = PBXBuildFile; fileRef = 795E918552549AB6BC12B754 /* v3_info.c */; };
 		8D4D45558A57A498081173A7 /* tls_method.cc in Sources */ = {isa = PBXBuildFile; fileRef = 4A3C15FEB510C3395FD5F590 /* tls_method.cc */; };
-		8D6FAE7B0C80F8F0E04EB0A6 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		8E020DACE9872B68FC3E6052 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		8E18831246C37254FB7B98BC /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		8D6FAE7B0C80F8F0E04EB0A6 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		8E020DACE9872B68FC3E6052 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		8E18831246C37254FB7B98BC /* (null) in Sources */ = {isa = PBXBuildFile; };
 		8E2081DA1BD5E033F64ADCA1 /* f_int.c in Sources */ = {isa = PBXBuildFile; fileRef = 14645F81C0FF2CA7CAD38BF2 /* f_int.c */; };
 		8E5C278A051A757DEA4FBDF7 /* aesv8-armx64.S in Sources */ = {isa = PBXBuildFile; fileRef = BA9D06470988366ED112C208 /* aesv8-armx64.S */; };
-		8E623100E5BA9336AF0B9D91 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		8E9AEE9D338FA01438F58212 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		8E9C07F5BDED73EF170C96A1 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		8E623100E5BA9336AF0B9D91 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		8E9AEE9D338FA01438F58212 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		8E9C07F5BDED73EF170C96A1 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		8F011AD36151F4C5055D3941 /* a_mbstr.c in Sources */ = {isa = PBXBuildFile; fileRef = 98BCE20CFFDAD2A77F39498C /* a_mbstr.c */; };
 		8F14CA39AAE3F519859D5A08 /* e_rc4.c in Sources */ = {isa = PBXBuildFile; fileRef = 6413D786E773B4FA92B3EA28 /* e_rc4.c */; };
 		8F15E722CB24A1604432EDCE /* v3_bitst.c in Sources */ = {isa = PBXBuildFile; fileRef = 19078C0D9FD1EDEA58B29987 /* v3_bitst.c */; };
@@ -484,9 +484,9 @@
 		8FD98673A3CEFACB507A37CF /* ex_data.c in Sources */ = {isa = PBXBuildFile; fileRef = 4F7AED107588476ABE2ABCE1 /* ex_data.c */; };
 		90016B4036282EBFFA5D59F5 /* v3_pmaps.c in Sources */ = {isa = PBXBuildFile; fileRef = 0396A0FA7324137074AF6356 /* v3_pmaps.c */; };
 		905C749F69D7D25DB4539100 /* cpu-aarch64-linux.c in Sources */ = {isa = PBXBuildFile; fileRef = 6D7EDA0FA370A0AB18644E01 /* cpu-aarch64-linux.c */; };
-		90836A68A17E9A2A1E748CEA /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		90836A68A17E9A2A1E748CEA /* (null) in Sources */ = {isa = PBXBuildFile; };
 		9135E830B133355FDDEA137F /* p_dsa_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = 4EBA6DA9BA0E52AB8839B4C8 /* p_dsa_asn1.c */; };
-		915BD8EE9FFF0299156A7671 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		915BD8EE9FFF0299156A7671 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		91CD0BD8C27D7A34E75763F7 /* a_i2d_fp.c in Sources */ = {isa = PBXBuildFile; fileRef = 150495FB44BCE2F37FA95E55 /* a_i2d_fp.c */; };
 		9210E3F76FF34970C9E59B9D /* t_req.c in Sources */ = {isa = PBXBuildFile; fileRef = 6BBFB313860596FE96663ECB /* t_req.c */; };
 		923FE15255F97E8FCCB08740 /* pem_pk8.c in Sources */ = {isa = PBXBuildFile; fileRef = 87F7E9647ED80A0905AC51C1 /* pem_pk8.c */; };
@@ -494,7 +494,7 @@
 		930C90EDDFCB642AB875EED1 /* dtls_method.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1AFDA9EF121DF0DE240A7DD1 /* dtls_method.cc */; };
 		93126A43AB7412B42633251B /* asn_pack.c in Sources */ = {isa = PBXBuildFile; fileRef = 6CCAD94536C6ED18C16CF7E3 /* asn_pack.c */; };
 		942DE356FE05CFE4CE10B939 /* pem_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 6151C1E83346838803639A94 /* pem_lib.c */; };
-		94902B75B33F95CBF17623D1 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		94902B75B33F95CBF17623D1 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		94ACC9C44D211C77C6FAFB42 /* trampoline-x86.S in Sources */ = {isa = PBXBuildFile; fileRef = 443CAD46CC5EDE99ED4A5D99 /* trampoline-x86.S */; };
 		953DD9C3A8099852679E4835 /* pem_oth.c in Sources */ = {isa = PBXBuildFile; fileRef = 92851568ED10D0C9C7C23D97 /* pem_oth.c */; };
 		9577BC90CF013F1DD0AD65E6 /* x_exten.c in Sources */ = {isa = PBXBuildFile; fileRef = 1CE277743B6A1901F40B2F9C /* x_exten.c */; };
@@ -502,8 +502,8 @@
 		95A0D4E31D9023B5EF2DE97C /* asn1_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 4EF33A71743AC5D3E047F268 /* asn1_lib.c */; };
 		95A659C0B18C65447C919CBF /* ssl_transcript.cc in Sources */ = {isa = PBXBuildFile; fileRef = 7CB75E0504CCE1BD0096B202 /* ssl_transcript.cc */; };
 		95A8372CC32642CB97A5EF2C /* engine.c in Sources */ = {isa = PBXBuildFile; fileRef = 95CC2FCA0159642C9A4ECB6A /* engine.c */; };
-		95F66580DCC8786B6B6F4204 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		95FE4E59B77B67919213295D /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		95F66580DCC8786B6B6F4204 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		95FE4E59B77B67919213295D /* (null) in Sources */ = {isa = PBXBuildFile; };
 		9661111C9CFBBDF5487AF159 /* sha256-armv8.S in Sources */ = {isa = PBXBuildFile; fileRef = 469931B7DF85C06E3ED6759F /* sha256-armv8.S */; };
 		968B0C8A797DD9BC7B454EA8 /* rsa_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = 168CB17B865EF3921ED536D7 /* rsa_asn1.c */; };
 		97648F81331CF217C2FDB438 /* a_octet.c in Sources */ = {isa = PBXBuildFile; fileRef = 752C466B046BE268E003DE89 /* a_octet.c */; };
@@ -516,22 +516,22 @@
 		98E8012F0D2C2748E26DA524 /* asn1_compat.c in Sources */ = {isa = PBXBuildFile; fileRef = 22354C3686D4BD44D77ED990 /* asn1_compat.c */; };
 		990B3D8A06CED9461B5393F6 /* x_attrib.c in Sources */ = {isa = PBXBuildFile; fileRef = 65AD780C8B21956EAA073425 /* x_attrib.c */; };
 		993984B0C9A9D15EA2838CED /* refcount_lock.c in Sources */ = {isa = PBXBuildFile; fileRef = 2301CF793788230F58289E12 /* refcount_lock.c */; };
-		99580A142AE55B184E38A708 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		9973CB826D61EE04063C32F7 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		99580A142AE55B184E38A708 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		9973CB826D61EE04063C32F7 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		9AB3A3349FAAEC3B8B9E3E8E /* print.c in Sources */ = {isa = PBXBuildFile; fileRef = 3BFD47EF870331B0CA1F1689 /* print.c */; };
-		9AE434F33E0B0322461173E7 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		9AE434F33E0B0322461173E7 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		9AF5F84F4971A8A2F419EA43 /* err_data.c in Sources */ = {isa = PBXBuildFile; fileRef = 003F2551708A65D09588819A /* err_data.c */; };
-		9B53A6F156B079F64B0B27C9 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		9B91D02C903FC090E206D1C2 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		9B53A6F156B079F64B0B27C9 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		9B91D02C903FC090E206D1C2 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		9BCAE6315BF5D63AA2BA0ACC /* by_file.c in Sources */ = {isa = PBXBuildFile; fileRef = 6A983710429FB7C7B105ED74 /* by_file.c */; };
-		9C0BE3ABC7B866988B0DC5C1 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		9C0BE3ABC7B866988B0DC5C1 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		9C7CFD9BA0065C091EA3F3B9 /* bio_mem.c in Sources */ = {isa = PBXBuildFile; fileRef = 17B8446F563EF1EAF315041D /* bio_mem.c */; };
 		9C985A512D2C6952A3F8FDE2 /* x509_d2.c in Sources */ = {isa = PBXBuildFile; fileRef = 57267DFA1DBC96BBF2D79360 /* x509_d2.c */; };
 		9CA220B5EDC4901477097D3D /* thread_none.c in Sources */ = {isa = PBXBuildFile; fileRef = F639021AB01EBF66298D3937 /* thread_none.c */; };
 		9CFA4D70C06D15283EBC70DA /* pool.c in Sources */ = {isa = PBXBuildFile; fileRef = 2F02A5AE2AD958C375B7D205 /* pool.c */; };
 		9D510F51BB800CC028E4D3D2 /* x509_vpm.c in Sources */ = {isa = PBXBuildFile; fileRef = 0E1D1E8E85B1918FD2BE3A17 /* x509_vpm.c */; };
 		9D57B973EE61B0BDC8721F02 /* rand_extra.c in Sources */ = {isa = PBXBuildFile; fileRef = 17C5AF6267F93F474F74CE15 /* rand_extra.c */; };
-		9D95657CEADC836890AC7A26 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		9D95657CEADC836890AC7A26 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		9DE5BBFE3D8A353779815B2A /* x509_ext.c in Sources */ = {isa = PBXBuildFile; fileRef = 26331B634DFE6AE10160CCE9 /* x509_ext.c */; };
 		9E27AD066FE3D671370037C0 /* hash_to_curve.c in Sources */ = {isa = PBXBuildFile; fileRef = 2CB9153513892563E8DAA4A8 /* hash_to_curve.c */; };
 		9F00E8E2223C1A3300EC1EF3 /* objcthemis.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A24B5223A8FA8005CB63A /* objcthemis.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -723,7 +723,7 @@
 		9F4A2620223ABEF2005CB63A /* secure_session_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A242E223A74AF005CB63A /* secure_session_utils.c */; };
 		9F4A2621223ABEF2005CB63A /* secure_session.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2438223A74AF005CB63A /* secure_session.c */; };
 		9F4A2622223ABEF2005CB63A /* sym_enc_message.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2431223A74AF005CB63A /* sym_enc_message.c */; };
-		9F4F7C57C0E7986C44CFAE37 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		9F4F7C57C0E7986C44CFAE37 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		9F6B385523D9D11600EA5D1B /* secure_cell_seal_passphrase.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F6B385423D9D11600EA5D1B /* secure_cell_seal_passphrase.c */; };
 		9F6B385623D9D11600EA5D1B /* secure_cell_seal_passphrase.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F6B385423D9D11600EA5D1B /* secure_cell_seal_passphrase.c */; };
 		9F70B2C1241D0FEC009CB629 /* themis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E8D7223C197900EC1EF3 /* themis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -785,13 +785,13 @@
 		A06116E75A90B9DE1B6A43F8 /* v3_pcons.c in Sources */ = {isa = PBXBuildFile; fileRef = 4C50A854C1EAD9EF9B194814 /* v3_pcons.c */; };
 		A11A0923A3879E3F9D5068F6 /* d1_srtp.cc in Sources */ = {isa = PBXBuildFile; fileRef = 8D003C2E052B7FE57735E052 /* d1_srtp.cc */; };
 		A1924BDF525A648BD65B1702 /* a_digest.c in Sources */ = {isa = PBXBuildFile; fileRef = 95CD409D48EEAFF9D8F98442 /* a_digest.c */; };
-		A1D784F0537449166788142C /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		A1D784F0537449166788142C /* (null) in Sources */ = {isa = PBXBuildFile; };
 		A2589CB25D88CC3BC608AE80 /* vpaes-x86.S in Sources */ = {isa = PBXBuildFile; fileRef = 340CEF11EBCCCF31C4C44A09 /* vpaes-x86.S */; };
 		A2921373E98B810BF568BEA6 /* sha512-x86_64.S in Sources */ = {isa = PBXBuildFile; fileRef = D2A025ECE744B8A9759714BB /* sha512-x86_64.S */; };
-		A296501CEDBB84279A22AD66 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		A296501CEDBB84279A22AD66 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		A2E5560409B1457AA2013D6B /* refcount_lock.c in Sources */ = {isa = PBXBuildFile; fileRef = 2301CF793788230F58289E12 /* refcount_lock.c */; };
 		A301E0D17A39C99E5E135555 /* x86_64-mont.S in Sources */ = {isa = PBXBuildFile; fileRef = 73CB9D99654C15BF1970094C /* x86_64-mont.S */; };
-		A32587A0E6C55D21196DC424 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		A32587A0E6C55D21196DC424 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		A337C7DDE8EEE611D9716E2D /* handoff.cc in Sources */ = {isa = PBXBuildFile; fileRef = A1E597219C43F5D8F0A42190 /* handoff.cc */; };
 		A3718C97323073252A79FD07 /* e_tls.c in Sources */ = {isa = PBXBuildFile; fileRef = 136B10737C2A992E86B7EC17 /* e_tls.c */; };
 		A38527051C50AE736726CC17 /* by_dir.c in Sources */ = {isa = PBXBuildFile; fileRef = 1258860B218CC3CF285F880F /* by_dir.c */; };
@@ -812,7 +812,7 @@
 		A746F4FC57C00C3A5F55FA6E /* convert.c in Sources */ = {isa = PBXBuildFile; fileRef = 78A26D24578B17CE601F4891 /* convert.c */; };
 		A80DA39794401A4A57806704 /* ber.c in Sources */ = {isa = PBXBuildFile; fileRef = 1F462B8738F23CC847F3629B /* ber.c */; };
 		A842FC602977FA66928224A1 /* windows.c in Sources */ = {isa = PBXBuildFile; fileRef = 642CD0E9E215ECA43275185B /* windows.c */; };
-		A84541467945783DF34A5E77 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		A84541467945783DF34A5E77 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		A8456304FE70B6627027E7EA /* algorithm.c in Sources */ = {isa = PBXBuildFile; fileRef = A437EC79DE61C9AB74B0381D /* algorithm.c */; };
 		A887A56E6E552D5BC23E49A3 /* ex_data.c in Sources */ = {isa = PBXBuildFile; fileRef = 4F7AED107588476ABE2ABCE1 /* ex_data.c */; };
 		A8BA780599AACDF5FB934BA8 /* x509.c in Sources */ = {isa = PBXBuildFile; fileRef = 21E124D303337F706E63497E /* x509.c */; };
@@ -823,7 +823,7 @@
 		A97A229E2C5C6CA7752EBB3A /* ssl_lib.cc in Sources */ = {isa = PBXBuildFile; fileRef = 5EA5C35141601D18390BEF41 /* ssl_lib.cc */; };
 		A9A75C26074580196258931D /* x_pkey.c in Sources */ = {isa = PBXBuildFile; fileRef = 11CBF80145331DAD232B46DA /* x_pkey.c */; };
 		AAB94E620A60FAC8E97F4C0F /* cpu-ppc64le.c in Sources */ = {isa = PBXBuildFile; fileRef = 11487D804E6245C0D28CDE0F /* cpu-ppc64le.c */; };
-		AB700C7F7CECE1B9000EDABE /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		AB700C7F7CECE1B9000EDABE /* (null) in Sources */ = {isa = PBXBuildFile; };
 		ABB742A5CE7762869CCFC376 /* dh_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = B4B017D0440D2A4B02D7F5A6 /* dh_asn1.c */; };
 		ABB87780BCD28CB6830112E0 /* tasn_utl.c in Sources */ = {isa = PBXBuildFile; fileRef = 93DBD9B95A237CF23D20BC51 /* tasn_utl.c */; };
 		ABE4E258D74F9BE3787EAB41 /* d1_lib.cc in Sources */ = {isa = PBXBuildFile; fileRef = 0B2480E96418AA722F4B1533 /* d1_lib.cc */; };
@@ -832,20 +832,20 @@
 		AC48B681579AAAE628540C86 /* pcy_map.c in Sources */ = {isa = PBXBuildFile; fileRef = 59FC75CF6DE8F8E2C45C4B09 /* pcy_map.c */; };
 		ACBF3047149AB3459F31652D /* x509_lu.c in Sources */ = {isa = PBXBuildFile; fileRef = 3E0D3549980F9749B037C49A /* x509_lu.c */; };
 		ACED6FFA78A7DA325C424D99 /* tasn_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 1C90A3D3E1A4931A45FC577F /* tasn_enc.c */; };
-		ACFEFC8BC170A565C82556F7 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		ACFEFC8BC170A565C82556F7 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		AD5C4A24A85F9191BC916DCC /* encrypted_client_hello.cc in Sources */ = {isa = PBXBuildFile; fileRef = 78827B2C5E783A656A2D98CA /* encrypted_client_hello.cc */; };
-		ADCCC1165BB374AD2B52E1EB /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		ADCCC1165BB374AD2B52E1EB /* (null) in Sources */ = {isa = PBXBuildFile; };
 		ADD1F6118F7F77425B7FE977 /* params.c in Sources */ = {isa = PBXBuildFile; fileRef = 71FE59DD329237B9FFF000BA /* params.c */; };
-		AE2FDA266A7E7AF10AD5F363 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		AE533CE36406DE383473773C /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		AE2FDA266A7E7AF10AD5F363 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		AE533CE36406DE383473773C /* (null) in Sources */ = {isa = PBXBuildFile; };
 		AE8E2B5C52F74F7C5A7AA248 /* t_x509a.c in Sources */ = {isa = PBXBuildFile; fileRef = 1DFC350CD9DC62EF36047DBD /* t_x509a.c */; };
 		AF3CB57AFA5F88EBD439F766 /* asn1_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 4EF33A71743AC5D3E047F268 /* asn1_lib.c */; };
 		AF47B3319159F300C088AA1E /* pair.c in Sources */ = {isa = PBXBuildFile; fileRef = 7EB848A937B59FF1C0E48C2C /* pair.c */; };
 		AF53785DE7875353045F4108 /* pbkdf.c in Sources */ = {isa = PBXBuildFile; fileRef = E00FBF8254DB6F121322C7CF /* pbkdf.c */; };
-		AF5BDFD99CED0A9F7D90413C /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		AF5BDFD99CED0A9F7D90413C /* (null) in Sources */ = {isa = PBXBuildFile; };
 		B0523B5E49525E8F715BB9F7 /* x509name.c in Sources */ = {isa = PBXBuildFile; fileRef = 163CE4A11AAC94EDA445E20F /* x509name.c */; };
-		B0FC96493F43BB0AE1A2EF54 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		B163496D246934B52B3400FD /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		B0FC96493F43BB0AE1A2EF54 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		B163496D246934B52B3400FD /* (null) in Sources */ = {isa = PBXBuildFile; };
 		B16D2AAAEC757E12A0FA4B8D /* cbb.c in Sources */ = {isa = PBXBuildFile; fileRef = 3A72594CE11062A04E626323 /* cbb.c */; };
 		B1DAE9411A5EB0358DD75FE9 /* v3_conf.c in Sources */ = {isa = PBXBuildFile; fileRef = 5CA60B2BE5AA67EAD75774BC /* v3_conf.c */; };
 		B209E18269DC03AA75711758 /* fd.c in Sources */ = {isa = PBXBuildFile; fileRef = 7FFCF8CA42EF6F7FA3646DFE /* fd.c */; };
@@ -859,14 +859,14 @@
 		B439232A8143E4F9873561C7 /* ssl_stat.cc in Sources */ = {isa = PBXBuildFile; fileRef = 6B1B6D6B321438A8D34C2B86 /* ssl_stat.cc */; };
 		B4BDDF84DBAE59A4FA3FC4A3 /* s3_pkt.cc in Sources */ = {isa = PBXBuildFile; fileRef = 4B99C93A91E01D305AA2702D /* s3_pkt.cc */; };
 		B4C822544BE467BD7151CADE /* x_spki.c in Sources */ = {isa = PBXBuildFile; fileRef = 45A6244416D7F9A0909AB664 /* x_spki.c */; };
-		B50F5E7D5F90CABF7654ACE8 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		B50F5E7D5F90CABF7654ACE8 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		B53C83B4586ABCE71A2267D2 /* algorithm.c in Sources */ = {isa = PBXBuildFile; fileRef = A437EC79DE61C9AB74B0381D /* algorithm.c */; };
 		B5B912B2B0671724CBE07AD7 /* tls_record.cc in Sources */ = {isa = PBXBuildFile; fileRef = D9D20FB06463526438913D28 /* tls_record.cc */; };
 		B5E3A44882A71E2D08377221 /* ssl_asn1.cc in Sources */ = {isa = PBXBuildFile; fileRef = EDF96D02C1748A9976CC8803 /* ssl_asn1.cc */; };
-		B65093E0BB25B3CCA7962185 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		B65093E0BB25B3CCA7962185 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		B68A325CA3DED2441796E89F /* bio_mem.c in Sources */ = {isa = PBXBuildFile; fileRef = 17B8446F563EF1EAF315041D /* bio_mem.c */; };
 		B6BA78E65BE24651B2560AEE /* v3_utl.c in Sources */ = {isa = PBXBuildFile; fileRef = 1A3CF1EC54CAACAC9E7904BD /* v3_utl.c */; };
-		B70A0D96A712C6450C3EE6D2 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		B70A0D96A712C6450C3EE6D2 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		B7549D866184AD4F58215EAB /* x86-mont.S in Sources */ = {isa = PBXBuildFile; fileRef = 16B2E9E209BD8C11562ED17D /* x86-mont.S */; };
 		B766FD90A18763DB6E7A314D /* x_req.c in Sources */ = {isa = PBXBuildFile; fileRef = 16E7DC716B9C1642C99EEE04 /* x_req.c */; };
 		B7DA6E8436E0B59C35F37EEE /* ssl_key_share.cc in Sources */ = {isa = PBXBuildFile; fileRef = 109CE71D6B7BD4CCF2922F6E /* ssl_key_share.cc */; };
@@ -879,39 +879,39 @@
 		BADF175835F6F543D478E515 /* t_crl.c in Sources */ = {isa = PBXBuildFile; fileRef = 3FA51A3AD44830372D0BECD3 /* t_crl.c */; };
 		BAE89B9C5C5CCF25158A65BD /* a_object.c in Sources */ = {isa = PBXBuildFile; fileRef = 1950D98DFAE5150D6E4D25A6 /* a_object.c */; };
 		BB7C53AE645A8A78EF8323EA /* vpaes-x86_64.S in Sources */ = {isa = PBXBuildFile; fileRef = 97D4EC317E640223585B1464 /* vpaes-x86_64.S */; };
-		BBB5FC3960F65EED253BD996 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		BBCA8F846F579C52394C4E7D /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		BBB5FC3960F65EED253BD996 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		BBCA8F846F579C52394C4E7D /* (null) in Sources */ = {isa = PBXBuildFile; };
 		BC0DCA321B15D3A55D0A63D2 /* a_utf8.c in Sources */ = {isa = PBXBuildFile; fileRef = 33D151529FF09F98CE101C54 /* a_utf8.c */; };
 		BC706B7AE48199DE00A971B5 /* pcy_map.c in Sources */ = {isa = PBXBuildFile; fileRef = 59FC75CF6DE8F8E2C45C4B09 /* pcy_map.c */; };
 		BCCDC3BA5E5D93F3A1EEF2EA /* cpu-aarch64-fuchsia.c in Sources */ = {isa = PBXBuildFile; fileRef = 3D803BAC3DC4424647E6168E /* cpu-aarch64-fuchsia.c */; };
-		BCEC4AC09B9E0C91CBE2BC28 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		BCEC4AC09B9E0C91CBE2BC28 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		BD8CCFD97410BE2B2859792A /* t1_lib.cc in Sources */ = {isa = PBXBuildFile; fileRef = D30DCB120336217B0543EA79 /* t1_lib.cc */; };
 		BDC0EE3DA5721F4CBD30D7AE /* a_sign.c in Sources */ = {isa = PBXBuildFile; fileRef = 5D02D66741B1D9C6858A96B6 /* a_sign.c */; };
-		BDC102681453DE1A54AA151C /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		BDC102681453DE1A54AA151C /* (null) in Sources */ = {isa = PBXBuildFile; };
 		BEB17CC50529E8870AEE2C0B /* passive.c in Sources */ = {isa = PBXBuildFile; fileRef = CF685E3B70524E50C3638D2B /* passive.c */; };
 		BECA3BDAF3EFA1A54E223E3B /* refcount_c11.c in Sources */ = {isa = PBXBuildFile; fileRef = 0280A3D732820375556EC136 /* refcount_c11.c */; };
-		BF487B75277B957DD38F862B /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		BF7A58248236B2DEB365EB25 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		BF487B75277B957DD38F862B /* (null) in Sources */ = {isa = PBXBuildFile; };
+		BF7A58248236B2DEB365EB25 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		BFF9F86E445A3E62291606D0 /* v3_ia5.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D28B55C96DB5A30AA5950C4 /* v3_ia5.c */; };
 		C0252705D83FA2FF839829D6 /* base64.c in Sources */ = {isa = PBXBuildFile; fileRef = 6EB9FD1B2EC068C9811B11E1 /* base64.c */; };
-		C03E3EB33BAB2B23517529AB /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		C03E3EB33BAB2B23517529AB /* (null) in Sources */ = {isa = PBXBuildFile; };
 		C0F87300A4B9B665C214D6C0 /* v3_info.c in Sources */ = {isa = PBXBuildFile; fileRef = 795E918552549AB6BC12B754 /* v3_info.c */; };
-		C20AAC1980EEEDB74E4CD1A3 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		C22437D3AC35FD370D0C2321 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		C20AAC1980EEEDB74E4CD1A3 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		C22437D3AC35FD370D0C2321 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		C224870D6EBFEC4FCB8C227B /* print.c in Sources */ = {isa = PBXBuildFile; fileRef = 3BFD47EF870331B0CA1F1689 /* print.c */; };
 		C23C05CAB3A518AA3600F41E /* ssl_stat.cc in Sources */ = {isa = PBXBuildFile; fileRef = 6B1B6D6B321438A8D34C2B86 /* ssl_stat.cc */; };
-		C3EAB548A4D54B8A6E963918 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		C3EAB548A4D54B8A6E963918 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		C428EAE8C07E6DE980DCCA74 /* stack.c in Sources */ = {isa = PBXBuildFile; fileRef = 381CDDD9F69B86E2674A2203 /* stack.c */; };
 		C42E23BD9D20B75868EF1822 /* aes128gcmsiv-x86_64.S in Sources */ = {isa = PBXBuildFile; fileRef = 4E42C23DB3E2C73C0110AAC7 /* aes128gcmsiv-x86_64.S */; };
 		C44F1D3B22A80FD9232BFF66 /* v3_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 06268D1C3A20585C7D38BFC7 /* v3_lib.c */; };
-		C473D6013E0FE9F944F14294 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		C473D6013E0FE9F944F14294 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		C476FB7539609CFCF40BF847 /* cbs.c in Sources */ = {isa = PBXBuildFile; fileRef = 5DC08DF270AFB29BE7484B90 /* cbs.c */; };
-		C4B7E30F8924A8B15956C718 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		C4B7E30F8924A8B15956C718 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		C4EB0115BC42E9B82F3A5866 /* tls13_client.cc in Sources */ = {isa = PBXBuildFile; fileRef = 5C5DF275EA487EA1E0F1ADE8 /* tls13_client.cc */; };
 		C628DAFD116EE12E3991B6DF /* pem_info.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A66F0379BBAA59EDDED6E9 /* pem_info.c */; };
 		C71E4E8A23EE89C49BA88D99 /* bio_ssl.cc in Sources */ = {isa = PBXBuildFile; fileRef = BB30A1AF51ADE35D7E818BF3 /* bio_ssl.cc */; };
 		C73C668207609FF32C18767B /* spake25519.c in Sources */ = {isa = PBXBuildFile; fileRef = 3ED2034F44739EF4CB2FBC88 /* spake25519.c */; };
-		C7B85B1FAC98705AAC83E228 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		C7B85B1FAC98705AAC83E228 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		C7D117145C4457B151A128D2 /* v3_skey.c in Sources */ = {isa = PBXBuildFile; fileRef = 5B0C6774ECB344A044A82C59 /* v3_skey.c */; };
 		C865BC22A6DB39C78F1ED4EB /* pcy_data.c in Sources */ = {isa = PBXBuildFile; fileRef = 682966D322E4528C1E925810 /* pcy_data.c */; };
 		C8F58F33428E2E35E7A1DAEC /* forkunsafe.c in Sources */ = {isa = PBXBuildFile; fileRef = 818F63B8F54437740060E643 /* forkunsafe.c */; };
@@ -922,21 +922,21 @@
 		C9DC6595AF889990981644AA /* base64.c in Sources */ = {isa = PBXBuildFile; fileRef = 6EB9FD1B2EC068C9811B11E1 /* base64.c */; };
 		CA1346CEBDC682F53BC4B421 /* thread_pthread.c in Sources */ = {isa = PBXBuildFile; fileRef = 9618195051F731FED87604C4 /* thread_pthread.c */; };
 		CAAD3AFC9F6398BA04C3AB12 /* asn1_par.c in Sources */ = {isa = PBXBuildFile; fileRef = 614BD318E9D622DC7A79CA00 /* asn1_par.c */; };
-		CABD573F7168209A77490C88 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		CABD573F7168209A77490C88 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		CAEE2FFC3D3C65ACA77095E6 /* i2d_pr.c in Sources */ = {isa = PBXBuildFile; fileRef = 93A271CB1989BA640C107747 /* i2d_pr.c */; };
 		CB36584E09A8A2F85AE2D91C /* x509_set.c in Sources */ = {isa = PBXBuildFile; fileRef = 144B11BC120D749B56527711 /* x509_set.c */; };
-		CB985BD7156063EB38CEC562 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		CBBBA9F42DE573C99EA85567 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		CB985BD7156063EB38CEC562 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		CBBBA9F42DE573C99EA85567 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		CBC56E36D878BD9195442B63 /* t_x509a.c in Sources */ = {isa = PBXBuildFile; fileRef = 1DFC350CD9DC62EF36047DBD /* t_x509a.c */; };
-		CC070075846EE226C6F932C6 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		CC070075846EE226C6F932C6 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		CC0E3E3A1C76E68922C486A2 /* x509_att.c in Sources */ = {isa = PBXBuildFile; fileRef = 227257FE24F35DBF96618204 /* x509_att.c */; };
-		CCA1551FDE6EF303BA90C9E1 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		CCA1551FDE6EF303BA90C9E1 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		CCB8AA9AC0B6B7702A747486 /* sha1-586.S in Sources */ = {isa = PBXBuildFile; fileRef = 1501360BEF783ECAE4E3AA39 /* sha1-586.S */; };
 		CCF99D60143DB068CD1588D7 /* ghash-ssse3-x86.S in Sources */ = {isa = PBXBuildFile; fileRef = 753B23CB6E7B1B529B4945C1 /* ghash-ssse3-x86.S */; };
 		CD15FBCA4EBF43C37A7282F1 /* a_sign.c in Sources */ = {isa = PBXBuildFile; fileRef = 5D02D66741B1D9C6858A96B6 /* a_sign.c */; };
 		CD9F43E40D07C3990A97173D /* p_ed25519_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = 315F65543860FC3FCF71C55B /* p_ed25519_asn1.c */; };
 		CDE40DD6DBB1099342B86356 /* bcm.c in Sources */ = {isa = PBXBuildFile; fileRef = 3195B40B230CCE8EC15D6A95 /* bcm.c */; };
-		CEA0232613E3BAEAC1ECC876 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		CEA0232613E3BAEAC1ECC876 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		CEE835D1FEB73F66D94DC3B4 /* sha512-armv4.S in Sources */ = {isa = PBXBuildFile; fileRef = A24575E32D0EE548B3FD9F17 /* sha512-armv4.S */; };
 		CFAB81B00BB38636539FE84C /* x509spki.c in Sources */ = {isa = PBXBuildFile; fileRef = 290FB02DB7B283DBDF1FB397 /* x509spki.c */; };
 		D006FC326C993F12BFD7BD60 /* tasn_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 1C90A3D3E1A4931A45FC577F /* tasn_enc.c */; };
@@ -952,7 +952,7 @@
 		D47BF42A32D2BFF4DD8ED8BE /* dsa_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = 92F57D1743D65892A41DDD97 /* dsa_asn1.c */; };
 		D4A61AE89A63248C70820692 /* ssl_versions.cc in Sources */ = {isa = PBXBuildFile; fileRef = E74B6C0B76327463829DA2A4 /* ssl_versions.cc */; };
 		D4D56C2BBFD79CF66438E349 /* pkcs7_x509.c in Sources */ = {isa = PBXBuildFile; fileRef = 36ECED028C795E6C35C4CEB6 /* pkcs7_x509.c */; };
-		D51642A37267911A979573E4 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		D51642A37267911A979573E4 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		D5C0F444E94B6E035F02853A /* rsa_pss.c in Sources */ = {isa = PBXBuildFile; fileRef = 65C257F11F97056D16E27186 /* rsa_pss.c */; };
 		D6797F0D2DAD39EE79F1DC1E /* cmac.c in Sources */ = {isa = PBXBuildFile; fileRef = 79DC230DE6DE77EC7FE7EEDF /* cmac.c */; };
 		D7078EF1E1C3B8767627B341 /* e_aesccm.c in Sources */ = {isa = PBXBuildFile; fileRef = 385351340F3777A72413B7BE /* e_aesccm.c */; };
@@ -961,12 +961,12 @@
 		D80EA72A39C3E589C0E05B37 /* sha1-armv4-large.S in Sources */ = {isa = PBXBuildFile; fileRef = 9B3B84D45873C689B102F452 /* sha1-armv4-large.S */; };
 		D83E5FA84B33C329D46E4087 /* tls_cbc.c in Sources */ = {isa = PBXBuildFile; fileRef = 906940DC60EF4000C434BA4D /* tls_cbc.c */; };
 		D9481CD2DC5532D259532DD3 /* engine.c in Sources */ = {isa = PBXBuildFile; fileRef = 95CC2FCA0159642C9A4ECB6A /* engine.c */; };
-		D979724485776601BAC5061F /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		D9B3B3BF30E803302297B814 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		D979724485776601BAC5061F /* (null) in Sources */ = {isa = PBXBuildFile; };
+		D9B3B3BF30E803302297B814 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		D9F841F00E13677FF25FB31C /* poly1305_arm.c in Sources */ = {isa = PBXBuildFile; fileRef = 53CD3B797EDE1C8C499CD16E /* poly1305_arm.c */; };
 		DAF9E8934D9CD86CEEFD1B2C /* f_enum.c in Sources */ = {isa = PBXBuildFile; fileRef = 1B73F6BA3A6D4280D24319D9 /* f_enum.c */; };
 		DB61DDF57CEE86ABF1DA4CAF /* a_utctm.c in Sources */ = {isa = PBXBuildFile; fileRef = B87489135780021DBBBBFB12 /* a_utctm.c */; };
-		DB640B3A86C13D5B2A09DECB /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		DB640B3A86C13D5B2A09DECB /* (null) in Sources */ = {isa = PBXBuildFile; };
 		DB7EB4B066174CF47D408EB0 /* x509_req.c in Sources */ = {isa = PBXBuildFile; fileRef = 02A51C17489D420A71D7AC85 /* x509_req.c */; };
 		DBCD69B4776B3694B5543399 /* a_dup.c in Sources */ = {isa = PBXBuildFile; fileRef = 102AF1D55456151F508A7C4A /* a_dup.c */; };
 		DD0D1024FFA448E5E4C65E02 /* pcy_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 5827BAC56090657E311CC8FD /* pcy_lib.c */; };
@@ -985,47 +985,47 @@
 		E4DB9EE72699C33887C13274 /* p_x25519_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = 9A38C7098396BFBF857BBE8D /* p_x25519_asn1.c */; };
 		E5574435D485101D8844EB16 /* thread.c in Sources */ = {isa = PBXBuildFile; fileRef = B34936067433B64D020E129C /* thread.c */; };
 		E5655AE4E2D2434957CC4225 /* f_int.c in Sources */ = {isa = PBXBuildFile; fileRef = 14645F81C0FF2CA7CAD38BF2 /* f_int.c */; };
-		E58AE69EA7A1BDAE2BA6086B /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		E5950C5DCA3F5B1D8AB3F5A7 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		E58AE69EA7A1BDAE2BA6086B /* (null) in Sources */ = {isa = PBXBuildFile; };
+		E5950C5DCA3F5B1D8AB3F5A7 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		E6211D45AE1448E0B969B245 /* e_tls.c in Sources */ = {isa = PBXBuildFile; fileRef = 136B10737C2A992E86B7EC17 /* e_tls.c */; };
 		E64A41FAC5B61DD8757C2CF1 /* v3_akey.c in Sources */ = {isa = PBXBuildFile; fileRef = 91D520844D49ADC49E1A70B8 /* v3_akey.c */; };
 		E6979FA1831E2E4C3228A19E /* ec_derive.c in Sources */ = {isa = PBXBuildFile; fileRef = 944E25D4E83DBE736299E6ED /* ec_derive.c */; };
-		E69A9D104EA3C853FDF6C0B6 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		E69A9D104EA3C853FDF6C0B6 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		E72EB4B9A33CEF9D1E6565FD /* hash_to_curve.c in Sources */ = {isa = PBXBuildFile; fileRef = 2CB9153513892563E8DAA4A8 /* hash_to_curve.c */; };
 		E75A4612872BAC52AD8E6EC6 /* sha512-armv8.S in Sources */ = {isa = PBXBuildFile; fileRef = 402CFACCC6BA4ABFD21B642F /* sha512-armv8.S */; };
 		E7612744B21FBA98B6C27978 /* a_gentm.c in Sources */ = {isa = PBXBuildFile; fileRef = 02648893B99FA192BF18C7D9 /* a_gentm.c */; };
 		E859330115668BD1FF7E26DD /* blake2.c in Sources */ = {isa = PBXBuildFile; fileRef = D6036EB3A60237627F3AEB47 /* blake2.c */; };
-		E92E332C1268CBBE12B22B08 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		E92E332C1268CBBE12B22B08 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		E92F832807647155B1619FA3 /* chacha-armv8.S in Sources */ = {isa = PBXBuildFile; fileRef = 770F133D98157EE2473BFBA1 /* chacha-armv8.S */; };
 		E9EA1FE182C3B31B7F9B1DA1 /* hpke.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F009525BAD3D69CA6CFDAD5 /* hpke.c */; };
 		EA080302B8826557F304969D /* p_rsa_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = 8BB0887EC587795C7DD1B950 /* p_rsa_asn1.c */; };
 		EA2247C90FAF72DCC4FB82B1 /* s3_pkt.cc in Sources */ = {isa = PBXBuildFile; fileRef = 4B99C93A91E01D305AA2702D /* s3_pkt.cc */; };
 		EA53F0364191E656042C14F5 /* cpu-intel.c in Sources */ = {isa = PBXBuildFile; fileRef = 9DCF1E1E5903FDED6A994244 /* cpu-intel.c */; };
 		EA67E0DBFC68070322C1F2FD /* sha1-armv8.S in Sources */ = {isa = PBXBuildFile; fileRef = 78811EB6D224E4E4C5A8D83F /* sha1-armv8.S */; };
-		ED806EF61781490AE85CB483 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		ED806EF61781490AE85CB483 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		EDCEF56CD4802F93FD7282A1 /* a_int.c in Sources */ = {isa = PBXBuildFile; fileRef = 80BDCBB23AD2A536C6556FAD /* a_int.c */; };
 		EDF8D6D3E65714E0E5F7B6B4 /* asn1_compat.c in Sources */ = {isa = PBXBuildFile; fileRef = 22354C3686D4BD44D77ED990 /* asn1_compat.c */; };
-		EE1F18457E58DB2DE923736E /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		EE1F18457E58DB2DE923736E /* (null) in Sources */ = {isa = PBXBuildFile; };
 		EE9699F74DE7631D5A54C14D /* tls13_client.cc in Sources */ = {isa = PBXBuildFile; fileRef = 5C5DF275EA487EA1E0F1ADE8 /* tls13_client.cc */; };
 		EEDD8E006747307F4E15682E /* pem_pkey.c in Sources */ = {isa = PBXBuildFile; fileRef = EFDDCE5DB28C1E3A5BAEE28A /* pem_pkey.c */; };
 		EF26794088CFC040DF57241B /* socket.c in Sources */ = {isa = PBXBuildFile; fileRef = 4548A24187C07A2099E69654 /* socket.c */; };
-		EF69A2BA72967CC8FAE1BFCA /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		EF69A2BA72967CC8FAE1BFCA /* (null) in Sources */ = {isa = PBXBuildFile; };
 		EF92C2FD284424EB14C00983 /* v3_crld.c in Sources */ = {isa = PBXBuildFile; fileRef = D55F718790190C6021095A6C /* v3_crld.c */; };
 		F01A2700AFFFCDEFE25BC24F /* bio.c in Sources */ = {isa = PBXBuildFile; fileRef = 4F02F875BF1F552B7332D939 /* bio.c */; };
-		F0377E3AAE488098C249360C /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		F0377E3AAE488098C249360C /* (null) in Sources */ = {isa = PBXBuildFile; };
 		F0912E3A125A55FDBC7AF419 /* x_attrib.c in Sources */ = {isa = PBXBuildFile; fileRef = 65AD780C8B21956EAA073425 /* x_attrib.c */; };
-		F0919D96DD681230E2D61779 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		F0919D96DD681230E2D61779 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		F107D00C4C8926BB32A56A04 /* hkdf.c in Sources */ = {isa = PBXBuildFile; fileRef = 5E6AC366157705E772E21A34 /* hkdf.c */; };
 		F1240597AFC985496FBF0DE1 /* obj_xref.c in Sources */ = {isa = PBXBuildFile; fileRef = B24FEABC9A2EDA5791D9C54E /* obj_xref.c */; };
 		F1D53D50AB91DF27FC9363D9 /* a_d2i_fp.c in Sources */ = {isa = PBXBuildFile; fileRef = 1767CD47FB8219FDB1938182 /* a_d2i_fp.c */; };
 		F1E7865078B979A6F9591843 /* vpaes-armv7.S in Sources */ = {isa = PBXBuildFile; fileRef = 7F120B819D3A2CF45E5EC68D /* vpaes-armv7.S */; };
 		F2E318B9484D62DB15BF71BA /* trampoline-x86_64.S in Sources */ = {isa = PBXBuildFile; fileRef = 3509901AB8EE7A301809A0CB /* trampoline-x86_64.S */; };
 		F2EEA1C5AC1D124862A16FE3 /* v3_pcia.c in Sources */ = {isa = PBXBuildFile; fileRef = 91A0A8696759B64EC82EA8DC /* v3_pcia.c */; };
-		F33735D2F7298FF059A4F215 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		F33735D2F7298FF059A4F215 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		F3C5F8E3F50F3DBE52067562 /* bcm.c in Sources */ = {isa = PBXBuildFile; fileRef = 3195B40B230CCE8EC15D6A95 /* bcm.c */; };
 		F525602006D2F829870B004E /* t1_enc.cc in Sources */ = {isa = PBXBuildFile; fileRef = 142419D94855EA3479F31D15 /* t1_enc.cc */; };
-		F52856EAD80B4904C40D0C88 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		F53B3A9035E93436D4945B58 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		F52856EAD80B4904C40D0C88 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		F53B3A9035E93436D4945B58 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		F751F3522CBC8ED1264EB2E7 /* chacha.c in Sources */ = {isa = PBXBuildFile; fileRef = 8C8483FACDA514EE7D64C0F7 /* chacha.c */; };
 		F75FDC2F205C177307E3DD15 /* pcy_cache.c in Sources */ = {isa = PBXBuildFile; fileRef = 0CF1D0153DF30C568C9147AD /* pcy_cache.c */; };
 		F7625FD4DD8DE7E074BC61B4 /* buf.c in Sources */ = {isa = PBXBuildFile; fileRef = 428BD394C05EA490FB491D3A /* buf.c */; };
@@ -1038,9 +1038,9 @@
 		F8CFED85A924E1368E90171D /* a_enum.c in Sources */ = {isa = PBXBuildFile; fileRef = 7086FCF8C238C1E4EBB9309D /* a_enum.c */; };
 		F8D8A6FDF2740290F8D6F110 /* t_x509.c in Sources */ = {isa = PBXBuildFile; fileRef = 9B3979357642B5C047A03E2A /* t_x509.c */; };
 		F8ED25A6E7E3904BFF89757E /* unicode.c in Sources */ = {isa = PBXBuildFile; fileRef = 38A829938DD1A3BE15681B03 /* unicode.c */; };
-		F8F57E76517D9BEEA8D644FC /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		F8F57E76517D9BEEA8D644FC /* (null) in Sources */ = {isa = PBXBuildFile; };
 		F9F63D13ED8794049C0C9FA8 /* sha1-armv8.S in Sources */ = {isa = PBXBuildFile; fileRef = 345398B47021E306965F75AE /* sha1-armv8.S */; };
-		FA1D781788CD08FD7D5E737D /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		FA1D781788CD08FD7D5E737D /* (null) in Sources */ = {isa = PBXBuildFile; };
 		FA633840578DC05E0CF0D6A2 /* digest_extra.c in Sources */ = {isa = PBXBuildFile; fileRef = 378778FC6BD1CC062C411F7F /* digest_extra.c */; };
 		FA673AA40582AFF10C4E94FD /* sign.c in Sources */ = {isa = PBXBuildFile; fileRef = 943FE87362A65AF78C86D6D7 /* sign.c */; };
 		FAF64D8F5CBCBD55867E5E64 /* f_enum.c in Sources */ = {isa = PBXBuildFile; fileRef = 1B73F6BA3A6D4280D24319D9 /* f_enum.c */; };
@@ -1050,17 +1050,17 @@
 		FC18EDD8194374493E1780C9 /* e_aesctrhmac.c in Sources */ = {isa = PBXBuildFile; fileRef = 82754E8AA82907E55AB63C59 /* e_aesctrhmac.c */; };
 		FC4D0C3B892DEA554B63F495 /* pool.c in Sources */ = {isa = PBXBuildFile; fileRef = 2F02A5AE2AD958C375B7D205 /* pool.c */; };
 		FC9FA9FE4AAA80F95CF1C60E /* socket_helper.c in Sources */ = {isa = PBXBuildFile; fileRef = 3BC1100D25BBEFB54BDF81E2 /* socket_helper.c */; };
-		FCB31DF6E65D102938363814 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		FCB31DF6E65D102938363814 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		FCC1C4B239D965519B9E8807 /* v3_int.c in Sources */ = {isa = PBXBuildFile; fileRef = AF3FCF964D54F9365D5BC031 /* v3_int.c */; };
-		FCE8884952D94C7EA445BC40 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		FCE8884952D94C7EA445BC40 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		FCEA4E7B546F01E2AC766B76 /* buf.c in Sources */ = {isa = PBXBuildFile; fileRef = 428BD394C05EA490FB491D3A /* buf.c */; };
-		FD7BB83D1A974EC2D1AC116B /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		FD89E2465B0F8130B8BFB926 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		FD7BB83D1A974EC2D1AC116B /* (null) in Sources */ = {isa = PBXBuildFile; };
+		FD89E2465B0F8130B8BFB926 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		FDA3278BB661923943AB30B6 /* v3_utl.c in Sources */ = {isa = PBXBuildFile; fileRef = 1A3CF1EC54CAACAC9E7904BD /* v3_utl.c */; };
 		FDC1AA4620EB7817E1201572 /* curve25519.c in Sources */ = {isa = PBXBuildFile; fileRef = 8108DF0E1E0A6D8CBFF11998 /* curve25519.c */; };
-		FE58518A1CF88D6AC2587B08 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		FE58518A1CF88D6AC2587B08 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		FEE5F426756F9F98068604CE /* a_octet.c in Sources */ = {isa = PBXBuildFile; fileRef = 752C466B046BE268E003DE89 /* a_octet.c */; };
-		FF4836E5C545B5FBA26561B5 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		FF4836E5C545B5FBA26561B5 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		FF96003D08D90CD92CE1F91C /* obj.c in Sources */ = {isa = PBXBuildFile; fileRef = 4AC445F076CA03A291762953 /* obj.c */; };
 		FFF2CE63451C34C288BD273C /* a_digest.c in Sources */ = {isa = PBXBuildFile; fileRef = 95CD409D48EEAFF9D8F98442 /* a_digest.c */; };
 /* End PBXBuildFile section */
@@ -1164,19 +1164,19 @@
 		027F768B3C4092F2B0C34908 /* sha256-x86_64.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "sha256-x86_64.S"; path = "third_party/boringssl/mac-x86_64/crypto/fipsmodule/sha256-x86_64.S"; sourceTree = SOURCE_ROOT; };
 		0280A3D732820375556EC136 /* refcount_c11.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = refcount_c11.c; path = third_party/boringssl/src/crypto/refcount_c11.c; sourceTree = SOURCE_ROOT; };
 		02A51C17489D420A71D7AC85 /* x509_req.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = x509_req.c; path = third_party/boringssl/src/crypto/x509/x509_req.c; sourceTree = SOURCE_ROOT; };
-		0396A0FA7324137074AF6356 /* v3_pmaps.c */ = {isa = PBXFileReference; includeInIndex = 1; name = v3_pmaps.c; path = third_party/boringssl/src/crypto/x509v3/v3_pmaps.c; sourceTree = SOURCE_ROOT; };
+		0396A0FA7324137074AF6356 /* v3_pmaps.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = v3_pmaps.c; path = third_party/boringssl/src/crypto/x509v3/v3_pmaps.c; sourceTree = SOURCE_ROOT; };
 		043E65BAE8B2FBA273C538C5 /* tasn_dec.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = tasn_dec.c; path = third_party/boringssl/src/crypto/asn1/tasn_dec.c; sourceTree = SOURCE_ROOT; };
 		04824F87B932C541B981F035 /* internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = internal.h; path = third_party/boringssl/src/crypto/err/internal.h; sourceTree = SOURCE_ROOT; };
-		06268D1C3A20585C7D38BFC7 /* v3_lib.c */ = {isa = PBXFileReference; includeInIndex = 1; name = v3_lib.c; path = third_party/boringssl/src/crypto/x509v3/v3_lib.c; sourceTree = SOURCE_ROOT; };
-		069B84410555410235C3E9E4 /* evp_ctx.c */ = {isa = PBXFileReference; includeInIndex = 1; name = evp_ctx.c; path = third_party/boringssl/src/crypto/evp/evp_ctx.c; sourceTree = SOURCE_ROOT; };
-		0749151FB22F9562B88AAE89 /* md5-x86_64.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "md5-x86_64.S"; path = "third_party/boringssl/mac-x86_64/crypto/fipsmodule/md5-x86_64.S"; sourceTree = SOURCE_ROOT; };
+		06268D1C3A20585C7D38BFC7 /* v3_lib.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = v3_lib.c; path = third_party/boringssl/src/crypto/x509v3/v3_lib.c; sourceTree = SOURCE_ROOT; };
+		069B84410555410235C3E9E4 /* evp_ctx.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = evp_ctx.c; path = third_party/boringssl/src/crypto/evp/evp_ctx.c; sourceTree = SOURCE_ROOT; };
+		0749151FB22F9562B88AAE89 /* md5-x86_64.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "md5-x86_64.S"; path = "third_party/boringssl/mac-x86_64/crypto/fipsmodule/md5-x86_64.S"; sourceTree = SOURCE_ROOT; };
 		074C12921965F2E8784B6D10 /* ripemd.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ripemd.h; path = third_party/boringssl/src/include/openssl/ripemd.h; sourceTree = SOURCE_ROOT; };
 		076C03F157AB6EB1C6464A76 /* connect.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = connect.c; path = third_party/boringssl/src/crypto/bio/connect.c; sourceTree = SOURCE_ROOT; };
 		081D6ECB5DE8C6DCCB2FB36D /* pkcs7.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = pkcs7.h; path = third_party/boringssl/src/include/openssl/pkcs7.h; sourceTree = SOURCE_ROOT; };
 		08370EFE6E5E67DC2D897F6B /* a_type.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = a_type.c; path = third_party/boringssl/src/crypto/asn1/a_type.c; sourceTree = SOURCE_ROOT; };
-		09BD3B60DB67ED53C9DEB8AF /* pkcs7.c */ = {isa = PBXFileReference; includeInIndex = 1; name = pkcs7.c; path = third_party/boringssl/src/crypto/pkcs7/pkcs7.c; sourceTree = SOURCE_ROOT; };
-		0A2124CD3818E07F4D8B4EC8 /* asn1_gen.c */ = {isa = PBXFileReference; includeInIndex = 1; name = asn1_gen.c; path = third_party/boringssl/src/crypto/x509/asn1_gen.c; sourceTree = SOURCE_ROOT; };
-		0B2480E96418AA722F4B1533 /* d1_lib.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = d1_lib.cc; path = third_party/boringssl/src/ssl/d1_lib.cc; sourceTree = SOURCE_ROOT; };
+		09BD3B60DB67ED53C9DEB8AF /* pkcs7.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = pkcs7.c; path = third_party/boringssl/src/crypto/pkcs7/pkcs7.c; sourceTree = SOURCE_ROOT; };
+		0A2124CD3818E07F4D8B4EC8 /* asn1_gen.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = asn1_gen.c; path = third_party/boringssl/src/crypto/x509/asn1_gen.c; sourceTree = SOURCE_ROOT; };
+		0B2480E96418AA722F4B1533 /* d1_lib.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = d1_lib.cc; path = third_party/boringssl/src/ssl/d1_lib.cc; sourceTree = SOURCE_ROOT; };
 		0CB074DBE53D9B5AE7487BF7 /* p256_table.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = p256_table.h; path = third_party/boringssl/src/crypto/fipsmodule/ec/p256_table.h; sourceTree = SOURCE_ROOT; };
 		0CF1D0153DF30C568C9147AD /* pcy_cache.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = pcy_cache.c; path = third_party/boringssl/src/crypto/x509v3/pcy_cache.c; sourceTree = SOURCE_ROOT; };
 		0E1D1E8E85B1918FD2BE3A17 /* x509_vpm.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = x509_vpm.c; path = third_party/boringssl/src/crypto/x509/x509_vpm.c; sourceTree = SOURCE_ROOT; };
@@ -1184,9 +1184,9 @@
 		0F28E86C2E11D1FDDB10BD9C /* conf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = conf.h; path = third_party/boringssl/src/include/openssl/conf.h; sourceTree = SOURCE_ROOT; };
 		0F862C98C5A81A00100E0130 /* nid.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = nid.h; path = third_party/boringssl/src/include/openssl/nid.h; sourceTree = SOURCE_ROOT; };
 		102AF1D55456151F508A7C4A /* a_dup.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = a_dup.c; path = third_party/boringssl/src/crypto/asn1/a_dup.c; sourceTree = SOURCE_ROOT; };
-		10539F57503AD1B16A2BF020 /* trampoline-armv4.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "trampoline-armv4.S"; path = "third_party/boringssl/ios-arm/crypto/test/trampoline-armv4.S"; sourceTree = SOURCE_ROOT; };
+		10539F57503AD1B16A2BF020 /* trampoline-armv4.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "trampoline-armv4.S"; path = "third_party/boringssl/ios-arm/crypto/test/trampoline-armv4.S"; sourceTree = SOURCE_ROOT; };
 		10740AF3E4867C435195451D /* opensslv.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = opensslv.h; path = third_party/boringssl/src/include/openssl/opensslv.h; sourceTree = SOURCE_ROOT; };
-		109CE71D6B7BD4CCF2922F6E /* ssl_key_share.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = ssl_key_share.cc; path = third_party/boringssl/src/ssl/ssl_key_share.cc; sourceTree = SOURCE_ROOT; };
+		109CE71D6B7BD4CCF2922F6E /* ssl_key_share.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = ssl_key_share.cc; path = third_party/boringssl/src/ssl/ssl_key_share.cc; sourceTree = SOURCE_ROOT; };
 		11487D804E6245C0D28CDE0F /* cpu-ppc64le.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = "cpu-ppc64le.c"; path = "third_party/boringssl/src/crypto/cpu-ppc64le.c"; sourceTree = SOURCE_ROOT; };
 		11CBF80145331DAD232B46DA /* x_pkey.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = x_pkey.c; path = third_party/boringssl/src/crypto/x509/x_pkey.c; sourceTree = SOURCE_ROOT; };
 		11FC0D577EB9AC61C9413503 /* x509rset.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = x509rset.c; path = third_party/boringssl/src/crypto/x509/x509rset.c; sourceTree = SOURCE_ROOT; };
@@ -1194,36 +1194,36 @@
 		12954F4621C73F4FAB30C158 /* p256_32.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = p256_32.h; path = third_party/boringssl/src/third_party/fiat/p256_32.h; sourceTree = SOURCE_ROOT; };
 		136B10737C2A992E86B7EC17 /* e_tls.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = e_tls.c; path = third_party/boringssl/src/crypto/cipher_extra/e_tls.c; sourceTree = SOURCE_ROOT; };
 		140601C4AC244CBDFBFFF359 /* ecdsa.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecdsa.h; path = third_party/boringssl/src/include/openssl/ecdsa.h; sourceTree = SOURCE_ROOT; };
-		142419D94855EA3479F31D15 /* t1_enc.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = t1_enc.cc; path = third_party/boringssl/src/ssl/t1_enc.cc; sourceTree = SOURCE_ROOT; };
+		142419D94855EA3479F31D15 /* t1_enc.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = t1_enc.cc; path = third_party/boringssl/src/ssl/t1_enc.cc; sourceTree = SOURCE_ROOT; };
 		1431566151214CF53931BCDE /* internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = internal.h; path = third_party/boringssl/src/crypto/chacha/internal.h; sourceTree = SOURCE_ROOT; };
 		144B11BC120D749B56527711 /* x509_set.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = x509_set.c; path = third_party/boringssl/src/crypto/x509/x509_set.c; sourceTree = SOURCE_ROOT; };
 		14645F81C0FF2CA7CAD38BF2 /* f_int.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = f_int.c; path = third_party/boringssl/src/crypto/asn1/f_int.c; sourceTree = SOURCE_ROOT; };
 		148E127C993451F865C25E20 /* crypto.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = crypto.c; path = third_party/boringssl/src/crypto/crypto.c; sourceTree = SOURCE_ROOT; };
 		14BABBBF9DFE7AA9C2FD9E0E /* bn-586.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "bn-586.S"; path = "third_party/boringssl/mac-x86/crypto/fipsmodule/bn-586.S"; sourceTree = SOURCE_ROOT; };
 		1501360BEF783ECAE4E3AA39 /* sha1-586.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "sha1-586.S"; path = "third_party/boringssl/mac-x86/crypto/fipsmodule/sha1-586.S"; sourceTree = SOURCE_ROOT; };
-		150495FB44BCE2F37FA95E55 /* a_i2d_fp.c */ = {isa = PBXFileReference; includeInIndex = 1; name = a_i2d_fp.c; path = third_party/boringssl/src/crypto/asn1/a_i2d_fp.c; sourceTree = SOURCE_ROOT; };
+		150495FB44BCE2F37FA95E55 /* a_i2d_fp.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = a_i2d_fp.c; path = third_party/boringssl/src/crypto/asn1/a_i2d_fp.c; sourceTree = SOURCE_ROOT; };
 		163CE4A11AAC94EDA445E20F /* x509name.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = x509name.c; path = third_party/boringssl/src/crypto/x509/x509name.c; sourceTree = SOURCE_ROOT; };
 		1662F915750875363FF82D11 /* e_null.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = e_null.c; path = third_party/boringssl/src/crypto/cipher_extra/e_null.c; sourceTree = SOURCE_ROOT; };
 		168CB17B865EF3921ED536D7 /* rsa_asn1.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = rsa_asn1.c; path = third_party/boringssl/src/crypto/rsa_extra/rsa_asn1.c; sourceTree = SOURCE_ROOT; };
-		16B2E9E209BD8C11562ED17D /* x86-mont.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "x86-mont.S"; path = "third_party/boringssl/mac-x86/crypto/fipsmodule/x86-mont.S"; sourceTree = SOURCE_ROOT; };
+		16B2E9E209BD8C11562ED17D /* x86-mont.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "x86-mont.S"; path = "third_party/boringssl/mac-x86/crypto/fipsmodule/x86-mont.S"; sourceTree = SOURCE_ROOT; };
 		16E7DC716B9C1642C99EEE04 /* x_req.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = x_req.c; path = third_party/boringssl/src/crypto/x509/x_req.c; sourceTree = SOURCE_ROOT; };
 		17087C55C2D10CBCEC2E39FA /* rsa_print.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = rsa_print.c; path = third_party/boringssl/src/crypto/rsa_extra/rsa_print.c; sourceTree = SOURCE_ROOT; };
-		1767CD47FB8219FDB1938182 /* a_d2i_fp.c */ = {isa = PBXFileReference; includeInIndex = 1; name = a_d2i_fp.c; path = third_party/boringssl/src/crypto/asn1/a_d2i_fp.c; sourceTree = SOURCE_ROOT; };
+		1767CD47FB8219FDB1938182 /* a_d2i_fp.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = a_d2i_fp.c; path = third_party/boringssl/src/crypto/asn1/a_d2i_fp.c; sourceTree = SOURCE_ROOT; };
 		17B8446F563EF1EAF315041D /* bio_mem.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = bio_mem.c; path = third_party/boringssl/src/crypto/bio/bio_mem.c; sourceTree = SOURCE_ROOT; };
 		17C5AF6267F93F474F74CE15 /* rand_extra.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = rand_extra.c; path = third_party/boringssl/src/crypto/rand_extra/rand_extra.c; sourceTree = SOURCE_ROOT; };
-		189C3D0F63876DA24A3F8D58 /* chacha-x86.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "chacha-x86.S"; path = "third_party/boringssl/mac-x86/crypto/chacha/chacha-x86.S"; sourceTree = SOURCE_ROOT; };
+		189C3D0F63876DA24A3F8D58 /* chacha-x86.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "chacha-x86.S"; path = "third_party/boringssl/mac-x86/crypto/chacha/chacha-x86.S"; sourceTree = SOURCE_ROOT; };
 		18DBD528980FDD683B495C8D /* hmac.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = hmac.h; path = third_party/boringssl/src/include/openssl/hmac.h; sourceTree = SOURCE_ROOT; };
 		19078C0D9FD1EDEA58B29987 /* v3_bitst.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = v3_bitst.c; path = third_party/boringssl/src/crypto/x509v3/v3_bitst.c; sourceTree = SOURCE_ROOT; };
 		1950D98DFAE5150D6E4D25A6 /* a_object.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = a_object.c; path = third_party/boringssl/src/crypto/asn1/a_object.c; sourceTree = SOURCE_ROOT; };
 		1A3CF1EC54CAACAC9E7904BD /* v3_utl.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = v3_utl.c; path = third_party/boringssl/src/crypto/x509v3/v3_utl.c; sourceTree = SOURCE_ROOT; };
-		1AFDA9EF121DF0DE240A7DD1 /* dtls_method.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = dtls_method.cc; path = third_party/boringssl/src/ssl/dtls_method.cc; sourceTree = SOURCE_ROOT; };
+		1AFDA9EF121DF0DE240A7DD1 /* dtls_method.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = dtls_method.cc; path = third_party/boringssl/src/ssl/dtls_method.cc; sourceTree = SOURCE_ROOT; };
 		1B73F6BA3A6D4280D24319D9 /* f_enum.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = f_enum.c; path = third_party/boringssl/src/crypto/asn1/f_enum.c; sourceTree = SOURCE_ROOT; };
 		1BCCB23EF328672D6F529090 /* arm_arch.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = arm_arch.h; path = third_party/boringssl/src/include/openssl/arm_arch.h; sourceTree = SOURCE_ROOT; };
 		1BE87FEDC9596FE408C2F1C9 /* ec_key.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ec_key.h; path = third_party/boringssl/src/include/openssl/ec_key.h; sourceTree = SOURCE_ROOT; };
-		1C90A3D3E1A4931A45FC577F /* tasn_enc.c */ = {isa = PBXFileReference; includeInIndex = 1; name = tasn_enc.c; path = third_party/boringssl/src/crypto/asn1/tasn_enc.c; sourceTree = SOURCE_ROOT; };
+		1C90A3D3E1A4931A45FC577F /* tasn_enc.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = tasn_enc.c; path = third_party/boringssl/src/crypto/asn1/tasn_enc.c; sourceTree = SOURCE_ROOT; };
 		1CE277743B6A1901F40B2F9C /* x_exten.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = x_exten.c; path = third_party/boringssl/src/crypto/x509/x_exten.c; sourceTree = SOURCE_ROOT; };
 		1D3DCBE38C0E700374D7137E /* internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = internal.h; path = third_party/boringssl/src/crypto/x509/internal.h; sourceTree = SOURCE_ROOT; };
-		1DFC350CD9DC62EF36047DBD /* t_x509a.c */ = {isa = PBXFileReference; includeInIndex = 1; name = t_x509a.c; path = third_party/boringssl/src/crypto/x509/t_x509a.c; sourceTree = SOURCE_ROOT; };
+		1DFC350CD9DC62EF36047DBD /* t_x509a.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = t_x509a.c; path = third_party/boringssl/src/crypto/x509/t_x509a.c; sourceTree = SOURCE_ROOT; };
 		1E43AAB939593DB582313755 /* chacha20_poly1305_x86_64.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = chacha20_poly1305_x86_64.S; path = "third_party/boringssl/mac-x86_64/crypto/cipher_extra/chacha20_poly1305_x86_64.S"; sourceTree = SOURCE_ROOT; };
 		1F462B8738F23CC847F3629B /* ber.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = ber.c; path = third_party/boringssl/src/crypto/bytestring/ber.c; sourceTree = SOURCE_ROOT; };
 		1F634ACDE9D45D78F2A70F41 /* digest.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = digest.h; path = third_party/boringssl/src/include/openssl/digest.h; sourceTree = SOURCE_ROOT; };
@@ -1235,35 +1235,35 @@
 		2148ED7084B556A740E18E14 /* fips_shared_support.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = fips_shared_support.c; path = third_party/boringssl/src/crypto/fipsmodule/fips_shared_support.c; sourceTree = SOURCE_ROOT; };
 		21E124D303337F706E63497E /* x509.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = x509.c; path = third_party/boringssl/src/crypto/x509/x509.c; sourceTree = SOURCE_ROOT; };
 		22354C3686D4BD44D77ED990 /* asn1_compat.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = asn1_compat.c; path = third_party/boringssl/src/crypto/bytestring/asn1_compat.c; sourceTree = SOURCE_ROOT; };
-		224C7B79EB507B9A4BF0463D /* cipher_extra.c */ = {isa = PBXFileReference; includeInIndex = 1; name = cipher_extra.c; path = third_party/boringssl/src/crypto/cipher_extra/cipher_extra.c; sourceTree = SOURCE_ROOT; };
+		224C7B79EB507B9A4BF0463D /* cipher_extra.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = cipher_extra.c; path = third_party/boringssl/src/crypto/cipher_extra/cipher_extra.c; sourceTree = SOURCE_ROOT; };
 		227257FE24F35DBF96618204 /* x509_att.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = x509_att.c; path = third_party/boringssl/src/crypto/x509/x509_att.c; sourceTree = SOURCE_ROOT; };
-		2296BEA874A895EA1BDBB436 /* tls13_enc.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = tls13_enc.cc; path = third_party/boringssl/src/ssl/tls13_enc.cc; sourceTree = SOURCE_ROOT; };
+		2296BEA874A895EA1BDBB436 /* tls13_enc.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = tls13_enc.cc; path = third_party/boringssl/src/ssl/tls13_enc.cc; sourceTree = SOURCE_ROOT; };
 		2301CF793788230F58289E12 /* refcount_lock.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = refcount_lock.c; path = third_party/boringssl/src/crypto/refcount_lock.c; sourceTree = SOURCE_ROOT; };
 		23543DA64FB53E45DE2F8794 /* p256-x86_64-table.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "p256-x86_64-table.h"; path = "third_party/boringssl/src/crypto/fipsmodule/ec/p256-x86_64-table.h"; sourceTree = SOURCE_ROOT; };
 		239801E138F254CB7FE9C0E0 /* ec_asn1.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = ec_asn1.c; path = third_party/boringssl/src/crypto/ec_extra/ec_asn1.c; sourceTree = SOURCE_ROOT; };
 		241B25163903EF7B024202B4 /* tls1.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = tls1.h; path = third_party/boringssl/src/include/openssl/tls1.h; sourceTree = SOURCE_ROOT; };
 		25EB746D9D567A9A0C0A04F0 /* charmap.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = charmap.h; path = third_party/boringssl/src/crypto/x509/charmap.h; sourceTree = SOURCE_ROOT; };
-		26331B634DFE6AE10160CCE9 /* x509_ext.c */ = {isa = PBXFileReference; includeInIndex = 1; name = x509_ext.c; path = third_party/boringssl/src/crypto/x509/x509_ext.c; sourceTree = SOURCE_ROOT; };
-		276EE70F4BD22BE0C7344F6C /* handshake_server.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = handshake_server.cc; path = third_party/boringssl/src/ssl/handshake_server.cc; sourceTree = SOURCE_ROOT; };
+		26331B634DFE6AE10160CCE9 /* x509_ext.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = x509_ext.c; path = third_party/boringssl/src/crypto/x509/x509_ext.c; sourceTree = SOURCE_ROOT; };
+		276EE70F4BD22BE0C7344F6C /* handshake_server.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = handshake_server.cc; path = third_party/boringssl/src/ssl/handshake_server.cc; sourceTree = SOURCE_ROOT; };
 		2786829E57A4F4AC01D977BA /* rc4.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = rc4.h; path = third_party/boringssl/src/include/openssl/rc4.h; sourceTree = SOURCE_ROOT; };
-		290FB02DB7B283DBDF1FB397 /* x509spki.c */ = {isa = PBXFileReference; includeInIndex = 1; name = x509spki.c; path = third_party/boringssl/src/crypto/x509/x509spki.c; sourceTree = SOURCE_ROOT; };
+		290FB02DB7B283DBDF1FB397 /* x509spki.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = x509spki.c; path = third_party/boringssl/src/crypto/x509/x509spki.c; sourceTree = SOURCE_ROOT; };
 		29A7FB9838437DC90845D5E5 /* file.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = file.c; path = third_party/boringssl/src/crypto/bio/file.c; sourceTree = SOURCE_ROOT; };
 		2B86F692353610B2666B8230 /* pcy_tree.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = pcy_tree.c; path = third_party/boringssl/src/crypto/x509v3/pcy_tree.c; sourceTree = SOURCE_ROOT; };
 		2C35A96D60A831415CDC12B7 /* ossl_typ.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ossl_typ.h; path = third_party/boringssl/src/include/openssl/ossl_typ.h; sourceTree = SOURCE_ROOT; };
-		2CB9153513892563E8DAA4A8 /* hash_to_curve.c */ = {isa = PBXFileReference; includeInIndex = 1; name = hash_to_curve.c; path = third_party/boringssl/src/crypto/ec_extra/hash_to_curve.c; sourceTree = SOURCE_ROOT; };
-		2F02A5AE2AD958C375B7D205 /* pool.c */ = {isa = PBXFileReference; includeInIndex = 1; name = pool.c; path = third_party/boringssl/src/crypto/pool/pool.c; sourceTree = SOURCE_ROOT; };
-		2F1683BF1D2C3DEE3E455130 /* x509_obj.c */ = {isa = PBXFileReference; includeInIndex = 1; name = x509_obj.c; path = third_party/boringssl/src/crypto/x509/x509_obj.c; sourceTree = SOURCE_ROOT; };
-		2F250883B7FF6BB34D64D55D /* ghashv8-armx64.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "ghashv8-armx64.S"; path = "third_party/boringssl/ios-aarch64/crypto/fipsmodule/ghashv8-armx64.S"; sourceTree = SOURCE_ROOT; };
+		2CB9153513892563E8DAA4A8 /* hash_to_curve.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = hash_to_curve.c; path = third_party/boringssl/src/crypto/ec_extra/hash_to_curve.c; sourceTree = SOURCE_ROOT; };
+		2F02A5AE2AD958C375B7D205 /* pool.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = pool.c; path = third_party/boringssl/src/crypto/pool/pool.c; sourceTree = SOURCE_ROOT; };
+		2F1683BF1D2C3DEE3E455130 /* x509_obj.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = x509_obj.c; path = third_party/boringssl/src/crypto/x509/x509_obj.c; sourceTree = SOURCE_ROOT; };
+		2F250883B7FF6BB34D64D55D /* ghashv8-armx64.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "ghashv8-armx64.S"; path = "third_party/boringssl/ios-aarch64/crypto/fipsmodule/ghashv8-armx64.S"; sourceTree = SOURCE_ROOT; };
 		2F2BE92783B72A2F21B0E093 /* siphash.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = siphash.c; path = third_party/boringssl/src/crypto/siphash/siphash.c; sourceTree = SOURCE_ROOT; };
-		2F9796240DCF3D61199E86EC /* ghash-neon-armv8.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "ghash-neon-armv8.S"; path = "third_party/boringssl/ios-aarch64/crypto/fipsmodule/ghash-neon-armv8.S"; sourceTree = SOURCE_ROOT; };
+		2F9796240DCF3D61199E86EC /* ghash-neon-armv8.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "ghash-neon-armv8.S"; path = "third_party/boringssl/ios-aarch64/crypto/fipsmodule/ghash-neon-armv8.S"; sourceTree = SOURCE_ROOT; };
 		2FB602A5D3F8B679D3E20ABE /* internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = internal.h; path = third_party/boringssl/src/crypto/evp/internal.h; sourceTree = SOURCE_ROOT; };
 		308BCB682304D8E6968BFF34 /* evp.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = evp.h; path = third_party/boringssl/src/include/openssl/evp.h; sourceTree = SOURCE_ROOT; };
-		30B2FFAAB2758A27C881CAE7 /* aesv8-armx64.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "aesv8-armx64.S"; path = "third_party/boringssl/ios-aarch64/crypto/fipsmodule/aesv8-armx64.S"; sourceTree = SOURCE_ROOT; };
+		30B2FFAAB2758A27C881CAE7 /* aesv8-armx64.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "aesv8-armx64.S"; path = "third_party/boringssl/ios-aarch64/crypto/fipsmodule/aesv8-armx64.S"; sourceTree = SOURCE_ROOT; };
 		30FC8E575F4775DB44ED500D /* x509_vfy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = x509_vfy.h; path = third_party/boringssl/src/include/openssl/x509_vfy.h; sourceTree = SOURCE_ROOT; };
 		311485E0365FAAF88702425D /* internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = internal.h; path = third_party/boringssl/src/crypto/fipsmodule/des/internal.h; sourceTree = SOURCE_ROOT; };
 		31498604FF0AF2E19071A302 /* pcy_node.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = pcy_node.c; path = third_party/boringssl/src/crypto/x509v3/pcy_node.c; sourceTree = SOURCE_ROOT; };
 		315F65543860FC3FCF71C55B /* p_ed25519_asn1.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = p_ed25519_asn1.c; path = third_party/boringssl/src/crypto/evp/p_ed25519_asn1.c; sourceTree = SOURCE_ROOT; };
-		3195B40B230CCE8EC15D6A95 /* bcm.c */ = {isa = PBXFileReference; includeInIndex = 1; name = bcm.c; path = third_party/boringssl/src/crypto/fipsmodule/bcm.c; sourceTree = SOURCE_ROOT; };
+		3195B40B230CCE8EC15D6A95 /* bcm.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = bcm.c; path = third_party/boringssl/src/crypto/fipsmodule/bcm.c; sourceTree = SOURCE_ROOT; };
 		31E2B7F5F54CD4FFB40E0166 /* internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = internal.h; path = third_party/boringssl/src/crypto/bio/internal.h; sourceTree = SOURCE_ROOT; };
 		3270AF8E6E0EC697830557F8 /* internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = internal.h; path = third_party/boringssl/src/crypto/ec_extra/internal.h; sourceTree = SOURCE_ROOT; };
 		3303AD88B0487CA3761ADF73 /* conf_def.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = conf_def.h; path = third_party/boringssl/src/crypto/conf/conf_def.h; sourceTree = SOURCE_ROOT; };
@@ -1273,12 +1273,12 @@
 		3405D29EE244521ECB93E643 /* crypto.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = crypto.h; path = third_party/boringssl/src/include/openssl/crypto.h; sourceTree = SOURCE_ROOT; };
 		340CEF11EBCCCF31C4C44A09 /* vpaes-x86.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "vpaes-x86.S"; path = "third_party/boringssl/mac-x86/crypto/fipsmodule/vpaes-x86.S"; sourceTree = SOURCE_ROOT; };
 		342E05C9EBC2F2E072B5B69E /* x_val.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = x_val.c; path = third_party/boringssl/src/crypto/x509/x_val.c; sourceTree = SOURCE_ROOT; };
-		345398B47021E306965F75AE /* sha1-armv8.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "sha1-armv8.S"; path = "third_party/boringssl/ios-aarch64/crypto/fipsmodule/sha1-armv8.S"; sourceTree = SOURCE_ROOT; };
+		345398B47021E306965F75AE /* sha1-armv8.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "sha1-armv8.S"; path = "third_party/boringssl/ios-aarch64/crypto/fipsmodule/sha1-armv8.S"; sourceTree = SOURCE_ROOT; };
 		345C731A054B312D066CAD95 /* internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = internal.h; path = third_party/boringssl/src/crypto/fipsmodule/cipher/internal.h; sourceTree = SOURCE_ROOT; };
 		3509901AB8EE7A301809A0CB /* trampoline-x86_64.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "trampoline-x86_64.S"; path = "third_party/boringssl/mac-x86_64/crypto/test/trampoline-x86_64.S"; sourceTree = SOURCE_ROOT; };
 		35863F9624DF00778A37D922 /* internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = internal.h; path = third_party/boringssl/src/crypto/fipsmodule/md5/internal.h; sourceTree = SOURCE_ROOT; };
 		35D7984E610B3D60BE049E02 /* tasn_new.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = tasn_new.c; path = third_party/boringssl/src/crypto/asn1/tasn_new.c; sourceTree = SOURCE_ROOT; };
-		35EAC9D27DBC3694463F71F8 /* ghash-x86_64.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "ghash-x86_64.S"; path = "third_party/boringssl/mac-x86_64/crypto/fipsmodule/ghash-x86_64.S"; sourceTree = SOURCE_ROOT; };
+		35EAC9D27DBC3694463F71F8 /* ghash-x86_64.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "ghash-x86_64.S"; path = "third_party/boringssl/mac-x86_64/crypto/fipsmodule/ghash-x86_64.S"; sourceTree = SOURCE_ROOT; };
 		36194904259A158C5AD20F14 /* siphash.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = siphash.h; path = third_party/boringssl/src/include/openssl/siphash.h; sourceTree = SOURCE_ROOT; };
 		3685B31892C75255256975B2 /* curve25519_tables.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = curve25519_tables.h; path = third_party/boringssl/src/crypto/curve25519/curve25519_tables.h; sourceTree = SOURCE_ROOT; };
 		36ECED028C795E6C35C4CEB6 /* pkcs7_x509.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = pkcs7_x509.c; path = third_party/boringssl/src/crypto/pkcs7/pkcs7_x509.c; sourceTree = SOURCE_ROOT; };
@@ -1288,70 +1288,70 @@
 		385351340F3777A72413B7BE /* e_aesccm.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = e_aesccm.c; path = third_party/boringssl/src/crypto/cipher_extra/e_aesccm.c; sourceTree = SOURCE_ROOT; };
 		388B50675A22B5705B4EB3B9 /* v3_ncons.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = v3_ncons.c; path = third_party/boringssl/src/crypto/x509v3/v3_ncons.c; sourceTree = SOURCE_ROOT; };
 		38A829938DD1A3BE15681B03 /* unicode.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = unicode.c; path = third_party/boringssl/src/crypto/bytestring/unicode.c; sourceTree = SOURCE_ROOT; };
-		39BA416547F7588F0937E644 /* d1_both.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = d1_both.cc; path = third_party/boringssl/src/ssl/d1_both.cc; sourceTree = SOURCE_ROOT; };
-		3A4BC7880B6D48002C90A211 /* aesni-x86_64.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "aesni-x86_64.S"; path = "third_party/boringssl/mac-x86_64/crypto/fipsmodule/aesni-x86_64.S"; sourceTree = SOURCE_ROOT; };
+		39BA416547F7588F0937E644 /* d1_both.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = d1_both.cc; path = third_party/boringssl/src/ssl/d1_both.cc; sourceTree = SOURCE_ROOT; };
+		3A4BC7880B6D48002C90A211 /* aesni-x86_64.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "aesni-x86_64.S"; path = "third_party/boringssl/mac-x86_64/crypto/fipsmodule/aesni-x86_64.S"; sourceTree = SOURCE_ROOT; };
 		3A72594CE11062A04E626323 /* cbb.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = cbb.c; path = third_party/boringssl/src/crypto/bytestring/cbb.c; sourceTree = SOURCE_ROOT; };
 		3ADEE369D8265CF897BC7A37 /* aesni-gcm-x86_64.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "aesni-gcm-x86_64.S"; path = "third_party/boringssl/mac-x86_64/crypto/fipsmodule/aesni-gcm-x86_64.S"; sourceTree = SOURCE_ROOT; };
 		3B1EBD3DF6F9ED2653A22F21 /* vpm_int.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = vpm_int.h; path = third_party/boringssl/src/crypto/x509/vpm_int.h; sourceTree = SOURCE_ROOT; };
 		3BC1100D25BBEFB54BDF81E2 /* socket_helper.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = socket_helper.c; path = third_party/boringssl/src/crypto/bio/socket_helper.c; sourceTree = SOURCE_ROOT; };
-		3BFD47EF870331B0CA1F1689 /* print.c */ = {isa = PBXFileReference; includeInIndex = 1; name = print.c; path = third_party/boringssl/src/crypto/evp/print.c; sourceTree = SOURCE_ROOT; };
+		3BFD47EF870331B0CA1F1689 /* print.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = print.c; path = third_party/boringssl/src/crypto/evp/print.c; sourceTree = SOURCE_ROOT; };
 		3D42E6618B13266367C37EB4 /* poly1305.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = poly1305.h; path = third_party/boringssl/src/include/openssl/poly1305.h; sourceTree = SOURCE_ROOT; };
-		3D803BAC3DC4424647E6168E /* cpu-aarch64-fuchsia.c */ = {isa = PBXFileReference; includeInIndex = 1; name = "cpu-aarch64-fuchsia.c"; path = "third_party/boringssl/src/crypto/cpu-aarch64-fuchsia.c"; sourceTree = SOURCE_ROOT; };
-		3E0D3549980F9749B037C49A /* x509_lu.c */ = {isa = PBXFileReference; includeInIndex = 1; name = x509_lu.c; path = third_party/boringssl/src/crypto/x509/x509_lu.c; sourceTree = SOURCE_ROOT; };
+		3D803BAC3DC4424647E6168E /* cpu-aarch64-fuchsia.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = "cpu-aarch64-fuchsia.c"; path = "third_party/boringssl/src/crypto/cpu-aarch64-fuchsia.c"; sourceTree = SOURCE_ROOT; };
+		3E0D3549980F9749B037C49A /* x509_lu.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = x509_lu.c; path = third_party/boringssl/src/crypto/x509/x509_lu.c; sourceTree = SOURCE_ROOT; };
 		3E83F0A6E5DFCBCAD5B0BFE7 /* x_crl.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = x_crl.c; path = third_party/boringssl/src/crypto/x509/x_crl.c; sourceTree = SOURCE_ROOT; };
 		3ED2034F44739EF4CB2FBC88 /* spake25519.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = spake25519.c; path = third_party/boringssl/src/crypto/curve25519/spake25519.c; sourceTree = SOURCE_ROOT; };
 		3EE3DFBB3C397BEC734849EC /* rsaz-avx2.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "rsaz-avx2.S"; path = "third_party/boringssl/mac-x86_64/crypto/fipsmodule/rsaz-avx2.S"; sourceTree = SOURCE_ROOT; };
-		3F6093D305A339C78F82B3CC /* v3_ocsp.c */ = {isa = PBXFileReference; includeInIndex = 1; name = v3_ocsp.c; path = third_party/boringssl/src/crypto/x509v3/v3_ocsp.c; sourceTree = SOURCE_ROOT; };
+		3F6093D305A339C78F82B3CC /* v3_ocsp.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = v3_ocsp.c; path = third_party/boringssl/src/crypto/x509v3/v3_ocsp.c; sourceTree = SOURCE_ROOT; };
 		3FA51A3AD44830372D0BECD3 /* t_crl.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = t_crl.c; path = third_party/boringssl/src/crypto/x509/t_crl.c; sourceTree = SOURCE_ROOT; };
-		402CFACCC6BA4ABFD21B642F /* sha512-armv8.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "sha512-armv8.S"; path = "third_party/boringssl/ios-aarch64/crypto/fipsmodule/sha512-armv8.S"; sourceTree = SOURCE_ROOT; };
-		40489B408C550104B165EBE1 /* bn_asn1.c */ = {isa = PBXFileReference; includeInIndex = 1; name = bn_asn1.c; path = third_party/boringssl/src/crypto/bn_extra/bn_asn1.c; sourceTree = SOURCE_ROOT; };
+		402CFACCC6BA4ABFD21B642F /* sha512-armv8.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "sha512-armv8.S"; path = "third_party/boringssl/ios-aarch64/crypto/fipsmodule/sha512-armv8.S"; sourceTree = SOURCE_ROOT; };
+		40489B408C550104B165EBE1 /* bn_asn1.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = bn_asn1.c; path = third_party/boringssl/src/crypto/bn_extra/bn_asn1.c; sourceTree = SOURCE_ROOT; };
 		404B7E35A96E1F3FDC8E9406 /* internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = internal.h; path = third_party/boringssl/src/crypto/pkcs8/internal.h; sourceTree = SOURCE_ROOT; };
-		40834C452855B97F603F1D4B /* ssl_file.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = ssl_file.cc; path = third_party/boringssl/src/ssl/ssl_file.cc; sourceTree = SOURCE_ROOT; };
+		40834C452855B97F603F1D4B /* ssl_file.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = ssl_file.cc; path = third_party/boringssl/src/ssl/ssl_file.cc; sourceTree = SOURCE_ROOT; };
 		408C1853400081A9F3A79703 /* buffer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = buffer.h; path = third_party/boringssl/src/include/openssl/buffer.h; sourceTree = SOURCE_ROOT; };
 		40C9077A4FBA10CD0D9B8DCC /* internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = internal.h; path = third_party/boringssl/src/crypto/bytestring/internal.h; sourceTree = SOURCE_ROOT; };
 		411D9C112D2BEC83F1FBED52 /* x509_cmp.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = x509_cmp.c; path = third_party/boringssl/src/crypto/x509/x509_cmp.c; sourceTree = SOURCE_ROOT; };
 		419E292AB2D0B4B39CA88DA4 /* curve25519_32.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = curve25519_32.h; path = third_party/boringssl/src/third_party/fiat/curve25519_32.h; sourceTree = SOURCE_ROOT; };
 		4230D87182D21863F22FA737 /* internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = internal.h; path = third_party/boringssl/src/crypto/fipsmodule/modes/internal.h; sourceTree = SOURCE_ROOT; };
-		428BD394C05EA490FB491D3A /* buf.c */ = {isa = PBXFileReference; includeInIndex = 1; name = buf.c; path = third_party/boringssl/src/crypto/buf/buf.c; sourceTree = SOURCE_ROOT; };
+		428BD394C05EA490FB491D3A /* buf.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = buf.c; path = third_party/boringssl/src/crypto/buf/buf.c; sourceTree = SOURCE_ROOT; };
 		4295E51900489B9C17B54D6F /* hkdf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = hkdf.h; path = third_party/boringssl/src/include/openssl/hkdf.h; sourceTree = SOURCE_ROOT; };
 		42E9F7996CA4A8271C5BD614 /* blowfish.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = blowfish.h; path = third_party/boringssl/src/include/openssl/blowfish.h; sourceTree = SOURCE_ROOT; };
 		431AF269F1D171958CC80769 /* rc4.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = rc4.c; path = third_party/boringssl/src/crypto/rc4/rc4.c; sourceTree = SOURCE_ROOT; };
-		43D8DF77ED203E92E92477DD /* sha512-armv8.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "sha512-armv8.S"; path = "third_party/boringssl/ios-aarch64/crypto/fipsmodule/sha512-armv8.S"; sourceTree = SOURCE_ROOT; };
-		443CAD46CC5EDE99ED4A5D99 /* trampoline-x86.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "trampoline-x86.S"; path = "third_party/boringssl/mac-x86/crypto/test/trampoline-x86.S"; sourceTree = SOURCE_ROOT; };
+		43D8DF77ED203E92E92477DD /* sha512-armv8.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "sha512-armv8.S"; path = "third_party/boringssl/ios-aarch64/crypto/fipsmodule/sha512-armv8.S"; sourceTree = SOURCE_ROOT; };
+		443CAD46CC5EDE99ED4A5D99 /* trampoline-x86.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "trampoline-x86.S"; path = "third_party/boringssl/mac-x86/crypto/test/trampoline-x86.S"; sourceTree = SOURCE_ROOT; };
 		444F441C87AABC440866A900 /* ecdh.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ecdh.h; path = third_party/boringssl/src/include/openssl/ecdh.h; sourceTree = SOURCE_ROOT; };
-		445D99E3F2D2E23044127878 /* a_strnid.c */ = {isa = PBXFileReference; includeInIndex = 1; name = a_strnid.c; path = third_party/boringssl/src/crypto/asn1/a_strnid.c; sourceTree = SOURCE_ROOT; };
+		445D99E3F2D2E23044127878 /* a_strnid.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = a_strnid.c; path = third_party/boringssl/src/crypto/asn1/a_strnid.c; sourceTree = SOURCE_ROOT; };
 		4548A24187C07A2099E69654 /* socket.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = socket.c; path = third_party/boringssl/src/crypto/bio/socket.c; sourceTree = SOURCE_ROOT; };
-		45A6244416D7F9A0909AB664 /* x_spki.c */ = {isa = PBXFileReference; includeInIndex = 1; name = x_spki.c; path = third_party/boringssl/src/crypto/x509/x_spki.c; sourceTree = SOURCE_ROOT; };
-		469931B7DF85C06E3ED6759F /* sha256-armv8.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "sha256-armv8.S"; path = "third_party/boringssl/ios-aarch64/crypto/fipsmodule/sha256-armv8.S"; sourceTree = SOURCE_ROOT; };
+		45A6244416D7F9A0909AB664 /* x_spki.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = x_spki.c; path = third_party/boringssl/src/crypto/x509/x_spki.c; sourceTree = SOURCE_ROOT; };
+		469931B7DF85C06E3ED6759F /* sha256-armv8.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "sha256-armv8.S"; path = "third_party/boringssl/ios-aarch64/crypto/fipsmodule/sha256-armv8.S"; sourceTree = SOURCE_ROOT; };
 		46A92E5AB98DB71A68ED8DD6 /* internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = internal.h; path = third_party/boringssl/src/crypto/fipsmodule/sha/internal.h; sourceTree = SOURCE_ROOT; };
-		46D49BABD342EDF458E0E9A9 /* x_algor.c */ = {isa = PBXFileReference; includeInIndex = 1; name = x_algor.c; path = third_party/boringssl/src/crypto/x509/x_algor.c; sourceTree = SOURCE_ROOT; };
-		46EEFBE0EB930750E2CFF81D /* md5-586.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "md5-586.S"; path = "third_party/boringssl/mac-x86/crypto/fipsmodule/md5-586.S"; sourceTree = SOURCE_ROOT; };
+		46D49BABD342EDF458E0E9A9 /* x_algor.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = x_algor.c; path = third_party/boringssl/src/crypto/x509/x_algor.c; sourceTree = SOURCE_ROOT; };
+		46EEFBE0EB930750E2CFF81D /* md5-586.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "md5-586.S"; path = "third_party/boringssl/mac-x86/crypto/fipsmodule/md5-586.S"; sourceTree = SOURCE_ROOT; };
 		477F738F512DAA7E171E67B5 /* asn1_locl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = asn1_locl.h; path = third_party/boringssl/src/crypto/asn1/asn1_locl.h; sourceTree = SOURCE_ROOT; };
 		480BFF2590448FA91027A3AC /* curve25519.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = curve25519.h; path = third_party/boringssl/src/include/openssl/curve25519.h; sourceTree = SOURCE_ROOT; };
-		48D1F629BA07F82DC8B45DB0 /* armv8-mont.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "armv8-mont.S"; path = "third_party/boringssl/ios-aarch64/crypto/fipsmodule/armv8-mont.S"; sourceTree = SOURCE_ROOT; };
+		48D1F629BA07F82DC8B45DB0 /* armv8-mont.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "armv8-mont.S"; path = "third_party/boringssl/ios-aarch64/crypto/fipsmodule/armv8-mont.S"; sourceTree = SOURCE_ROOT; };
 		4914822D1328CA2EC4B64178 /* p_ec_asn1.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = p_ec_asn1.c; path = third_party/boringssl/src/crypto/evp/p_ec_asn1.c; sourceTree = SOURCE_ROOT; };
-		4A3C15FEB510C3395FD5F590 /* tls_method.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = tls_method.cc; path = third_party/boringssl/src/ssl/tls_method.cc; sourceTree = SOURCE_ROOT; };
+		4A3C15FEB510C3395FD5F590 /* tls_method.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = tls_method.cc; path = third_party/boringssl/src/ssl/tls_method.cc; sourceTree = SOURCE_ROOT; };
 		4AC445F076CA03A291762953 /* obj.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = obj.c; path = third_party/boringssl/src/crypto/obj/obj.c; sourceTree = SOURCE_ROOT; };
 		4B4EE9CD9AE016AF4425E1F1 /* v3_genn.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = v3_genn.c; path = third_party/boringssl/src/crypto/x509v3/v3_genn.c; sourceTree = SOURCE_ROOT; };
-		4B8B7BBB9F596DFF423FC5F7 /* chacha-armv8.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "chacha-armv8.S"; path = "third_party/boringssl/ios-aarch64/crypto/chacha/chacha-armv8.S"; sourceTree = SOURCE_ROOT; };
-		4B99C93A91E01D305AA2702D /* s3_pkt.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = s3_pkt.cc; path = third_party/boringssl/src/ssl/s3_pkt.cc; sourceTree = SOURCE_ROOT; };
+		4B8B7BBB9F596DFF423FC5F7 /* chacha-armv8.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "chacha-armv8.S"; path = "third_party/boringssl/ios-aarch64/crypto/chacha/chacha-armv8.S"; sourceTree = SOURCE_ROOT; };
+		4B99C93A91E01D305AA2702D /* s3_pkt.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = s3_pkt.cc; path = third_party/boringssl/src/ssl/s3_pkt.cc; sourceTree = SOURCE_ROOT; };
 		4C0ED393FA85526282634662 /* cpu-arm-linux.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = "cpu-arm-linux.c"; path = "third_party/boringssl/src/crypto/cpu-arm-linux.c"; sourceTree = SOURCE_ROOT; };
 		4C50A854C1EAD9EF9B194814 /* v3_pcons.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = v3_pcons.c; path = third_party/boringssl/src/crypto/x509v3/v3_pcons.c; sourceTree = SOURCE_ROOT; };
 		4D8CF9C08C1C57695758F4AF /* bytestring.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = bytestring.h; path = third_party/boringssl/src/include/openssl/bytestring.h; sourceTree = SOURCE_ROOT; };
 		4DD75B725C8C6AFF73377FE1 /* hrss.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = hrss.c; path = third_party/boringssl/src/crypto/hrss/hrss.c; sourceTree = SOURCE_ROOT; };
-		4E42C23DB3E2C73C0110AAC7 /* aes128gcmsiv-x86_64.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "aes128gcmsiv-x86_64.S"; path = "third_party/boringssl/mac-x86_64/crypto/cipher_extra/aes128gcmsiv-x86_64.S"; sourceTree = SOURCE_ROOT; };
+		4E42C23DB3E2C73C0110AAC7 /* aes128gcmsiv-x86_64.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "aes128gcmsiv-x86_64.S"; path = "third_party/boringssl/mac-x86_64/crypto/cipher_extra/aes128gcmsiv-x86_64.S"; sourceTree = SOURCE_ROOT; };
 		4EBA6DA9BA0E52AB8839B4C8 /* p_dsa_asn1.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = p_dsa_asn1.c; path = third_party/boringssl/src/crypto/evp/p_dsa_asn1.c; sourceTree = SOURCE_ROOT; };
-		4EF33A71743AC5D3E047F268 /* asn1_lib.c */ = {isa = PBXFileReference; includeInIndex = 1; name = asn1_lib.c; path = third_party/boringssl/src/crypto/asn1/asn1_lib.c; sourceTree = SOURCE_ROOT; };
-		4F02F875BF1F552B7332D939 /* bio.c */ = {isa = PBXFileReference; includeInIndex = 1; name = bio.c; path = third_party/boringssl/src/crypto/bio/bio.c; sourceTree = SOURCE_ROOT; };
-		4F5E8B814FB7E4CD267C6AD7 /* armv4-mont.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "armv4-mont.S"; path = "third_party/boringssl/ios-arm/crypto/fipsmodule/armv4-mont.S"; sourceTree = SOURCE_ROOT; };
-		4F7AED107588476ABE2ABCE1 /* ex_data.c */ = {isa = PBXFileReference; includeInIndex = 1; name = ex_data.c; path = third_party/boringssl/src/crypto/ex_data.c; sourceTree = SOURCE_ROOT; };
+		4EF33A71743AC5D3E047F268 /* asn1_lib.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = asn1_lib.c; path = third_party/boringssl/src/crypto/asn1/asn1_lib.c; sourceTree = SOURCE_ROOT; };
+		4F02F875BF1F552B7332D939 /* bio.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = bio.c; path = third_party/boringssl/src/crypto/bio/bio.c; sourceTree = SOURCE_ROOT; };
+		4F5E8B814FB7E4CD267C6AD7 /* armv4-mont.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "armv4-mont.S"; path = "third_party/boringssl/ios-arm/crypto/fipsmodule/armv4-mont.S"; sourceTree = SOURCE_ROOT; };
+		4F7AED107588476ABE2ABCE1 /* ex_data.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = ex_data.c; path = third_party/boringssl/src/crypto/ex_data.c; sourceTree = SOURCE_ROOT; };
 		50932522CF41FC56F6AEA8C6 /* dh.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = dh.h; path = third_party/boringssl/src/include/openssl/dh.h; sourceTree = SOURCE_ROOT; };
-		518752FF816A5A9E7D03A298 /* ssl_session.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = ssl_session.cc; path = third_party/boringssl/src/ssl/ssl_session.cc; sourceTree = SOURCE_ROOT; };
+		518752FF816A5A9E7D03A298 /* ssl_session.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = ssl_session.cc; path = third_party/boringssl/src/ssl/ssl_session.cc; sourceTree = SOURCE_ROOT; };
 		52709FD043287F666526E35F /* aesni-x86.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "aesni-x86.S"; path = "third_party/boringssl/mac-x86/crypto/fipsmodule/aesni-x86.S"; sourceTree = SOURCE_ROOT; };
 		52E560A080589BC0EB66C9A6 /* internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = internal.h; path = third_party/boringssl/src/crypto/poly1305/internal.h; sourceTree = SOURCE_ROOT; };
-		53CD3B797EDE1C8C499CD16E /* poly1305_arm.c */ = {isa = PBXFileReference; includeInIndex = 1; name = poly1305_arm.c; path = third_party/boringssl/src/crypto/poly1305/poly1305_arm.c; sourceTree = SOURCE_ROOT; };
+		53CD3B797EDE1C8C499CD16E /* poly1305_arm.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = poly1305_arm.c; path = third_party/boringssl/src/crypto/poly1305/poly1305_arm.c; sourceTree = SOURCE_ROOT; };
 		53F81B8DA0D0EE6A19316A45 /* chacha.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = chacha.h; path = third_party/boringssl/src/include/openssl/chacha.h; sourceTree = SOURCE_ROOT; };
-		543D272EA33AC52256BAF7CB /* ssl_cert.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = ssl_cert.cc; path = third_party/boringssl/src/ssl/ssl_cert.cc; sourceTree = SOURCE_ROOT; };
+		543D272EA33AC52256BAF7CB /* ssl_cert.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = ssl_cert.cc; path = third_party/boringssl/src/ssl/ssl_cert.cc; sourceTree = SOURCE_ROOT; };
 		55E9156A73F759702196BBA4 /* ssl3.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ssl3.h; path = third_party/boringssl/src/include/openssl/ssl3.h; sourceTree = SOURCE_ROOT; };
 		565892681653F7D811BF256A /* engine.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = engine.h; path = third_party/boringssl/src/include/openssl/engine.h; sourceTree = SOURCE_ROOT; };
 		5717D37A1D32B48E5812E828 /* v3_cpols.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = v3_cpols.c; path = third_party/boringssl/src/crypto/x509v3/v3_cpols.c; sourceTree = SOURCE_ROOT; };
@@ -1360,24 +1360,24 @@
 		5827BAC56090657E311CC8FD /* pcy_lib.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = pcy_lib.c; path = third_party/boringssl/src/crypto/x509v3/pcy_lib.c; sourceTree = SOURCE_ROOT; };
 		5903CD0B0B9AF424473EA027 /* getrandom_fillin.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = getrandom_fillin.h; path = third_party/boringssl/src/crypto/fipsmodule/rand/getrandom_fillin.h; sourceTree = SOURCE_ROOT; };
 		59921E0EBF5DE6FF6444AB33 /* p_ec.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = p_ec.c; path = third_party/boringssl/src/crypto/evp/p_ec.c; sourceTree = SOURCE_ROOT; };
-		59A0CA2D4382EB7BD0461DB2 /* x509_v3.c */ = {isa = PBXFileReference; includeInIndex = 1; name = x509_v3.c; path = third_party/boringssl/src/crypto/x509/x509_v3.c; sourceTree = SOURCE_ROOT; };
+		59A0CA2D4382EB7BD0461DB2 /* x509_v3.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = x509_v3.c; path = third_party/boringssl/src/crypto/x509/x509_v3.c; sourceTree = SOURCE_ROOT; };
 		59FC75CF6DE8F8E2C45C4B09 /* pcy_map.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = pcy_map.c; path = third_party/boringssl/src/crypto/x509v3/pcy_map.c; sourceTree = SOURCE_ROOT; };
 		5A577CB220DB56BE1792AFA7 /* printf.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = printf.c; path = third_party/boringssl/src/crypto/bio/printf.c; sourceTree = SOURCE_ROOT; };
 		5A9C0310D1A1186C0A2FAE3E /* rsa.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = rsa.h; path = third_party/boringssl/src/include/openssl/rsa.h; sourceTree = SOURCE_ROOT; };
 		5B001C610B9903157D81B35C /* p256-x86_64-asm.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "p256-x86_64-asm.S"; path = "third_party/boringssl/mac-x86_64/crypto/fipsmodule/p256-x86_64-asm.S"; sourceTree = SOURCE_ROOT; };
 		5B0C6774ECB344A044A82C59 /* v3_skey.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = v3_skey.c; path = third_party/boringssl/src/crypto/x509v3/v3_skey.c; sourceTree = SOURCE_ROOT; };
-		5C5DF275EA487EA1E0F1ADE8 /* tls13_client.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = tls13_client.cc; path = third_party/boringssl/src/ssl/tls13_client.cc; sourceTree = SOURCE_ROOT; };
+		5C5DF275EA487EA1E0F1ADE8 /* tls13_client.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = tls13_client.cc; path = third_party/boringssl/src/ssl/tls13_client.cc; sourceTree = SOURCE_ROOT; };
 		5C97F074DD0A8D197AEF561C /* srtp.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = srtp.h; path = third_party/boringssl/src/include/openssl/srtp.h; sourceTree = SOURCE_ROOT; };
 		5CA60B2BE5AA67EAD75774BC /* v3_conf.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = v3_conf.c; path = third_party/boringssl/src/crypto/x509v3/v3_conf.c; sourceTree = SOURCE_ROOT; };
 		5D02D66741B1D9C6858A96B6 /* a_sign.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = a_sign.c; path = third_party/boringssl/src/crypto/x509/a_sign.c; sourceTree = SOURCE_ROOT; };
 		5DC08DF270AFB29BE7484B90 /* cbs.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = cbs.c; path = third_party/boringssl/src/crypto/bytestring/cbs.c; sourceTree = SOURCE_ROOT; };
-		5E0BC97DA3735203D9D5C048 /* ghash-neon-armv8.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "ghash-neon-armv8.S"; path = "third_party/boringssl/ios-aarch64/crypto/fipsmodule/ghash-neon-armv8.S"; sourceTree = SOURCE_ROOT; };
+		5E0BC97DA3735203D9D5C048 /* ghash-neon-armv8.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "ghash-neon-armv8.S"; path = "third_party/boringssl/ios-aarch64/crypto/fipsmodule/ghash-neon-armv8.S"; sourceTree = SOURCE_ROOT; };
 		5E6AC366157705E772E21A34 /* hkdf.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = hkdf.c; path = third_party/boringssl/src/crypto/hkdf/hkdf.c; sourceTree = SOURCE_ROOT; };
-		5EA5C35141601D18390BEF41 /* ssl_lib.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = ssl_lib.cc; path = third_party/boringssl/src/ssl/ssl_lib.cc; sourceTree = SOURCE_ROOT; };
+		5EA5C35141601D18390BEF41 /* ssl_lib.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = ssl_lib.cc; path = third_party/boringssl/src/ssl/ssl_lib.cc; sourceTree = SOURCE_ROOT; };
 		60FC92A758D7AAFE0F19903A /* bio.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = bio.h; path = third_party/boringssl/src/include/openssl/bio.h; sourceTree = SOURCE_ROOT; };
-		614BD318E9D622DC7A79CA00 /* asn1_par.c */ = {isa = PBXFileReference; includeInIndex = 1; name = asn1_par.c; path = third_party/boringssl/src/crypto/asn1/asn1_par.c; sourceTree = SOURCE_ROOT; };
-		6151C1E83346838803639A94 /* pem_lib.c */ = {isa = PBXFileReference; includeInIndex = 1; name = pem_lib.c; path = third_party/boringssl/src/crypto/pem/pem_lib.c; sourceTree = SOURCE_ROOT; };
-		61A12AF57A4EF06C81A24522 /* pkcs8.c */ = {isa = PBXFileReference; includeInIndex = 1; name = pkcs8.c; path = third_party/boringssl/src/crypto/pkcs8/pkcs8.c; sourceTree = SOURCE_ROOT; };
+		614BD318E9D622DC7A79CA00 /* asn1_par.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = asn1_par.c; path = third_party/boringssl/src/crypto/asn1/asn1_par.c; sourceTree = SOURCE_ROOT; };
+		6151C1E83346838803639A94 /* pem_lib.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = pem_lib.c; path = third_party/boringssl/src/crypto/pem/pem_lib.c; sourceTree = SOURCE_ROOT; };
+		61A12AF57A4EF06C81A24522 /* pkcs8.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = pkcs8.c; path = third_party/boringssl/src/crypto/pkcs8/pkcs8.c; sourceTree = SOURCE_ROOT; };
 		61C22051AED692CF7D6653D3 /* internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = internal.h; path = third_party/boringssl/src/crypto/conf/internal.h; sourceTree = SOURCE_ROOT; };
 		622A8739543801456BBDA66F /* err.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = err.c; path = third_party/boringssl/src/crypto/err/err.c; sourceTree = SOURCE_ROOT; };
 		622DBF359D8430487A68FEC0 /* poly1305_vec.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = poly1305_vec.c; path = third_party/boringssl/src/crypto/poly1305/poly1305_vec.c; sourceTree = SOURCE_ROOT; };
@@ -1386,35 +1386,35 @@
 		637A88650AF52ACE8BF41414 /* sha1-x86_64.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "sha1-x86_64.S"; path = "third_party/boringssl/mac-x86_64/crypto/fipsmodule/sha1-x86_64.S"; sourceTree = SOURCE_ROOT; };
 		6413D786E773B4FA92B3EA28 /* e_rc4.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = e_rc4.c; path = third_party/boringssl/src/crypto/cipher_extra/e_rc4.c; sourceTree = SOURCE_ROOT; };
 		642CD0E9E215ECA43275185B /* windows.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = windows.c; path = third_party/boringssl/src/crypto/rand_extra/windows.c; sourceTree = SOURCE_ROOT; };
-		64425DFB7D789748463000D0 /* ssl_x509.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = ssl_x509.cc; path = third_party/boringssl/src/ssl/ssl_x509.cc; sourceTree = SOURCE_ROOT; };
+		64425DFB7D789748463000D0 /* ssl_x509.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = ssl_x509.cc; path = third_party/boringssl/src/ssl/ssl_x509.cc; sourceTree = SOURCE_ROOT; };
 		648B01216C5D636015EEB03D /* pkcs8.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = pkcs8.h; path = third_party/boringssl/src/include/openssl/pkcs8.h; sourceTree = SOURCE_ROOT; };
-		655553F23840F5CBB0E5B8B5 /* s3_both.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = s3_both.cc; path = third_party/boringssl/src/ssl/s3_both.cc; sourceTree = SOURCE_ROOT; };
+		655553F23840F5CBB0E5B8B5 /* s3_both.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = s3_both.cc; path = third_party/boringssl/src/ssl/s3_both.cc; sourceTree = SOURCE_ROOT; };
 		65727C46B0B529DE60D49461 /* pem_x509.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = pem_x509.c; path = third_party/boringssl/src/crypto/pem/pem_x509.c; sourceTree = SOURCE_ROOT; };
-		6578E1A9125E1BBD3D0D1AB7 /* v3_akeya.c */ = {isa = PBXFileReference; includeInIndex = 1; name = v3_akeya.c; path = third_party/boringssl/src/crypto/x509v3/v3_akeya.c; sourceTree = SOURCE_ROOT; };
+		6578E1A9125E1BBD3D0D1AB7 /* v3_akeya.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = v3_akeya.c; path = third_party/boringssl/src/crypto/x509v3/v3_akeya.c; sourceTree = SOURCE_ROOT; };
 		65A65C51BC92DDC624E888B9 /* v3_extku.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = v3_extku.c; path = third_party/boringssl/src/crypto/x509v3/v3_extku.c; sourceTree = SOURCE_ROOT; };
 		65AD780C8B21956EAA073425 /* x_attrib.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = x_attrib.c; path = third_party/boringssl/src/crypto/x509/x_attrib.c; sourceTree = SOURCE_ROOT; };
 		65BBF5C6CBCB80EC87646306 /* des.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = des.h; path = third_party/boringssl/src/include/openssl/des.h; sourceTree = SOURCE_ROOT; };
 		65C257F11F97056D16E27186 /* rsa_pss.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = rsa_pss.c; path = third_party/boringssl/src/crypto/x509/rsa_pss.c; sourceTree = SOURCE_ROOT; };
 		663FE4F652045993D628C6FC /* type_check.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = type_check.h; path = third_party/boringssl/src/include/openssl/type_check.h; sourceTree = SOURCE_ROOT; };
-		669A5FA948E3F5341D97AA40 /* tls13_both.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = tls13_both.cc; path = third_party/boringssl/src/ssl/tls13_both.cc; sourceTree = SOURCE_ROOT; };
-		682966D322E4528C1E925810 /* pcy_data.c */ = {isa = PBXFileReference; includeInIndex = 1; name = pcy_data.c; path = third_party/boringssl/src/crypto/x509v3/pcy_data.c; sourceTree = SOURCE_ROOT; };
+		669A5FA948E3F5341D97AA40 /* tls13_both.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = tls13_both.cc; path = third_party/boringssl/src/ssl/tls13_both.cc; sourceTree = SOURCE_ROOT; };
+		682966D322E4528C1E925810 /* pcy_data.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = pcy_data.c; path = third_party/boringssl/src/crypto/x509v3/pcy_data.c; sourceTree = SOURCE_ROOT; };
 		691D09F70E11969560013B0E /* x_all.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = x_all.c; path = third_party/boringssl/src/crypto/x509/x_all.c; sourceTree = SOURCE_ROOT; };
 		699CF476A8E660A1DA11A9CA /* ghash-ssse3-x86_64.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "ghash-ssse3-x86_64.S"; path = "third_party/boringssl/mac-x86_64/crypto/fipsmodule/ghash-ssse3-x86_64.S"; sourceTree = SOURCE_ROOT; };
 		69E0262BB483E9F51F43E6A6 /* cast.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = cast.h; path = third_party/boringssl/src/include/openssl/cast.h; sourceTree = SOURCE_ROOT; };
 		6A1172B7A0C810A62762D6AE /* v3_pci.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = v3_pci.c; path = third_party/boringssl/src/crypto/x509v3/v3_pci.c; sourceTree = SOURCE_ROOT; };
 		6A983710429FB7C7B105ED74 /* by_file.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = by_file.c; path = third_party/boringssl/src/crypto/x509/by_file.c; sourceTree = SOURCE_ROOT; };
-		6B1B6D6B321438A8D34C2B86 /* ssl_stat.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = ssl_stat.cc; path = third_party/boringssl/src/ssl/ssl_stat.cc; sourceTree = SOURCE_ROOT; };
+		6B1B6D6B321438A8D34C2B86 /* ssl_stat.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = ssl_stat.cc; path = third_party/boringssl/src/ssl/ssl_stat.cc; sourceTree = SOURCE_ROOT; };
 		6B2B89C7F5D823897EBB16A3 /* cipher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = cipher.h; path = third_party/boringssl/src/include/openssl/cipher.h; sourceTree = SOURCE_ROOT; };
 		6BBFB313860596FE96663ECB /* t_req.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = t_req.c; path = third_party/boringssl/src/crypto/x509/t_req.c; sourceTree = SOURCE_ROOT; };
 		6BCAF6CE5C57D45C8F52525B /* ext_dat.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ext_dat.h; path = third_party/boringssl/src/crypto/x509v3/ext_dat.h; sourceTree = SOURCE_ROOT; };
 		6C4CF550A889CCF25FC29E73 /* e_os2.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = e_os2.h; path = third_party/boringssl/src/include/openssl/e_os2.h; sourceTree = SOURCE_ROOT; };
-		6C50D8F5606EE11D0BAF5E36 /* evp_asn1.c */ = {isa = PBXFileReference; includeInIndex = 1; name = evp_asn1.c; path = third_party/boringssl/src/crypto/evp/evp_asn1.c; sourceTree = SOURCE_ROOT; };
+		6C50D8F5606EE11D0BAF5E36 /* evp_asn1.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = evp_asn1.c; path = third_party/boringssl/src/crypto/evp/evp_asn1.c; sourceTree = SOURCE_ROOT; };
 		6CCAD94536C6ED18C16CF7E3 /* asn_pack.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = asn_pack.c; path = third_party/boringssl/src/crypto/asn1/asn_pack.c; sourceTree = SOURCE_ROOT; };
 		6CE20512C94B30F997E6EF38 /* x_name.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = x_name.c; path = third_party/boringssl/src/crypto/x509/x_name.c; sourceTree = SOURCE_ROOT; };
 		6CE76ED22BCBD3400A95ADDF /* sha.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = sha.h; path = third_party/boringssl/src/include/openssl/sha.h; sourceTree = SOURCE_ROOT; };
 		6D7EDA0FA370A0AB18644E01 /* cpu-aarch64-linux.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = "cpu-aarch64-linux.c"; path = "third_party/boringssl/src/crypto/cpu-aarch64-linux.c"; sourceTree = SOURCE_ROOT; };
 		6E41B560C4081194F69C3316 /* p256_beeu-x86_64-asm.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "p256_beeu-x86_64-asm.S"; path = "third_party/boringssl/mac-x86_64/crypto/fipsmodule/p256_beeu-x86_64-asm.S"; sourceTree = SOURCE_ROOT; };
-		6E48EAC687DE0A94C1801B53 /* x509_txt.c */ = {isa = PBXFileReference; includeInIndex = 1; name = x509_txt.c; path = third_party/boringssl/src/crypto/x509/x509_txt.c; sourceTree = SOURCE_ROOT; };
+		6E48EAC687DE0A94C1801B53 /* x509_txt.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = x509_txt.c; path = third_party/boringssl/src/crypto/x509/x509_txt.c; sourceTree = SOURCE_ROOT; };
 		6E4DCE5480FADFDA683118CC /* trust_token.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = trust_token.c; path = third_party/boringssl/src/crypto/trust_token/trust_token.c; sourceTree = SOURCE_ROOT; };
 		6E5FE0BB7FC46C61DA9D9B33 /* internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = internal.h; path = third_party/boringssl/src/crypto/dsa/internal.h; sourceTree = SOURCE_ROOT; };
 		6E780F87E2AC3F150B4C81A5 /* evp.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = evp.c; path = third_party/boringssl/src/crypto/evp/evp.c; sourceTree = SOURCE_ROOT; };
@@ -1422,53 +1422,53 @@
 		6EE258C0E242CFEA4D755541 /* pem_xaux.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = pem_xaux.c; path = third_party/boringssl/src/crypto/pem/pem_xaux.c; sourceTree = SOURCE_ROOT; };
 		6F60B1DDBEA9B4D9FFF7D79C /* stack.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = stack.h; path = third_party/boringssl/src/include/openssl/stack.h; sourceTree = SOURCE_ROOT; };
 		6F749173CED7EBF53076E623 /* trust_token.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = trust_token.h; path = third_party/boringssl/src/include/openssl/trust_token.h; sourceTree = SOURCE_ROOT; };
-		6FB575443BE267EC454CD820 /* bsaes-armv7.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "bsaes-armv7.S"; path = "third_party/boringssl/ios-arm/crypto/fipsmodule/bsaes-armv7.S"; sourceTree = SOURCE_ROOT; };
+		6FB575443BE267EC454CD820 /* bsaes-armv7.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "bsaes-armv7.S"; path = "third_party/boringssl/ios-arm/crypto/fipsmodule/bsaes-armv7.S"; sourceTree = SOURCE_ROOT; };
 		7086FCF8C238C1E4EBB9309D /* a_enum.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = a_enum.c; path = third_party/boringssl/src/crypto/asn1/a_enum.c; sourceTree = SOURCE_ROOT; };
 		70E1093198E23200A5FD6181 /* conf.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = conf.c; path = third_party/boringssl/src/crypto/conf/conf.c; sourceTree = SOURCE_ROOT; };
-		71331EC04EF2810329EA1BD8 /* handshake.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = handshake.cc; path = third_party/boringssl/src/ssl/handshake.cc; sourceTree = SOURCE_ROOT; };
+		71331EC04EF2810329EA1BD8 /* handshake.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = handshake.cc; path = third_party/boringssl/src/ssl/handshake.cc; sourceTree = SOURCE_ROOT; };
 		714C0A11821D1BDB26676CA8 /* asn1_mac.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = asn1_mac.h; path = third_party/boringssl/src/include/openssl/asn1_mac.h; sourceTree = SOURCE_ROOT; };
 		71A7CFA18E5FEDB346744D27 /* x_sig.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = x_sig.c; path = third_party/boringssl/src/crypto/x509/x_sig.c; sourceTree = SOURCE_ROOT; };
-		71DA2CDD3FD692B3E4CC7729 /* ssl_privkey.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = ssl_privkey.cc; path = third_party/boringssl/src/ssl/ssl_privkey.cc; sourceTree = SOURCE_ROOT; };
-		71FE59DD329237B9FFF000BA /* params.c */ = {isa = PBXFileReference; includeInIndex = 1; name = params.c; path = third_party/boringssl/src/crypto/dh_extra/params.c; sourceTree = SOURCE_ROOT; };
+		71DA2CDD3FD692B3E4CC7729 /* ssl_privkey.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = ssl_privkey.cc; path = third_party/boringssl/src/ssl/ssl_privkey.cc; sourceTree = SOURCE_ROOT; };
+		71FE59DD329237B9FFF000BA /* params.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = params.c; path = third_party/boringssl/src/crypto/dh_extra/params.c; sourceTree = SOURCE_ROOT; };
 		72BE52AD3173633753933FE8 /* derive_key.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = derive_key.c; path = third_party/boringssl/src/crypto/cipher_extra/derive_key.c; sourceTree = SOURCE_ROOT; };
-		738AE7F8FFF94C490D489442 /* sha256-586.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "sha256-586.S"; path = "third_party/boringssl/mac-x86/crypto/fipsmodule/sha256-586.S"; sourceTree = SOURCE_ROOT; };
+		738AE7F8FFF94C490D489442 /* sha256-586.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "sha256-586.S"; path = "third_party/boringssl/mac-x86/crypto/fipsmodule/sha256-586.S"; sourceTree = SOURCE_ROOT; };
 		73CB9D99654C15BF1970094C /* x86_64-mont.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "x86_64-mont.S"; path = "third_party/boringssl/mac-x86_64/crypto/fipsmodule/x86_64-mont.S"; sourceTree = SOURCE_ROOT; };
 		74B99B2B1BAD90A9D0CDE516 /* a_strex.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = a_strex.c; path = third_party/boringssl/src/crypto/x509/a_strex.c; sourceTree = SOURCE_ROOT; };
 		74E902B3917408E045951319 /* v3_prn.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = v3_prn.c; path = third_party/boringssl/src/crypto/x509v3/v3_prn.c; sourceTree = SOURCE_ROOT; };
-		74F314353358212AE8751B2A /* x_info.c */ = {isa = PBXFileReference; includeInIndex = 1; name = x_info.c; path = third_party/boringssl/src/crypto/x509/x_info.c; sourceTree = SOURCE_ROOT; };
-		752C466B046BE268E003DE89 /* a_octet.c */ = {isa = PBXFileReference; includeInIndex = 1; name = a_octet.c; path = third_party/boringssl/src/crypto/asn1/a_octet.c; sourceTree = SOURCE_ROOT; };
-		753B23CB6E7B1B529B4945C1 /* ghash-ssse3-x86.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "ghash-ssse3-x86.S"; path = "third_party/boringssl/mac-x86/crypto/fipsmodule/ghash-ssse3-x86.S"; sourceTree = SOURCE_ROOT; };
-		769AE91218729C8A31265046 /* chacha-armv4.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "chacha-armv4.S"; path = "third_party/boringssl/ios-arm/crypto/chacha/chacha-armv4.S"; sourceTree = SOURCE_ROOT; };
+		74F314353358212AE8751B2A /* x_info.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = x_info.c; path = third_party/boringssl/src/crypto/x509/x_info.c; sourceTree = SOURCE_ROOT; };
+		752C466B046BE268E003DE89 /* a_octet.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = a_octet.c; path = third_party/boringssl/src/crypto/asn1/a_octet.c; sourceTree = SOURCE_ROOT; };
+		753B23CB6E7B1B529B4945C1 /* ghash-ssse3-x86.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "ghash-ssse3-x86.S"; path = "third_party/boringssl/mac-x86/crypto/fipsmodule/ghash-ssse3-x86.S"; sourceTree = SOURCE_ROOT; };
+		769AE91218729C8A31265046 /* chacha-armv4.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "chacha-armv4.S"; path = "third_party/boringssl/ios-arm/crypto/chacha/chacha-armv4.S"; sourceTree = SOURCE_ROOT; };
 		76D03C2023EE62EB63E3A393 /* internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = internal.h; path = third_party/boringssl/src/crypto/hrss/internal.h; sourceTree = SOURCE_ROOT; };
-		770F133D98157EE2473BFBA1 /* chacha-armv8.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "chacha-armv8.S"; path = "third_party/boringssl/ios-aarch64/crypto/chacha/chacha-armv8.S"; sourceTree = SOURCE_ROOT; };
+		770F133D98157EE2473BFBA1 /* chacha-armv8.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "chacha-armv8.S"; path = "third_party/boringssl/ios-aarch64/crypto/chacha/chacha-armv8.S"; sourceTree = SOURCE_ROOT; };
 		77DB8F716E0867DBF81D4294 /* internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = internal.h; path = third_party/boringssl/src/crypto/fipsmodule/ec/internal.h; sourceTree = SOURCE_ROOT; };
-		77F3FBF88BF0BC0574369136 /* x509cset.c */ = {isa = PBXFileReference; includeInIndex = 1; name = x509cset.c; path = third_party/boringssl/src/crypto/x509/x509cset.c; sourceTree = SOURCE_ROOT; };
+		77F3FBF88BF0BC0574369136 /* x509cset.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = x509cset.c; path = third_party/boringssl/src/crypto/x509/x509cset.c; sourceTree = SOURCE_ROOT; };
 		77F892463CFE6CCFBA96A1F6 /* internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = internal.h; path = third_party/boringssl/src/crypto/fipsmodule/tls/internal.h; sourceTree = SOURCE_ROOT; };
 		781039BE709E9A484FD9F050 /* v3_enum.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = v3_enum.c; path = third_party/boringssl/src/crypto/x509v3/v3_enum.c; sourceTree = SOURCE_ROOT; };
 		7811B9D6494A5AB21BEBBA0D /* p5_pbev2.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = p5_pbev2.c; path = third_party/boringssl/src/crypto/pkcs8/p5_pbev2.c; sourceTree = SOURCE_ROOT; };
-		78811EB6D224E4E4C5A8D83F /* sha1-armv8.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "sha1-armv8.S"; path = "third_party/boringssl/ios-aarch64/crypto/fipsmodule/sha1-armv8.S"; sourceTree = SOURCE_ROOT; };
-		78827B2C5E783A656A2D98CA /* encrypted_client_hello.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = encrypted_client_hello.cc; path = third_party/boringssl/src/ssl/encrypted_client_hello.cc; sourceTree = SOURCE_ROOT; };
-		78A26D24578B17CE601F4891 /* convert.c */ = {isa = PBXFileReference; includeInIndex = 1; name = convert.c; path = third_party/boringssl/src/crypto/bn_extra/convert.c; sourceTree = SOURCE_ROOT; };
-		7912CB6711FFD85DFB08D6C8 /* co-586.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "co-586.S"; path = "third_party/boringssl/mac-x86/crypto/fipsmodule/co-586.S"; sourceTree = SOURCE_ROOT; };
+		78811EB6D224E4E4C5A8D83F /* sha1-armv8.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "sha1-armv8.S"; path = "third_party/boringssl/ios-aarch64/crypto/fipsmodule/sha1-armv8.S"; sourceTree = SOURCE_ROOT; };
+		78827B2C5E783A656A2D98CA /* encrypted_client_hello.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = encrypted_client_hello.cc; path = third_party/boringssl/src/ssl/encrypted_client_hello.cc; sourceTree = SOURCE_ROOT; };
+		78A26D24578B17CE601F4891 /* convert.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = convert.c; path = third_party/boringssl/src/crypto/bn_extra/convert.c; sourceTree = SOURCE_ROOT; };
+		7912CB6711FFD85DFB08D6C8 /* co-586.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "co-586.S"; path = "third_party/boringssl/mac-x86/crypto/fipsmodule/co-586.S"; sourceTree = SOURCE_ROOT; };
 		793F0A16A292F619548A485C /* err.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = err.h; path = third_party/boringssl/src/include/openssl/err.h; sourceTree = SOURCE_ROOT; };
 		794EEC46FFE4E65BAB33F73D /* cmac.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = cmac.h; path = third_party/boringssl/src/include/openssl/cmac.h; sourceTree = SOURCE_ROOT; };
-		795E918552549AB6BC12B754 /* v3_info.c */ = {isa = PBXFileReference; includeInIndex = 1; name = v3_info.c; path = third_party/boringssl/src/crypto/x509v3/v3_info.c; sourceTree = SOURCE_ROOT; };
+		795E918552549AB6BC12B754 /* v3_info.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = v3_info.c; path = third_party/boringssl/src/crypto/x509v3/v3_info.c; sourceTree = SOURCE_ROOT; };
 		7978CF291703B36A587425BB /* asn1t.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = asn1t.h; path = third_party/boringssl/src/include/openssl/asn1t.h; sourceTree = SOURCE_ROOT; };
 		79DA264908929F17D6DC09BD /* rdrand-x86_64.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "rdrand-x86_64.S"; path = "third_party/boringssl/mac-x86_64/crypto/fipsmodule/rdrand-x86_64.S"; sourceTree = SOURCE_ROOT; };
 		79DC230DE6DE77EC7FE7EEDF /* cmac.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = cmac.c; path = third_party/boringssl/src/crypto/cmac/cmac.c; sourceTree = SOURCE_ROOT; };
 		7A25F00B92A64DB27E2B16D4 /* fork_detect.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = fork_detect.h; path = third_party/boringssl/src/crypto/fipsmodule/rand/fork_detect.h; sourceTree = SOURCE_ROOT; };
 		7A9760BB5B08D3D3BE9D6C42 /* pem_all.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = pem_all.c; path = third_party/boringssl/src/crypto/pem/pem_all.c; sourceTree = SOURCE_ROOT; };
-		7CB75E0504CCE1BD0096B202 /* ssl_transcript.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = ssl_transcript.cc; path = third_party/boringssl/src/ssl/ssl_transcript.cc; sourceTree = SOURCE_ROOT; };
+		7CB75E0504CCE1BD0096B202 /* ssl_transcript.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = ssl_transcript.cc; path = third_party/boringssl/src/ssl/ssl_transcript.cc; sourceTree = SOURCE_ROOT; };
 		7EB848A937B59FF1C0E48C2C /* pair.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = pair.c; path = third_party/boringssl/src/crypto/bio/pair.c; sourceTree = SOURCE_ROOT; };
 		7EF28BEB6BACDA2EC13AD181 /* x509_def.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = x509_def.c; path = third_party/boringssl/src/crypto/x509/x509_def.c; sourceTree = SOURCE_ROOT; };
-		7F120B819D3A2CF45E5EC68D /* vpaes-armv7.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "vpaes-armv7.S"; path = "third_party/boringssl/ios-arm/crypto/fipsmodule/vpaes-armv7.S"; sourceTree = SOURCE_ROOT; };
+		7F120B819D3A2CF45E5EC68D /* vpaes-armv7.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "vpaes-armv7.S"; path = "third_party/boringssl/ios-arm/crypto/fipsmodule/vpaes-armv7.S"; sourceTree = SOURCE_ROOT; };
 		7F26D944DE7F0FAA47B9CB12 /* delocate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = delocate.h; path = third_party/boringssl/src/crypto/fipsmodule/delocate.h; sourceTree = SOURCE_ROOT; };
 		7F7F9267CEC47A4AC5F1B7F3 /* scrypt.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = scrypt.c; path = third_party/boringssl/src/crypto/evp/scrypt.c; sourceTree = SOURCE_ROOT; };
-		7FB570A33D00E615CCD35D7B /* x86_64-mont5.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "x86_64-mont5.S"; path = "third_party/boringssl/mac-x86_64/crypto/fipsmodule/x86_64-mont5.S"; sourceTree = SOURCE_ROOT; };
+		7FB570A33D00E615CCD35D7B /* x86_64-mont5.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "x86_64-mont5.S"; path = "third_party/boringssl/mac-x86_64/crypto/fipsmodule/x86_64-mont5.S"; sourceTree = SOURCE_ROOT; };
 		7FFCF8CA42EF6F7FA3646DFE /* fd.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = fd.c; path = third_party/boringssl/src/crypto/bio/fd.c; sourceTree = SOURCE_ROOT; };
 		80075ED44D0B8CABDB3A6CEC /* p256-x86_64.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "p256-x86_64.h"; path = "third_party/boringssl/src/crypto/fipsmodule/ec/p256-x86_64.h"; sourceTree = SOURCE_ROOT; };
-		800D1B99751682F24DC6BCDF /* pkcs8_x509.c */ = {isa = PBXFileReference; includeInIndex = 1; name = pkcs8_x509.c; path = third_party/boringssl/src/crypto/pkcs8/pkcs8_x509.c; sourceTree = SOURCE_ROOT; };
-		80BDCBB23AD2A536C6556FAD /* a_int.c */ = {isa = PBXFileReference; includeInIndex = 1; name = a_int.c; path = third_party/boringssl/src/crypto/asn1/a_int.c; sourceTree = SOURCE_ROOT; };
+		800D1B99751682F24DC6BCDF /* pkcs8_x509.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = pkcs8_x509.c; path = third_party/boringssl/src/crypto/pkcs8/pkcs8_x509.c; sourceTree = SOURCE_ROOT; };
+		80BDCBB23AD2A536C6556FAD /* a_int.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = a_int.c; path = third_party/boringssl/src/crypto/asn1/a_int.c; sourceTree = SOURCE_ROOT; };
 		8108DF0E1E0A6D8CBFF11998 /* curve25519.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = curve25519.c; path = third_party/boringssl/src/crypto/curve25519/curve25519.c; sourceTree = SOURCE_ROOT; };
 		818F63B8F54437740060E643 /* forkunsafe.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = forkunsafe.c; path = third_party/boringssl/src/crypto/rand_extra/forkunsafe.c; sourceTree = SOURCE_ROOT; };
 		82754E8AA82907E55AB63C59 /* e_aesctrhmac.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = e_aesctrhmac.c; path = third_party/boringssl/src/crypto/cipher_extra/e_aesctrhmac.c; sourceTree = SOURCE_ROOT; };
@@ -1478,13 +1478,13 @@
 		84E10FB8AD8145DCC442A8DA /* v3_purp.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = v3_purp.c; path = third_party/boringssl/src/crypto/x509v3/v3_purp.c; sourceTree = SOURCE_ROOT; };
 		8565B956EDD92173990B7013 /* x509_trs.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = x509_trs.c; path = third_party/boringssl/src/crypto/x509/x509_trs.c; sourceTree = SOURCE_ROOT; };
 		8748FEF0B2E8FDB2DA3FA631 /* internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = internal.h; path = third_party/boringssl/src/crypto/trust_token/internal.h; sourceTree = SOURCE_ROOT; };
-		87F7E9647ED80A0905AC51C1 /* pem_pk8.c */ = {isa = PBXFileReference; includeInIndex = 1; name = pem_pk8.c; path = third_party/boringssl/src/crypto/pem/pem_pk8.c; sourceTree = SOURCE_ROOT; };
+		87F7E9647ED80A0905AC51C1 /* pem_pk8.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = pem_pk8.c; path = third_party/boringssl/src/crypto/pem/pem_pk8.c; sourceTree = SOURCE_ROOT; };
 		87FE78FEDADDD59E21059F01 /* time_support.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = time_support.c; path = third_party/boringssl/src/crypto/asn1/time_support.c; sourceTree = SOURCE_ROOT; };
-		8822800239BC5753B234DD94 /* trampoline-armv8.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "trampoline-armv8.S"; path = "third_party/boringssl/ios-aarch64/crypto/test/trampoline-armv8.S"; sourceTree = SOURCE_ROOT; };
+		8822800239BC5753B234DD94 /* trampoline-armv8.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "trampoline-armv8.S"; path = "third_party/boringssl/ios-aarch64/crypto/test/trampoline-armv8.S"; sourceTree = SOURCE_ROOT; };
 		88D3C1AEF8FD1320EE422AE3 /* dsa.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = dsa.c; path = third_party/boringssl/src/crypto/dsa/dsa.c; sourceTree = SOURCE_ROOT; };
 		892A42B51ED1E3869ED83FEE /* p256_64.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = p256_64.h; path = third_party/boringssl/src/third_party/fiat/p256_64.h; sourceTree = SOURCE_ROOT; };
-		89FBD593BF89A485F4F54CB3 /* ghash-armv4.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "ghash-armv4.S"; path = "third_party/boringssl/ios-arm/crypto/fipsmodule/ghash-armv4.S"; sourceTree = SOURCE_ROOT; };
-		8A4734E09CA210E631D7EFE1 /* d1_pkt.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = d1_pkt.cc; path = third_party/boringssl/src/ssl/d1_pkt.cc; sourceTree = SOURCE_ROOT; };
+		89FBD593BF89A485F4F54CB3 /* ghash-armv4.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "ghash-armv4.S"; path = "third_party/boringssl/ios-arm/crypto/fipsmodule/ghash-armv4.S"; sourceTree = SOURCE_ROOT; };
+		8A4734E09CA210E631D7EFE1 /* d1_pkt.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = d1_pkt.cc; path = third_party/boringssl/src/ssl/d1_pkt.cc; sourceTree = SOURCE_ROOT; };
 		8A525A4D643330B509A0DB05 /* pool.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = pool.h; path = third_party/boringssl/src/include/openssl/pool.h; sourceTree = SOURCE_ROOT; };
 		8AA091F74FD426AD3F151242 /* obj.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = obj.h; path = third_party/boringssl/src/include/openssl/obj.h; sourceTree = SOURCE_ROOT; };
 		8AB984108EEB8355F86FD303 /* md4.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = md4.h; path = third_party/boringssl/src/include/openssl/md4.h; sourceTree = SOURCE_ROOT; };
@@ -1496,49 +1496,49 @@
 		8C9E5D24B8DFD460712F74E4 /* deterministic.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = deterministic.c; path = third_party/boringssl/src/crypto/rand_extra/deterministic.c; sourceTree = SOURCE_ROOT; };
 		8CBD2367EB12E18AFEEE2FC3 /* md5.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = md5.h; path = third_party/boringssl/src/include/openssl/md5.h; sourceTree = SOURCE_ROOT; };
 		8CE7FBEA00AECF0D990D28A7 /* a_print.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = a_print.c; path = third_party/boringssl/src/crypto/asn1/a_print.c; sourceTree = SOURCE_ROOT; };
-		8D003C2E052B7FE57735E052 /* d1_srtp.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = d1_srtp.cc; path = third_party/boringssl/src/ssl/d1_srtp.cc; sourceTree = SOURCE_ROOT; };
+		8D003C2E052B7FE57735E052 /* d1_srtp.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = d1_srtp.cc; path = third_party/boringssl/src/ssl/d1_srtp.cc; sourceTree = SOURCE_ROOT; };
 		8D41D5DEF314AF341D4573A6 /* obj_dat.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = obj_dat.h; path = third_party/boringssl/src/crypto/obj/obj_dat.h; sourceTree = SOURCE_ROOT; };
 		8DF59799E5E2E83C681B2AD7 /* p_rsa.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = p_rsa.c; path = third_party/boringssl/src/crypto/evp/p_rsa.c; sourceTree = SOURCE_ROOT; };
 		8EC52C5890A368A58BB4BF7B /* p_ed25519.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = p_ed25519.c; path = third_party/boringssl/src/crypto/evp/p_ed25519.c; sourceTree = SOURCE_ROOT; };
 		900F3583CA4F5E9CFB234B9A /* buf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = buf.h; path = third_party/boringssl/src/include/openssl/buf.h; sourceTree = SOURCE_ROOT; };
 		906940DC60EF4000C434BA4D /* tls_cbc.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = tls_cbc.c; path = third_party/boringssl/src/crypto/cipher_extra/tls_cbc.c; sourceTree = SOURCE_ROOT; };
 		90D4F156E8AD3C01289C17BB /* f_string.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = f_string.c; path = third_party/boringssl/src/crypto/asn1/f_string.c; sourceTree = SOURCE_ROOT; };
-		90E0C8F68FBDD6C0027A96D9 /* thread_win.c */ = {isa = PBXFileReference; includeInIndex = 1; name = thread_win.c; path = third_party/boringssl/src/crypto/thread_win.c; sourceTree = SOURCE_ROOT; };
+		90E0C8F68FBDD6C0027A96D9 /* thread_win.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = thread_win.c; path = third_party/boringssl/src/crypto/thread_win.c; sourceTree = SOURCE_ROOT; };
 		91A0A8696759B64EC82EA8DC /* v3_pcia.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = v3_pcia.c; path = third_party/boringssl/src/crypto/x509v3/v3_pcia.c; sourceTree = SOURCE_ROOT; };
 		91B76BAD835175216ADD4C06 /* ecdsa_asn1.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = ecdsa_asn1.c; path = third_party/boringssl/src/crypto/ecdsa_extra/ecdsa_asn1.c; sourceTree = SOURCE_ROOT; };
 		91D520844D49ADC49E1A70B8 /* v3_akey.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = v3_akey.c; path = third_party/boringssl/src/crypto/x509v3/v3_akey.c; sourceTree = SOURCE_ROOT; };
 		91E947F686E016F5A06F8C82 /* ex_data.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ex_data.h; path = third_party/boringssl/src/include/openssl/ex_data.h; sourceTree = SOURCE_ROOT; };
 		9225565EF36639FA77686263 /* internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = internal.h; path = third_party/boringssl/src/crypto/fipsmodule/bn/internal.h; sourceTree = SOURCE_ROOT; };
 		925263B169041363A7112C3D /* internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = internal.h; path = third_party/boringssl/src/crypto/pkcs7/internal.h; sourceTree = SOURCE_ROOT; };
-		92851568ED10D0C9C7C23D97 /* pem_oth.c */ = {isa = PBXFileReference; includeInIndex = 1; name = pem_oth.c; path = third_party/boringssl/src/crypto/pem/pem_oth.c; sourceTree = SOURCE_ROOT; };
+		92851568ED10D0C9C7C23D97 /* pem_oth.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = pem_oth.c; path = third_party/boringssl/src/crypto/pem/pem_oth.c; sourceTree = SOURCE_ROOT; };
 		92F57D1743D65892A41DDD97 /* dsa_asn1.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = dsa_asn1.c; path = third_party/boringssl/src/crypto/dsa/dsa_asn1.c; sourceTree = SOURCE_ROOT; };
 		9313CF758A0348A8FA3759AC /* pmbtoken.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = pmbtoken.c; path = third_party/boringssl/src/crypto/trust_token/pmbtoken.c; sourceTree = SOURCE_ROOT; };
 		9359FB9D669D5BEC261292D9 /* x_pubkey.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = x_pubkey.c; path = third_party/boringssl/src/crypto/x509/x_pubkey.c; sourceTree = SOURCE_ROOT; };
 		93A271CB1989BA640C107747 /* i2d_pr.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = i2d_pr.c; path = third_party/boringssl/src/crypto/x509/i2d_pr.c; sourceTree = SOURCE_ROOT; };
 		93C016D067CB32C87A8C85F9 /* internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = internal.h; path = third_party/boringssl/src/crypto/fipsmodule/ecdsa/internal.h; sourceTree = SOURCE_ROOT; };
 		93DBD9B95A237CF23D20BC51 /* tasn_utl.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = tasn_utl.c; path = third_party/boringssl/src/crypto/asn1/tasn_utl.c; sourceTree = SOURCE_ROOT; };
-		943FE87362A65AF78C86D6D7 /* sign.c */ = {isa = PBXFileReference; includeInIndex = 1; name = sign.c; path = third_party/boringssl/src/crypto/evp/sign.c; sourceTree = SOURCE_ROOT; };
+		943FE87362A65AF78C86D6D7 /* sign.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = sign.c; path = third_party/boringssl/src/crypto/evp/sign.c; sourceTree = SOURCE_ROOT; };
 		944E25D4E83DBE736299E6ED /* ec_derive.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = ec_derive.c; path = third_party/boringssl/src/crypto/ec_extra/ec_derive.c; sourceTree = SOURCE_ROOT; };
-		955EDFD13CF1326AB347D0AE /* e_rc2.c */ = {isa = PBXFileReference; includeInIndex = 1; name = e_rc2.c; path = third_party/boringssl/src/crypto/cipher_extra/e_rc2.c; sourceTree = SOURCE_ROOT; };
+		955EDFD13CF1326AB347D0AE /* e_rc2.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = e_rc2.c; path = third_party/boringssl/src/crypto/cipher_extra/e_rc2.c; sourceTree = SOURCE_ROOT; };
 		95CC2FCA0159642C9A4ECB6A /* engine.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = engine.c; path = third_party/boringssl/src/crypto/engine/engine.c; sourceTree = SOURCE_ROOT; };
-		95CD409D48EEAFF9D8F98442 /* a_digest.c */ = {isa = PBXFileReference; includeInIndex = 1; name = a_digest.c; path = third_party/boringssl/src/crypto/x509/a_digest.c; sourceTree = SOURCE_ROOT; };
+		95CD409D48EEAFF9D8F98442 /* a_digest.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = a_digest.c; path = third_party/boringssl/src/crypto/x509/a_digest.c; sourceTree = SOURCE_ROOT; };
 		9618195051F731FED87604C4 /* thread_pthread.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = thread_pthread.c; path = third_party/boringssl/src/crypto/thread_pthread.c; sourceTree = SOURCE_ROOT; };
 		97644B8EC3FF3AD5EA2F59D8 /* e_chacha20poly1305.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = e_chacha20poly1305.c; path = third_party/boringssl/src/crypto/cipher_extra/e_chacha20poly1305.c; sourceTree = SOURCE_ROOT; };
 		97D4EC317E640223585B1464 /* vpaes-x86_64.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "vpaes-x86_64.S"; path = "third_party/boringssl/mac-x86_64/crypto/fipsmodule/vpaes-x86_64.S"; sourceTree = SOURCE_ROOT; };
 		986EBE54841C81A6D0530319 /* internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = internal.h; path = third_party/boringssl/src/crypto/curve25519/internal.h; sourceTree = SOURCE_ROOT; };
 		98BAD203EEAC9BEB79581797 /* pcy_int.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = pcy_int.h; path = third_party/boringssl/src/crypto/x509v3/pcy_int.h; sourceTree = SOURCE_ROOT; };
 		98BCE20CFFDAD2A77F39498C /* a_mbstr.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = a_mbstr.c; path = third_party/boringssl/src/crypto/asn1/a_mbstr.c; sourceTree = SOURCE_ROOT; };
-		9A38C7098396BFBF857BBE8D /* p_x25519_asn1.c */ = {isa = PBXFileReference; includeInIndex = 1; name = p_x25519_asn1.c; path = third_party/boringssl/src/crypto/evp/p_x25519_asn1.c; sourceTree = SOURCE_ROOT; };
+		9A38C7098396BFBF857BBE8D /* p_x25519_asn1.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = p_x25519_asn1.c; path = third_party/boringssl/src/crypto/evp/p_x25519_asn1.c; sourceTree = SOURCE_ROOT; };
 		9A4213668691076F6B8C1F0D /* x509v3.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = x509v3.h; path = third_party/boringssl/src/include/openssl/x509v3.h; sourceTree = SOURCE_ROOT; };
 		9A95045F93F8CB0DD158DEDD /* fuchsia.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = fuchsia.c; path = third_party/boringssl/src/crypto/rand_extra/fuchsia.c; sourceTree = SOURCE_ROOT; };
 		9ABF20549F95CD05DAF1B653 /* internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = internal.h; path = third_party/boringssl/src/crypto/hpke/internal.h; sourceTree = SOURCE_ROOT; };
 		9B18676C61937D7798C7170C /* base64.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = base64.h; path = third_party/boringssl/src/include/openssl/base64.h; sourceTree = SOURCE_ROOT; };
 		9B3979357642B5C047A03E2A /* t_x509.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = t_x509.c; path = third_party/boringssl/src/crypto/x509/t_x509.c; sourceTree = SOURCE_ROOT; };
-		9B3B84D45873C689B102F452 /* sha1-armv4-large.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "sha1-armv4-large.S"; path = "third_party/boringssl/ios-arm/crypto/fipsmodule/sha1-armv4-large.S"; sourceTree = SOURCE_ROOT; };
-		9C8A0F700B9726EC82DE2E82 /* vpaes-armv8.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "vpaes-armv8.S"; path = "third_party/boringssl/ios-aarch64/crypto/fipsmodule/vpaes-armv8.S"; sourceTree = SOURCE_ROOT; };
+		9B3B84D45873C689B102F452 /* sha1-armv4-large.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "sha1-armv4-large.S"; path = "third_party/boringssl/ios-arm/crypto/fipsmodule/sha1-armv4-large.S"; sourceTree = SOURCE_ROOT; };
+		9C8A0F700B9726EC82DE2E82 /* vpaes-armv8.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "vpaes-armv8.S"; path = "third_party/boringssl/ios-aarch64/crypto/fipsmodule/vpaes-armv8.S"; sourceTree = SOURCE_ROOT; };
 		9CE91498F46D069A4D4C5E62 /* md32_common.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = md32_common.h; path = third_party/boringssl/src/crypto/fipsmodule/digest/md32_common.h; sourceTree = SOURCE_ROOT; };
-		9D28B55C96DB5A30AA5950C4 /* v3_ia5.c */ = {isa = PBXFileReference; includeInIndex = 1; name = v3_ia5.c; path = third_party/boringssl/src/crypto/x509v3/v3_ia5.c; sourceTree = SOURCE_ROOT; };
-		9DAF449D0061FFBF2F43A81F /* voprf.c */ = {isa = PBXFileReference; includeInIndex = 1; name = voprf.c; path = third_party/boringssl/src/crypto/trust_token/voprf.c; sourceTree = SOURCE_ROOT; };
+		9D28B55C96DB5A30AA5950C4 /* v3_ia5.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = v3_ia5.c; path = third_party/boringssl/src/crypto/x509v3/v3_ia5.c; sourceTree = SOURCE_ROOT; };
+		9DAF449D0061FFBF2F43A81F /* voprf.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = voprf.c; path = third_party/boringssl/src/crypto/trust_token/voprf.c; sourceTree = SOURCE_ROOT; };
 		9DCCA41CD887DC31F56A481E /* hexdump.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = hexdump.c; path = third_party/boringssl/src/crypto/bio/hexdump.c; sourceTree = SOURCE_ROOT; };
 		9DCF1E1E5903FDED6A994244 /* cpu-intel.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = "cpu-intel.c"; path = "third_party/boringssl/src/crypto/cpu-intel.c"; sourceTree = SOURCE_ROOT; };
 		9E4FEEECAFDF9195F8699F07 /* a_bool.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = a_bool.c; path = third_party/boringssl/src/crypto/asn1/a_bool.c; sourceTree = SOURCE_ROOT; };
@@ -1679,6 +1679,25 @@
 		9F4A24C1223A8FA8005CB63A /* skeygen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = skeygen.h; path = "src/wrappers/themis/Obj-C/objcthemis/skeygen.h"; sourceTree = "<group>"; };
 		9F4A24C2223A8FA8005CB63A /* smessage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = smessage.h; path = "src/wrappers/themis/Obj-C/objcthemis/smessage.h"; sourceTree = "<group>"; };
 		9F4A24C3223A8FA8005CB63A /* scell_token.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = scell_token.h; path = "src/wrappers/themis/Obj-C/objcthemis/scell_token.h"; sourceTree = "<group>"; };
+		9F52B00E263D2F840025EB78 /* soter_sign_ecdsa.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = soter_sign_ecdsa.c; path = src/soter/boringssl/soter_sign_ecdsa.c; sourceTree = "<group>"; };
+		9F52B00F263D2F840025EB78 /* soter_rand.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = soter_rand.c; path = src/soter/boringssl/soter_rand.c; sourceTree = "<group>"; };
+		9F52B010263D2F840025EB78 /* soter_sym.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = soter_sym.c; path = src/soter/boringssl/soter_sym.c; sourceTree = "<group>"; };
+		9F52B011263D2F840025EB78 /* soter_hash.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = soter_hash.c; path = src/soter/boringssl/soter_hash.c; sourceTree = "<group>"; };
+		9F52B012263D2F840025EB78 /* soter_ecdsa_common.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = soter_ecdsa_common.c; path = src/soter/boringssl/soter_ecdsa_common.c; sourceTree = "<group>"; };
+		9F52B013263D2F840025EB78 /* soter_rsa_common.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = soter_rsa_common.h; path = src/soter/boringssl/soter_rsa_common.h; sourceTree = "<group>"; };
+		9F52B014263D2F840025EB78 /* soter_verify_rsa.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = soter_verify_rsa.c; path = src/soter/boringssl/soter_verify_rsa.c; sourceTree = "<group>"; };
+		9F52B015263D2F840025EB78 /* soter_wipe.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = soter_wipe.c; path = src/soter/boringssl/soter_wipe.c; sourceTree = "<group>"; };
+		9F52B016263D2F840025EB78 /* soter_rsa_common.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = soter_rsa_common.c; path = src/soter/boringssl/soter_rsa_common.c; sourceTree = "<group>"; };
+		9F52B017263D2F840025EB78 /* soter_asym_cipher.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = soter_asym_cipher.c; path = src/soter/boringssl/soter_asym_cipher.c; sourceTree = "<group>"; };
+		9F52B018263D2F840025EB78 /* soter_kdf.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = soter_kdf.c; path = src/soter/boringssl/soter_kdf.c; sourceTree = "<group>"; };
+		9F52B019263D2F840025EB78 /* soter_ecdsa_common.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = soter_ecdsa_common.h; path = src/soter/boringssl/soter_ecdsa_common.h; sourceTree = "<group>"; };
+		9F52B01A263D2F850025EB78 /* soter_rsa_key.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = soter_rsa_key.c; path = src/soter/boringssl/soter_rsa_key.c; sourceTree = "<group>"; };
+		9F52B01B263D2F850025EB78 /* soter_engine.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = soter_engine.h; path = src/soter/boringssl/soter_engine.h; sourceTree = "<group>"; };
+		9F52B01C263D2F850025EB78 /* soter_rsa_key_pair_gen.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = soter_rsa_key_pair_gen.c; path = src/soter/boringssl/soter_rsa_key_pair_gen.c; sourceTree = "<group>"; };
+		9F52B01D263D2F850025EB78 /* soter_verify_ecdsa.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = soter_verify_ecdsa.c; path = src/soter/boringssl/soter_verify_ecdsa.c; sourceTree = "<group>"; };
+		9F52B01E263D2F850025EB78 /* soter_ec_key.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = soter_ec_key.c; path = src/soter/boringssl/soter_ec_key.c; sourceTree = "<group>"; };
+		9F52B01F263D2F850025EB78 /* soter_sign_rsa.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = soter_sign_rsa.c; path = src/soter/boringssl/soter_sign_rsa.c; sourceTree = "<group>"; };
+		9F52B020263D2F850025EB78 /* soter_asym_ka.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = soter_asym_ka.c; path = src/soter/boringssl/soter_asym_ka.c; sourceTree = "<group>"; };
 		9F56693F25546397005CF297 /* libboringssl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libboringssl.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		9F56694F255463B5005CF297 /* libboringssl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libboringssl.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		9F6B385423D9D11600EA5D1B /* secure_cell_seal_passphrase.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = secure_cell_seal_passphrase.c; path = src/themis/secure_cell_seal_passphrase.c; sourceTree = "<group>"; };
@@ -1722,79 +1741,79 @@
 		9FB1BC9A233BEC9900930861 /* themis_portable_endian.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = themis_portable_endian.h; path = src/themis/themis_portable_endian.h; sourceTree = "<group>"; };
 		9FB1BC9D233BECB900930861 /* soter_portable_endian.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = soter_portable_endian.h; path = src/soter/soter_portable_endian.h; sourceTree = "<group>"; };
 		9FBD853C223BFB5E009EAEB3 /* openssl.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = openssl.framework; path = Carthage/Build/iOS/openssl.framework; sourceTree = "<group>"; };
-		A1E597219C43F5D8F0A42190 /* handoff.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = handoff.cc; path = third_party/boringssl/src/ssl/handoff.cc; sourceTree = SOURCE_ROOT; };
-		A24575E32D0EE548B3FD9F17 /* sha512-armv4.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "sha512-armv4.S"; path = "third_party/boringssl/ios-arm/crypto/fipsmodule/sha512-armv4.S"; sourceTree = SOURCE_ROOT; };
-		A437EC79DE61C9AB74B0381D /* algorithm.c */ = {isa = PBXFileReference; includeInIndex = 1; name = algorithm.c; path = third_party/boringssl/src/crypto/x509/algorithm.c; sourceTree = SOURCE_ROOT; };
+		A1E597219C43F5D8F0A42190 /* handoff.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = handoff.cc; path = third_party/boringssl/src/ssl/handoff.cc; sourceTree = SOURCE_ROOT; };
+		A24575E32D0EE548B3FD9F17 /* sha512-armv4.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "sha512-armv4.S"; path = "third_party/boringssl/ios-arm/crypto/fipsmodule/sha512-armv4.S"; sourceTree = SOURCE_ROOT; };
+		A437EC79DE61C9AB74B0381D /* algorithm.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = algorithm.c; path = third_party/boringssl/src/crypto/x509/algorithm.c; sourceTree = SOURCE_ROOT; };
 		A93C8D39544BFEAA51DBEC67 /* pkcs12.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = pkcs12.h; path = third_party/boringssl/src/include/openssl/pkcs12.h; sourceTree = SOURCE_ROOT; };
 		ACA4DABF8A8C5F023B818075 /* blake2.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = blake2.h; path = third_party/boringssl/src/include/openssl/blake2.h; sourceTree = SOURCE_ROOT; };
-		AF3FCF964D54F9365D5BC031 /* v3_int.c */ = {isa = PBXFileReference; includeInIndex = 1; name = v3_int.c; path = third_party/boringssl/src/crypto/x509v3/v3_int.c; sourceTree = SOURCE_ROOT; };
-		AF493028D7E2A9296D8241AA /* handshake_client.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = handshake_client.cc; path = third_party/boringssl/src/ssl/handshake_client.cc; sourceTree = SOURCE_ROOT; };
-		AFA5053EB14A930FA4E9C564 /* s3_lib.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = s3_lib.cc; path = third_party/boringssl/src/ssl/s3_lib.cc; sourceTree = SOURCE_ROOT; };
-		B1335F2CD6708EAAC7DCE6AE /* ssl_cipher.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = ssl_cipher.cc; path = third_party/boringssl/src/ssl/ssl_cipher.cc; sourceTree = SOURCE_ROOT; };
+		AF3FCF964D54F9365D5BC031 /* v3_int.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = v3_int.c; path = third_party/boringssl/src/crypto/x509v3/v3_int.c; sourceTree = SOURCE_ROOT; };
+		AF493028D7E2A9296D8241AA /* handshake_client.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = handshake_client.cc; path = third_party/boringssl/src/ssl/handshake_client.cc; sourceTree = SOURCE_ROOT; };
+		AFA5053EB14A930FA4E9C564 /* s3_lib.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = s3_lib.cc; path = third_party/boringssl/src/ssl/s3_lib.cc; sourceTree = SOURCE_ROOT; };
+		B1335F2CD6708EAAC7DCE6AE /* ssl_cipher.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = ssl_cipher.cc; path = third_party/boringssl/src/ssl/ssl_cipher.cc; sourceTree = SOURCE_ROOT; };
 		B14A5514339BC85323E92B3A /* internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = internal.h; path = third_party/boringssl/src/crypto/internal.h; sourceTree = SOURCE_ROOT; };
 		B15884146F9A68C694BBBCE4 /* internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = internal.h; path = third_party/boringssl/src/crypto/fipsmodule/aes/internal.h; sourceTree = SOURCE_ROOT; };
-		B24FEABC9A2EDA5791D9C54E /* obj_xref.c */ = {isa = PBXFileReference; includeInIndex = 1; name = obj_xref.c; path = third_party/boringssl/src/crypto/obj/obj_xref.c; sourceTree = SOURCE_ROOT; };
-		B34936067433B64D020E129C /* thread.c */ = {isa = PBXFileReference; includeInIndex = 1; name = thread.c; path = third_party/boringssl/src/crypto/thread.c; sourceTree = SOURCE_ROOT; };
+		B24FEABC9A2EDA5791D9C54E /* obj_xref.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = obj_xref.c; path = third_party/boringssl/src/crypto/obj/obj_xref.c; sourceTree = SOURCE_ROOT; };
+		B34936067433B64D020E129C /* thread.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = thread.c; path = third_party/boringssl/src/crypto/thread.c; sourceTree = SOURCE_ROOT; };
 		B3A0FCFCBC3FB9DDEA3DC5BC /* objects.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = objects.h; path = third_party/boringssl/src/include/openssl/objects.h; sourceTree = SOURCE_ROOT; };
 		B47DEF0E0A634B49C8E83138 /* aes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = aes.h; path = third_party/boringssl/src/include/openssl/aes.h; sourceTree = SOURCE_ROOT; };
-		B4B017D0440D2A4B02D7F5A6 /* dh_asn1.c */ = {isa = PBXFileReference; includeInIndex = 1; name = dh_asn1.c; path = third_party/boringssl/src/crypto/dh_extra/dh_asn1.c; sourceTree = SOURCE_ROOT; };
+		B4B017D0440D2A4B02D7F5A6 /* dh_asn1.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = dh_asn1.c; path = third_party/boringssl/src/crypto/dh_extra/dh_asn1.c; sourceTree = SOURCE_ROOT; };
 		B57C79461A3AB9E838401BEC /* internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = internal.h; path = third_party/boringssl/src/crypto/fipsmodule/digest/internal.h; sourceTree = SOURCE_ROOT; };
-		B6F0D491D2E8A0ECABA855B2 /* x_x509.c */ = {isa = PBXFileReference; includeInIndex = 1; name = x_x509.c; path = third_party/boringssl/src/crypto/x509/x_x509.c; sourceTree = SOURCE_ROOT; };
-		B87489135780021DBBBBFB12 /* a_utctm.c */ = {isa = PBXFileReference; includeInIndex = 1; name = a_utctm.c; path = third_party/boringssl/src/crypto/asn1/a_utctm.c; sourceTree = SOURCE_ROOT; };
-		BA9D06470988366ED112C208 /* aesv8-armx64.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "aesv8-armx64.S"; path = "third_party/boringssl/ios-aarch64/crypto/fipsmodule/aesv8-armx64.S"; sourceTree = SOURCE_ROOT; };
-		BB30A1AF51ADE35D7E818BF3 /* bio_ssl.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = bio_ssl.cc; path = third_party/boringssl/src/ssl/bio_ssl.cc; sourceTree = SOURCE_ROOT; };
+		B6F0D491D2E8A0ECABA855B2 /* x_x509.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = x_x509.c; path = third_party/boringssl/src/crypto/x509/x_x509.c; sourceTree = SOURCE_ROOT; };
+		B87489135780021DBBBBFB12 /* a_utctm.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = a_utctm.c; path = third_party/boringssl/src/crypto/asn1/a_utctm.c; sourceTree = SOURCE_ROOT; };
+		BA9D06470988366ED112C208 /* aesv8-armx64.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "aesv8-armx64.S"; path = "third_party/boringssl/ios-aarch64/crypto/fipsmodule/aesv8-armx64.S"; sourceTree = SOURCE_ROOT; };
+		BB30A1AF51ADE35D7E818BF3 /* bio_ssl.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = bio_ssl.cc; path = third_party/boringssl/src/ssl/bio_ssl.cc; sourceTree = SOURCE_ROOT; };
 		BB6BCF60124311044DF5453C /* cpu.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = cpu.h; path = third_party/boringssl/src/include/openssl/cpu.h; sourceTree = SOURCE_ROOT; };
 		BC769B8B2DA25375EBA4B290 /* evp_errors.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = evp_errors.h; path = third_party/boringssl/src/include/openssl/evp_errors.h; sourceTree = SOURCE_ROOT; };
 		C01AD5365B027AA7F58A9FFA /* internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = internal.h; path = third_party/boringssl/src/crypto/pool/internal.h; sourceTree = SOURCE_ROOT; };
-		C1ABC536FB3F8634D74F7F7A /* vpaes-armv8.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "vpaes-armv8.S"; path = "third_party/boringssl/ios-aarch64/crypto/fipsmodule/vpaes-armv8.S"; sourceTree = SOURCE_ROOT; };
-		C23D55306C0AE1551049E48A /* tls13_server.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = tls13_server.cc; path = third_party/boringssl/src/ssl/tls13_server.cc; sourceTree = SOURCE_ROOT; };
-		C56561387502ACD084C07F37 /* tasn_typ.c */ = {isa = PBXFileReference; includeInIndex = 1; name = tasn_typ.c; path = third_party/boringssl/src/crypto/asn1/tasn_typ.c; sourceTree = SOURCE_ROOT; };
-		C5F919A83A7654413C658106 /* sha256-armv8.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "sha256-armv8.S"; path = "third_party/boringssl/ios-aarch64/crypto/fipsmodule/sha256-armv8.S"; sourceTree = SOURCE_ROOT; };
+		C1ABC536FB3F8634D74F7F7A /* vpaes-armv8.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "vpaes-armv8.S"; path = "third_party/boringssl/ios-aarch64/crypto/fipsmodule/vpaes-armv8.S"; sourceTree = SOURCE_ROOT; };
+		C23D55306C0AE1551049E48A /* tls13_server.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = tls13_server.cc; path = third_party/boringssl/src/ssl/tls13_server.cc; sourceTree = SOURCE_ROOT; };
+		C56561387502ACD084C07F37 /* tasn_typ.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = tasn_typ.c; path = third_party/boringssl/src/crypto/asn1/tasn_typ.c; sourceTree = SOURCE_ROOT; };
+		C5F919A83A7654413C658106 /* sha256-armv8.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "sha256-armv8.S"; path = "third_party/boringssl/ios-aarch64/crypto/fipsmodule/sha256-armv8.S"; sourceTree = SOURCE_ROOT; };
 		C66BE80383F39EA47B45232A /* internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = internal.h; path = third_party/boringssl/src/crypto/fipsmodule/rsa/internal.h; sourceTree = SOURCE_ROOT; };
-		C8B2488D2DF9F6B28EAB8D59 /* dtls_record.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = dtls_record.cc; path = third_party/boringssl/src/ssl/dtls_record.cc; sourceTree = SOURCE_ROOT; };
-		C949CF6DF8CD6FBE2BA8CA03 /* ghash-x86.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "ghash-x86.S"; path = "third_party/boringssl/mac-x86/crypto/fipsmodule/ghash-x86.S"; sourceTree = SOURCE_ROOT; };
+		C8B2488D2DF9F6B28EAB8D59 /* dtls_record.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = dtls_record.cc; path = third_party/boringssl/src/ssl/dtls_record.cc; sourceTree = SOURCE_ROOT; };
+		C949CF6DF8CD6FBE2BA8CA03 /* ghash-x86.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "ghash-x86.S"; path = "third_party/boringssl/mac-x86/crypto/fipsmodule/ghash-x86.S"; sourceTree = SOURCE_ROOT; };
 		CD39A7DE56A598A4A1D4E778 /* dsa.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = dsa.h; path = third_party/boringssl/src/include/openssl/dsa.h; sourceTree = SOURCE_ROOT; };
-		CD857B10E68746228A73FBFD /* ecdh_extra.c */ = {isa = PBXFileReference; includeInIndex = 1; name = ecdh_extra.c; path = third_party/boringssl/src/crypto/ecdh_extra/ecdh_extra.c; sourceTree = SOURCE_ROOT; };
-		CF42E16B19B6562EC64825AE /* aesv8-armx32.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "aesv8-armx32.S"; path = "third_party/boringssl/ios-arm/crypto/fipsmodule/aesv8-armx32.S"; sourceTree = SOURCE_ROOT; };
-		CF685E3B70524E50C3638D2B /* passive.c */ = {isa = PBXFileReference; includeInIndex = 1; name = passive.c; path = third_party/boringssl/src/crypto/rand_extra/passive.c; sourceTree = SOURCE_ROOT; };
-		D1A66F0379BBAA59EDDED6E9 /* pem_info.c */ = {isa = PBXFileReference; includeInIndex = 1; name = pem_info.c; path = third_party/boringssl/src/crypto/pem/pem_info.c; sourceTree = SOURCE_ROOT; };
-		D23FE1D8C732A8F9A04112CC /* ssl_buffer.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = ssl_buffer.cc; path = third_party/boringssl/src/ssl/ssl_buffer.cc; sourceTree = SOURCE_ROOT; };
+		CD857B10E68746228A73FBFD /* ecdh_extra.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = ecdh_extra.c; path = third_party/boringssl/src/crypto/ecdh_extra/ecdh_extra.c; sourceTree = SOURCE_ROOT; };
+		CF42E16B19B6562EC64825AE /* aesv8-armx32.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "aesv8-armx32.S"; path = "third_party/boringssl/ios-arm/crypto/fipsmodule/aesv8-armx32.S"; sourceTree = SOURCE_ROOT; };
+		CF685E3B70524E50C3638D2B /* passive.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = passive.c; path = third_party/boringssl/src/crypto/rand_extra/passive.c; sourceTree = SOURCE_ROOT; };
+		D1A66F0379BBAA59EDDED6E9 /* pem_info.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = pem_info.c; path = third_party/boringssl/src/crypto/pem/pem_info.c; sourceTree = SOURCE_ROOT; };
+		D23FE1D8C732A8F9A04112CC /* ssl_buffer.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = ssl_buffer.cc; path = third_party/boringssl/src/ssl/ssl_buffer.cc; sourceTree = SOURCE_ROOT; };
 		D2859A8E6B65BACB2F380B5B /* ec.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ec.h; path = third_party/boringssl/src/include/openssl/ec.h; sourceTree = SOURCE_ROOT; };
-		D2A025ECE744B8A9759714BB /* sha512-x86_64.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "sha512-x86_64.S"; path = "third_party/boringssl/mac-x86_64/crypto/fipsmodule/sha512-x86_64.S"; sourceTree = SOURCE_ROOT; };
-		D30DCB120336217B0543EA79 /* t1_lib.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = t1_lib.cc; path = third_party/boringssl/src/ssl/t1_lib.cc; sourceTree = SOURCE_ROOT; };
-		D55F718790190C6021095A6C /* v3_crld.c */ = {isa = PBXFileReference; includeInIndex = 1; name = v3_crld.c; path = third_party/boringssl/src/crypto/x509v3/v3_crld.c; sourceTree = SOURCE_ROOT; };
-		D6036EB3A60237627F3AEB47 /* blake2.c */ = {isa = PBXFileReference; includeInIndex = 1; name = blake2.c; path = third_party/boringssl/src/crypto/blake2/blake2.c; sourceTree = SOURCE_ROOT; };
+		D2A025ECE744B8A9759714BB /* sha512-x86_64.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "sha512-x86_64.S"; path = "third_party/boringssl/mac-x86_64/crypto/fipsmodule/sha512-x86_64.S"; sourceTree = SOURCE_ROOT; };
+		D30DCB120336217B0543EA79 /* t1_lib.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = t1_lib.cc; path = third_party/boringssl/src/ssl/t1_lib.cc; sourceTree = SOURCE_ROOT; };
+		D55F718790190C6021095A6C /* v3_crld.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = v3_crld.c; path = third_party/boringssl/src/crypto/x509v3/v3_crld.c; sourceTree = SOURCE_ROOT; };
+		D6036EB3A60237627F3AEB47 /* blake2.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = blake2.c; path = third_party/boringssl/src/crypto/blake2/blake2.c; sourceTree = SOURCE_ROOT; };
 		D60E359AEEB08E910EE60F47 /* dtls1.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = dtls1.h; path = third_party/boringssl/src/include/openssl/dtls1.h; sourceTree = SOURCE_ROOT; };
 		D6ADADA43F3ADD223A23E10C /* mem.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mem.h; path = third_party/boringssl/src/include/openssl/mem.h; sourceTree = SOURCE_ROOT; };
 		D893FA2F8F428251A340CE65 /* internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = internal.h; path = third_party/boringssl/src/crypto/fipsmodule/rand/internal.h; sourceTree = SOURCE_ROOT; };
-		D9D20FB06463526438913D28 /* tls_record.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = tls_record.cc; path = third_party/boringssl/src/ssl/tls_record.cc; sourceTree = SOURCE_ROOT; };
-		DB52E49149BF2604FA35EB62 /* a_verify.c */ = {isa = PBXFileReference; includeInIndex = 1; name = a_verify.c; path = third_party/boringssl/src/crypto/x509/a_verify.c; sourceTree = SOURCE_ROOT; };
-		DC28CBD0B5058B7463F60F2D /* cpu-arm.c */ = {isa = PBXFileReference; includeInIndex = 1; name = "cpu-arm.c"; path = "third_party/boringssl/src/crypto/cpu-arm.c"; sourceTree = SOURCE_ROOT; };
+		D9D20FB06463526438913D28 /* tls_record.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = tls_record.cc; path = third_party/boringssl/src/ssl/tls_record.cc; sourceTree = SOURCE_ROOT; };
+		DB52E49149BF2604FA35EB62 /* a_verify.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = a_verify.c; path = third_party/boringssl/src/crypto/x509/a_verify.c; sourceTree = SOURCE_ROOT; };
+		DC28CBD0B5058B7463F60F2D /* cpu-arm.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = "cpu-arm.c"; path = "third_party/boringssl/src/crypto/cpu-arm.c"; sourceTree = SOURCE_ROOT; };
 		DEF472536C0696895BA4027D /* safestack.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = safestack.h; path = third_party/boringssl/src/include/openssl/safestack.h; sourceTree = SOURCE_ROOT; };
-		E00FBF8254DB6F121322C7CF /* pbkdf.c */ = {isa = PBXFileReference; includeInIndex = 1; name = pbkdf.c; path = third_party/boringssl/src/crypto/evp/pbkdf.c; sourceTree = SOURCE_ROOT; };
+		E00FBF8254DB6F121322C7CF /* pbkdf.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = pbkdf.c; path = third_party/boringssl/src/crypto/evp/pbkdf.c; sourceTree = SOURCE_ROOT; };
 		E0B260808DF02272BFCDAF1C /* cpu-arm-linux.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "cpu-arm-linux.h"; path = "third_party/boringssl/src/crypto/cpu-arm-linux.h"; sourceTree = SOURCE_ROOT; };
-		E148698EAD73CBF38CDCC4FD /* poly1305.c */ = {isa = PBXFileReference; includeInIndex = 1; name = poly1305.c; path = third_party/boringssl/src/crypto/poly1305/poly1305.c; sourceTree = SOURCE_ROOT; };
-		E548BC5EDC591F42C0DFD9FD /* digestsign.c */ = {isa = PBXFileReference; includeInIndex = 1; name = digestsign.c; path = third_party/boringssl/src/crypto/evp/digestsign.c; sourceTree = SOURCE_ROOT; };
-		E6C39B32E8F7A02341EA2816 /* trampoline-armv8.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "trampoline-armv8.S"; path = "third_party/boringssl/ios-aarch64/crypto/test/trampoline-armv8.S"; sourceTree = SOURCE_ROOT; };
-		E74B6C0B76327463829DA2A4 /* ssl_versions.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = ssl_versions.cc; path = third_party/boringssl/src/ssl/ssl_versions.cc; sourceTree = SOURCE_ROOT; };
-		E75DDABF68BE969F6986D0A8 /* cpu-aarch64-win.c */ = {isa = PBXFileReference; includeInIndex = 1; name = "cpu-aarch64-win.c"; path = "third_party/boringssl/src/crypto/cpu-aarch64-win.c"; sourceTree = SOURCE_ROOT; };
+		E148698EAD73CBF38CDCC4FD /* poly1305.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = poly1305.c; path = third_party/boringssl/src/crypto/poly1305/poly1305.c; sourceTree = SOURCE_ROOT; };
+		E548BC5EDC591F42C0DFD9FD /* digestsign.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = digestsign.c; path = third_party/boringssl/src/crypto/evp/digestsign.c; sourceTree = SOURCE_ROOT; };
+		E6C39B32E8F7A02341EA2816 /* trampoline-armv8.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "trampoline-armv8.S"; path = "third_party/boringssl/ios-aarch64/crypto/test/trampoline-armv8.S"; sourceTree = SOURCE_ROOT; };
+		E74B6C0B76327463829DA2A4 /* ssl_versions.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = ssl_versions.cc; path = third_party/boringssl/src/ssl/ssl_versions.cc; sourceTree = SOURCE_ROOT; };
+		E75DDABF68BE969F6986D0A8 /* cpu-aarch64-win.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = "cpu-aarch64-win.c"; path = "third_party/boringssl/src/crypto/cpu-aarch64-win.c"; sourceTree = SOURCE_ROOT; };
 		E857D58670972739E0016EA6 /* thread.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = thread.h; path = third_party/boringssl/src/include/openssl/thread.h; sourceTree = SOURCE_ROOT; };
-		E8C6715C179FA3D4A3A06275 /* ssl_aead_ctx.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = ssl_aead_ctx.cc; path = third_party/boringssl/src/ssl/ssl_aead_ctx.cc; sourceTree = SOURCE_ROOT; };
-		E91BA244589DB9AC0F9E7226 /* p_x25519.c */ = {isa = PBXFileReference; includeInIndex = 1; name = p_x25519.c; path = third_party/boringssl/src/crypto/evp/p_x25519.c; sourceTree = SOURCE_ROOT; };
-		E91CA1068AA898116E483642 /* ghashv8-armx64.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "ghashv8-armx64.S"; path = "third_party/boringssl/ios-aarch64/crypto/fipsmodule/ghashv8-armx64.S"; sourceTree = SOURCE_ROOT; };
-		EA60E9F16FF71A769C05B9C8 /* ghashv8-armx32.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "ghashv8-armx32.S"; path = "third_party/boringssl/ios-arm/crypto/fipsmodule/ghashv8-armx32.S"; sourceTree = SOURCE_ROOT; };
+		E8C6715C179FA3D4A3A06275 /* ssl_aead_ctx.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = ssl_aead_ctx.cc; path = third_party/boringssl/src/ssl/ssl_aead_ctx.cc; sourceTree = SOURCE_ROOT; };
+		E91BA244589DB9AC0F9E7226 /* p_x25519.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = p_x25519.c; path = third_party/boringssl/src/crypto/evp/p_x25519.c; sourceTree = SOURCE_ROOT; };
+		E91CA1068AA898116E483642 /* ghashv8-armx64.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "ghashv8-armx64.S"; path = "third_party/boringssl/ios-aarch64/crypto/fipsmodule/ghashv8-armx64.S"; sourceTree = SOURCE_ROOT; };
+		EA60E9F16FF71A769C05B9C8 /* ghashv8-armx32.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "ghashv8-armx32.S"; path = "third_party/boringssl/ios-arm/crypto/fipsmodule/ghashv8-armx32.S"; sourceTree = SOURCE_ROOT; };
 		EB26651CEB24BF24B4B4DF58 /* ssl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ssl.h; path = third_party/boringssl/src/include/openssl/ssl.h; sourceTree = SOURCE_ROOT; };
-		EBC02A3B5E57B8136E731FC0 /* chacha-x86_64.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "chacha-x86_64.S"; path = "third_party/boringssl/mac-x86_64/crypto/chacha/chacha-x86_64.S"; sourceTree = SOURCE_ROOT; };
+		EBC02A3B5E57B8136E731FC0 /* chacha-x86_64.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "chacha-x86_64.S"; path = "third_party/boringssl/mac-x86_64/crypto/chacha/chacha-x86_64.S"; sourceTree = SOURCE_ROOT; };
 		EC1EA8DFF048AAA83C33CB8E /* pem.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = pem.h; path = third_party/boringssl/src/include/openssl/pem.h; sourceTree = SOURCE_ROOT; };
-		EDF96D02C1748A9976CC8803 /* ssl_asn1.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = ssl_asn1.cc; path = third_party/boringssl/src/ssl/ssl_asn1.cc; sourceTree = SOURCE_ROOT; };
-		EE56A5B2B53EB6A894438E56 /* armv8-mont.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "armv8-mont.S"; path = "third_party/boringssl/ios-aarch64/crypto/fipsmodule/armv8-mont.S"; sourceTree = SOURCE_ROOT; };
-		EFDDCE5DB28C1E3A5BAEE28A /* pem_pkey.c */ = {isa = PBXFileReference; includeInIndex = 1; name = pem_pkey.c; path = third_party/boringssl/src/crypto/pem/pem_pkey.c; sourceTree = SOURCE_ROOT; };
-		F00A02AAA9B71BB161525E01 /* a_bitstr.c */ = {isa = PBXFileReference; includeInIndex = 1; name = a_bitstr.c; path = third_party/boringssl/src/crypto/asn1/a_bitstr.c; sourceTree = SOURCE_ROOT; };
-		F35F00B76815E45A436C8D8D /* sha256-armv4.S */ = {isa = PBXFileReference; includeInIndex = 1; name = "sha256-armv4.S"; path = "third_party/boringssl/ios-arm/crypto/fipsmodule/sha256-armv4.S"; sourceTree = SOURCE_ROOT; };
+		EDF96D02C1748A9976CC8803 /* ssl_asn1.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = ssl_asn1.cc; path = third_party/boringssl/src/ssl/ssl_asn1.cc; sourceTree = SOURCE_ROOT; };
+		EE56A5B2B53EB6A894438E56 /* armv8-mont.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "armv8-mont.S"; path = "third_party/boringssl/ios-aarch64/crypto/fipsmodule/armv8-mont.S"; sourceTree = SOURCE_ROOT; };
+		EFDDCE5DB28C1E3A5BAEE28A /* pem_pkey.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = pem_pkey.c; path = third_party/boringssl/src/crypto/pem/pem_pkey.c; sourceTree = SOURCE_ROOT; };
+		F00A02AAA9B71BB161525E01 /* a_bitstr.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = a_bitstr.c; path = third_party/boringssl/src/crypto/asn1/a_bitstr.c; sourceTree = SOURCE_ROOT; };
+		F35F00B76815E45A436C8D8D /* sha256-armv4.S */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.asm; name = "sha256-armv4.S"; path = "third_party/boringssl/ios-arm/crypto/fipsmodule/sha256-armv4.S"; sourceTree = SOURCE_ROOT; };
 		F50FF99785BFA8446A164849 /* internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = internal.h; path = third_party/boringssl/src/ssl/internal.h; sourceTree = SOURCE_ROOT; };
-		F5177B300FA2E27C15E382AE /* lhash.c */ = {isa = PBXFileReference; includeInIndex = 1; name = lhash.c; path = third_party/boringssl/src/crypto/lhash/lhash.c; sourceTree = SOURCE_ROOT; };
-		F639021AB01EBF66298D3937 /* thread_none.c */ = {isa = PBXFileReference; includeInIndex = 1; name = thread_none.c; path = third_party/boringssl/src/crypto/thread_none.c; sourceTree = SOURCE_ROOT; };
-		FCCD00B7DD60035AE898B96C /* x509_vfy.c */ = {isa = PBXFileReference; includeInIndex = 1; name = x509_vfy.c; path = third_party/boringssl/src/crypto/x509/x509_vfy.c; sourceTree = SOURCE_ROOT; };
+		F5177B300FA2E27C15E382AE /* lhash.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = lhash.c; path = third_party/boringssl/src/crypto/lhash/lhash.c; sourceTree = SOURCE_ROOT; };
+		F639021AB01EBF66298D3937 /* thread_none.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = thread_none.c; path = third_party/boringssl/src/crypto/thread_none.c; sourceTree = SOURCE_ROOT; };
+		FCCD00B7DD60035AE898B96C /* x509_vfy.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = x509_vfy.c; path = third_party/boringssl/src/crypto/x509/x509_vfy.c; sourceTree = SOURCE_ROOT; };
 		FF1CD3753FB2CF017C084A17 /* lhash.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = lhash.h; path = third_party/boringssl/src/include/openssl/lhash.h; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
@@ -2387,6 +2406,7 @@
 				9F7E521D2571DE970054558B /* include */,
 				9F4A23A6223A742F005CB63A /* ed25519 */,
 				9F4A2383223A740E005CB63A /* openssl */,
+				9F52B00D263D2F5E0025EB78 /* boringssl */,
 				9F4A2348223A73B0005CB63A /* soter_container.c */,
 				9F4A2358223A73B1005CB63A /* soter_container.h */,
 				9F4A234D223A73B0005CB63A /* soter_crc32.c */,
@@ -2573,6 +2593,32 @@
 				9F4A24BA223A8FA8005CB63A /* ssession.m */,
 			);
 			name = objcthemis;
+			sourceTree = "<group>";
+		};
+		9F52B00D263D2F5E0025EB78 /* boringssl */ = {
+			isa = PBXGroup;
+			children = (
+				9F52B017263D2F840025EB78 /* soter_asym_cipher.c */,
+				9F52B020263D2F850025EB78 /* soter_asym_ka.c */,
+				9F52B01E263D2F850025EB78 /* soter_ec_key.c */,
+				9F52B012263D2F840025EB78 /* soter_ecdsa_common.c */,
+				9F52B019263D2F840025EB78 /* soter_ecdsa_common.h */,
+				9F52B01B263D2F850025EB78 /* soter_engine.h */,
+				9F52B011263D2F840025EB78 /* soter_hash.c */,
+				9F52B018263D2F840025EB78 /* soter_kdf.c */,
+				9F52B00F263D2F840025EB78 /* soter_rand.c */,
+				9F52B016263D2F840025EB78 /* soter_rsa_common.c */,
+				9F52B013263D2F840025EB78 /* soter_rsa_common.h */,
+				9F52B01C263D2F850025EB78 /* soter_rsa_key_pair_gen.c */,
+				9F52B01A263D2F850025EB78 /* soter_rsa_key.c */,
+				9F52B00E263D2F840025EB78 /* soter_sign_ecdsa.c */,
+				9F52B01F263D2F850025EB78 /* soter_sign_rsa.c */,
+				9F52B010263D2F840025EB78 /* soter_sym.c */,
+				9F52B01D263D2F850025EB78 /* soter_verify_ecdsa.c */,
+				9F52B014263D2F840025EB78 /* soter_verify_rsa.c */,
+				9F52B015263D2F840025EB78 /* soter_wipe.c */,
+			);
+			name = boringssl;
 			sourceTree = "<group>";
 		};
 		9F56693A2554637D005CF297 /* BoringSSL */ = {
@@ -3174,52 +3220,52 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2C3651FA89368A30368F6BE6 /* BuildFile in Sources */,
-				94902B75B33F95CBF17623D1 /* BuildFile in Sources */,
-				1B9681A5F4DC9D329A06A371 /* BuildFile in Sources */,
-				49EDACA726ED8487F4D0AEFD /* BuildFile in Sources */,
-				5AE3DFB922177CD825C9ED47 /* BuildFile in Sources */,
-				1EB65ECE376ED7A56F2D04B6 /* BuildFile in Sources */,
-				37FA26F137AD90C616390DB0 /* BuildFile in Sources */,
-				1A35E909190D77B387D6D494 /* BuildFile in Sources */,
-				0D50B00714063FCB2B1E905B /* BuildFile in Sources */,
-				D51642A37267911A979573E4 /* BuildFile in Sources */,
-				34DE553C2D20341704AC578E /* BuildFile in Sources */,
-				490D770E24C9CED82390B52D /* BuildFile in Sources */,
-				49AC091FF369E6B9AB2F98E0 /* BuildFile in Sources */,
+				2C3651FA89368A30368F6BE6 /* (null) in Sources */,
+				94902B75B33F95CBF17623D1 /* (null) in Sources */,
+				1B9681A5F4DC9D329A06A371 /* (null) in Sources */,
+				49EDACA726ED8487F4D0AEFD /* (null) in Sources */,
+				5AE3DFB922177CD825C9ED47 /* (null) in Sources */,
+				1EB65ECE376ED7A56F2D04B6 /* (null) in Sources */,
+				37FA26F137AD90C616390DB0 /* (null) in Sources */,
+				1A35E909190D77B387D6D494 /* (null) in Sources */,
+				0D50B00714063FCB2B1E905B /* (null) in Sources */,
+				D51642A37267911A979573E4 /* (null) in Sources */,
+				34DE553C2D20341704AC578E /* (null) in Sources */,
+				490D770E24C9CED82390B52D /* (null) in Sources */,
+				49AC091FF369E6B9AB2F98E0 /* (null) in Sources */,
 				2F740AAB90BBEDAD53E42626 /* err_data.c in Sources */,
-				01FD716BC1C0188B0FD2E195 /* BuildFile in Sources */,
+				01FD716BC1C0188B0FD2E195 /* (null) in Sources */,
 				8BAB26C2356DD938AF5A6EE2 /* a_bool.c in Sources */,
-				A296501CEDBB84279A22AD66 /* BuildFile in Sources */,
+				A296501CEDBB84279A22AD66 /* (null) in Sources */,
 				DBCD69B4776B3694B5543399 /* a_dup.c in Sources */,
 				5F2030D63CAFF29CD2A5D654 /* a_enum.c in Sources */,
 				73DDE8CAC60142D82B7A916D /* a_gentm.c in Sources */,
-				54A2C6692A2B5364C634FA1B /* BuildFile in Sources */,
-				4E3D2D46C2CC12154F2F4FF7 /* BuildFile in Sources */,
+				54A2C6692A2B5364C634FA1B /* (null) in Sources */,
+				4E3D2D46C2CC12154F2F4FF7 /* (null) in Sources */,
 				501902A3E86557DC2D68AEB4 /* a_mbstr.c in Sources */,
 				BAE89B9C5C5CCF25158A65BD /* a_object.c in Sources */,
-				46C0B1AAFEF103C3D5964EB0 /* BuildFile in Sources */,
+				46C0B1AAFEF103C3D5964EB0 /* (null) in Sources */,
 				4516FF8423AB52A88EBFC4C2 /* a_print.c in Sources */,
-				8E18831246C37254FB7B98BC /* BuildFile in Sources */,
+				8E18831246C37254FB7B98BC /* (null) in Sources */,
 				7D71D54C78887AD48F87B8E7 /* a_time.c in Sources */,
 				1D276CB5CED4C14ECF6A339C /* a_type.c in Sources */,
-				88303405FDD6FCF337579C3E /* BuildFile in Sources */,
+				88303405FDD6FCF337579C3E /* (null) in Sources */,
 				2758FF6D7CB6E6F97E65AE76 /* a_utf8.c in Sources */,
-				8E623100E5BA9336AF0B9D91 /* BuildFile in Sources */,
-				FE58518A1CF88D6AC2587B08 /* BuildFile in Sources */,
+				8E623100E5BA9336AF0B9D91 /* (null) in Sources */,
+				FE58518A1CF88D6AC2587B08 /* (null) in Sources */,
 				93126A43AB7412B42633251B /* asn_pack.c in Sources */,
 				FAF64D8F5CBCBD55867E5E64 /* f_enum.c in Sources */,
 				E5655AE4E2D2434957CC4225 /* f_int.c in Sources */,
 				3626796056891CA565E6C6DC /* f_string.c in Sources */,
 				7F3A626AC7CF798EF7F1271C /* tasn_dec.c in Sources */,
-				8C6143C18F6A436CFF0E604F /* BuildFile in Sources */,
+				8C6143C18F6A436CFF0E604F /* (null) in Sources */,
 				D0E8F4F86BF61A33DE300798 /* tasn_fre.c in Sources */,
 				0E03E4E20AE0601C7744CBC7 /* tasn_new.c in Sources */,
-				7E0F98E988386FAA5E824DDB /* BuildFile in Sources */,
+				7E0F98E988386FAA5E824DDB /* (null) in Sources */,
 				ABB87780BCD28CB6830112E0 /* tasn_utl.c in Sources */,
 				1187E2330B1CDA4C8CF2C8AE /* time_support.c in Sources */,
 				C9DC6595AF889990981644AA /* base64.c in Sources */,
-				8A7F36618F9B88D0017ADC63 /* BuildFile in Sources */,
+				8A7F36618F9B88D0017ADC63 /* (null) in Sources */,
 				9C7CFD9BA0065C091EA3F3B9 /* bio_mem.c in Sources */,
 				15C02ED1E55E82E90DCA70AE /* connect.c in Sources */,
 				1D683711B22881657AFE2F38 /* fd.c in Sources */,
@@ -3229,55 +3275,55 @@
 				7745990A96FFCBA792C376ED /* printf.c in Sources */,
 				EF26794088CFC040DF57241B /* socket.c in Sources */,
 				586101F7A6907579377F7E49 /* socket_helper.c in Sources */,
-				C473D6013E0FE9F944F14294 /* BuildFile in Sources */,
-				6DF4D3D48656F19734F61F56 /* BuildFile in Sources */,
-				1D21296AB535D863B04BBF87 /* BuildFile in Sources */,
+				C473D6013E0FE9F944F14294 /* (null) in Sources */,
+				6DF4D3D48656F19734F61F56 /* (null) in Sources */,
+				1D21296AB535D863B04BBF87 /* (null) in Sources */,
 				98E8012F0D2C2748E26DA524 /* asn1_compat.c in Sources */,
 				A80DA39794401A4A57806704 /* ber.c in Sources */,
 				B16D2AAAEC757E12A0FA4B8D /* cbb.c in Sources */,
 				A5785613BFAE93205B1E2EAF /* cbs.c in Sources */,
 				F8ED25A6E7E3904BFF89757E /* unicode.c in Sources */,
 				6276B92793073248507326E1 /* chacha.c in Sources */,
-				018EE780A8CB28AD5B4CA010 /* BuildFile in Sources */,
+				018EE780A8CB28AD5B4CA010 /* (null) in Sources */,
 				D419FCA43FC70F1F2FA20F70 /* derive_key.c in Sources */,
 				D137B4C88C03CEA2D329EA3F /* e_aesccm.c in Sources */,
 				FC18EDD8194374493E1780C9 /* e_aesctrhmac.c in Sources */,
 				A8EE38FFC614A01661F2CFB2 /* e_aesgcmsiv.c in Sources */,
 				B9F431CFB35B71C7BA2B25FC /* e_chacha20poly1305.c in Sources */,
 				64480168FCE48AE30D8AACD6 /* e_null.c in Sources */,
-				CEA0232613E3BAEAC1ECC876 /* BuildFile in Sources */,
+				CEA0232613E3BAEAC1ECC876 /* (null) in Sources */,
 				8F14CA39AAE3F519859D5A08 /* e_rc4.c in Sources */,
 				E6211D45AE1448E0B969B245 /* e_tls.c in Sources */,
 				C9AB0BCBA5229DFC00A1E560 /* tls_cbc.c in Sources */,
 				1CD6028458FBF0416EC76B0E /* cmac.c in Sources */,
 				1F1AF31A94C152B12D12D651 /* conf.c in Sources */,
-				5B57F1D55E09C49C0CBABE78 /* BuildFile in Sources */,
+				5B57F1D55E09C49C0CBABE78 /* (null) in Sources */,
 				25D3A6B0772AB0D4B751BD39 /* cpu-aarch64-linux.c in Sources */,
 				4A1F5A665A1842D861F7175F /* cpu-arm-linux.c in Sources */,
-				3A770C70133081AF5414A38C /* BuildFile in Sources */,
+				3A770C70133081AF5414A38C /* (null) in Sources */,
 				35F6D695DD128F0B6B0A45AC /* cpu-intel.c in Sources */,
 				AAB94E620A60FAC8E97F4C0F /* cpu-ppc64le.c in Sources */,
 				51370471CFBE01E41916195B /* crypto.c in Sources */,
 				FDC1AA4620EB7817E1201572 /* curve25519.c in Sources */,
 				52B63B709D1901958DF63070 /* spake25519.c in Sources */,
-				4960656D84CFCF2BECFA388F /* BuildFile in Sources */,
-				BCEC4AC09B9E0C91CBE2BC28 /* BuildFile in Sources */,
-				6149F66CA7F650F243709CA0 /* BuildFile in Sources */,
-				350D48872BA6A21FB03FDE43 /* BuildFile in Sources */,
+				4960656D84CFCF2BECFA388F /* (null) in Sources */,
+				BCEC4AC09B9E0C91CBE2BC28 /* (null) in Sources */,
+				6149F66CA7F650F243709CA0 /* (null) in Sources */,
+				350D48872BA6A21FB03FDE43 /* (null) in Sources */,
 				FA633840578DC05E0CF0D6A2 /* digest_extra.c in Sources */,
 				61C4C63527B0310956789DFE /* dsa.c in Sources */,
 				D47BF42A32D2BFF4DD8ED8BE /* dsa_asn1.c in Sources */,
 				3DCCE4B4FE49BD88311FF8D6 /* ec_asn1.c in Sources */,
 				08D40297FD1469BD103FA948 /* ec_derive.c in Sources */,
-				99580A142AE55B184E38A708 /* BuildFile in Sources */,
-				78F51793DEAFED77BE3233EA /* BuildFile in Sources */,
+				99580A142AE55B184E38A708 /* (null) in Sources */,
+				78F51793DEAFED77BE3233EA /* (null) in Sources */,
 				3E3880B37A3D71734426B2E9 /* ecdsa_asn1.c in Sources */,
 				95A8372CC32642CB97A5EF2C /* engine.c in Sources */,
 				06DC3AF26A72FD9500BC090A /* err.c in Sources */,
-				FCB31DF6E65D102938363814 /* BuildFile in Sources */,
+				FCB31DF6E65D102938363814 /* (null) in Sources */,
 				7DEAA0154B3ABB053C34C73E /* evp.c in Sources */,
-				6493313DD7E7C00257339FE2 /* BuildFile in Sources */,
-				611F877467789981E7106926 /* BuildFile in Sources */,
+				6493313DD7E7C00257339FE2 /* (null) in Sources */,
+				611F877467789981E7106926 /* (null) in Sources */,
 				7CB4B8BE5A3C25B461CA085B /* p_dsa_asn1.c in Sources */,
 				A59A9F667356A53640179B67 /* p_ec.c in Sources */,
 				394795CF0C2CB04AD57A6D66 /* p_ec_asn1.c in Sources */,
@@ -3285,39 +3331,39 @@
 				CD9F43E40D07C3990A97173D /* p_ed25519_asn1.c in Sources */,
 				118BAFE80E73400F140D7DD7 /* p_rsa.c in Sources */,
 				5E6749E98C7A1075DEC25EC4 /* p_rsa_asn1.c in Sources */,
-				89EF79990902B227BEA7C84C /* BuildFile in Sources */,
-				AE533CE36406DE383473773C /* BuildFile in Sources */,
-				7049D19A94F392F6AD0C1A84 /* BuildFile in Sources */,
-				36D1BF7258C8F63A02C805A1 /* BuildFile in Sources */,
+				89EF79990902B227BEA7C84C /* (null) in Sources */,
+				AE533CE36406DE383473773C /* (null) in Sources */,
+				7049D19A94F392F6AD0C1A84 /* (null) in Sources */,
+				36D1BF7258C8F63A02C805A1 /* (null) in Sources */,
 				A6DE26A523F540D02B4855B1 /* scrypt.c in Sources */,
-				BDC102681453DE1A54AA151C /* BuildFile in Sources */,
-				3B3559D64CAE11BAEB967F5C /* BuildFile in Sources */,
-				28FCFD58B68E73098C15D5AD /* BuildFile in Sources */,
+				BDC102681453DE1A54AA151C /* (null) in Sources */,
+				3B3559D64CAE11BAEB967F5C /* (null) in Sources */,
+				28FCFD58B68E73098C15D5AD /* (null) in Sources */,
 				3B98B242EE8FED9C2357FF33 /* fips_shared_support.c in Sources */,
-				2BF6E7EDC845E7C95D8DC2CD /* BuildFile in Sources */,
+				2BF6E7EDC845E7C95D8DC2CD /* (null) in Sources */,
 				F107D00C4C8926BB32A56A04 /* hkdf.c in Sources */,
 				3DBF7CA212F416B23DF648A7 /* hrss.c in Sources */,
-				BBCA8F846F579C52394C4E7D /* BuildFile in Sources */,
+				BBCA8F846F579C52394C4E7D /* (null) in Sources */,
 				66394A9F95D38CDD74AAF595 /* mem.c in Sources */,
 				FF96003D08D90CD92CE1F91C /* obj.c in Sources */,
-				915BD8EE9FFF0299156A7671 /* BuildFile in Sources */,
+				915BD8EE9FFF0299156A7671 /* (null) in Sources */,
 				E1E2941D02FDDD07C7B4F617 /* pem_all.c in Sources */,
-				1AE53F7F2E3AB77A0F5F450F /* BuildFile in Sources */,
-				90836A68A17E9A2A1E748CEA /* BuildFile in Sources */,
-				43E11138FAAE2EFDF81CB7BA /* BuildFile in Sources */,
-				BF487B75277B957DD38F862B /* BuildFile in Sources */,
-				B163496D246934B52B3400FD /* BuildFile in Sources */,
+				1AE53F7F2E3AB77A0F5F450F /* (null) in Sources */,
+				90836A68A17E9A2A1E748CEA /* (null) in Sources */,
+				43E11138FAAE2EFDF81CB7BA /* (null) in Sources */,
+				BF487B75277B957DD38F862B /* (null) in Sources */,
+				B163496D246934B52B3400FD /* (null) in Sources */,
 				847828B5B3C19D7A2E5B39BC /* pem_x509.c in Sources */,
 				7802CEB5C4A643F9F1B292C1 /* pem_xaux.c in Sources */,
-				216B09FADAC7DC1D8F90FD53 /* BuildFile in Sources */,
+				216B09FADAC7DC1D8F90FD53 /* (null) in Sources */,
 				4DBEB11609C74754FEE64F5B /* pkcs7_x509.c in Sources */,
 				56582FC351B0A72F8FD83254 /* p5_pbev2.c in Sources */,
-				5FF3598E55179C29119EEB11 /* BuildFile in Sources */,
-				0A070B34055F7410505B91C5 /* BuildFile in Sources */,
-				7BD1391024EC420052658E16 /* BuildFile in Sources */,
-				55DE436455A20282EA080F0E /* BuildFile in Sources */,
+				5FF3598E55179C29119EEB11 /* (null) in Sources */,
+				0A070B34055F7410505B91C5 /* (null) in Sources */,
+				7BD1391024EC420052658E16 /* (null) in Sources */,
+				55DE436455A20282EA080F0E /* (null) in Sources */,
 				5A68F278C83E03C27E4F59FE /* poly1305_vec.c in Sources */,
-				1A0A47D591B9170BB55062E2 /* BuildFile in Sources */,
+				1A0A47D591B9170BB55062E2 /* (null) in Sources */,
 				731C2901ADEAFFEED5B210D5 /* deterministic.c in Sources */,
 				C8F58F33428E2E35E7A1DAEC /* forkunsafe.c in Sources */,
 				30A39BCA2F56EA31D3955981 /* fuchsia.c in Sources */,
@@ -3330,18 +3376,18 @@
 				31F58B3DBC91D7B481EF4129 /* rsa_print.c in Sources */,
 				58C7FEECCF2032F5B97C4850 /* siphash.c in Sources */,
 				C428EAE8C07E6DE980DCCA74 /* stack.c in Sources */,
-				ACFEFC8BC170A565C82556F7 /* BuildFile in Sources */,
-				2C8528A68D987921D607D2C2 /* BuildFile in Sources */,
+				ACFEFC8BC170A565C82556F7 /* (null) in Sources */,
+				2C8528A68D987921D607D2C2 /* (null) in Sources */,
 				69325C0ED38D89FDC4A3DEB4 /* thread_pthread.c in Sources */,
-				9B91D02C903FC090E206D1C2 /* BuildFile in Sources */,
+				9B91D02C903FC090E206D1C2 /* (null) in Sources */,
 				7BC5D63A800D91C835A3970B /* pmbtoken.c in Sources */,
 				543C532F482A5095DC98CB4D /* trust_token.c in Sources */,
-				2BDD978A1B7B0ADF80EBA66E /* BuildFile in Sources */,
+				2BDD978A1B7B0ADF80EBA66E /* (null) in Sources */,
 				BDC0EE3DA5721F4CBD30D7AE /* a_sign.c in Sources */,
 				7AFAA1AECDF6DDEC4097C52E /* a_strex.c in Sources */,
-				2BD7704FACC59AC8028B0FB9 /* BuildFile in Sources */,
-				13CDB180FC581E77C30A514C /* BuildFile in Sources */,
-				46D22A4C867C9D7FEFD23BB2 /* BuildFile in Sources */,
+				2BD7704FACC59AC8028B0FB9 /* (null) in Sources */,
+				13CDB180FC581E77C30A514C /* (null) in Sources */,
+				46D22A4C867C9D7FEFD23BB2 /* (null) in Sources */,
 				0105639509A1E43307959913 /* by_dir.c in Sources */,
 				6361852F6BE0C8CAE88C870C /* by_file.c in Sources */,
 				CAEE2FFC3D3C65ACA77095E6 /* i2d_pr.c in Sources */,
@@ -3349,85 +3395,85 @@
 				BADF175835F6F543D478E515 /* t_crl.c in Sources */,
 				9210E3F76FF34970C9E59B9D /* t_req.c in Sources */,
 				423A6457F66546235105535F /* t_x509.c in Sources */,
-				78802AA1FEA8ABFB6D59DE77 /* BuildFile in Sources */,
+				78802AA1FEA8ABFB6D59DE77 /* (null) in Sources */,
 				A8BA780599AACDF5FB934BA8 /* x509.c in Sources */,
 				29B207B6DCEAD605F75354C0 /* x509_att.c in Sources */,
 				45BB564067C692E2D0D97591 /* x509_cmp.c in Sources */,
 				9C985A512D2C6952A3F8FDE2 /* x509_d2.c in Sources */,
 				03E71D9EB41A39B5B2C112D1 /* x509_def.c in Sources */,
-				493D8D46A818F4902A549D67 /* BuildFile in Sources */,
-				9D95657CEADC836890AC7A26 /* BuildFile in Sources */,
-				55CBCCDEF6ED579B53A97062 /* BuildFile in Sources */,
-				AF5BDFD99CED0A9F7D90413C /* BuildFile in Sources */,
+				493D8D46A818F4902A549D67 /* (null) in Sources */,
+				9D95657CEADC836890AC7A26 /* (null) in Sources */,
+				55CBCCDEF6ED579B53A97062 /* (null) in Sources */,
+				AF5BDFD99CED0A9F7D90413C /* (null) in Sources */,
 				70E4BB109AE70408403B2C25 /* x509_req.c in Sources */,
 				CB36584E09A8A2F85AE2D91C /* x509_set.c in Sources */,
 				118EB82D6E9022B96E1079AF /* x509_trs.c in Sources */,
-				2929048DF8A07F61D10C0DDE /* BuildFile in Sources */,
-				A84541467945783DF34A5E77 /* BuildFile in Sources */,
-				ADCCC1165BB374AD2B52E1EB /* BuildFile in Sources */,
+				2929048DF8A07F61D10C0DDE /* (null) in Sources */,
+				A84541467945783DF34A5E77 /* (null) in Sources */,
+				ADCCC1165BB374AD2B52E1EB /* (null) in Sources */,
 				9D510F51BB800CC028E4D3D2 /* x509_vpm.c in Sources */,
-				FA1D781788CD08FD7D5E737D /* BuildFile in Sources */,
+				FA1D781788CD08FD7D5E737D /* (null) in Sources */,
 				B0523B5E49525E8F715BB9F7 /* x509name.c in Sources */,
 				10D135443E3AE8A0AF4CD5C4 /* x509rset.c in Sources */,
-				073E8E037F4B1FA8E8AA792A /* BuildFile in Sources */,
-				E5950C5DCA3F5B1D8AB3F5A7 /* BuildFile in Sources */,
+				073E8E037F4B1FA8E8AA792A /* (null) in Sources */,
+				E5950C5DCA3F5B1D8AB3F5A7 /* (null) in Sources */,
 				70044FD74C83892F36B98A34 /* x_all.c in Sources */,
 				F0912E3A125A55FDBC7AF419 /* x_attrib.c in Sources */,
 				0604EBF20967C481D6CA8D91 /* x_crl.c in Sources */,
 				6A648134677FDF8569103138 /* x_exten.c in Sources */,
-				C20AAC1980EEEDB74E4CD1A3 /* BuildFile in Sources */,
+				C20AAC1980EEEDB74E4CD1A3 /* (null) in Sources */,
 				DD4AF9024DDD95CD9FC51463 /* x_name.c in Sources */,
 				28D4A7D9A1D7CCC3968057AD /* x_pkey.c in Sources */,
 				033E7B691361C0563121D276 /* x_pubkey.c in Sources */,
 				447FA09D58B5797F9B818404 /* x_req.c in Sources */,
 				6A210B9C768DCE43332F0EFA /* x_sig.c in Sources */,
-				F8F57E76517D9BEEA8D644FC /* BuildFile in Sources */,
+				F8F57E76517D9BEEA8D644FC /* (null) in Sources */,
 				4FA31F447362D34ACD1EC7D0 /* x_val.c in Sources */,
-				73FDBABF4CAF49E46CFFBEB6 /* BuildFile in Sources */,
+				73FDBABF4CAF49E46CFFBEB6 /* (null) in Sources */,
 				976F4BE0D6367CF998A132D9 /* x_x509a.c in Sources */,
 				F75FDC2F205C177307E3DD15 /* pcy_cache.c in Sources */,
-				68E069C9F4EA00503869D4F1 /* BuildFile in Sources */,
+				68E069C9F4EA00503869D4F1 /* (null) in Sources */,
 				DD0D1024FFA448E5E4C65E02 /* pcy_lib.c in Sources */,
 				AC48B681579AAAE628540C86 /* pcy_map.c in Sources */,
 				40356BAF72410D5F750305A8 /* pcy_node.c in Sources */,
 				6A71667C78F13F00F7154680 /* pcy_tree.c in Sources */,
 				33C3A3BEF250652DB7C1E077 /* v3_akey.c in Sources */,
-				E92E332C1268CBBE12B22B08 /* BuildFile in Sources */,
+				E92E332C1268CBBE12B22B08 /* (null) in Sources */,
 				D00DD993676FB4B8EECCD1AE /* v3_alt.c in Sources */,
 				34EF6E1D5766601F554D801B /* v3_bcons.c in Sources */,
 				D7573D5C90AC84EE84A0500A /* v3_bitst.c in Sources */,
 				770D956C87AA78100DE88E07 /* v3_conf.c in Sources */,
 				AC44F24A695BE251B1EE2BF4 /* v3_cpols.c in Sources */,
-				B50F5E7D5F90CABF7654ACE8 /* BuildFile in Sources */,
+				B50F5E7D5F90CABF7654ACE8 /* (null) in Sources */,
 				5AC270CB716F5A8E7DF6E444 /* v3_enum.c in Sources */,
 				31A2CC31592794087DAC24D8 /* v3_extku.c in Sources */,
 				1DCA26A470420AFCFEDFFD05 /* v3_genn.c in Sources */,
-				5B61FB4F6034E4BD6E02484F /* BuildFile in Sources */,
-				F53B3A9035E93436D4945B58 /* BuildFile in Sources */,
-				70BD3667CEE5029D0FEAED00 /* BuildFile in Sources */,
-				42487C57C6AE4E10A5E8469A /* BuildFile in Sources */,
+				5B61FB4F6034E4BD6E02484F /* (null) in Sources */,
+				F53B3A9035E93436D4945B58 /* (null) in Sources */,
+				70BD3667CEE5029D0FEAED00 /* (null) in Sources */,
+				42487C57C6AE4E10A5E8469A /* (null) in Sources */,
 				4F7BE1E590DE5784850851E2 /* v3_ncons.c in Sources */,
-				8D6FAE7B0C80F8F0E04EB0A6 /* BuildFile in Sources */,
+				8D6FAE7B0C80F8F0E04EB0A6 /* (null) in Sources */,
 				8BC0D733242F08D9361432C5 /* v3_pci.c in Sources */,
 				F2EEA1C5AC1D124862A16FE3 /* v3_pcia.c in Sources */,
 				E334698AC10261D271AE77C9 /* v3_pcons.c in Sources */,
-				F52856EAD80B4904C40D0C88 /* BuildFile in Sources */,
-				81047581B0DA4B73D9F10125 /* BuildFile in Sources */,
+				F52856EAD80B4904C40D0C88 /* (null) in Sources */,
+				81047581B0DA4B73D9F10125 /* (null) in Sources */,
 				67CEB7830BA42D523C4C423C /* v3_prn.c in Sources */,
 				A97057B53717391EBD321DB2 /* v3_purp.c in Sources */,
 				46D0984532B8FE15B3CD1701 /* v3_skey.c in Sources */,
-				67C0A6CF7887D47BBC235F0E /* BuildFile in Sources */,
+				67C0A6CF7887D47BBC235F0E /* (null) in Sources */,
 				FDA3278BB661923943AB30B6 /* v3_utl.c in Sources */,
-				1B2F22BB5A8A37DAFC323E14 /* BuildFile in Sources */,
-				2E8E2ACFA325740F188C9E55 /* BuildFile in Sources */,
-				1B056733A5A9A484A11940D9 /* BuildFile in Sources */,
-				72A9DFEBAE2B1F83E01EE6E5 /* BuildFile in Sources */,
-				3984A7A9719C0B3E0991C566 /* BuildFile in Sources */,
-				C22437D3AC35FD370D0C2321 /* BuildFile in Sources */,
-				3A9294BD816B3EE92E692347 /* BuildFile in Sources */,
-				852540E7992C41D1BB4FD105 /* BuildFile in Sources */,
+				1B2F22BB5A8A37DAFC323E14 /* (null) in Sources */,
+				2E8E2ACFA325740F188C9E55 /* (null) in Sources */,
+				1B056733A5A9A484A11940D9 /* (null) in Sources */,
+				72A9DFEBAE2B1F83E01EE6E5 /* (null) in Sources */,
+				3984A7A9719C0B3E0991C566 /* (null) in Sources */,
+				C22437D3AC35FD370D0C2321 /* (null) in Sources */,
+				3A9294BD816B3EE92E692347 /* (null) in Sources */,
+				852540E7992C41D1BB4FD105 /* (null) in Sources */,
 				E9EA1FE182C3B31B7F9B1DA1 /* hpke.c in Sources */,
-				BBB5FC3960F65EED253BD996 /* BuildFile in Sources */,
+				BBB5FC3960F65EED253BD996 /* (null) in Sources */,
 				9831BF75F6811E991EA7C975 /* bio_ssl.cc in Sources */,
 				41410D05E161A2BDC17E05B0 /* d1_both.cc in Sources */,
 				86C5499ECF7DA29DA7C5A37F /* d1_lib.cc in Sources */,
@@ -3572,52 +3618,52 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4D2FA827533D7910A9EE2008 /* BuildFile in Sources */,
-				9973CB826D61EE04063C32F7 /* BuildFile in Sources */,
-				3EF35E5C96674A4ACFF6A716 /* BuildFile in Sources */,
-				C3EAB548A4D54B8A6E963918 /* BuildFile in Sources */,
-				617923A6BF1E4A36340DC0B6 /* BuildFile in Sources */,
-				6EED196FFE03C2358C1F246E /* BuildFile in Sources */,
-				7E20134EBC2B4947A30004C4 /* BuildFile in Sources */,
-				4E2C7E4C5DF42EFDDC649C50 /* BuildFile in Sources */,
-				62D8E1E782AFE9FDAC5EDD39 /* BuildFile in Sources */,
-				E58AE69EA7A1BDAE2BA6086B /* BuildFile in Sources */,
-				37138F894C392FCCD2E5D2D7 /* BuildFile in Sources */,
-				4A8347CEFB33ED5AF117812D /* BuildFile in Sources */,
-				95F66580DCC8786B6B6F4204 /* BuildFile in Sources */,
+				4D2FA827533D7910A9EE2008 /* (null) in Sources */,
+				9973CB826D61EE04063C32F7 /* (null) in Sources */,
+				3EF35E5C96674A4ACFF6A716 /* (null) in Sources */,
+				C3EAB548A4D54B8A6E963918 /* (null) in Sources */,
+				617923A6BF1E4A36340DC0B6 /* (null) in Sources */,
+				6EED196FFE03C2358C1F246E /* (null) in Sources */,
+				7E20134EBC2B4947A30004C4 /* (null) in Sources */,
+				4E2C7E4C5DF42EFDDC649C50 /* (null) in Sources */,
+				62D8E1E782AFE9FDAC5EDD39 /* (null) in Sources */,
+				E58AE69EA7A1BDAE2BA6086B /* (null) in Sources */,
+				37138F894C392FCCD2E5D2D7 /* (null) in Sources */,
+				4A8347CEFB33ED5AF117812D /* (null) in Sources */,
+				95F66580DCC8786B6B6F4204 /* (null) in Sources */,
 				9AF5F84F4971A8A2F419EA43 /* err_data.c in Sources */,
-				6A34E90A533DD74CAC154E61 /* BuildFile in Sources */,
+				6A34E90A533DD74CAC154E61 /* (null) in Sources */,
 				5BF29FCAF510954F36095AFC /* a_bool.c in Sources */,
-				E69A9D104EA3C853FDF6C0B6 /* BuildFile in Sources */,
+				E69A9D104EA3C853FDF6C0B6 /* (null) in Sources */,
 				4E95B7544EF866AFFA43694F /* a_dup.c in Sources */,
 				F8CFED85A924E1368E90171D /* a_enum.c in Sources */,
 				E7612744B21FBA98B6C27978 /* a_gentm.c in Sources */,
-				5F9BCDC1BB148BFEC29401A5 /* BuildFile in Sources */,
-				B65093E0BB25B3CCA7962185 /* BuildFile in Sources */,
+				5F9BCDC1BB148BFEC29401A5 /* (null) in Sources */,
+				B65093E0BB25B3CCA7962185 /* (null) in Sources */,
 				8F011AD36151F4C5055D3941 /* a_mbstr.c in Sources */,
 				A6E03D3096A6F00415342147 /* a_object.c in Sources */,
-				6C56639C3F24DA5935B90026 /* BuildFile in Sources */,
+				6C56639C3F24DA5935B90026 /* (null) in Sources */,
 				70B53B388C0F5B25315EF0B8 /* a_print.c in Sources */,
-				35027C9AD29018ECAE82F534 /* BuildFile in Sources */,
+				35027C9AD29018ECAE82F534 /* (null) in Sources */,
 				43BD1B3E2D4FA605511EA00D /* a_time.c in Sources */,
 				1F13F800F43120139B33948C /* a_type.c in Sources */,
-				456E33C768281D3288C063B3 /* BuildFile in Sources */,
+				456E33C768281D3288C063B3 /* (null) in Sources */,
 				BC0DCA321B15D3A55D0A63D2 /* a_utf8.c in Sources */,
-				7447267EAF54E1AD1C16A643 /* BuildFile in Sources */,
-				88AF7FC3A0C54C93EE4ACA53 /* BuildFile in Sources */,
+				7447267EAF54E1AD1C16A643 /* (null) in Sources */,
+				88AF7FC3A0C54C93EE4ACA53 /* (null) in Sources */,
 				6183EF7C0D72DC782A8CD0DE /* asn_pack.c in Sources */,
 				DAF9E8934D9CD86CEEFD1B2C /* f_enum.c in Sources */,
 				8E2081DA1BD5E033F64ADCA1 /* f_int.c in Sources */,
 				A92B9F588FD8DEF53CCF1DFE /* f_string.c in Sources */,
 				A5305B38B32819B634B296A7 /* tasn_dec.c in Sources */,
-				841572601AA102E4C449A9EB /* BuildFile in Sources */,
+				841572601AA102E4C449A9EB /* (null) in Sources */,
 				98900268EAC82EFF3AAB69AF /* tasn_fre.c in Sources */,
 				33FECDFE6D8337B419550ED8 /* tasn_new.c in Sources */,
-				1A3DC31F84BE6A287333A953 /* BuildFile in Sources */,
+				1A3DC31F84BE6A287333A953 /* (null) in Sources */,
 				7CB46C708808AC0F8E81619C /* tasn_utl.c in Sources */,
 				5275EB4E76A952AE1C6CC7BF /* time_support.c in Sources */,
 				C0252705D83FA2FF839829D6 /* base64.c in Sources */,
-				EF69A2BA72967CC8FAE1BFCA /* BuildFile in Sources */,
+				EF69A2BA72967CC8FAE1BFCA /* (null) in Sources */,
 				B68A325CA3DED2441796E89F /* bio_mem.c in Sources */,
 				E0EE21F067FCCD57F4452EB4 /* connect.c in Sources */,
 				B209E18269DC03AA75711758 /* fd.c in Sources */,
@@ -3627,55 +3673,55 @@
 				A70854D9DFB29472510D9051 /* printf.c in Sources */,
 				F8CA35590C7BE0293F3F6FC4 /* socket.c in Sources */,
 				FC9FA9FE4AAA80F95CF1C60E /* socket_helper.c in Sources */,
-				CABD573F7168209A77490C88 /* BuildFile in Sources */,
-				5F49B1A0D5F7D4A85D6E5BBD /* BuildFile in Sources */,
-				5FEAA33F60E349DA4444D0C7 /* BuildFile in Sources */,
+				CABD573F7168209A77490C88 /* (null) in Sources */,
+				5F49B1A0D5F7D4A85D6E5BBD /* (null) in Sources */,
+				5FEAA33F60E349DA4444D0C7 /* (null) in Sources */,
 				EDF8D6D3E65714E0E5F7B6B4 /* asn1_compat.c in Sources */,
 				8CAAC0AE0671B4F73DD36E76 /* ber.c in Sources */,
 				060D0CC9C82D307DB91587E8 /* cbb.c in Sources */,
 				C476FB7539609CFCF40BF847 /* cbs.c in Sources */,
 				10837919A960A21983528FBF /* unicode.c in Sources */,
 				F751F3522CBC8ED1264EB2E7 /* chacha.c in Sources */,
-				6B79D106C41F11E999FA195B /* BuildFile in Sources */,
+				6B79D106C41F11E999FA195B /* (null) in Sources */,
 				BA5D25252820567A524F83B5 /* derive_key.c in Sources */,
 				D7078EF1E1C3B8767627B341 /* e_aesccm.c in Sources */,
 				1037981DB7C47F8AB093EA63 /* e_aesctrhmac.c in Sources */,
 				62E32C3A26D03BF57AD753E5 /* e_aesgcmsiv.c in Sources */,
 				FB00E15388AB037F1F8C531F /* e_chacha20poly1305.c in Sources */,
 				E124B22ED598B83BFB1D6497 /* e_null.c in Sources */,
-				5423581175FF15B4B16848F8 /* BuildFile in Sources */,
+				5423581175FF15B4B16848F8 /* (null) in Sources */,
 				95939769BFC549378E746E6C /* e_rc4.c in Sources */,
 				A3718C97323073252A79FD07 /* e_tls.c in Sources */,
 				D83E5FA84B33C329D46E4087 /* tls_cbc.c in Sources */,
 				D6797F0D2DAD39EE79F1DC1E /* cmac.c in Sources */,
 				58E259AFBB4203107D655A2B /* conf.c in Sources */,
-				C7B85B1FAC98705AAC83E228 /* BuildFile in Sources */,
+				C7B85B1FAC98705AAC83E228 /* (null) in Sources */,
 				905C749F69D7D25DB4539100 /* cpu-aarch64-linux.c in Sources */,
 				A8E75E224F2E29FDC007AE51 /* cpu-arm-linux.c in Sources */,
-				8296213B2F86071A1ED7354D /* BuildFile in Sources */,
+				8296213B2F86071A1ED7354D /* (null) in Sources */,
 				EA53F0364191E656042C14F5 /* cpu-intel.c in Sources */,
 				407A17BB1993DDBF865A39DD /* cpu-ppc64le.c in Sources */,
 				A6138F7F8BB4BB3A8C9BF6A6 /* crypto.c in Sources */,
 				191B80362FB79DF2F2EC1ED6 /* curve25519.c in Sources */,
 				C73C668207609FF32C18767B /* spake25519.c in Sources */,
-				EE1F18457E58DB2DE923736E /* BuildFile in Sources */,
-				95FE4E59B77B67919213295D /* BuildFile in Sources */,
-				22CB9C82519B308F61574066 /* BuildFile in Sources */,
-				02E9439882A4864DC0A34FD8 /* BuildFile in Sources */,
+				EE1F18457E58DB2DE923736E /* (null) in Sources */,
+				95FE4E59B77B67919213295D /* (null) in Sources */,
+				22CB9C82519B308F61574066 /* (null) in Sources */,
+				02E9439882A4864DC0A34FD8 /* (null) in Sources */,
 				1D87BB81898EA45D0B475B4D /* digest_extra.c in Sources */,
 				4B6DC412BA68E1539B03A239 /* dsa.c in Sources */,
 				0D00EC09894950934444C46E /* dsa_asn1.c in Sources */,
 				D147BB0D532C76C979E455F5 /* ec_asn1.c in Sources */,
 				E6979FA1831E2E4C3228A19E /* ec_derive.c in Sources */,
-				20FC40501C8BAF025F461FEB /* BuildFile in Sources */,
-				75567E14AF9EF4DA0B0FDF27 /* BuildFile in Sources */,
+				20FC40501C8BAF025F461FEB /* (null) in Sources */,
+				75567E14AF9EF4DA0B0FDF27 /* (null) in Sources */,
 				BAC65464CCD5BF7DD49416D5 /* ecdsa_asn1.c in Sources */,
 				D9481CD2DC5532D259532DD3 /* engine.c in Sources */,
 				72AA683592AB306D1ED3A429 /* err.c in Sources */,
-				89075C2301FBB614BC720312 /* BuildFile in Sources */,
+				89075C2301FBB614BC720312 /* (null) in Sources */,
 				37F89306301A708503B2DB65 /* evp.c in Sources */,
-				DB640B3A86C13D5B2A09DECB /* BuildFile in Sources */,
-				8E9AEE9D338FA01438F58212 /* BuildFile in Sources */,
+				DB640B3A86C13D5B2A09DECB /* (null) in Sources */,
+				8E9AEE9D338FA01438F58212 /* (null) in Sources */,
 				9135E830B133355FDDEA137F /* p_dsa_asn1.c in Sources */,
 				672AC86CB3C593704E697530 /* p_ec.c in Sources */,
 				318FD614D5A1B68B29EF5EF9 /* p_ec_asn1.c in Sources */,
@@ -3683,39 +3729,39 @@
 				553BA595BE6BDC421C3BF372 /* p_ed25519_asn1.c in Sources */,
 				610B729CA0DE45C00CFE8DCD /* p_rsa.c in Sources */,
 				EA080302B8826557F304969D /* p_rsa_asn1.c in Sources */,
-				5DE9FFEDA770485C44AC2F87 /* BuildFile in Sources */,
-				FD89E2465B0F8130B8BFB926 /* BuildFile in Sources */,
-				5C2A8AF6C9D550C6E7DAC5AD /* BuildFile in Sources */,
-				CCA1551FDE6EF303BA90C9E1 /* BuildFile in Sources */,
+				5DE9FFEDA770485C44AC2F87 /* (null) in Sources */,
+				FD89E2465B0F8130B8BFB926 /* (null) in Sources */,
+				5C2A8AF6C9D550C6E7DAC5AD /* (null) in Sources */,
+				CCA1551FDE6EF303BA90C9E1 /* (null) in Sources */,
 				7A4FD7979ECB9946E1997C14 /* scrypt.c in Sources */,
-				0D5474C3710E25C05CFDC341 /* BuildFile in Sources */,
-				8E020DACE9872B68FC3E6052 /* BuildFile in Sources */,
-				C4B7E30F8924A8B15956C718 /* BuildFile in Sources */,
+				0D5474C3710E25C05CFDC341 /* (null) in Sources */,
+				8E020DACE9872B68FC3E6052 /* (null) in Sources */,
+				C4B7E30F8924A8B15956C718 /* (null) in Sources */,
 				4B2FCACD5B4D88212F190D42 /* fips_shared_support.c in Sources */,
-				182FBDF3338C6AB3DB980B81 /* BuildFile in Sources */,
+				182FBDF3338C6AB3DB980B81 /* (null) in Sources */,
 				088F268D54BF1F51BFCB6797 /* hkdf.c in Sources */,
 				56BD4C3033EB5AF45580EDE8 /* hrss.c in Sources */,
-				32593A65C4F530BE1268EF1A /* BuildFile in Sources */,
+				32593A65C4F530BE1268EF1A /* (null) in Sources */,
 				42A21580843AEB221326DA8C /* mem.c in Sources */,
 				4D91233F729E3FF653043128 /* obj.c in Sources */,
-				2B190A07927823BD6A88EDED /* BuildFile in Sources */,
+				2B190A07927823BD6A88EDED /* (null) in Sources */,
 				AC362A0448270F4DCD109F30 /* pem_all.c in Sources */,
-				22D04738EF9B0F20B59B0595 /* BuildFile in Sources */,
-				8A5421446B7788EDFC876DB0 /* BuildFile in Sources */,
-				38715C899B30DC431377C5DD /* BuildFile in Sources */,
-				53E2A7313DD580871DDD42E9 /* BuildFile in Sources */,
-				BF7A58248236B2DEB365EB25 /* BuildFile in Sources */,
+				22D04738EF9B0F20B59B0595 /* (null) in Sources */,
+				8A5421446B7788EDFC876DB0 /* (null) in Sources */,
+				38715C899B30DC431377C5DD /* (null) in Sources */,
+				53E2A7313DD580871DDD42E9 /* (null) in Sources */,
+				BF7A58248236B2DEB365EB25 /* (null) in Sources */,
 				FB2CCB6CD77108E5DB3760F4 /* pem_x509.c in Sources */,
 				138E79FD192E94A4BE5632F8 /* pem_xaux.c in Sources */,
-				9B53A6F156B079F64B0B27C9 /* BuildFile in Sources */,
+				9B53A6F156B079F64B0B27C9 /* (null) in Sources */,
 				D4D56C2BBFD79CF66438E349 /* pkcs7_x509.c in Sources */,
 				5607EF3B3AE3BC160AB0FD8B /* p5_pbev2.c in Sources */,
-				F33735D2F7298FF059A4F215 /* BuildFile in Sources */,
-				5292E4A72BC733B86DFF57D0 /* BuildFile in Sources */,
-				3E066F3097D645D88C5806BE /* BuildFile in Sources */,
-				48DF38FC21952CA55EBD4D9A /* BuildFile in Sources */,
+				F33735D2F7298FF059A4F215 /* (null) in Sources */,
+				5292E4A72BC733B86DFF57D0 /* (null) in Sources */,
+				3E066F3097D645D88C5806BE /* (null) in Sources */,
+				48DF38FC21952CA55EBD4D9A /* (null) in Sources */,
 				2994B6EFC9387420E6D9FD55 /* poly1305_vec.c in Sources */,
-				B0FC96493F43BB0AE1A2EF54 /* BuildFile in Sources */,
+				B0FC96493F43BB0AE1A2EF54 /* (null) in Sources */,
 				405514699746E072B04A2BBA /* deterministic.c in Sources */,
 				A4360DFD492BD95879D9C02D /* forkunsafe.c in Sources */,
 				2CA5AE6D970AF0E8AB6D07BF /* fuchsia.c in Sources */,
@@ -3728,18 +3774,18 @@
 				4BE3B931E8DFC72E24077BA1 /* rsa_print.c in Sources */,
 				0DBE90F642DDB7FBF8DF4B97 /* siphash.c in Sources */,
 				E0E4069403F575AB60C424EA /* stack.c in Sources */,
-				3CDE08A38BE71A60768C48A8 /* BuildFile in Sources */,
-				A1D784F0537449166788142C /* BuildFile in Sources */,
+				3CDE08A38BE71A60768C48A8 /* (null) in Sources */,
+				A1D784F0537449166788142C /* (null) in Sources */,
 				CA1346CEBDC682F53BC4B421 /* thread_pthread.c in Sources */,
-				F0377E3AAE488098C249360C /* BuildFile in Sources */,
+				F0377E3AAE488098C249360C /* (null) in Sources */,
 				1C67FDB3E86BA6915861BA6D /* pmbtoken.c in Sources */,
 				DE6EE62FF85E2D37247F478B /* trust_token.c in Sources */,
-				CBBBA9F42DE573C99EA85567 /* BuildFile in Sources */,
+				CBBBA9F42DE573C99EA85567 /* (null) in Sources */,
 				CD15FBCA4EBF43C37A7282F1 /* a_sign.c in Sources */,
 				A035C6D5CE56250F1088E027 /* a_strex.c in Sources */,
-				0C2A90442F6AE21923566AAD /* BuildFile in Sources */,
-				4B9E0CFEDC29B3E5F38004B0 /* BuildFile in Sources */,
-				B70A0D96A712C6450C3EE6D2 /* BuildFile in Sources */,
+				0C2A90442F6AE21923566AAD /* (null) in Sources */,
+				4B9E0CFEDC29B3E5F38004B0 /* (null) in Sources */,
+				B70A0D96A712C6450C3EE6D2 /* (null) in Sources */,
 				A38527051C50AE736726CC17 /* by_dir.c in Sources */,
 				9BCAE6315BF5D63AA2BA0ACC /* by_file.c in Sources */,
 				3A0A3562156B7A0BA0F5644B /* i2d_pr.c in Sources */,
@@ -3747,109 +3793,109 @@
 				560C1799145B24EB8D627145 /* t_crl.c in Sources */,
 				63525A82AFCAC5F65ADC194A /* t_req.c in Sources */,
 				F8D8A6FDF2740290F8D6F110 /* t_x509.c in Sources */,
-				50F30C481E8769D0161B970E /* BuildFile in Sources */,
+				50F30C481E8769D0161B970E /* (null) in Sources */,
 				764E30F2348FA53D138894FF /* x509.c in Sources */,
 				CC0E3E3A1C76E68922C486A2 /* x509_att.c in Sources */,
 				A55CA7BEC8CEA338939EE3C1 /* x509_cmp.c in Sources */,
 				240F52513D8C09B304F9DB91 /* x509_d2.c in Sources */,
 				3C480BDB1160546C05437187 /* x509_def.c in Sources */,
-				2E06848746D3CF2378264BF7 /* BuildFile in Sources */,
-				3A9F8998B0164D80AE443187 /* BuildFile in Sources */,
-				614484A9C160DE7F9FD30C21 /* BuildFile in Sources */,
-				397A455350C69A71E1B39C04 /* BuildFile in Sources */,
+				2E06848746D3CF2378264BF7 /* (null) in Sources */,
+				3A9F8998B0164D80AE443187 /* (null) in Sources */,
+				614484A9C160DE7F9FD30C21 /* (null) in Sources */,
+				397A455350C69A71E1B39C04 /* (null) in Sources */,
 				DB7EB4B066174CF47D408EB0 /* x509_req.c in Sources */,
 				A6E4EF438C542077A488C4B3 /* x509_set.c in Sources */,
 				00715282C8D28EECA6F225B6 /* x509_trs.c in Sources */,
-				09F6309C8A751C081A905241 /* BuildFile in Sources */,
-				17FAEB9CF96F6C6124570875 /* BuildFile in Sources */,
-				C03E3EB33BAB2B23517529AB /* BuildFile in Sources */,
+				09F6309C8A751C081A905241 /* (null) in Sources */,
+				17FAEB9CF96F6C6124570875 /* (null) in Sources */,
+				C03E3EB33BAB2B23517529AB /* (null) in Sources */,
 				09BCE64A01F6D9DE5F5D96B2 /* x509_vpm.c in Sources */,
-				AE2FDA266A7E7AF10AD5F363 /* BuildFile in Sources */,
+				AE2FDA266A7E7AF10AD5F363 /* (null) in Sources */,
 				8F484BA80AD59D5CE3666D80 /* x509name.c in Sources */,
 				69AC94E133967CD8205A8199 /* x509rset.c in Sources */,
-				4A3D988F1505B9BA9DEDE3BE /* BuildFile in Sources */,
-				02B1DE2F13C9F69176A71B4F /* BuildFile in Sources */,
+				4A3D988F1505B9BA9DEDE3BE /* (null) in Sources */,
+				02B1DE2F13C9F69176A71B4F /* (null) in Sources */,
 				B85D8F1B6DB2CA3F5E414D0E /* x_all.c in Sources */,
 				990B3D8A06CED9461B5393F6 /* x_attrib.c in Sources */,
 				6F4E1BB3F5FF49DA19CEFE81 /* x_crl.c in Sources */,
 				9577BC90CF013F1DD0AD65E6 /* x_exten.c in Sources */,
-				1F360DF1D4BDD0058151DB57 /* BuildFile in Sources */,
+				1F360DF1D4BDD0058151DB57 /* (null) in Sources */,
 				15916C97F664330664FA49BD /* x_name.c in Sources */,
 				A9A75C26074580196258931D /* x_pkey.c in Sources */,
 				C9B7353C1DFD165A74E46705 /* x_pubkey.c in Sources */,
 				B766FD90A18763DB6E7A314D /* x_req.c in Sources */,
 				881A096DA629D3EBDC3767DB /* x_sig.c in Sources */,
-				631DB9BB33207274E88BBC41 /* BuildFile in Sources */,
+				631DB9BB33207274E88BBC41 /* (null) in Sources */,
 				6C8273E0FEEE84389466CCC3 /* x_val.c in Sources */,
-				5A00C7ECB0E8C51F71AC2D5F /* BuildFile in Sources */,
+				5A00C7ECB0E8C51F71AC2D5F /* (null) in Sources */,
 				06165E0601EA2690FED3A972 /* x_x509a.c in Sources */,
 				03E6884B7F77E1BDB8E8C324 /* pcy_cache.c in Sources */,
-				9AE434F33E0B0322461173E7 /* BuildFile in Sources */,
+				9AE434F33E0B0322461173E7 /* (null) in Sources */,
 				8F98393502D93E04D070CE9F /* pcy_lib.c in Sources */,
 				BC706B7AE48199DE00A971B5 /* pcy_map.c in Sources */,
 				222B1AF606E755465F23A038 /* pcy_node.c in Sources */,
 				B35008E0BA76E8698DF722B0 /* pcy_tree.c in Sources */,
 				E64A41FAC5B61DD8757C2CF1 /* v3_akey.c in Sources */,
-				FF4836E5C545B5FBA26561B5 /* BuildFile in Sources */,
+				FF4836E5C545B5FBA26561B5 /* (null) in Sources */,
 				6CBB7E62C3C092A21B3D1074 /* v3_alt.c in Sources */,
 				814B1614A75802258A403753 /* v3_bcons.c in Sources */,
 				8F15E722CB24A1604432EDCE /* v3_bitst.c in Sources */,
 				B1DAE9411A5EB0358DD75FE9 /* v3_conf.c in Sources */,
 				5AC89FE8FD81768934684584 /* v3_cpols.c in Sources */,
-				2AE3AB381A44D9C4130E4771 /* BuildFile in Sources */,
+				2AE3AB381A44D9C4130E4771 /* (null) in Sources */,
 				F8323A6147836458304A2139 /* v3_enum.c in Sources */,
 				8996DCADA8AB563D99284225 /* v3_extku.c in Sources */,
 				0E3BDC6E1077A3624B7DCE37 /* v3_genn.c in Sources */,
-				1F1A92281E36C34D5FFA90D5 /* BuildFile in Sources */,
-				3F8441722F1EEC03840F7EFC /* BuildFile in Sources */,
-				D979724485776601BAC5061F /* BuildFile in Sources */,
-				444AA334E305003BE74A51D2 /* BuildFile in Sources */,
+				1F1A92281E36C34D5FFA90D5 /* (null) in Sources */,
+				3F8441722F1EEC03840F7EFC /* (null) in Sources */,
+				D979724485776601BAC5061F /* (null) in Sources */,
+				444AA334E305003BE74A51D2 /* (null) in Sources */,
 				24A0C953BC2309B1BF8DBD0A /* v3_ncons.c in Sources */,
-				ED806EF61781490AE85CB483 /* BuildFile in Sources */,
+				ED806EF61781490AE85CB483 /* (null) in Sources */,
 				48B8D48BABE257F119C5B8AD /* v3_pci.c in Sources */,
 				686298E16BA3CB5FDD38C1E2 /* v3_pcia.c in Sources */,
 				A06116E75A90B9DE1B6A43F8 /* v3_pcons.c in Sources */,
-				FCE8884952D94C7EA445BC40 /* BuildFile in Sources */,
-				CC070075846EE226C6F932C6 /* BuildFile in Sources */,
+				FCE8884952D94C7EA445BC40 /* (null) in Sources */,
+				CC070075846EE226C6F932C6 /* (null) in Sources */,
 				538E3329C097151B2D64B34D /* v3_prn.c in Sources */,
 				F81A3B959BBB20880D5088EB /* v3_purp.c in Sources */,
 				C7D117145C4457B151A128D2 /* v3_skey.c in Sources */,
-				FD7BB83D1A974EC2D1AC116B /* BuildFile in Sources */,
+				FD7BB83D1A974EC2D1AC116B /* (null) in Sources */,
 				B6BA78E65BE24651B2560AEE /* v3_utl.c in Sources */,
-				8E9C07F5BDED73EF170C96A1 /* BuildFile in Sources */,
+				8E9C07F5BDED73EF170C96A1 /* (null) in Sources */,
 				1ED96538E54E862F880AE3AF /* aesni-x86.S in Sources */,
 				30E5CAA1F675FEB1086182D7 /* bn-586.S in Sources */,
-				F0919D96DD681230E2D61779 /* BuildFile in Sources */,
-				3D2D405AB38A2176506B6349 /* BuildFile in Sources */,
-				001FFF61CD680060AB1BED0D /* BuildFile in Sources */,
-				9C0BE3ABC7B866988B0DC5C1 /* BuildFile in Sources */,
+				F0919D96DD681230E2D61779 /* (null) in Sources */,
+				3D2D405AB38A2176506B6349 /* (null) in Sources */,
+				001FFF61CD680060AB1BED0D /* (null) in Sources */,
+				9C0BE3ABC7B866988B0DC5C1 /* (null) in Sources */,
 				CCB8AA9AC0B6B7702A747486 /* sha1-586.S in Sources */,
-				CB985BD7156063EB38CEC562 /* BuildFile in Sources */,
+				CB985BD7156063EB38CEC562 /* (null) in Sources */,
 				3397D7EF47B95D6F2154BD1C /* sha512-586.S in Sources */,
 				A2589CB25D88CC3BC608AE80 /* vpaes-x86.S in Sources */,
-				9F4F7C57C0E7986C44CFAE37 /* BuildFile in Sources */,
-				5E7792314B7C17B62B1A6B4F /* BuildFile in Sources */,
-				1D5741C158B018BE59AF03B1 /* BuildFile in Sources */,
-				A32587A0E6C55D21196DC424 /* BuildFile in Sources */,
+				9F4F7C57C0E7986C44CFAE37 /* (null) in Sources */,
+				5E7792314B7C17B62B1A6B4F /* (null) in Sources */,
+				1D5741C158B018BE59AF03B1 /* (null) in Sources */,
+				A32587A0E6C55D21196DC424 /* (null) in Sources */,
 				6DC5DCACCA06708CBD05E78C /* chacha20_poly1305_x86_64.S in Sources */,
 				5D047520D3CBCA2836A89E7F /* aesni-gcm-x86_64.S in Sources */,
-				6DA8046AA88A71BB57435465 /* BuildFile in Sources */,
+				6DA8046AA88A71BB57435465 /* (null) in Sources */,
 				25D78B2BE3694E12B3E18483 /* ghash-ssse3-x86_64.S in Sources */,
-				214B29C73CFC2F40325D98F0 /* BuildFile in Sources */,
-				28CACE988565726CB0AAC899 /* BuildFile in Sources */,
+				214B29C73CFC2F40325D98F0 /* (null) in Sources */,
+				28CACE988565726CB0AAC899 /* (null) in Sources */,
 				F8B88AB4F04F603B7856C895 /* p256-x86_64-asm.S in Sources */,
 				08E64D37D36AA5BE136B7BE5 /* p256_beeu-x86_64-asm.S in Sources */,
 				55557B89BC5DEFAC9313E916 /* rdrand-x86_64.S in Sources */,
 				56F9BE28BB5CB7D6F205D896 /* rsaz-avx2.S in Sources */,
 				825774580BB7F2A382AAD09E /* sha1-x86_64.S in Sources */,
 				3456532B5861C3A786DD8B29 /* sha256-x86_64.S in Sources */,
-				AB700C7F7CECE1B9000EDABE /* BuildFile in Sources */,
+				AB700C7F7CECE1B9000EDABE /* (null) in Sources */,
 				BB7C53AE645A8A78EF8323EA /* vpaes-x86_64.S in Sources */,
 				A301E0D17A39C99E5E135555 /* x86_64-mont.S in Sources */,
-				D9B3B3BF30E803302297B814 /* BuildFile in Sources */,
+				D9B3B3BF30E803302297B814 /* (null) in Sources */,
 				F2E318B9484D62DB15BF71BA /* trampoline-x86_64.S in Sources */,
 				2CA657B68D19D78AC1942A0F /* hpke.c in Sources */,
-				2D9BC916CCA11F0412B07977 /* BuildFile in Sources */,
+				2D9BC916CCA11F0412B07977 /* (null) in Sources */,
 				C71E4E8A23EE89C49BA88D99 /* bio_ssl.cc in Sources */,
 				28570EB1BB5C6DFF27200E8E /* d1_both.cc in Sources */,
 				ABE4E258D74F9BE3787EAB41 /* d1_lib.cc in Sources */,
@@ -4357,11 +4403,21 @@
 					"*armv7*.S",
 					"*armv8*.S",
 				);
-				"GCC_PREPROCESSOR_DEFINITIONS[sdk=iphonesimulator*]" = "OPENSSL_NO_ASM=1 $(inherited)";
+				"GCC_PREPROCESSOR_DEFINITIONS[sdk=iphonesimulator*]" = (
+					"OPENSSL_NO_ASM=1",
+					"$(inherited)",
+				);
 				GCC_WARN_INHIBIT_ALL_WARNINGS = YES;
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/third_party/boringssl/src/include";
-				"INCLUDED_SOURCE_FILE_NAMES[sdk=iphoneos*][arch=arm64*]" = "*armx64*.S *armv8*.S";
-				"INCLUDED_SOURCE_FILE_NAMES[sdk=iphoneos*][arch=armv7*]" = "*armx32*.S *armv4*.S *armv7*.S";
+				"INCLUDED_SOURCE_FILE_NAMES[sdk=iphoneos*][arch=arm64*]" = (
+					"*armx64*.S",
+					"*armv8*.S",
+				);
+				"INCLUDED_SOURCE_FILE_NAMES[sdk=iphoneos*][arch=armv7*]" = (
+					"*armx32*.S",
+					"*armv4*.S",
+					"*armv7*.S",
+				);
 				PRODUCT_NAME = boringssl;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -4378,11 +4434,21 @@
 					"*armv7*.S",
 					"*armv8*.S",
 				);
-				"GCC_PREPROCESSOR_DEFINITIONS[sdk=iphonesimulator*]" = "OPENSSL_NO_ASM=1 $(inherited)";
+				"GCC_PREPROCESSOR_DEFINITIONS[sdk=iphonesimulator*]" = (
+					"OPENSSL_NO_ASM=1",
+					"$(inherited)",
+				);
 				GCC_WARN_INHIBIT_ALL_WARNINGS = YES;
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/third_party/boringssl/src/include";
-				"INCLUDED_SOURCE_FILE_NAMES[sdk=iphoneos*][arch=arm64*]" = "*armx64*.S *armv8*.S";
-				"INCLUDED_SOURCE_FILE_NAMES[sdk=iphoneos*][arch=armv7*]" = "*armx32*.S *armv4*.S *armv7*.S";
+				"INCLUDED_SOURCE_FILE_NAMES[sdk=iphoneos*][arch=arm64*]" = (
+					"*armx64*.S",
+					"*armv8*.S",
+				);
+				"INCLUDED_SOURCE_FILE_NAMES[sdk=iphoneos*][arch=armv7*]" = (
+					"*armx32*.S",
+					"*armv4*.S",
+					"*armv7*.S",
+				);
 				PRODUCT_NAME = boringssl;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -4405,9 +4471,20 @@
 				EXECUTABLE_PREFIX = lib;
 				GCC_WARN_INHIBIT_ALL_WARNINGS = YES;
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/third_party/boringssl/src/include";
-				"INCLUDED_SOURCE_FILE_NAMES[sdk=macosx*][arch=i386]" = "x86-*.S *-586.S *-x86.S";
-				"INCLUDED_SOURCE_FILE_NAMES[sdk=macosx*][arch=x86_64]" = "x86_64-*.S *-x86_64.S *-x86_64-*.S";
-				"INCLUDED_SOURCE_FILE_NAMES[sdk=macosx*][arch=arm64*]" = "*armx64*.S *armv8*.S";
+				"INCLUDED_SOURCE_FILE_NAMES[sdk=macosx*][arch=arm64*]" = (
+					"*armx64*.S",
+					"*armv8*.S",
+				);
+				"INCLUDED_SOURCE_FILE_NAMES[sdk=macosx*][arch=i386]" = (
+					"x86-*.S",
+					"*-586.S",
+					"*-x86.S",
+				);
+				"INCLUDED_SOURCE_FILE_NAMES[sdk=macosx*][arch=x86_64]" = (
+					"x86_64-*.S",
+					"*-x86_64.S",
+					"*-x86_64-*.S",
+				);
 				PRODUCT_NAME = boringssl;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -4430,9 +4507,20 @@
 				EXECUTABLE_PREFIX = lib;
 				GCC_WARN_INHIBIT_ALL_WARNINGS = YES;
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/third_party/boringssl/src/include";
-				"INCLUDED_SOURCE_FILE_NAMES[sdk=macosx*][arch=i386]" = "x86-*.S *-586.S *-x86.S";
-				"INCLUDED_SOURCE_FILE_NAMES[sdk=macosx*][arch=x86_64]" = "x86_64-*.S *-x86_64.S *-x86_64-*.S";
-				"INCLUDED_SOURCE_FILE_NAMES[sdk=macosx*][arch=arm64*]" = "*armx64*.S *armv8*.S";
+				"INCLUDED_SOURCE_FILE_NAMES[sdk=macosx*][arch=arm64*]" = (
+					"*armx64*.S",
+					"*armv8*.S",
+				);
+				"INCLUDED_SOURCE_FILE_NAMES[sdk=macosx*][arch=i386]" = (
+					"x86-*.S",
+					"*-586.S",
+					"*-x86.S",
+				);
+				"INCLUDED_SOURCE_FILE_NAMES[sdk=macosx*][arch=x86_64]" = (
+					"x86_64-*.S",
+					"*-x86_64.S",
+					"*-x86_64-*.S",
+				);
 				PRODUCT_NAME = boringssl;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;

--- a/Themis.xcodeproj/xcshareddata/xcschemes/Test Themis (BoringSSL, Swift 5, iOS).xcscheme
+++ b/Themis.xcodeproj/xcshareddata/xcschemes/Test Themis (BoringSSL, Swift 5, iOS).xcscheme
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1220"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9F52B1A6263D3CA00025EB78"
+               BuildableName = "Test Themis (BoringSSL, Swift 5, iOS).xctest"
+               BlueprintName = "Test Themis (BoringSSL, Swift 5, iOS)"
+               ReferencedContainer = "container:Themis.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Themis.xcodeproj/xcshareddata/xcschemes/Test Themis (BoringSSL, Swift 5, macOS).xcscheme
+++ b/Themis.xcodeproj/xcshareddata/xcschemes/Test Themis (BoringSSL, Swift 5, macOS).xcscheme
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1220"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9F52B1CA263D3CA60025EB78"
+               BuildableName = "Test Themis (BoringSSL, Swift 5, macOS).xctest"
+               BlueprintName = "Test Themis (BoringSSL, Swift 5, macOS)"
+               ReferencedContainer = "container:Themis.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Now that Xcode knows how to build embedded BoringSSL, teach it to build Themis which uses this BoringSSL.

This adds two new targets:

- Themis (iOS) - BoringSSL
- Themis (macOS) - BoringSSL

which produce the same `themis.framework`, but linked against BoringSSL.

Note that these come *without* shared schemes. This is to prevent Carthage from building them and overwriting OpenSSL-based builds. The targets build the same framework—`themis.framework`—and Carthage is too stupid to put results into separate directories or something.

That is, right now this should not affect users in any way. Only the developers are able to build Themis with BoringSSL, and the main purpose of this PR is allow experimentation with BoringSSL-based builds. Strategy for BoringSSL support and transition are to be decided later: there are many options, each with their own tradeoffs. Right now we should focus on testing whether BoringSSL is a viable alternative at all.

That said, this PR does add some new testing targets which are exercised on GitHub Actions.

This PR builds on top of #743 and should be rebased and merged after that PR is merged.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] ~~Example projects and code samples are up-to-date~~ (it's not time)
- [X] ~~Changelog is updated~~ (not needed, IMO)
- [x] Rebased after #743 is merged

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md