### PR TITLE
Work around Carthage braindeath

### DIFF
--- a/.github/workflows/test-objc.yaml
+++ b/.github/workflows/test-objc.yaml
@@ -119,6 +119,17 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+      # Work around Carthage braindeath and let it focus on building the project
+      # that actually matters not a gazillion of examples with SPM dependencies.
+      # If these issues get resolved, they might contain a better way:
+      # https://github.com/Carthage/Carthage/issues/3148
+      # https://github.com/Carthage/Carthage/issues/1227
+      - name: Remove Carthage distractions
+        run: |
+          rm -rf docs/examples/objc
+          rm -rf docs/examples/swift
+          rm -rf tests/objcthemis/objcthemis.xcworkspace
+          rm -rf tests/objcthemis/objcthemis.xcodeproj
       - name: Pull Carthage dependencies
         run: |
           carthage bootstrap --use-xcframeworks
@@ -174,6 +185,17 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+      # Work around Carthage braindeath and let it focus on building the project
+      # that actually matters not a gazillion of examples with SPM dependencies.
+      # If these issues get resolved, they might contain a better way:
+      # https://github.com/Carthage/Carthage/issues/3148
+      # https://github.com/Carthage/Carthage/issues/1227
+      - name: Remove Carthage distractions
+        run: |
+          rm -rf docs/examples/objc
+          rm -rf docs/examples/swift
+          rm -rf tests/objcthemis/objcthemis.xcworkspace
+          rm -rf tests/objcthemis/objcthemis.xcodeproj
       - name: Pull Carthage dependencies
         run: |
           carthage bootstrap --use-xcframeworks


### PR DESCRIPTION
Carthage has this weird ardency to build every Xcode project in can find in the source tree instead of working only with the one in the root dir.

There is probably some deep, well-intentioned reason behind that, but it also causes issues for us. Carthage will end up visiting all the example projects, some of which use SPM to pull Themis dependency, and each of them will do so independently, causing builds to time out.

We are miraculously saved by Themis being distributed as binaries, so Carthage and SPM at least fetch the binary and don't go deeper. If we have supported only from-source builds, this would have led to infinite recursion.

There is not much that *we* can do about it, but at least we can keep CI builds in shape with a workaround. If all distractions are removed, Carthage will focus on the Xcode project it is supposed to work with. This at least lets out CI to function.

Users that instruct Carthage to build dependencies from source (via `--no-use-binaries`) will still experience this issue of extremely long build times and occasional failures. If that's the case for you, please accept my condolences, go complain in Carthage issue tracker, and maybe think about choosing a different line of work.

## Benchmark

| Job | Before | After |
| -- | -- | -- |
| Carthage project | ❌ times out in 3m | ✅ builds in 1m 30s |
| Unit tests (Carthage) | ❌ times out in 3m | ✅ builds in 1m 30s  |

Such detail, much science.

Timeouts don't happen all the time, and even with these changes Carthage sometimes takes 3–5 minutes to think of England, but I believe this will be a bit of an improvement.

## References

- https://github.com/Carthage/Carthage/issues/3148 – Carthage 0.37.0 goes into an infinite loop of building subprojects forever

## Checklist

- [x] Change is covered by automated tests
- [x] Benchmark results are attached (if applicable)
- [x] The [coding guidelines] are followed
- [x] ~~Example projects and code samples are up-to-date~~ (they're okay, we build them individually)
- [x] ~~Changelog is updated~~ (no improvement for users)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md