### PR TITLE
Prefer GitHub Discussions for general inquiries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,7 @@ Themis is an open-source, Apache 2 licensed software, maintained by [Cossack Lab
 
 We highly encourage you to: 
 
+  - Ask questions and participate in [discussions on GitHub](https://github.com/cossacklabs/themis/discussions).
   - Report any bugs and request features via [GitHub Issues](https://github.com/cossacklabs/themis/issues).
   - Report bugs that you have fixes with a patch via [GitHub Pull request](https://github.com/cossacklabs/themis/pulls) (after issuing a corresponding issue and leaving a link to pull there).
   - Add something new to Themis. There is a certain design scheme according to which we'd like to keep developing Themis. If your contributions fall along with it, we'd be more than glad to accept some fundamental additions. It's better to discuss the subject using [email](mailto:dev@cossacklabs.com) before taking action.

--- a/README.md
+++ b/README.md
@@ -178,7 +178,10 @@ Drop us an email to [info@cossacklabs.com](mailto:info@cossacklabs.com) or check
 
 # Contacts
 
-If you want to ask a technical question, feel free to raise an [issue](https://github.com/cossacklabs/themis/issues) or write to [dev@cossacklabs.com](mailto:dev@cossacklabs.com).
+If you want to ask a technical question, report a bug or suggest a feature,
+feel free to [start a discussion on GitHub](https://github.com/cossacklabs/themis/discussions),
+raise an issue in the [issue tracker](https://github.com/cossacklabs/themis/issues),
+or write to [dev@cossacklabs.com](mailto:dev@cossacklabs.com).
 
 To talk to the business wing of Cossack Labs Limited, drop us an email to [info@cossacklabs.com](mailto:info@cossacklabs.com).
 


### PR DESCRIPTION
This feature is still technically in beta but it's already usable. That's a nice way to keep general "question" issues out of the issue tracker which should contain only something actionable.

Make Discussions the first link in “Contacts” section so that you'd like to click if you just want to chat about something and not to report a bug. Add this link to contribution guide too so that users will have a chance to know that Discussions is a thing.