### PR TITLE
update CocoaPods examples with Themis 0.13.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,7 +117,7 @@ _Code:_
   - Updated Objective-C examples (iOS and macOS, Carthage and CocoaPods) to showcase usage of the newest Secure Cell API: generating symmetric keys and using Secure Cell with Passphrase ([#688](https://github.com/cossacklabs/themis/pull/688)) and to use latest Themis 0.13.4 ([#701](https://github.com/cossacklabs/themis/pull/701), [#703](https://github.com/cossacklabs/themis/pull/703), [#706](https://github.com/cossacklabs/themis/pull/706), [#723](https://github.com/cossacklabs/themis/pull/723), [#724](https://github.com/cossacklabs/themis/pull/724), [#726](https://github.com/cossacklabs/themis/pull/726), [#740](https://github.com/cossacklabs/themis/pull/740)).
   - `TSSession` initializer now returns an error (`nil`) when given incorrect key type ([#710](https://github.com/cossacklabs/themis/pull/710)).
   - Improved compatibility with Xcode 12 ([#742](https://github.com/cossacklabs/themis/pull/742)).
-  - Updated Carthage examples to use Themis XCFramework ([#823](https://github.com/cossacklabs/themis/pull/823)).
+  - Updated CocoaPods examples to the latest Themis version 0.13.10 ([#834](https://github.com/cossacklabs/themis/pull/834)).
 
 - **PHP**
 
@@ -147,6 +147,7 @@ _Code:_
   - Updated Swift examples (iOS and macOS, Carthage and CocoaPods) to showcase usage of the newest Secure Cell API: generating symmetric keys and using Secure Cell with Passphrase ([#688](https://github.com/cossacklabs/themis/pull/688)) and to use latest Themis 0.13.4 ([#701](https://github.com/cossacklabs/themis/pull/701), [#703](https://github.com/cossacklabs/themis/pull/703), [#706](https://github.com/cossacklabs/themis/pull/706), [#740](https://github.com/cossacklabs/themis/pull/740)).
   - `TSSession` initializer now returns an error (`nil`) when given incorrect key type ([#710](https://github.com/cossacklabs/themis/pull/710)).
   - Improved compatibility with Xcode 12 ([#742](https://github.com/cossacklabs/themis/pull/742)).
+  - Updated CocoaPods examples to the latest Themis version 0.13.10 ([#834](https://github.com/cossacklabs/themis/pull/834)).
 
 - **WebAssembly**
 

--- a/docs/examples/objc/iOS-CocoaPods/Podfile
+++ b/docs/examples/objc/iOS-CocoaPods/Podfile
@@ -23,6 +23,6 @@ use_frameworks!
 
 target :"ThemisTest" do
 
-  pod 'themis', '0.13.4'
+  pod 'themis', '0.13.10'
 
 end

--- a/docs/examples/objc/iOS-CocoaPods/Podfile.lock
+++ b/docs/examples/objc/iOS-CocoaPods/Podfile.lock
@@ -1,29 +1,29 @@
 PODS:
-  - CLOpenSSL (1.1.10801)
-  - themis (0.13.4):
-    - themis/openssl-1.1.1 (= 0.13.4)
-  - themis/openssl-1.1.1 (0.13.4):
-    - CLOpenSSL (~> 1.1.10801)
-    - themis/openssl-1.1.1/core (= 0.13.4)
-    - themis/openssl-1.1.1/objcwrapper (= 0.13.4)
-  - themis/openssl-1.1.1/core (0.13.4):
-    - CLOpenSSL (~> 1.1.10801)
-  - themis/openssl-1.1.1/objcwrapper (0.13.4):
-    - CLOpenSSL (~> 1.1.10801)
+  - CLOpenSSL-XCF (1.1.11101)
+  - themis (0.13.10):
+    - themis/openssl-1.1.1 (= 0.13.10)
+  - themis/openssl-1.1.1 (0.13.10):
+    - CLOpenSSL-XCF (= 1.1.11101)
+    - themis/openssl-1.1.1/core (= 0.13.10)
+    - themis/openssl-1.1.1/objcwrapper (= 0.13.10)
+  - themis/openssl-1.1.1/core (0.13.10):
+    - CLOpenSSL-XCF (= 1.1.11101)
+  - themis/openssl-1.1.1/objcwrapper (0.13.10):
+    - CLOpenSSL-XCF (= 1.1.11101)
     - themis/openssl-1.1.1/core
 
 DEPENDENCIES:
-  - themis (= 0.13.4)
+  - themis (= 0.13.10)
 
 SPEC REPOS:
   trunk:
-    - CLOpenSSL
+    - CLOpenSSL-XCF
     - themis
 
 SPEC CHECKSUMS:
-  CLOpenSSL: 6e477eaa77effa115295c36234bba65e22db9e2d
-  themis: 967e38135e07efa3a73f6ad11bd1425c5b1e51ef
+  CLOpenSSL-XCF: 71ce1fb96734754ea5936e239e15999129413793
+  themis: 1fc3604d5efabec8e7f004701ba5413de9a52ccc
 
-PODFILE CHECKSUM: fd4355e78b5319a8b343137a3804c304ea06b9a1
+PODFILE CHECKSUM: 015d2f867c3c97acda2d4da730a61438e08c0528
 
-COCOAPODS: 1.9.1
+COCOAPODS: 1.10.1

--- a/docs/examples/objc/iOS-CocoaPods/ThemisTest/ThemisTest.xcodeproj/project.pbxproj
+++ b/docs/examples/objc/iOS-CocoaPods/ThemisTest/ThemisTest.xcodeproj/project.pbxproj
@@ -153,6 +153,7 @@
 				7316248E1ADB174200972A7A /* Sources */,
 				7316248F1ADB174200972A7A /* Frameworks */,
 				731624901ADB174200972A7A /* Resources */,
+				B071ABE1AE5DF249A9A57F2C /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -234,6 +235,26 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B071ABE1AE5DF249A9A57F2C /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ThemisTest/Pods-ThemisTest-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/themis/themis.framework",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/openssl/openssl.framework/openssl",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/themis.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/openssl.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ThemisTest/Pods-ThemisTest-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/docs/examples/swift/iOS-CocoaPods/Podfile
+++ b/docs/examples/swift/iOS-CocoaPods/Podfile
@@ -16,13 +16,13 @@
 
 source 'https://cdn.cocoapods.org/'
 
-platform :ios, '10.0'
+platform :ios, '12.0'
 project 'ThemisSwift/ThemisSwift.xcodeproj'
 inhibit_all_warnings!
 use_frameworks!
 
 target :"ThemisSwift" do
 
-  pod 'themis', '0.13.4'
+  pod 'themis', '0.13.10'
 
 end

--- a/docs/examples/swift/iOS-CocoaPods/Podfile.lock
+++ b/docs/examples/swift/iOS-CocoaPods/Podfile.lock
@@ -1,29 +1,29 @@
 PODS:
-  - CLOpenSSL (1.1.10801)
-  - themis (0.13.4):
-    - themis/openssl-1.1.1 (= 0.13.4)
-  - themis/openssl-1.1.1 (0.13.4):
-    - CLOpenSSL (~> 1.1.10801)
-    - themis/openssl-1.1.1/core (= 0.13.4)
-    - themis/openssl-1.1.1/objcwrapper (= 0.13.4)
-  - themis/openssl-1.1.1/core (0.13.4):
-    - CLOpenSSL (~> 1.1.10801)
-  - themis/openssl-1.1.1/objcwrapper (0.13.4):
-    - CLOpenSSL (~> 1.1.10801)
+  - CLOpenSSL-XCF (1.1.11101)
+  - themis (0.13.10):
+    - themis/openssl-1.1.1 (= 0.13.10)
+  - themis/openssl-1.1.1 (0.13.10):
+    - CLOpenSSL-XCF (= 1.1.11101)
+    - themis/openssl-1.1.1/core (= 0.13.10)
+    - themis/openssl-1.1.1/objcwrapper (= 0.13.10)
+  - themis/openssl-1.1.1/core (0.13.10):
+    - CLOpenSSL-XCF (= 1.1.11101)
+  - themis/openssl-1.1.1/objcwrapper (0.13.10):
+    - CLOpenSSL-XCF (= 1.1.11101)
     - themis/openssl-1.1.1/core
 
 DEPENDENCIES:
-  - themis (= 0.13.4)
+  - themis (= 0.13.10)
 
 SPEC REPOS:
   trunk:
-    - CLOpenSSL
+    - CLOpenSSL-XCF
     - themis
 
 SPEC CHECKSUMS:
-  CLOpenSSL: 6e477eaa77effa115295c36234bba65e22db9e2d
-  themis: 967e38135e07efa3a73f6ad11bd1425c5b1e51ef
+  CLOpenSSL-XCF: 71ce1fb96734754ea5936e239e15999129413793
+  themis: 1fc3604d5efabec8e7f004701ba5413de9a52ccc
 
-PODFILE CHECKSUM: b822afa98b5e8306e28e10355f5f291a4138b10a
+PODFILE CHECKSUM: 3d107027b13215dd8aa60c37d5a59e4534d1be8f
 
-COCOAPODS: 1.9.1
+COCOAPODS: 1.10.1

--- a/docs/examples/swift/iOS-CocoaPods/ThemisSwift/ThemisSwift.xcodeproj/project.pbxproj
+++ b/docs/examples/swift/iOS-CocoaPods/ThemisSwift/ThemisSwift.xcodeproj/project.pbxproj
@@ -147,6 +147,7 @@
 				739981141CC42C880095138F /* Frameworks */,
 				739981151CC42C880095138F /* Resources */,
 				73688AFE1CC4504F00D3C430 /* ShellScript */,
+				EF7FB655C649DB9910C5909E /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -244,6 +245,26 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		EF7FB655C649DB9910C5909E /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ThemisSwift/Pods-ThemisSwift-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/themis/themis.framework",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/openssl/openssl.framework/openssl",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/themis.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/openssl.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ThemisSwift/Pods-ThemisSwift-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */


### PR DESCRIPTION
Updated CocoaPods examples to use Themis 0.13.10.

The `Embed Pods Frameworks` part was added to `ThemisTest.xcodeproj` by the CocoaPods.
Tested on simulator, device, uploaded to TestFlight.

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Example projects and code samples are up-to-date (in case of API changes)
- [x] Changelog is updated (in case of notable or breaking changes)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
