### PR TITLE
BoringSSL support for XCFramework builds

### DIFF
--- a/scripts/create_xcframeworks.sh
+++ b/scripts/create_xcframeworks.sh
@@ -53,6 +53,7 @@ then
 fi
 
 build_xcf() {
+    local output_dir="$1"
     # creating required xcframework structure
     mkdir -p $output_dir/archives
     mkdir -p $output_dir/iphoneos
@@ -102,6 +103,7 @@ build_xcf() {
 }
 
 pack_xcf() {
+    local output_dir="$1"
     # zip the xcodeframework
     # SPM accepts binary targets only in zip format
     cd $output_dir
@@ -111,12 +113,13 @@ pack_xcf() {
 }
 
 checksum_xcf() {
+    local output_dir="$1"
     # calculate checksum from the directory with Package.swift
     # update the the checksum in Package.swift if that is a new release
     echo "XCF Checksum:"
     swift package compute-checksum $output_dir/themis.xcframework.zip
 }
 
-build_xcf
-pack_xcf
-checksum_xcf
+build_xcf    "$output_dir"
+pack_xcf     "$output_dir"
+checksum_xcf "$output_dir"

--- a/scripts/create_xcframeworks.sh
+++ b/scripts/create_xcframeworks.sh
@@ -25,61 +25,71 @@ then
     carthage bootstrap
 fi
 
-# creating required xcframework structure
-mkdir -p $output_dir/archives
-mkdir -p $output_dir/iphoneos
-mkdir -p $output_dir/macosx
+build_xcf() {
+    # creating required xcframework structure
+    mkdir -p $output_dir/archives
+    mkdir -p $output_dir/iphoneos
+    mkdir -p $output_dir/macosx
 
-# build the framework for iOS devices
-xcodebuild archive \
-    -scheme "Themis (iOS)" \
-    -destination="iOS" \
-    -archivePath $output_dir/archives/ios.xcarchive \
-    -derivedDataPath $output_dir/iphoneos \
-    -sdk iphoneos \
-    SKIP_INSTALL=NO \
-    BUILD_LIBRARIES_FOR_DISTRIBUTION=YES
+    # build the framework for iOS devices
+    xcodebuild archive \
+        -scheme "Themis (iOS)" \
+        -destination="iOS" \
+        -archivePath $output_dir/archives/ios.xcarchive \
+        -derivedDataPath $output_dir/iphoneos \
+        -sdk iphoneos \
+        SKIP_INSTALL=NO \
+        BUILD_LIBRARIES_FOR_DISTRIBUTION=YES
 
-# build the framework for iOS simulator
-xcodebuild archive \
-    -scheme "Themis (iOS)" \
-    -destination="iOS Simulator" \
-    -archivePath $output_dir/archives/iossimulator.xcarchive \
-    -derivedDataPath $output_dir/iphoneos \
-    -sdk iphonesimulator \
-    SKIP_INSTALL=NO \
-    BUILD_LIBRARIES_FOR_DISTRIBUTION=YES
+    # build the framework for iOS simulator
+    xcodebuild archive \
+        -scheme "Themis (iOS)" \
+        -destination="iOS Simulator" \
+        -archivePath $output_dir/archives/iossimulator.xcarchive \
+        -derivedDataPath $output_dir/iphoneos \
+        -sdk iphonesimulator \
+        SKIP_INSTALL=NO \
+        BUILD_LIBRARIES_FOR_DISTRIBUTION=YES
 
-# build the framework for macOS
-xcodebuild archive \
-    -scheme "Themis (macOS)" \
-    -destination="macOS" \
-    -archivePath $output_dir/archives/macosx.xcarchive \
-    -derivedDataPath $output_dir/macosx \
-    -sdk macosx \
-    SKIP_INSTALL=NO \
-    BUILD_LIBRARIES_FOR_DISTRIBUTION=YES
+    # build the framework for macOS
+    xcodebuild archive \
+        -scheme "Themis (macOS)" \
+        -destination="macOS" \
+        -archivePath $output_dir/archives/macosx.xcarchive \
+        -derivedDataPath $output_dir/macosx \
+        -sdk macosx \
+        SKIP_INSTALL=NO \
+        BUILD_LIBRARIES_FOR_DISTRIBUTION=YES
 
-# gather separate frameworks into a single xcframework
-xcodebuild -create-xcframework \
-    -framework $output_dir/archives/ios.xcarchive/Products/Library/Frameworks/themis.framework \
-    -framework $output_dir/archives/iossimulator.xcarchive/Products/Library/Frameworks/themis.framework \
-    -framework $output_dir/archives/macosx.xcarchive/Products/Library/Frameworks/themis.framework \
-    -output $output_dir/themis.xcframework
+    # gather separate frameworks into a single xcframework
+    xcodebuild -create-xcframework \
+        -framework $output_dir/archives/ios.xcarchive/Products/Library/Frameworks/themis.framework \
+        -framework $output_dir/archives/iossimulator.xcarchive/Products/Library/Frameworks/themis.framework \
+        -framework $output_dir/archives/macosx.xcarchive/Products/Library/Frameworks/themis.framework \
+        -output $output_dir/themis.xcframework
 
-# deleting the artifacts
-rm -rf $output_dir/archives
-rm -rf $output_dir/iphoneos
-rm -rf $output_dir/macosx
+    # deleting the artifacts
+    rm -rf $output_dir/archives
+    rm -rf $output_dir/iphoneos
+    rm -rf $output_dir/macosx
+}
 
-# zip the xcodeframework
-# SPM accepts binary targets only in zip format
-cd $output_dir
-zip -r themis.xcframework.zip themis.xcframework
-rm -rf themis.xcframework
-cd ~-
+pack_xcf() {
+    # zip the xcodeframework
+    # SPM accepts binary targets only in zip format
+    cd $output_dir
+    zip -r themis.xcframework.zip themis.xcframework
+    rm -rf themis.xcframework
+    cd ~-
+}
 
-# calculate checksum from the directory with Package.swift
-# update the the checksum in Package.swift if that is a new release
-echo "XCF Checksum:"
-swift package compute-checksum $output_dir/themis.xcframework.zip
+checksum_xcf() {
+    # calculate checksum from the directory with Package.swift
+    # update the the checksum in Package.swift if that is a new release
+    echo "XCF Checksum:"
+    swift package compute-checksum $output_dir/themis.xcframework.zip
+}
+
+build_xcf
+pack_xcf
+checksum_xcf

--- a/scripts/create_xcframeworks.sh
+++ b/scripts/create_xcframeworks.sh
@@ -18,16 +18,23 @@ then
     exit 1
 fi
 
+help() {
+    eval "echo \"$(cat $0 | awk 'NR == 3, /^$/ { print substr($0, 3) }')\""
+}
+
 build_clopenssl=
 build_boringssl=
 
 while [[ $# -gt 0 ]]
 do
     case "$1" in
+      -h|--help) help; exit;;
       --with-clopenssl) build_clopenssl=yes; shift;;
       --with-boringssl) build_boringssl=yes; shift;;
       *)
         echo >&2 "Unknown option: $1"
+        echo >&2
+        help
         exit 1
         ;;
     esac

--- a/scripts/create_xcframeworks.sh
+++ b/scripts/create_xcframeworks.sh
@@ -40,7 +40,7 @@ fi
 
 # CLOpenSSL builds expect Carthage dependencies to be fetched.
 # If they don't seem to be here, do a favor and pull them now.
-if [[ ! -d Carthage ]]
+if [[ -n "$build_clopenssl" && ! -d Carthage ]]
 then
     carthage bootstrap
 fi

--- a/scripts/create_xcframeworks.sh
+++ b/scripts/create_xcframeworks.sh
@@ -14,6 +14,10 @@ clopenssl_scheme_ios="Themis (iOS)"
 clopenssl_scheme_mac="Themis (macOS)"
 clopenssl_output_dir=$BUILD_PATH/xcf_output/CLOpenSSL
 
+boringssl_scheme_ios="Themis (iOS) - BoringSSL"
+boringssl_scheme_mac="Themis (macOS) - BoringSSL"
+boringssl_output_dir=$BUILD_PATH/xcf_output/BoringSSL
+
 if [[ (! -d Themis.xcodeproj) || (! -f Package.swift) ]]
 then
     echo >&2 "Please launch scripts/create_xcframeworks.sh from Themis repository root"
@@ -125,6 +129,9 @@ checksum_xcf() {
     swift package compute-checksum $output_dir/themis.xcframework.zip
 }
 
-build_xcf    "$clopenssl_output_dir" "$clopenssl_scheme_ios" "$clopenssl_scheme_mac"
-pack_xcf     "$clopenssl_output_dir"
-checksum_xcf "$clopenssl_output_dir"
+[[ -n "$build_clopenssl" ]] && build_xcf    "$clopenssl_output_dir" "$clopenssl_scheme_ios" "$clopenssl_scheme_mac"
+[[ -n "$build_boringssl" ]] && build_xcf    "$boringssl_output_dir" "$boringssl_scheme_ios" "$boringssl_scheme_mac"
+[[ -n "$build_clopenssl" ]] && pack_xcf     "$clopenssl_output_dir"
+[[ -n "$build_boringssl" ]] && pack_xcf     "$boringssl_output_dir"
+[[ -n "$build_clopenssl" ]] && checksum_xcf "$clopenssl_output_dir"
+[[ -n "$build_boringssl" ]] && checksum_xcf "$boringssl_output_dir"

--- a/scripts/create_xcframeworks.sh
+++ b/scripts/create_xcframeworks.sh
@@ -125,18 +125,21 @@ checksum_xcf() {
     local output_dir="$1"
     # calculate checksum from the directory with Package.swift
     # update the the checksum in Package.swift if that is a new release
-    echo "XCF Checksum:"
-    swift package compute-checksum $output_dir/themis.xcframework.zip
+    local filename="$output_dir/themis.xcframework.zip"
+    local checksum="$(swift package compute-checksum "$filename")"
+    echo "$checksum $filename"
 }
 
 echo "Building XCFramework..."
 [[ -n "$build_clopenssl" ]] && build_xcf    "$clopenssl_output_dir" "$clopenssl_scheme_ios" "$clopenssl_scheme_mac"
 [[ -n "$build_boringssl" ]] && build_xcf    "$boringssl_output_dir" "$boringssl_scheme_ios" "$boringssl_scheme_mac"
+echo
 
 echo "Packing XCFramework..."
 [[ -n "$build_clopenssl" ]] && pack_xcf     "$clopenssl_output_dir"
 [[ -n "$build_boringssl" ]] && pack_xcf     "$boringssl_output_dir"
+echo
 
-echo "Computing checksums..."
+echo "Computing XCFramework checksums..."
 [[ -n "$build_clopenssl" ]] && checksum_xcf "$clopenssl_output_dir"
 [[ -n "$build_boringssl" ]] && checksum_xcf "$boringssl_output_dir"

--- a/scripts/create_xcframeworks.sh
+++ b/scripts/create_xcframeworks.sh
@@ -10,7 +10,7 @@ set -eu
 
 BUILD_PATH=${BUILD_PATH:-build}
 
-output_dir=$BUILD_PATH/xcf_output
+clopenssl_output_dir=$BUILD_PATH/xcf_output/CLOpenSSL
 
 if [[ (! -d Themis.xcodeproj) || (! -f Package.swift) ]]
 then
@@ -120,6 +120,6 @@ checksum_xcf() {
     swift package compute-checksum $output_dir/themis.xcframework.zip
 }
 
-build_xcf    "$output_dir"
-pack_xcf     "$output_dir"
-checksum_xcf "$output_dir"
+build_xcf    "$clopenssl_output_dir"
+pack_xcf     "$clopenssl_output_dir"
+checksum_xcf "$clopenssl_output_dir"

--- a/scripts/create_xcframeworks.sh
+++ b/scripts/create_xcframeworks.sh
@@ -18,6 +18,13 @@ then
     exit 1
 fi
 
+# CLOpenSSL builds expect Carthage dependencies to be fetched.
+# If they don't seem to be here, do a favor and pull them now.
+if [[ ! -d Carthage ]]
+then
+    carthage bootstrap
+fi
+
 # creating required xcframework structure
 mkdir -p $output_dir/archives
 mkdir -p $output_dir/iphoneos

--- a/scripts/create_xcframeworks.sh
+++ b/scripts/create_xcframeworks.sh
@@ -129,9 +129,14 @@ checksum_xcf() {
     swift package compute-checksum $output_dir/themis.xcframework.zip
 }
 
+echo "Building XCFramework..."
 [[ -n "$build_clopenssl" ]] && build_xcf    "$clopenssl_output_dir" "$clopenssl_scheme_ios" "$clopenssl_scheme_mac"
 [[ -n "$build_boringssl" ]] && build_xcf    "$boringssl_output_dir" "$boringssl_scheme_ios" "$boringssl_scheme_mac"
+
+echo "Packing XCFramework..."
 [[ -n "$build_clopenssl" ]] && pack_xcf     "$clopenssl_output_dir"
 [[ -n "$build_boringssl" ]] && pack_xcf     "$boringssl_output_dir"
+
+echo "Computing checksums..."
 [[ -n "$build_clopenssl" ]] && checksum_xcf "$clopenssl_output_dir"
 [[ -n "$build_boringssl" ]] && checksum_xcf "$boringssl_output_dir"

--- a/scripts/create_xcframeworks.sh
+++ b/scripts/create_xcframeworks.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 #
-# Shebang to explicitly use bash and not break on macOS boxes with zsh as default shell.
+# Generate Themis XCFramework for iOS and macOS.
 #
-# This script generates Themis xcframework for iOS and macOS.
-# Run it from the repo root so the xcodebuild command finds Themis.xcodeproj
+#     scripts/create_xcframework.sh
+#
+# Output will be placed into $BUILD_PATH/xcf_output
 
-set -eu # common flags to ensure that the shell does not ignore failures
+set -eu
 
 BUILD_PATH=${BUILD_PATH:-build}
 

--- a/scripts/create_xcframeworks.sh
+++ b/scripts/create_xcframeworks.sh
@@ -2,7 +2,7 @@
 #
 # Generate Themis XCFramework for iOS and macOS.
 #
-#     scripts/create_xcframework.sh
+#     scripts/create_xcframework.sh [--with-clopenss] [--with-boringssl]
 #
 # Output will be placed into $BUILD_PATH/xcf_output
 
@@ -16,6 +16,26 @@ if [[ (! -d Themis.xcodeproj) || (! -f Package.swift) ]]
 then
     echo >&2 "Please launch scripts/create_xcframeworks.sh from Themis repository root"
     exit 1
+fi
+
+build_clopenssl=
+build_boringssl=
+
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+      --with-clopenssl) build_clopenssl=yes; shift;;
+      --with-boringssl) build_boringssl=yes; shift;;
+      *)
+        echo >&2 "Unknown option: $1"
+        exit 1
+        ;;
+    esac
+done
+
+if [[ -z "$build_clopenssl" && -z "$build_boringssl" ]]
+then
+    build_clopenssl=yes
 fi
 
 # CLOpenSSL builds expect Carthage dependencies to be fetched.

--- a/scripts/create_xcframeworks.sh
+++ b/scripts/create_xcframeworks.sh
@@ -10,6 +10,8 @@ set -eu
 
 BUILD_PATH=${BUILD_PATH:-build}
 
+clopenssl_scheme_ios="Themis (iOS)"
+clopenssl_scheme_mac="Themis (macOS)"
 clopenssl_output_dir=$BUILD_PATH/xcf_output/CLOpenSSL
 
 if [[ (! -d Themis.xcodeproj) || (! -f Package.swift) ]]
@@ -54,6 +56,9 @@ fi
 
 build_xcf() {
     local output_dir="$1"
+    local scheme_ios="$2"
+    local scheme_mac="$3"
+
     # creating required xcframework structure
     mkdir -p $output_dir/archives
     mkdir -p $output_dir/iphoneos
@@ -61,7 +66,7 @@ build_xcf() {
 
     # build the framework for iOS devices
     xcodebuild archive \
-        -scheme "Themis (iOS)" \
+        -scheme "$scheme_ios" \
         -destination="iOS" \
         -archivePath $output_dir/archives/ios.xcarchive \
         -derivedDataPath $output_dir/iphoneos \
@@ -71,7 +76,7 @@ build_xcf() {
 
     # build the framework for iOS simulator
     xcodebuild archive \
-        -scheme "Themis (iOS)" \
+        -scheme "$scheme_ios" \
         -destination="iOS Simulator" \
         -archivePath $output_dir/archives/iossimulator.xcarchive \
         -derivedDataPath $output_dir/iphoneos \
@@ -81,7 +86,7 @@ build_xcf() {
 
     # build the framework for macOS
     xcodebuild archive \
-        -scheme "Themis (macOS)" \
+        -scheme "$scheme_mac" \
         -destination="macOS" \
         -archivePath $output_dir/archives/macosx.xcarchive \
         -derivedDataPath $output_dir/macosx \
@@ -120,6 +125,6 @@ checksum_xcf() {
     swift package compute-checksum $output_dir/themis.xcframework.zip
 }
 
-build_xcf    "$clopenssl_output_dir"
+build_xcf    "$clopenssl_output_dir" "$clopenssl_scheme_ios" "$clopenssl_scheme_mac"
 pack_xcf     "$clopenssl_output_dir"
 checksum_xcf "$clopenssl_output_dir"

--- a/scripts/create_xcframeworks.sh
+++ b/scripts/create_xcframeworks.sh
@@ -12,7 +12,6 @@ BUILD_PATH=${BUILD_PATH:-build}
 
 output_dir=$BUILD_PATH/xcf_output
 
-project_dir=$(pwd) #repo root where Themis.xcodeproj and Package.swift are
 if [[ (! -d Themis.xcodeproj) || (! -f Package.swift) ]]
 then
     echo >&2 "Please launch scripts/create_xcframeworks.sh from Themis repository root"
@@ -70,11 +69,10 @@ rm -rf $output_dir/macosx
 # SPM accepts binary targets only in zip format
 cd $output_dir
 zip -r themis.xcframework.zip themis.xcframework
-
 rm -rf themis.xcframework
+cd ~-
 
 # calculate checksum from the directory with Package.swift
 # update the the checksum in Package.swift if that is a new release
-cd $project_dir
 echo "XCF Checksum:"
 swift package compute-checksum $output_dir/themis.xcframework.zip

--- a/scripts/create_xcframeworks.sh
+++ b/scripts/create_xcframeworks.sh
@@ -13,6 +13,11 @@ BUILD_PATH=${BUILD_PATH:-build}
 output_dir=$BUILD_PATH/xcf_output
 
 project_dir=$(pwd) #repo root where Themis.xcodeproj and Package.swift are
+if [[ (! -d Themis.xcodeproj) || (! -f Package.swift) ]]
+then
+    echo >&2 "Please launch scripts/create_xcframeworks.sh from Themis repository root"
+    exit 1
+fi
 
 # creating required xcframework structure
 mkdir -p $output_dir/archives

--- a/scripts/create_xcframeworks.sh
+++ b/scripts/create_xcframeworks.sh
@@ -8,7 +8,9 @@
 set -eu # common flags to ensure that the shell does not ignore failures
 
 BUILD_PATH=${BUILD_PATH:-build}
+
 output_dir=$BUILD_PATH/xcf_output
+
 project_dir=$(pwd) #repo root where Themis.xcodeproj and Package.swift are
 
 # creating required xcframework structure
@@ -18,40 +20,40 @@ mkdir -p $output_dir/macosx
 
 # build the framework for iOS devices
 xcodebuild archive \
--scheme "Themis (iOS)" \
--destination="iOS" \
--archivePath $output_dir/archives/ios.xcarchive \
--derivedDataPath $output_dir/iphoneos \
--sdk iphoneos \
-SKIP_INSTALL=NO \
-BUILD_LIBRARIES_FOR_DISTRIBUTION=YES
+    -scheme "Themis (iOS)" \
+    -destination="iOS" \
+    -archivePath $output_dir/archives/ios.xcarchive \
+    -derivedDataPath $output_dir/iphoneos \
+    -sdk iphoneos \
+    SKIP_INSTALL=NO \
+    BUILD_LIBRARIES_FOR_DISTRIBUTION=YES
 
 # build the framework for iOS simulator
 xcodebuild archive \
--scheme "Themis (iOS)" \
--destination="iOS Simulator" \
--archivePath $output_dir/archives/iossimulator.xcarchive \
--derivedDataPath $output_dir/iphoneos \
--sdk iphonesimulator \
-SKIP_INSTALL=NO \
-BUILD_LIBRARIES_FOR_DISTRIBUTION=YES
+    -scheme "Themis (iOS)" \
+    -destination="iOS Simulator" \
+    -archivePath $output_dir/archives/iossimulator.xcarchive \
+    -derivedDataPath $output_dir/iphoneos \
+    -sdk iphonesimulator \
+    SKIP_INSTALL=NO \
+    BUILD_LIBRARIES_FOR_DISTRIBUTION=YES
 
 # build the framework for macOS
 xcodebuild archive \
--scheme "Themis (macOS)" \
--destination="macOS" \
--archivePath $output_dir/archives/macosx.xcarchive \
--derivedDataPath $output_dir/macosx \
--sdk macosx \
-SKIP_INSTALL=NO \
-BUILD_LIBRARIES_FOR_DISTRIBUTION=YES
+    -scheme "Themis (macOS)" \
+    -destination="macOS" \
+    -archivePath $output_dir/archives/macosx.xcarchive \
+    -derivedDataPath $output_dir/macosx \
+    -sdk macosx \
+    SKIP_INSTALL=NO \
+    BUILD_LIBRARIES_FOR_DISTRIBUTION=YES
 
 # gather separate frameworks into a single xcframework
 xcodebuild -create-xcframework \
--framework $output_dir/archives/ios.xcarchive/Products/Library/Frameworks/themis.framework \
--framework $output_dir/archives/iossimulator.xcarchive/Products/Library/Frameworks/themis.framework \
--framework $output_dir/archives/macosx.xcarchive/Products/Library/Frameworks/themis.framework \
--output $output_dir/themis.xcframework
+    -framework $output_dir/archives/ios.xcarchive/Products/Library/Frameworks/themis.framework \
+    -framework $output_dir/archives/iossimulator.xcarchive/Products/Library/Frameworks/themis.framework \
+    -framework $output_dir/archives/macosx.xcarchive/Products/Library/Frameworks/themis.framework \
+    -output $output_dir/themis.xcframework
 
 # deleting the artifacts
 rm -rf $output_dir/archives


### PR DESCRIPTION
Teach @julepka's `scripts/create_xcframework.sh` building XCFrameworks with BoringSSL flavor.

Now if you

```
scripts/create_xcframework.sh --with-boringssl
```

then it builds `themis.xcframework` statically linked with BoringSSL from `third_party/boringssl` instead of CLOpenSSL fetched by Carthage.

It takes noticeably more time, but hey, it works. And the result is 10 MB thinner. Go ahead and check it out for yourself.

If no arguments are specified, the script still builds the CLOpenSSL flavor. You can also ask for CLOpenSSL explicitly: `--with-clopenssl`, or specify both flags to build both options.

Since you can't put two different `themis.xcframework` files into the same directory, the output paths have slightly changed:

- `build/xcf_output/BoringSSL/themis.xcframework.zip`
- `build/xcf_output/CLOpenSSL/themis.xcframework.zip`

## Checklist

- [X] ~~Change is covered by automated tests~~ (nope, the script is not exercised there)
- [X] The [coding guidelines] are followed
- [X] ~~Example projects and code samples are up-to-date~~  (they use what they use)
- [X] ~~Changelog is updated~~ (does not affect users, no change for them)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
