### PR TITLE
Use Ninja for BoringSSL if available

### DIFF
--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -297,7 +297,7 @@ jobs:
         run: |
           sudo sh -c 'echo "DEBIAN_FRONTEND=noninteractive" >> /etc/environment'
           sudo apt update
-          sudo apt install --yes gcc make libssl-dev valgrind
+          sudo apt install --yes gcc make libssl-dev valgrind ninja-build
       - name: Check out code
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/test-wasm.yaml
+++ b/.github/workflows/test-wasm.yaml
@@ -47,7 +47,7 @@ jobs:
         run: |
           sudo sh -c 'echo "DEBIAN_FRONTEND=noninteractive" >> /etc/environment'
           sudo apt update
-          sudo apt install --yes gcc make libssl-dev
+          sudo apt install --yes gcc make libssl-dev ninja-build
       - name: Install Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,7 @@ _Infrastructure:_
 - MSYS2 builds for Windows are now checked by CI ([#791](https://github.com/cossacklabs/themis/pull/791)).
 - Added automated tests for Android example project ([#813](https://github.com/cossacklabs/themis/pull/813)).
 - Added automated tests for desktop Java example project ([#816](https://github.com/cossacklabs/themis/pull/816)).
+- Embedded BoringSSL now builds faster if Ninja is available ([#837](https://github.com/cossacklabs/themis/pull/837)).
 
 ## [0.13.10](https://github.com/cossacklabs/themis/releases/tag/0.13.10), May 26th 2021
 

--- a/configure
+++ b/configure
@@ -248,6 +248,14 @@ detect_language_runtimes() {
     set_variable PYTHON3_VERSION    "$(exec 2>/dev/null; which python3 >/dev/null && python3 --version)"
 }
 
+detect_optional_toolchain() {
+    local ninja="$(which ninja 2>/dev/null || true)"
+    if [ -n "$ninja" ]
+    then
+        set_variable NINJA "$ninja"
+    fi
+}
+
 main() {
     write_boilerplate
     parse_commandline "$@"
@@ -258,6 +266,7 @@ main() {
     configure_macos_toolchain
     find_macos_openssl
     detect_language_runtimes
+    detect_optional_toolchain
     echo "configuration written to $configure_mk"
 }
 

--- a/src/soter/boringssl/soter.mk
+++ b/src/soter/boringssl/soter.mk
@@ -36,6 +36,10 @@ CRYPTO_ENGINE_LDFLAGS += -lcrypto -ldecrepit -lpthread
 SOTER_ENGINE_CMAKE_FLAGS += -DCMAKE_BUILD_TYPE=Release
 SOTER_ENGINE_CMAKE_FLAGS += -DCMAKE_C_FLAGS="-fpic"
 
+ifneq ($(NINJA),)
+SOTER_ENGINE_CMAKE_FLAGS += -G Ninja
+endif
+
 ifdef IS_LINUX
 RENAME_BORINGSSL_SYMBOLS = yes
 endif
@@ -60,7 +64,11 @@ $(BIN_PATH)/boringssl/crypto/libcrypto.a $(BIN_PATH)/boringssl/decrepit/libdecre
 	@mkdir -p $(BIN_PATH)/boringssl/stage-1
 	@cd $(BIN_PATH)/boringssl/stage-1 && \
 	 $(CMAKE) $(SOTER_ENGINE_CMAKE_FLAGS) $(abspath third_party/boringssl/src)
+ifeq ($(NINJA),)
 	@$(MAKE) -C $(BIN_PATH)/boringssl/stage-1 crypto decrepit
+else
+	@$(NINJA) -C $(BIN_PATH)/boringssl/stage-1 crypto decrepit
+endif
 	@mkdir -p $(BIN_PATH)/boringssl/crypto $(BIN_PATH)/boringssl/decrepit
 	@cp $(BIN_PATH)/boringssl/stage-1/crypto/libcrypto.a     $(BIN_PATH)/boringssl/crypto/libcrypto.a
 	@cp $(BIN_PATH)/boringssl/stage-1/decrepit/libdecrepit.a $(BIN_PATH)/boringssl/decrepit/libdecrepit.a
@@ -78,7 +86,11 @@ ifeq ($(RENAME_BORINGSSL_SYMBOLS),yes)
 	     -DBORINGSSL_PREFIX=$(SOTER_BORINGSSL_PREFIX) \
 	     -DBORINGSSL_PREFIX_SYMBOLS=../symbols.txt \
 	     $(abspath third_party/boringssl/src)
+ifeq ($(NINJA),)
 	@$(MAKE) -C $(BIN_PATH)/boringssl/stage-2 crypto decrepit
+else
+	@$(NINJA) -C $(BIN_PATH)/boringssl/stage-2 crypto decrepit
+endif
 	@mkdir -p $(BIN_PATH)/boringssl/crypto $(BIN_PATH)/boringssl/decrepit
 	@cp $(BIN_PATH)/boringssl/stage-2/crypto/libcrypto.a     $(BIN_PATH)/boringssl/crypto/libcrypto.a
 	@cp $(BIN_PATH)/boringssl/stage-2/decrepit/libdecrepit.a $(BIN_PATH)/boringssl/decrepit/libdecrepit.a


### PR DESCRIPTION
Ninja build tool significantly reduces compilation time for BoringSSL in default configuration.

This is mostly due to the fact that it performs parallel builds by default but there are other gains (Makefiles that CMake generates are not that optimal). `make -j4` is also a viable option, but it often ends up brittle.

<details>
<summary>Timings for my machine</summary>

As you can see, there is some gain in wall clock time (real), resulting in shorter builds. However, this comes mostly from better parallelization if you look at the user time.

### `time make ENGINE=boringssl`

master:

```
real	4m30.623s
user	3m32.624s
sys	0m33.530s
```

with ninja:

```
real	2m47.085s
user	4m47.580s
sys	0m34.020s
```

### `time emmake make wasmthemis`

master:

```
real	2m59.856s
user	2m14.338s
sys	0m29.650s
```

with ninja:

```
real	1m57.756s
user	3m13.189s
sys	0m33.403s
```

</details>

<details>
<summary>Timings for GitHub Actions</summary>

It's always nice to see builds run a bit quicker.

master:

| Test set    | Job                 | Step                          | Time   |
| --          | --                  | --                            | --     |
| Themis Core | Unit tests (ubuntu) | Build Themis Core (BoringSSL) | 3m 09s |
| Themis Core | Unit tests (macos)  | Build Themis Core (BoringSSL) | 6m 57s |
| Themis Core | Memory leaks        | Build Themis Core             | 4m 22s |
| WasmThemis  | Unit tests (16.x)   | Build WasmThemis              | 2m 34s |

with ninja:

| Test set    | Job                 | Step                          | Time   |
| --          | --                  | --                            | --     |
| Themis Core | Unit tests (ubuntu) | Build Themis Core (BoringSSL) | 2m 33s |
| Themis Core | Unit tests (macos)  | Build Themis Core (BoringSSL) | 2m 26s |
| Themis Core | Memory leaks        | Build Themis Core             | 2m 48s |
| WasmThemis  | Unit tests (16.x)   | Build WasmThemis              | 1m 45s |

</details>

## Checklist

- [x] Change is covered by automated tests
- [x] Benchmark results are attached (if applicable)
- [x] The [coding guidelines] are followed
- [x] Public API has proper documentation
- [x] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
