### PR TITLE
Test GoThemis with more versions of Go

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -32,7 +32,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.11.13', '1.12.17', '1.13.8', '1.14']
+        go:
+          - '1.11'
+          - '1.12'
+          - '1.13'
+          - '1.14'
+          - '1.15'
+          - '1.16'
       fail-fast: false
     steps:
       - name: Install system dependencies
@@ -44,6 +50,7 @@ jobs:
         uses: actions/setup-go@v1
         with:
           go-version: ${{ matrix.go }}
+      - run: go version
       - name: Check out code
         uses: actions/checkout@v2
       - name: Install Themis Core

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -57,12 +57,8 @@ jobs:
         run: |
           make
           sudo make install
-      - name: Install GoThemis
-        run: |
-          mkdir -p ~/go/src/$GOTHEMIS_IMPORT
-          rsync -auv gothemis/ ~/go/src/$GOTHEMIS_IMPORT
       - name: Run test suite (Go ${{ matrix.go }})
-        run: make test_go
+        run: cd gothemis && go test -v ./...
 
   examples:
     name: Code examples

--- a/tests/test.mk
+++ b/tests/test.mk
@@ -153,7 +153,7 @@ ifdef GO_VERSION
 	@echo "Running gothemis tests."
 	@echo "In case of errors, see https://docs.cossacklabs.com/themis/languages/go/"
 	@echo "------------------------------------------------------------"
-	@go test -v $(GOTHEMIS_IMPORT)/...
+	@GO111MODULE=off go test -v $(GOTHEMIS_IMPORT)/...
 endif
 
 test_rust:


### PR DESCRIPTION
Somehow we have forgot to add new versions when they come out.

Also, starting with Go 1.16 the module-aware way is the default. Existing CI scripts use `make test_go` target which expects GoThemis to be installed globally into GOPATH, and you need to run `go test` with explicit `GO111MODULE=off` for that to still work.

Migrate the CI scripts to run module-based unit tests for code in the repo. However, we still keep the existing behavior of `make test_go` (now even with Go 1.16+). Also, GoThemis is still installed globally for testing examples (which are not modularized) and integration tests (ditto). It still kinda works that way.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] ~~Changelog is updated~~ (don't need?)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md

- [X] Fix test run with Go 1.16