### PR TITLE
Merge CI fixes: `release/0.13` => `stable`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,6 +232,19 @@ jobs:
       WITH_FATAL_WARNINGS: yes
       SOTER_KDF_RUN_LONG_TESTS: yes
     steps:
+      # Emergency build hax. I don't have time to rebuild this Docker image properly,
+      # but at the same time want to install a newer Python. CircleCI build is dying
+      # anyway, so run for a while more with this abomination. As long as it's green.
+      - run:
+          name: Add Ubuntu 18.04 repositories
+          command: |
+            cat > bionic.list <<EOF
+            deb http://archive.ubuntu.com/ubuntu  bionic main
+            deb http://archive.ubuntu.com/ubuntu  bionic-updates main
+            deb http://security.ubuntu.com/ubuntu bionic-security main
+            EOF
+            sudo mv bionic.list /etc/apt/sources.list.d
+            sudo chown root:root /etc/apt/sources.list.d/bionic.list
       - run: sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get -y install libssl-dev python python-setuptools python3 python3-setuptools ruby-dev lcov libc6-dbg rsync software-properties-common pkg-config clang afl
       - run: sudo ln -sf /usr/bin/gcov-5 /usr/bin/gcov
       - run: sudo gem install coveralls-lcov
@@ -563,6 +576,19 @@ jobs:
       NO_NIST_STS: 1
       WITH_FATAL_WARNINGS: yes
     steps:
+      # Emergency build hax. I don't have time to rebuild this Docker image properly,
+      # but at the same time want to install a newer Python. CircleCI build is dying
+      # anyway, so run for a while more with this abomination. As long as it's green.
+      - run:
+          name: Add Ubuntu 18.04 repositories
+          command: |
+            cat > bionic.list <<EOF
+            deb http://archive.ubuntu.com/ubuntu  bionic main
+            deb http://archive.ubuntu.com/ubuntu  bionic-updates main
+            deb http://security.ubuntu.com/ubuntu bionic-security main
+            EOF
+            sudo mv bionic.list /etc/apt/sources.list.d
+            sudo chown root:root /etc/apt/sources.list.d/bionic.list
       # dependencies
       - run: sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get -y install libssl-dev python python-setuptools python3 python3-setuptools ruby-dev lcov libc6-dbg rsync software-properties-common pkg-config clang
       - run:

--- a/.github/workflows/test-java.yaml
+++ b/.github/workflows/test-java.yaml
@@ -59,8 +59,15 @@ jobs:
 
   android-tests:
     name: Android emulator
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
+      # This particular version of CMake confuses Gradle by not being semver.
+      # We're fine with 3.10.2 which is also installed. Keep an eye on the
+      # virtual environments though:
+      # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#android
+      - name: Nuke CMake 3.18.1-g262b901
+        run: |
+          ~/Library/Android/sdk/tools/bin/sdkmanager --uninstall 'cmake;3.18.1'
       - name: Check out code
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Pull in some stuff that should make all jobs green again. Except for Bitrise. [They might be working on it](https://discuss.bitrise.io/t/how-to-upgrade-carthage-to-version-0-38-0/16796). [Or maybe not](https://discuss.bitrise.io/t/update-carthage-to-0-38-0/16844).

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] ~~Changelog is updated~~ (no changes for users)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
