### PR TITLE
Unbreak Android build

### DIFF
--- a/.github/workflows/test-java.yaml
+++ b/.github/workflows/test-java.yaml
@@ -65,6 +65,13 @@ jobs:
     name: Android emulator
     runs-on: macos-latest
     steps:
+      # This particular version of CMake confuses Gradle by not being semver.
+      # We're fine with 3.10.2 which is also installed. Keep an eye on the
+      # virtual environments though:
+      # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#android
+      - name: Nuke CMake 3.18.1-g262b901
+        run: |
+          ~/Library/Android/sdk/tools/bin/sdkmanager --uninstall 'cmake;3.18.1'
       - name: Check out code
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/test-java.yaml
+++ b/.github/workflows/test-java.yaml
@@ -63,7 +63,7 @@ jobs:
 
   android-tests:
     name: Android emulator
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
       # This particular version of CMake confuses Gradle by not being semver.
       # We're fine with 3.10.2 which is also installed. Keep an eye on the


### PR DESCRIPTION
Honestly, this PR should read “unfuck Android build”, but 1) think of children, 2) this is impossible, the ecosystem is beyond salvation.

So... The builds were broken for a week with some errors like this:

```
> Configure project :android
Observed package id 'ndk;21.4.7075529' in inconsistent location '/Users/runner/Library/Android/sdk/ndk-bundle' (Expected '/Users/runner/Library/Android/sdk/ndk/21.4.7075529')

FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':android:assembleDebug'.
> A problem occurred configuring project ':boringssl'.
   > Invalid revision: 3.18.1-g262b901
```

Initially I thought that our Gradle setup got too old after all. We keep it pinned at 3.2.1 because that's the one that seems to work with NDK. So I have tried fixing it up from that angle, and spent several hours trying to do that.

Well, that's a red herring. The real reason is that Gradle does not like CMake version for the grave offense of not conforming to semver. I don't want to waste any more of my life on this than I already had, so just nuke that version out from the build machines, this seems to ~~fix~~ avoid the issue so far. Let's see when it breaks next time.

Some background reading:

- https://stackoverflow.com/questions/66540676/invalid-revision-3-18-1-cmake-in-android-studio
- https://github.com/actions/virtual-environments/issues/2689
- https://github.com/flutter/flutter/issues/75600
- https://github.com/zerotier/libzt/issues/119

The last issue in the list very aptly describes what I think about all this bullshit called Android ecosystem:

> In principle, there is nothing stopping ${your-library-with-native-code} from running on Android, but designing a build process for an android AAR that uses the NDK is not easy. Inevitably some combination of gradle rot, NDK changes, and general android studio bugs prevent any build process from surviving long-term.

And while we're at it, pin the runner to `macos-10.15`. GitHub people are working on adding macOS 11 support for Actions and it's probably going to happen soon. However, I don't really want to be notified about new and exciting ways to break our builds when that finally happens, so let's keep using the old environment for now.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] ~~Changelog is updated~~ (does not affect users)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
