### PR TITLE
Carthage XCF support and OpenSSL 1.1.1k

### DIFF
--- a/.github/workflows/test-objc.yaml
+++ b/.github/workflows/test-objc.yaml
@@ -126,13 +126,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Pull Carthage dependencies
         run: |
-
-          # Carthage versioning workaround:
-          # Themis requires Carthage version 0.38 and up to use XCF binary dependencies.
-          # Force upgrade is required until newer Carthage version is added to base images:
-          # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#package-management 
-          brew upgrade carthage
-
           carthage bootstrap --use-xcframeworks
           carthage build --no-skip-current --use-xcframeworks
       - name: Run unit tests (Swift 4, macOS)
@@ -186,13 +179,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Pull Carthage dependencies
         run: |
-
-          # Carthage versioning workaround:
-          # Themis requires Carthage version 0.38 and up to use XCF binary dependencies.
-          # Force upgrade is required until newer Carthage version is added to base images:
-          # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#package-management 
-          brew upgrade carthage
-
           carthage bootstrap --use-xcframeworks
       - name: Build Carthage projects
         run: |
@@ -276,13 +262,6 @@ jobs:
       - name: Build ObjCThemis for Generic Device (Carthage)
         if: always()
         run: |
-
-          # Carthage versioning workaround:
-          # Themis requires Carthage version 0.38 and up to use XCF binary dependencies.
-          # Force upgrade is required until newer Carthage version is added to base images:
-          # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#package-management 
-          brew upgrade carthage
-
           carthage bootstrap --platform iOS --use-xcframeworks
           rm -rf DerivedData
           xcodebuild \

--- a/.github/workflows/test-objc.yaml
+++ b/.github/workflows/test-objc.yaml
@@ -123,7 +123,15 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Pull Carthage dependencies
-        run: carthage bootstrap
+        run: |
+
+          # Carthage versioning workaround:
+          # Themis requires Carthage version 0.38 and up to use XCF binary dependencies.
+          # Force upgrade is required until newer Carthage version is added to base images:
+          # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#package-management 
+          brew upgrade carthage
+
+          carthage bootstrap
       - name: Run unit tests (Swift 4, macOS)
         if: always()
         run: |
@@ -172,22 +180,17 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Pull Carthage dependencies
-        run: carthage bootstrap
+        run: |
+
+          # Carthage versioning workaround:
+          # Themis requires Carthage version 0.38 and up to use XCF binary dependencies.
+          # Force upgrade is required until newer Carthage version is added to base images:
+          # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#package-management 
+          brew upgrade carthage
+
+          carthage bootstrap
       - name: Build Carthage projects - excluding arm64
         run: |
-          # ------ beginning of workaround
-          # from https://github.com/Carthage/Carthage/issues/3019#issuecomment-699143260
-          # supports Xcode 12.0.1
-          set -euo pipefail
-          xcconfig=$(mktemp /tmp/static.xcconfig.XXXXXX)
-          trap 'rm -f "$xcconfig"' INT TERM HUP EXIT
-          # For Xcode 12 make sure EXCLUDED_ARCHS is set to arm architectures otherwise
-          # the build will fail on lipo due to duplicate architectures.
-          echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
-          echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
-          export XCODE_XCCONFIG_FILE="$xcconfig"          
-          # ------ end of workaround
-
           carthage build --no-skip-current
 
   project-cocoapods:
@@ -266,6 +269,13 @@ jobs:
       - name: Build ObjCThemis for Generic Device (Carthage)
         if: always()
         run: |
+          
+          # Carthage versioning workaround:
+          # Themis requires Carthage version 0.38 and up to use XCF binary dependencies.
+          # Force upgrade is required until newer Carthage version is added to base images:
+          # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#package-management 
+          brew upgrade carthage
+
           carthage bootstrap --platform iOS
           rm -rf DerivedData
           xcodebuild \
@@ -297,22 +307,7 @@ jobs:
         if: always()
         run: |
           cd $GITHUB_WORKSPACE/docs/examples/objc/iOS-Carthage
-
-          # ------ beginning of workaround
-          # from https://github.com/Carthage/Carthage/issues/3019#issuecomment-699143260
-          # supports Xcode 12.0.1
-          set -euo pipefail
-          xcconfig=$(mktemp /tmp/static.xcconfig.XXXXXX)
-          trap 'rm -f "$xcconfig"' INT TERM HUP EXIT
-          # For Xcode 12 make sure EXCLUDED_ARCHS is set to arm architectures otherwise
-          # the build will fail on lipo due to duplicate architectures.
-          echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
-          echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
-          export XCODE_XCCONFIG_FILE="$xcconfig"          
-          # ------ end of workaround
-
           carthage bootstrap --platform iOS
-
           rm -rf DerivedData
           xcodebuild \
             -derivedDataPath DerivedData \
@@ -325,6 +320,7 @@ jobs:
         if: always()
         run: |
           cd $GITHUB_WORKSPACE/docs/examples/objc/macOS-Carthage
+          brew upgrade carthage
           carthage bootstrap --platform macOS
           rm -rf DerivedData
           xcodebuild \
@@ -352,20 +348,6 @@ jobs:
         if: always()
         run: |
           cd $GITHUB_WORKSPACE/docs/examples/swift/iOS-Carthage
-
-          # ------ beginning of workaround
-          # from https://github.com/Carthage/Carthage/issues/3019#issuecomment-699143260
-          # supports Xcode 12.0.1
-          set -euo pipefail
-          xcconfig=$(mktemp /tmp/static.xcconfig.XXXXXX)
-          trap 'rm -f "$xcconfig"' INT TERM HUP EXIT
-          # For Xcode 12 make sure EXCLUDED_ARCHS is set to arm architectures otherwise
-          # the build will fail on lipo due to duplicate architectures.
-          echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
-          echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
-          export XCODE_XCCONFIG_FILE="$xcconfig"          
-          # ------ end of workaround
-
           carthage bootstrap --platform iOS
           rm -rf DerivedData
           xcodebuild \

--- a/.github/workflows/test-objc.yaml
+++ b/.github/workflows/test-objc.yaml
@@ -131,7 +131,7 @@ jobs:
           # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#package-management 
           brew upgrade carthage
 
-          carthage bootstrap
+          carthage bootstrap --use-xcframeworks
       - name: Run unit tests (Swift 4, macOS)
         if: always()
         run: |
@@ -188,10 +188,10 @@ jobs:
           # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#package-management 
           brew upgrade carthage
 
-          carthage bootstrap
-      - name: Build Carthage projects - excluding arm64
+          carthage bootstrap --use-xcframeworks
+      - name: Build Carthage projects
         run: |
-          carthage build --no-skip-current
+          carthage build --no-skip-current --use-xcframeworks
 
   project-cocoapods:
     name: CocoaPods project
@@ -269,13 +269,6 @@ jobs:
       - name: Build ObjCThemis for Generic Device (Carthage)
         if: always()
         run: |
-          
-          # Carthage versioning workaround:
-          # Themis requires Carthage version 0.38 and up to use XCF binary dependencies.
-          # Force upgrade is required until newer Carthage version is added to base images:
-          # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#package-management 
-          brew upgrade carthage
-
           carthage bootstrap --platform iOS
           rm -rf DerivedData
           xcodebuild \
@@ -307,6 +300,21 @@ jobs:
         if: always()
         run: |
           cd $GITHUB_WORKSPACE/docs/examples/objc/iOS-Carthage
+
+          # ------ beginning of workaround
+          # This workaround lives here until we update example projects
+          # from https://github.com/Carthage/Carthage/issues/3019#issuecomment-699143260
+          # supports Xcode 12.0.1
+          set -euo pipefail
+          xcconfig=$(mktemp /tmp/static.xcconfig.XXXXXX)
+          trap 'rm -f "$xcconfig"' INT TERM HUP EXIT
+          # For Xcode 12 make sure EXCLUDED_ARCHS is set to arm architectures otherwise
+          # the build will fail on lipo due to duplicate architectures.
+          echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
+          echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
+          export XCODE_XCCONFIG_FILE="$xcconfig"          
+          # ------ end of workaround
+
           carthage bootstrap --platform iOS
           rm -rf DerivedData
           xcodebuild \
@@ -320,7 +328,6 @@ jobs:
         if: always()
         run: |
           cd $GITHUB_WORKSPACE/docs/examples/objc/macOS-Carthage
-          brew upgrade carthage
           carthage bootstrap --platform macOS
           rm -rf DerivedData
           xcodebuild \
@@ -348,6 +355,21 @@ jobs:
         if: always()
         run: |
           cd $GITHUB_WORKSPACE/docs/examples/swift/iOS-Carthage
+
+          # ------ beginning of workaround
+          # This workaround lives here until we update example projects
+          # from https://github.com/Carthage/Carthage/issues/3019#issuecomment-699143260
+          # supports Xcode 12.0.1
+          set -euo pipefail
+          xcconfig=$(mktemp /tmp/static.xcconfig.XXXXXX)
+          trap 'rm -f "$xcconfig"' INT TERM HUP EXIT
+          # For Xcode 12 make sure EXCLUDED_ARCHS is set to arm architectures otherwise
+          # the build will fail on lipo due to duplicate architectures.
+          echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
+          echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
+          export XCODE_XCCONFIG_FILE="$xcconfig"          
+          # ------ end of workaround
+
           carthage bootstrap --platform iOS
           rm -rf DerivedData
           xcodebuild \

--- a/.github/workflows/test-objc.yaml
+++ b/.github/workflows/test-objc.yaml
@@ -127,6 +127,8 @@ jobs:
       - name: Pull Carthage dependencies
         run: |
           carthage bootstrap --use-xcframeworks
+      - name: Build Carthage projects
+        run: |
           carthage build --no-skip-current --use-xcframeworks
       - name: Run unit tests (Swift 4, macOS)
         if: always()

--- a/.github/workflows/test-objc.yaml
+++ b/.github/workflows/test-objc.yaml
@@ -119,6 +119,8 @@ jobs:
   unit-tests-carthage:
     name: Unit tests (Carthage)
     runs-on: macos-latest
+    env:
+      GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -177,6 +179,8 @@ jobs:
   project-carthage:
     name: Carthage project
     runs-on: macos-latest
+    env:
+      GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -240,6 +244,8 @@ jobs:
   examples:
     name: Code examples
     runs-on: macos-latest
+    env:
+      GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/test-objc.yaml
+++ b/.github/workflows/test-objc.yaml
@@ -132,6 +132,7 @@ jobs:
           brew upgrade carthage
 
           carthage bootstrap --use-xcframeworks
+          carthage build --no-skip-current --use-xcframeworks
       - name: Run unit tests (Swift 4, macOS)
         if: always()
         run: |
@@ -269,7 +270,14 @@ jobs:
       - name: Build ObjCThemis for Generic Device (Carthage)
         if: always()
         run: |
-          carthage bootstrap --platform iOS
+
+          # Carthage versioning workaround:
+          # Themis requires Carthage version 0.38 and up to use XCF binary dependencies.
+          # Force upgrade is required until newer Carthage version is added to base images:
+          # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#package-management 
+          brew upgrade carthage
+
+          carthage bootstrap --platform iOS --use-xcframeworks
           rm -rf DerivedData
           xcodebuild \
             -derivedDataPath DerivedData \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 Changes that are currently in development and have not been released yet.
 
+## [0.13.9](https://github.com/cossacklabs/themis/releases/tag/0.13.8), May 11th 2021
+
+**Hotfix for Apple platforms:**
+
+- `themis` for Carthage switched to using xcframeworks
+- Updated OpenSSL to the latest 1.1.1k for Carthage
+
+_Code:_
+
+- **Objective-C / Swift**
+
+  - `themis` for Carthage now loads OpenSSL as xcframework, and Carthege builds `themis` as scframework as well.
+  - Updated OpenSSL to the latest 1.1.1k for Carthage
+  - `create_xcframeworks.sh` script (used for SPM) no longer requires `Themis.xcodeproj` modifications because OpenSSL is now added as xcframework.
+
 ## [0.13.8](https://github.com/cossacklabs/themis/releases/tag/0.13.8), April 30th 2021
 
 **Hotfix for Apple platforms:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Changes that are currently in development and have not been released yet.
 
 **Hotfix for Apple platforms:**
 
-- `themis` for Carthage switched to using XCFrameworks ([#817](https://github.com/cossacklabs/themis/pull/817)). So, the minimum required Carthage version is now [0.38.0](https://github.com/Carthage/Carthage/releases/tag/0.38.0).
+- `themis` for Carthage switched to using XCFrameworks ([#817](https://github.com/cossacklabs/themis/pull/817)). So, the minimum required Carthage version is now [0.38.0](https://github.com/Carthage/Carthage/releases/tag/0.38.0). You can continue using previous Themis version with previous Carthage versions.
 - Updated OpenSSL to the latest 1.1.1k for Carthage ([#817](https://github.com/cossacklabs/themis/pull/817)).
 
 _Code:_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,48 +4,48 @@
 
 Changes that are currently in development and have not been released yet.
 
-## [0.13.9](https://github.com/cossacklabs/themis/releases/tag/0.13.8), May 11th 2021
+## [0.13.9](https://github.com/cossacklabs/themis/releases/tag/0.13.9), May 14th 2021
 
 **Hotfix for Apple platforms:**
 
-- `themis` for Carthage switched to using xcframeworks
-- Updated OpenSSL to the latest 1.1.1k for Carthage
+- `themis` for Carthage switched to using XCFrameworks ([#817](https://github.com/cossacklabs/themis/pull/817)). So, the minimum required Carthage version is now [0.38.0](https://github.com/Carthage/Carthage/releases/tag/0.38.0).
+- Updated OpenSSL to the latest 1.1.1k for Carthage ([#817](https://github.com/cossacklabs/themis/pull/817)).
 
 _Code:_
 
 - **Objective-C / Swift**
 
-  - `themis` for Carthage now loads OpenSSL as xcframework, and Carthege builds `themis` as scframework as well.
-  - Updated OpenSSL to the latest 1.1.1k for Carthage
-  - `create_xcframeworks.sh` script (used for SPM) no longer requires `Themis.xcodeproj` modifications because OpenSSL is now added as xcframework.
+  - `themis` for Carthage now pulls OpenSSL dependency as XCFramework, and Carthage builds `themis` as XCFramework as well. `Themis.xcodeproj` now uses `openssl.xcframwork` and `themis.xcframework`. Carthage dependencies should be built with `--use-xcframeworks` flag ([#817](https://github.com/cossacklabs/themis/pull/817)).
+  - Updated OpenSSL to the latest 1.1.1k for Carthage ([#817](https://github.com/cossacklabs/themis/pull/817)).
+  - Tests (Github Actions) are updated to use the latest Carthage version (0.38.0 and up) and `--use-xcframeworks` flag ([#817](https://github.com/cossacklabs/themis/pull/817)).
 
 ## [0.13.8](https://github.com/cossacklabs/themis/releases/tag/0.13.8), April 30th 2021
 
 **Hotfix for Apple platforms:**
 
-- Updated OpenSSL to the latest 1.1.1k for SMP and attached `themis.xcframework`. (iOS and macOS).
-- New Swift and Objective-C example projects: SPM for iOS and macOS.
+- Updated OpenSSL to the latest 1.1.1k for SMP and attached `themis.xcframework` (iOS and macOS) ([#808](https://github.com/cossacklabs/themis/pull/808)).
+- New Swift and Objective-C example projects: SPM for iOS and macOS ([#808](https://github.com/cossacklabs/themis/pull/808)).
 
 _Code:_
 
 - **Objective-C / Swift**
 
-  - Updated OpenSSL to the latest 1.1.1k for SMP and attached `themis.xcframework`. It is `openssl-apple` version 1.1.11101.
-  - New Swift and Objective-C example projects: SPM for iOS and macOS.
-  - Updated SPM examples source code to remove deprecated calls.
+  - Updated OpenSSL to the latest 1.1.1k for SMP and attached `themis.xcframework`. It is `openssl-apple` version 1.1.11101 ([#808](https://github.com/cossacklabs/themis/pull/808)).
+  - New Swift and Objective-C example projects: SPM for iOS and macOS ([#808](https://github.com/cossacklabs/themis/pull/808)).
+  - Updated SPM examples source code to remove deprecated calls ([#808](https://github.com/cossacklabs/themis/pull/808)).
 
 ## [0.13.7](https://github.com/cossacklabs/themis/releases/tag/0.13.7), April 28th 2021
 
 **Hotfix for Apple platforms:**
 
-- `themis` is now packaged as xcframework. It is available in the release attached files section.
-- `themis` now supports SPM, its installation and usage are very straightforward, just add `themis` as SPM dependency.
+- `themis` is now packaged as XCFramework ([#789](https://github.com/cossacklabs/themis/pull/789)). It is available in the release attached files section.
+- `themis` now supports SPM ([#789](https://github.com/cossacklabs/themis/pull/789)), its installation and usage are very straightforward, just add `themis` as SPM dependency.
 
 _Code:_
 
 - **Objective-C / Swift**
 
-  - Added script to generate xcframework for iOS, iOS Simulator and macOS ([#789](https://github.com/cossacklabs/themis/pull/789)).
+  - Added script to generate XCFramework for iOS, iOS Simulator and macOS ([#789](https://github.com/cossacklabs/themis/pull/789)).
   - Added Package.swift file for SPM ([#789](https://github.com/cossacklabs/themis/pull/789)).
 
 ## [0.13.6](https://github.com/cossacklabs/themis/releases/tag/0.13.6), November 23rd 2020

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,2 @@
-# OpenSSL 1.1.1h
-binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-iPhone.json" == 1.1.10802
-binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-MacOSX.json" == 1.1.10802
+# OpenSSL 1.1.1k
+binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-xcframework.json" == 1.1.11101

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,1 @@
-binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-MacOSX.json" "1.1.10802"
-binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-iPhone.json" "1.1.10802"
+binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-xcframework.json" "1.1.11101"

--- a/Package.swift
+++ b/Package.swift
@@ -15,11 +15,11 @@ let package = Package(
     targets: [
         .binaryTarget(name: "themis",
                       // update version in URL path
-                      url: "https://github.com/cossacklabs/themis/releases/download/0.13.8/themis.xcframework.zip",
+                      url: "https://github.com/cossacklabs/themis/releases/download/0.13.9/themis.xcframework.zip",
                       // The scripts/create_xcframework.sh calculates the checksum when generating the XCF.
                       // Alternatively, run from package directory:
                       // swift package compute-checksum build/xcf_output/themis.xcframework.zip
-                      checksum: "afda7b2ab0ca86a73f55d309289283e648cd958b5cd9f16dc89d7157317b2165"),
+                      checksum: "5e1e3bb83cf18465e3705dd333fd94510c5a8464680d43025331efa8c999df23"),
 
     ]
 )

--- a/Themis.xcodeproj/project.pbxproj
+++ b/Themis.xcodeproj/project.pbxproj
@@ -17,6 +17,14 @@
 		6DB874A026497C350022A1F6 /* openssl.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6DB8748926497B8B0022A1F6 /* openssl.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6DB874A326497C390022A1F6 /* openssl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DB8748926497B8B0022A1F6 /* openssl.xcframework */; };
 		6DB874A626497C3E0022A1F6 /* openssl.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6DB8748926497B8B0022A1F6 /* openssl.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6DCCB1D6264D3223008072EF /* themis.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DCCB1D5264D3223008072EF /* themis.xcframework */; };
+		6DCCB1D9264D3233008072EF /* themis.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6DCCB1D5264D3223008072EF /* themis.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6DCCB1DC264D3246008072EF /* themis.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DCCB1D5264D3223008072EF /* themis.xcframework */; };
+		6DCCB1DF264D324C008072EF /* themis.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6DCCB1D5264D3223008072EF /* themis.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6DCCB1E2264D325A008072EF /* themis.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DCCB1D5264D3223008072EF /* themis.xcframework */; };
+		6DCCB1E5264D3261008072EF /* themis.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6DCCB1D5264D3223008072EF /* themis.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6DCCB1E8264D3269008072EF /* themis.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DCCB1D5264D3223008072EF /* themis.xcframework */; };
+		6DCCB1EB264D3270008072EF /* themis.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6DCCB1D5264D3223008072EF /* themis.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F00E8E2223C1A3300EC1EF3 /* objcthemis.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A24B5223A8FA8005CB63A /* objcthemis.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9F00E8E3223C1A3300EC1EF3 /* scell_context_imprint.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A24B9223A8FA8005CB63A /* scell_context_imprint.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9F00E8E4223C1A3300EC1EF3 /* scell_seal.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A24BC223A8FA8005CB63A /* scell_seal.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -209,7 +217,6 @@
 		9F4A2622223ABEF2005CB63A /* sym_enc_message.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2431223A74AF005CB63A /* sym_enc_message.c */; };
 		9F6B385523D9D11600EA5D1B /* secure_cell_seal_passphrase.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F6B385423D9D11600EA5D1B /* secure_cell_seal_passphrase.c */; };
 		9F6B385623D9D11600EA5D1B /* secure_cell_seal_passphrase.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F6B385423D9D11600EA5D1B /* secure_cell_seal_passphrase.c */; };
-		9F70B2C1241D0FEC009CB629 /* themis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E8D7223C197900EC1EF3 /* themis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F70B2D0241D1043009CB629 /* SecureComparatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2C7241D1042009CB629 /* SecureComparatorTests.m */; };
 		9F70B2D1241D1043009CB629 /* SecureCellTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2C8241D1042009CB629 /* SecureCellTests.m */; };
 		9F70B2D2241D1043009CB629 /* SecureComparatorTestsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CA241D1042009CB629 /* SecureComparatorTestsSwift.swift */; };
@@ -218,8 +225,6 @@
 		9F70B2D6241D1043009CB629 /* SecureCellTestsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CF241D1043009CB629 /* SecureCellTestsSwift.swift */; };
 		9F70B2D8241D1064009CB629 /* objthemis-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F70B2C9241D1042009CB629 /* objthemis-Bridging-Header.h */; };
 		9F70B2D9241D1065009CB629 /* StaticKeys.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F70B2CC241D1043009CB629 /* StaticKeys.h */; };
-		9F70B2E1241D1753009CB629 /* themis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E8D7223C197900EC1EF3 /* themis.framework */; };
-		9F70B2EC241D17A3009CB629 /* themis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F4A24A1223A8D7F005CB63A /* themis.framework */; };
 		9F70B2F3241D17BF009CB629 /* objthemis-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F70B2C9241D1042009CB629 /* objthemis-Bridging-Header.h */; };
 		9F70B2F4241D17C2009CB629 /* StaticKeys.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F70B2CC241D1043009CB629 /* StaticKeys.h */; };
 		9F70B2F5241D17CB009CB629 /* SecureCellTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2C8241D1042009CB629 /* SecureCellTests.m */; };
@@ -228,7 +233,6 @@
 		9F70B2F8241D17D0009CB629 /* SecureComparatorTestsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CA241D1042009CB629 /* SecureComparatorTestsSwift.swift */; };
 		9F70B2F9241D17D1009CB629 /* SecureMessageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CE241D1043009CB629 /* SecureMessageTests.m */; };
 		9F70B2FA241D17D3009CB629 /* SecureMessageTestsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CB241D1042009CB629 /* SecureMessageTestsSwift.swift */; };
-		9F70B2FD241D17F0009CB629 /* themis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F4A24A1223A8D7F005CB63A /* themis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F70B3072420E16E009CB629 /* objthemis-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F70B2C9241D1042009CB629 /* objthemis-Bridging-Header.h */; };
 		9F70B3082420E16E009CB629 /* StaticKeys.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F70B2CC241D1043009CB629 /* StaticKeys.h */; };
 		9F70B30A2420E16E009CB629 /* SecureComparatorTestsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CA241D1042009CB629 /* SecureComparatorTestsSwift.swift */; };
@@ -237,8 +241,6 @@
 		9F70B30D2420E16E009CB629 /* SecureMessageTestsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CB241D1042009CB629 /* SecureMessageTestsSwift.swift */; };
 		9F70B30E2420E16E009CB629 /* SecureMessageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CE241D1043009CB629 /* SecureMessageTests.m */; };
 		9F70B30F2420E16E009CB629 /* SecureCellTestsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CF241D1043009CB629 /* SecureCellTestsSwift.swift */; };
-		9F70B3112420E16E009CB629 /* themis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F4A24A1223A8D7F005CB63A /* themis.framework */; };
-		9F70B3142420E16E009CB629 /* themis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F4A24A1223A8D7F005CB63A /* themis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F70B31F2420E176009CB629 /* objthemis-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F70B2C9241D1042009CB629 /* objthemis-Bridging-Header.h */; };
 		9F70B3202420E176009CB629 /* StaticKeys.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F70B2CC241D1043009CB629 /* StaticKeys.h */; };
 		9F70B3222420E176009CB629 /* SecureCellTestsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CF241D1043009CB629 /* SecureCellTestsSwift.swift */; };
@@ -247,8 +249,6 @@
 		9F70B3252420E176009CB629 /* SecureComparatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2C7241D1042009CB629 /* SecureComparatorTests.m */; };
 		9F70B3262420E176009CB629 /* SecureComparatorTestsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CA241D1042009CB629 /* SecureComparatorTestsSwift.swift */; };
 		9F70B3272420E176009CB629 /* SecureMessageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CE241D1043009CB629 /* SecureMessageTests.m */; };
-		9F70B32A2420E176009CB629 /* themis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E8D7223C197900EC1EF3 /* themis.framework */; };
-		9F70B32C2420E176009CB629 /* themis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E8D7223C197900EC1EF3 /* themis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F874AB322CCB0D100E8DECA /* soter_ec_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F874AB122CCB0D100E8DECA /* soter_ec_key.c */; };
 		9F874AB422CCB0D100E8DECA /* soter_ec_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F874AB122CCB0D100E8DECA /* soter_ec_key.c */; };
 		9F874AB522CCB0D100E8DECA /* soter_rsa_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F874AB222CCB0D100E8DECA /* soter_rsa_key.c */; };
@@ -295,8 +295,8 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				6DCCB1EB264D3270008072EF /* themis.xcframework in Embed Frameworks */,
 				6DB874A626497C3E0022A1F6 /* openssl.xcframework in Embed Frameworks */,
-				9F70B2C1241D0FEC009CB629 /* themis.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -307,8 +307,8 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				6DCCB1E5264D3261008072EF /* themis.xcframework in Embed Frameworks */,
 				6DB874A026497C350022A1F6 /* openssl.xcframework in Embed Frameworks */,
-				9F70B2FD241D17F0009CB629 /* themis.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -319,8 +319,8 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				6DCCB1D9264D3233008072EF /* themis.xcframework in Embed Frameworks */,
 				6DB8749426497C1E0022A1F6 /* openssl.xcframework in Embed Frameworks */,
-				9F70B3142420E16E009CB629 /* themis.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -331,8 +331,8 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				6DCCB1DF264D324C008072EF /* themis.xcframework in Embed Frameworks */,
 				6DB8749A26497C2B0022A1F6 /* openssl.xcframework in Embed Frameworks */,
-				9F70B32C2420E176009CB629 /* themis.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -341,8 +341,8 @@
 
 /* Begin PBXFileReference section */
 		6DB8748926497B8B0022A1F6 /* openssl.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = openssl.xcframework; path = Carthage/Build/openssl.xcframework; sourceTree = "<group>"; };
+		6DCCB1D5264D3223008072EF /* themis.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = themis.xcframework; path = Carthage/Build/themis.xcframework; sourceTree = "<group>"; };
 		9F00E8D7223C197900EC1EF3 /* themis.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = themis.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		9F00E940223C1AFA00EC1EF3 /* openssl.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = openssl.framework; path = Carthage/Build/Mac/openssl.framework; sourceTree = "<group>"; };
 		9F0BBCE824E6FC810073CA52 /* themis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = themis.h; path = "src/wrappers/themis/Obj-C/Themis/themis.h"; sourceTree = "<group>"; };
 		9F33485723B38D9B00368291 /* soter_kdf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = soter_kdf.c; path = src/soter/openssl/soter_kdf.c; sourceTree = "<group>"; };
 		9F34EA3023D9CA0A0079A1D7 /* secure_cell_seal_passphrase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = secure_cell_seal_passphrase.h; path = src/themis/secure_cell_seal_passphrase.h; sourceTree = "<group>"; };
@@ -514,7 +514,6 @@
 		9F98F32722CCEB0E008E14E6 /* soter_wipe.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = soter_wipe.c; path = src/soter/openssl/soter_wipe.c; sourceTree = "<group>"; };
 		9FB1BC9A233BEC9900930861 /* themis_portable_endian.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = themis_portable_endian.h; path = src/themis/themis_portable_endian.h; sourceTree = "<group>"; };
 		9FB1BC9D233BECB900930861 /* soter_portable_endian.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = soter_portable_endian.h; path = src/soter/soter_portable_endian.h; sourceTree = "<group>"; };
-		9FBD853C223BFB5E009EAEB3 /* openssl.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = openssl.framework; path = Carthage/Build/iOS/openssl.framework; sourceTree = "<group>"; };
 		9FD4C3522260D41700132A88 /* soter_api.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = soter_api.h; path = src/soter/soter_api.h; sourceTree = "<group>"; };
 		9FD4C3532260D43B00132A88 /* themis_api.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = themis_api.h; path = src/themis/themis_api.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -540,8 +539,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6DCCB1E8264D3269008072EF /* themis.xcframework in Frameworks */,
 				6DB874A326497C390022A1F6 /* openssl.xcframework in Frameworks */,
-				9F70B2E1241D1753009CB629 /* themis.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -549,8 +548,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6DCCB1E2264D325A008072EF /* themis.xcframework in Frameworks */,
 				6DB8749D26497C300022A1F6 /* openssl.xcframework in Frameworks */,
-				9F70B2EC241D17A3009CB629 /* themis.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -559,7 +558,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6DB8749326497BEF0022A1F6 /* openssl.xcframework in Frameworks */,
-				9F70B3112420E16E009CB629 /* themis.framework in Frameworks */,
+				6DCCB1D6264D3223008072EF /* themis.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -567,8 +566,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6DCCB1DC264D3246008072EF /* themis.xcframework in Frameworks */,
 				6DB8749726497C240022A1F6 /* openssl.xcframework in Frameworks */,
-				9F70B32A2420E176009CB629 /* themis.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -768,9 +767,8 @@
 		9F4A2476223A885F005CB63A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				6DCCB1D5264D3223008072EF /* themis.xcframework */,
 				6DB8748926497B8B0022A1F6 /* openssl.xcframework */,
-				9F70B2DC241D16A9009CB629 /* iOS */,
-				9F70B2DB241D16A2009CB629 /* macOS */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -828,22 +826,6 @@
 				9F70B2CD241D1043009CB629 /* Info.plist */,
 			);
 			name = Tests;
-			sourceTree = "<group>";
-		};
-		9F70B2DB241D16A2009CB629 /* macOS */ = {
-			isa = PBXGroup;
-			children = (
-				9F00E940223C1AFA00EC1EF3 /* openssl.framework */,
-			);
-			name = macOS;
-			sourceTree = "<group>";
-		};
-		9F70B2DC241D16A9009CB629 /* iOS */ = {
-			isa = PBXGroup;
-			children = (
-				9FBD853C223BFB5E009EAEB3 /* openssl.framework */,
-			);
-			name = iOS;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */

--- a/Themis.xcodeproj/project.pbxproj
+++ b/Themis.xcodeproj/project.pbxproj
@@ -1466,7 +1466,7 @@
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 9;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1492,7 +1492,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.13.8;
+				MARKETING_VERSION = 0.13.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis;
 				PRODUCT_MODULE_NAME = themis;
 				PRODUCT_NAME = themis;
@@ -1508,7 +1508,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 9;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1534,7 +1534,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.13.8;
+				MARKETING_VERSION = 0.13.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis;
 				PRODUCT_MODULE_NAME = themis;
 				PRODUCT_NAME = themis;
@@ -1549,7 +1549,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 9;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				DEVELOPMENT_TEAM = "";
@@ -1578,7 +1578,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.13.8;
+				MARKETING_VERSION = 0.13.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis;
 				PRODUCT_MODULE_NAME = themis;
 				PRODUCT_NAME = themis;
@@ -1598,7 +1598,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 9;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				DEVELOPMENT_TEAM = "";
@@ -1627,7 +1627,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.13.8;
+				MARKETING_VERSION = 0.13.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis;
 				PRODUCT_MODULE_NAME = themis;
 				PRODUCT_NAME = themis;

--- a/Themis.xcodeproj/project.pbxproj
+++ b/Themis.xcodeproj/project.pbxproj
@@ -3,10 +3,20 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6DB8748A26497B8C0022A1F6 /* openssl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DB8748926497B8B0022A1F6 /* openssl.xcframework */; };
+		6DB8748E26497B950022A1F6 /* openssl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DB8748926497B8B0022A1F6 /* openssl.xcframework */; };
+		6DB8749326497BEF0022A1F6 /* openssl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DB8748926497B8B0022A1F6 /* openssl.xcframework */; };
+		6DB8749426497C1E0022A1F6 /* openssl.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6DB8748926497B8B0022A1F6 /* openssl.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6DB8749726497C240022A1F6 /* openssl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DB8748926497B8B0022A1F6 /* openssl.xcframework */; };
+		6DB8749A26497C2B0022A1F6 /* openssl.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6DB8748926497B8B0022A1F6 /* openssl.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6DB8749D26497C300022A1F6 /* openssl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DB8748926497B8B0022A1F6 /* openssl.xcframework */; };
+		6DB874A026497C350022A1F6 /* openssl.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6DB8748926497B8B0022A1F6 /* openssl.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6DB874A326497C390022A1F6 /* openssl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DB8748926497B8B0022A1F6 /* openssl.xcframework */; };
+		6DB874A626497C3E0022A1F6 /* openssl.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6DB8748926497B8B0022A1F6 /* openssl.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F00E8E2223C1A3300EC1EF3 /* objcthemis.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A24B5223A8FA8005CB63A /* objcthemis.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9F00E8E3223C1A3300EC1EF3 /* scell_context_imprint.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A24B9223A8FA8005CB63A /* scell_context_imprint.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9F00E8E4223C1A3300EC1EF3 /* scell_seal.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4A24BC223A8FA8005CB63A /* scell_seal.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -100,7 +110,6 @@
 		9F00E93D223C1AE600EC1EF3 /* secure_session_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A242E223A74AF005CB63A /* secure_session_utils.c */; };
 		9F00E93E223C1AE600EC1EF3 /* secure_session.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2438223A74AF005CB63A /* secure_session.c */; };
 		9F00E93F223C1AE600EC1EF3 /* sym_enc_message.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A2431223A74AF005CB63A /* sym_enc_message.c */; };
-		9F00E941223C1AFA00EC1EF3 /* openssl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E940223C1AFA00EC1EF3 /* openssl.framework */; };
 		9F0BBCE924E6FC820073CA52 /* themis.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F0BBCE824E6FC810073CA52 /* themis.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9F0BBCEA24E6FC820073CA52 /* themis.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F0BBCE824E6FC810073CA52 /* themis.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9F33485823B38D9B00368291 /* soter_kdf.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F33485723B38D9B00368291 /* soter_kdf.c */; };
@@ -209,9 +218,7 @@
 		9F70B2D6241D1043009CB629 /* SecureCellTestsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CF241D1043009CB629 /* SecureCellTestsSwift.swift */; };
 		9F70B2D8241D1064009CB629 /* objthemis-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F70B2C9241D1042009CB629 /* objthemis-Bridging-Header.h */; };
 		9F70B2D9241D1065009CB629 /* StaticKeys.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F70B2CC241D1043009CB629 /* StaticKeys.h */; };
-		9F70B2DD241D16B4009CB629 /* openssl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E940223C1AFA00EC1EF3 /* openssl.framework */; };
 		9F70B2E1241D1753009CB629 /* themis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E8D7223C197900EC1EF3 /* themis.framework */; };
-		9F70B2E2241D175E009CB629 /* openssl.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E940223C1AFA00EC1EF3 /* openssl.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F70B2EC241D17A3009CB629 /* themis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F4A24A1223A8D7F005CB63A /* themis.framework */; };
 		9F70B2F3241D17BF009CB629 /* objthemis-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F70B2C9241D1042009CB629 /* objthemis-Bridging-Header.h */; };
 		9F70B2F4241D17C2009CB629 /* StaticKeys.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F70B2CC241D1043009CB629 /* StaticKeys.h */; };
@@ -221,9 +228,7 @@
 		9F70B2F8241D17D0009CB629 /* SecureComparatorTestsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CA241D1042009CB629 /* SecureComparatorTestsSwift.swift */; };
 		9F70B2F9241D17D1009CB629 /* SecureMessageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CE241D1043009CB629 /* SecureMessageTests.m */; };
 		9F70B2FA241D17D3009CB629 /* SecureMessageTestsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CB241D1042009CB629 /* SecureMessageTestsSwift.swift */; };
-		9F70B2FB241D17D8009CB629 /* openssl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FBD853C223BFB5E009EAEB3 /* openssl.framework */; };
 		9F70B2FD241D17F0009CB629 /* themis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F4A24A1223A8D7F005CB63A /* themis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		9F70B2FE241D17F2009CB629 /* openssl.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9FBD853C223BFB5E009EAEB3 /* openssl.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F70B3072420E16E009CB629 /* objthemis-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F70B2C9241D1042009CB629 /* objthemis-Bridging-Header.h */; };
 		9F70B3082420E16E009CB629 /* StaticKeys.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F70B2CC241D1043009CB629 /* StaticKeys.h */; };
 		9F70B30A2420E16E009CB629 /* SecureComparatorTestsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CA241D1042009CB629 /* SecureComparatorTestsSwift.swift */; };
@@ -233,9 +238,7 @@
 		9F70B30E2420E16E009CB629 /* SecureMessageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CE241D1043009CB629 /* SecureMessageTests.m */; };
 		9F70B30F2420E16E009CB629 /* SecureCellTestsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CF241D1043009CB629 /* SecureCellTestsSwift.swift */; };
 		9F70B3112420E16E009CB629 /* themis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F4A24A1223A8D7F005CB63A /* themis.framework */; };
-		9F70B3122420E16E009CB629 /* openssl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FBD853C223BFB5E009EAEB3 /* openssl.framework */; };
 		9F70B3142420E16E009CB629 /* themis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F4A24A1223A8D7F005CB63A /* themis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		9F70B3152420E16E009CB629 /* openssl.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9FBD853C223BFB5E009EAEB3 /* openssl.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F70B31F2420E176009CB629 /* objthemis-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F70B2C9241D1042009CB629 /* objthemis-Bridging-Header.h */; };
 		9F70B3202420E176009CB629 /* StaticKeys.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F70B2CC241D1043009CB629 /* StaticKeys.h */; };
 		9F70B3222420E176009CB629 /* SecureCellTestsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CF241D1043009CB629 /* SecureCellTestsSwift.swift */; };
@@ -244,17 +247,14 @@
 		9F70B3252420E176009CB629 /* SecureComparatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2C7241D1042009CB629 /* SecureComparatorTests.m */; };
 		9F70B3262420E176009CB629 /* SecureComparatorTestsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CA241D1042009CB629 /* SecureComparatorTestsSwift.swift */; };
 		9F70B3272420E176009CB629 /* SecureMessageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B2CE241D1043009CB629 /* SecureMessageTests.m */; };
-		9F70B3292420E176009CB629 /* openssl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E940223C1AFA00EC1EF3 /* openssl.framework */; };
 		9F70B32A2420E176009CB629 /* themis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E8D7223C197900EC1EF3 /* themis.framework */; };
 		9F70B32C2420E176009CB629 /* themis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E8D7223C197900EC1EF3 /* themis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		9F70B32D2420E176009CB629 /* openssl.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F00E940223C1AFA00EC1EF3 /* openssl.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F874AB322CCB0D100E8DECA /* soter_ec_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F874AB122CCB0D100E8DECA /* soter_ec_key.c */; };
 		9F874AB422CCB0D100E8DECA /* soter_ec_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F874AB122CCB0D100E8DECA /* soter_ec_key.c */; };
 		9F874AB522CCB0D100E8DECA /* soter_rsa_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F874AB222CCB0D100E8DECA /* soter_rsa_key.c */; };
 		9F874AB622CCB0D100E8DECA /* soter_rsa_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F874AB222CCB0D100E8DECA /* soter_rsa_key.c */; };
 		9F98F32822CCEB0E008E14E6 /* soter_wipe.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F98F32722CCEB0E008E14E6 /* soter_wipe.c */; };
 		9F98F32922CCEB0E008E14E6 /* soter_wipe.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F98F32722CCEB0E008E14E6 /* soter_wipe.c */; };
-		9FBD853D223BFB5E009EAEB3 /* openssl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FBD853C223BFB5E009EAEB3 /* openssl.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -295,8 +295,8 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				6DB874A626497C3E0022A1F6 /* openssl.xcframework in Embed Frameworks */,
 				9F70B2C1241D0FEC009CB629 /* themis.framework in Embed Frameworks */,
-				9F70B2E2241D175E009CB629 /* openssl.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -307,8 +307,8 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				6DB874A026497C350022A1F6 /* openssl.xcframework in Embed Frameworks */,
 				9F70B2FD241D17F0009CB629 /* themis.framework in Embed Frameworks */,
-				9F70B2FE241D17F2009CB629 /* openssl.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -319,8 +319,8 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				6DB8749426497C1E0022A1F6 /* openssl.xcframework in Embed Frameworks */,
 				9F70B3142420E16E009CB629 /* themis.framework in Embed Frameworks */,
-				9F70B3152420E16E009CB629 /* openssl.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -331,8 +331,8 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				6DB8749A26497C2B0022A1F6 /* openssl.xcframework in Embed Frameworks */,
 				9F70B32C2420E176009CB629 /* themis.framework in Embed Frameworks */,
-				9F70B32D2420E176009CB629 /* openssl.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -340,6 +340,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		6DB8748926497B8B0022A1F6 /* openssl.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = openssl.xcframework; path = Carthage/Build/openssl.xcframework; sourceTree = "<group>"; };
 		9F00E8D7223C197900EC1EF3 /* themis.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = themis.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9F00E940223C1AFA00EC1EF3 /* openssl.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = openssl.framework; path = Carthage/Build/Mac/openssl.framework; sourceTree = "<group>"; };
 		9F0BBCE824E6FC810073CA52 /* themis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = themis.h; path = "src/wrappers/themis/Obj-C/Themis/themis.h"; sourceTree = "<group>"; };
@@ -523,7 +524,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9F00E941223C1AFA00EC1EF3 /* openssl.framework in Frameworks */,
+				6DB8748E26497B950022A1F6 /* openssl.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -531,7 +532,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9FBD853D223BFB5E009EAEB3 /* openssl.framework in Frameworks */,
+				6DB8748A26497B8C0022A1F6 /* openssl.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -539,7 +540,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9F70B2DD241D16B4009CB629 /* openssl.framework in Frameworks */,
+				6DB874A326497C390022A1F6 /* openssl.xcframework in Frameworks */,
 				9F70B2E1241D1753009CB629 /* themis.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -548,8 +549,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6DB8749D26497C300022A1F6 /* openssl.xcframework in Frameworks */,
 				9F70B2EC241D17A3009CB629 /* themis.framework in Frameworks */,
-				9F70B2FB241D17D8009CB629 /* openssl.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -557,8 +558,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6DB8749326497BEF0022A1F6 /* openssl.xcframework in Frameworks */,
 				9F70B3112420E16E009CB629 /* themis.framework in Frameworks */,
-				9F70B3122420E16E009CB629 /* openssl.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -566,7 +567,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9F70B3292420E176009CB629 /* openssl.framework in Frameworks */,
+				6DB8749726497C240022A1F6 /* openssl.xcframework in Frameworks */,
 				9F70B32A2420E176009CB629 /* themis.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -767,6 +768,7 @@
 		9F4A2476223A885F005CB63A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				6DB8748926497B8B0022A1F6 /* openssl.xcframework */,
 				9F70B2DC241D16A9009CB629 /* iOS */,
 				9F70B2DB241D16A2009CB629 /* macOS */,
 			);
@@ -1491,7 +1493,7 @@
 				EXPORTED_SYMBOLS_FILE = "$(PROJECT_DIR)/src/wrappers/themis/Obj-C/exported.symbols";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
+					"$(PROJECT_DIR)/Carthage/Build",
 				);
 				FRAMEWORK_VERSION = A;
 				GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = YES;
@@ -1533,7 +1535,7 @@
 				EXPORTED_SYMBOLS_FILE = "$(PROJECT_DIR)/src/wrappers/themis/Obj-C/exported.symbols";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
+					"$(PROJECT_DIR)/Carthage/Build",
 				);
 				FRAMEWORK_VERSION = A;
 				GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = YES;
@@ -1567,6 +1569,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 8;
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_ASSET_PATHS = "";
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1577,7 +1580,7 @@
 				EXPORTED_SYMBOLS_FILE = "$(PROJECT_DIR)/src/wrappers/themis/Obj-C/exported.symbols";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build",
 				);
 				GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = YES;
 				GCC_TREAT_INCOMPATIBLE_POINTER_TYPE_WARNINGS_AS_ERRORS = YES;
@@ -1615,6 +1618,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 8;
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_ASSET_PATHS = "";
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1625,7 +1629,7 @@
 				EXPORTED_SYMBOLS_FILE = "$(PROJECT_DIR)/src/wrappers/themis/Obj-C/exported.symbols";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build",
 				);
 				GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = YES;
 				GCC_TREAT_INCOMPATIBLE_POINTER_TYPE_WARNINGS_AS_ERRORS = YES;
@@ -1665,7 +1669,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
+					"$(PROJECT_DIR)/Carthage/Build",
 				);
 				INFOPLIST_FILE = tests/objcthemis/objthemis/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1692,7 +1696,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
+					"$(PROJECT_DIR)/Carthage/Build",
 				);
 				INFOPLIST_FILE = tests/objcthemis/objthemis/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1715,7 +1719,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build",
 				);
 				INFOPLIST_FILE = tests/objcthemis/objthemis/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1738,7 +1742,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build",
 				);
 				INFOPLIST_FILE = tests/objcthemis/objthemis/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1761,7 +1765,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build",
 				);
 				INFOPLIST_FILE = tests/objcthemis/objthemis/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1784,7 +1788,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build",
 				);
 				INFOPLIST_FILE = tests/objcthemis/objthemis/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1810,7 +1814,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
+					"$(PROJECT_DIR)/Carthage/Build",
 				);
 				INFOPLIST_FILE = tests/objcthemis/objthemis/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1837,7 +1841,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
+					"$(PROJECT_DIR)/Carthage/Build",
 				);
 				INFOPLIST_FILE = tests/objcthemis/objthemis/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (


### PR DESCRIPTION
Last Friday [Carthage released an important update](https://github.com/Carthage/Carthage/releases/tag/0.38.0): now, it supports binary dependencies with XCF. It means that Themis for Carthage can use OpenSSL XCF binary, and Themis itself will be build as an XCF. 🎉🎉🎉

What's new
* Themis Carthage moved to XCF
* Themis Carthage uses OpenSSL 1.1.1k (latest)
* No extra steps with `Themis.xcodeproj` required to build `themis.xcframework` with a script.

## Checklist

- [x] Change is covered by automated tests 
- [x] The [coding guidelines] are followed
- [x] Example projects and code samples are up-to-date (in case of API changes) - _We are going to update them after the release, cuz... no release - no examples :)_
- [x] Changelog is updated (in case of notable or breaking changes)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
