### PR TITLE
WasmThemis code examples

### DIFF
--- a/.github/workflows/test-wasm.yaml
+++ b/.github/workflows/test-wasm.yaml
@@ -29,6 +29,10 @@ env:
   # RNG tests tend to fail in virtualized environment due to /dev/random
   # not behaving properly. Disable them to avoid spurious failures.
   NO_NIST_STS: 1
+  # WasmThemis uses promises to handle asynchronous WebAssmebly compilation.
+  # Node.js by default prints a warning if the top-level promise is rejected.
+  # Make it rethrow the exception failing the tests in this case.
+  NODE_OPTIONS: --unhandled-rejections=strict
 
 jobs:
   build-wasmthemis:
@@ -114,6 +118,12 @@ jobs:
           - 14.x  # current LTS
           - 16.x  # current stable
       fail-fast: false
+    env:
+      # WasmThemis uses promises to handle asynchronous WebAssmebly compilation.
+      # Node.js by default prints a warning if the top-level promise is rejected.
+      # Make it rethrow the exception failing the tests in this case.
+      # "--unhandled-rejections" is supported since Node.js v12.0.0, v10.17.0
+      NODE_OPTIONS: --unhandled-rejections=strict
     steps:
       - name: Install Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1

--- a/.github/workflows/test-wasm.yaml
+++ b/.github/workflows/test-wasm.yaml
@@ -116,6 +116,55 @@ jobs:
       - name: Install WasmThemis
         run: |
           npm install ./build/wasm-themis.tgz
+      - name: Test examples (keygen, ES5)
+        if: always()
+        run: |
+          cd $GITHUB_WORKSPACE/docs/examples/wasm/node.js-es5
+          echo "Test keygen..."
+          node secure_keygen.js
+          echo "ok"
+      - name: Test examples (Secure Cell, ES5)
+        if: always()
+        run: |
+          cd $GITHUB_WORKSPACE/docs/examples/wasm/node.js-es5
+          echo "Test Secure Cell..."
+          node secure_cell.js
+          echo "ok"
+      - name: Test examples (Secure Message, ES5)
+        if: always()
+        run: |
+          cd $GITHUB_WORKSPACE/docs/examples/wasm/node.js-es5
+          echo "Test Secure Message..."
+          alice=($(node secure_keygen.js | cut -c 14-))
+          bob=($(node secure_keygen.js | cut -c 14-))
+          enc=$(node secure_message.js enc "${alice[0]}" "${bob[1]}" message)
+          dec=$(node secure_message.js dec "${bob[0]}" "${alice[1]}" "$enc")
+          test "$dec" = "message"
+          echo "ok"
+      - name: Test examples (Secure Session, ES5)
+        if: always()
+        run: |
+          cd $GITHUB_WORKSPACE/docs/examples/wasm/node.js-es5
+          echo "Test Secure Session..."
+          node secure_session_server.js | tee server-output.txt &
+          sleep 1 # give the server time to launch
+          node secure_session_client.js | tee client-output.txt
+          killall node
+          grep -q 'Hello' server-output.txt
+          grep -q 'Hello' client-output.txt
+          echo "ok"
+      - name: Test examples (Secure Comparator, ES5)
+        if: always()
+        run: |
+          cd $GITHUB_WORKSPACE/docs/examples/wasm/node.js-es5
+          echo "Test Secure Comparator..."
+          node secure_comparator_server.js | tee server-output.txt &
+          sleep 1 # give the server time to launch
+          node secure_comparator_client.js | tee client-output.txt
+          killall node
+          grep -q 'compare equal: true' server-output.txt
+          grep -q 'compare equal: true' client-output.txt
+          echo "ok"
       - name: Test tools (keygen, ES5)
         if: always()
         run: |

--- a/.github/workflows/test-wasm.yaml
+++ b/.github/workflows/test-wasm.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/test-wasm.yaml'
+      - 'docs/examples/wasm/**'
       - 'src/soter/**'
       - 'src/themis/**'
       - 'src/wrappers/themis/wasm/**'

--- a/.github/workflows/test-wasm.yaml
+++ b/.github/workflows/test-wasm.yaml
@@ -75,3 +75,101 @@ jobs:
           emmake make test
       - name: Run test suite (WasmThemis)
         run: make test_wasm
+
+  examples:
+    name: Code examples
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version:
+          - 12.x  # old LTS
+          - 14.x  # current LTS
+          - 16.x  # current stable
+      fail-fast: false
+    steps:
+      - name: Install system dependencies
+        run: |
+          sudo sh -c 'echo "DEBIAN_FRONTEND=noninteractive" >> /etc/environment'
+          sudo apt update
+          sudo apt install --yes gcc make libssl-dev ninja-build
+      - name: Install Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install Emscripten
+        run: |
+          # Install Emscripten toolchain as described in documentation:
+          # https://emscripten.org/docs/getting_started/downloads.html
+          cd $HOME
+          git clone https://github.com/emscripten-core/emsdk.git
+          cd $HOME/emsdk
+          ./emsdk install  2.0.13
+          ./emsdk activate 2.0.13
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Build WasmThemis
+        run: |
+          source "$HOME/emsdk/emsdk_env.sh"
+          emmake make wasmthemis
+      - name: Install WasmThemis
+        run: |
+          npm install ./build/wasm-themis.tgz
+      - name: Test tools (keygen, ES5)
+        if: always()
+        run: |
+          echo "Test keygen..."
+          node ./tools/js/wasm-themis/keygen.js
+          test -e key
+          test -e key.pub
+          rm key key.pub
+          echo "ok"
+      - name: Test tools (Secure Cell, ES5)
+        if: always()
+        run: |
+          echo "Test Secure Cell (Seal)..."
+          enc=$(node ./tools/js/wasm-themis/scell_seal_string_echo.js \
+                    enc "master-key" "message" "associated context")
+          dec=$(node ./tools/js/wasm-themis/scell_seal_string_echo.js \
+                    dec "master-key" "$enc" "associated context")
+          test "$dec" = "message"
+          echo "ok"
+
+          echo "Test Secure Cell (Seal + passphrase)..."
+          enc=$(node ./tools/js/wasm-themis/scell_seal_string_echo_pw.js \
+                    enc "passphrase" "message" "associated context")
+          dec=$(node ./tools/js/wasm-themis/scell_seal_string_echo_pw.js \
+                    dec "passphrase" "$enc" "associated context")
+          test "$dec" = "message"
+          echo "ok"
+
+          echo "Test Secure Cell (Token Protect)..."
+          enc=$(node ./tools/js/wasm-themis/scell_token_string_echo.js \
+                    enc "master-key" "message" "associated context")
+          dec=$(node ./tools/js/wasm-themis/scell_token_string_echo.js \
+                    dec "master-key" "$enc" "associated context")
+          test "$dec" = "message"
+          echo "ok"
+
+          echo "Test Secure Cell (Context Imprint)..."
+          enc=$(node ./tools/js/wasm-themis/scell_context_string_echo.js \
+                    enc "master-key" "message" "associated context")
+          dec=$(node ./tools/js/wasm-themis/scell_context_string_echo.js \
+                    dec "master-key" "$enc" "associated context")
+          test "$dec" = "message"
+          echo "ok"
+      - name: Test tools (Secure Message, ES5)
+        if: always()
+        run: |
+          echo "Test Secure Message (encryption)..."
+          enc=$(node ./tools/js/wasm-themis/smessage_encryption.js \
+                    enc ./tests/_integration/keys/client.priv \
+                        ./tests/_integration/keys/server.pub \
+                    "your secure message")
+          dec=$(node ./tools/js/wasm-themis/smessage_encryption.js \
+                    dec ./tests/_integration/keys/client.priv \
+                        ./tests/_integration/keys/server.pub \
+                    "$enc")
+          test "$dec" = "your secure message"
+          echo "ok"

--- a/.github/workflows/test-wasm.yaml
+++ b/.github/workflows/test-wasm.yaml
@@ -123,12 +123,26 @@ jobs:
           echo "Test keygen..."
           node secure_keygen.js
           echo "ok"
+      - name: Test examples (keygen, ES6)
+        if: always()
+        run: |
+          cd $GITHUB_WORKSPACE/docs/examples/wasm/node.js-es6
+          echo "Test keygen..."
+          node secure_keygen.mjs
+          echo "ok"
       - name: Test examples (Secure Cell, ES5)
         if: always()
         run: |
           cd $GITHUB_WORKSPACE/docs/examples/wasm/node.js-es5
           echo "Test Secure Cell..."
           node secure_cell.js
+          echo "ok"
+      - name: Test examples (Secure Cell, ES6)
+        if: always()
+        run: |
+          cd $GITHUB_WORKSPACE/docs/examples/wasm/node.js-es6
+          echo "Test Secure Cell..."
+          node secure_cell.mjs
           echo "ok"
       - name: Test examples (Secure Message, ES5)
         if: always()
@@ -139,6 +153,17 @@ jobs:
           bob=($(node secure_keygen.js | cut -c 14-))
           enc=$(node secure_message.js enc "${alice[0]}" "${bob[1]}" message)
           dec=$(node secure_message.js dec "${bob[0]}" "${alice[1]}" "$enc")
+          test "$dec" = "message"
+          echo "ok"
+      - name: Test examples (Secure Message, ES6)
+        if: always()
+        run: |
+          cd $GITHUB_WORKSPACE/docs/examples/wasm/node.js-es6
+          echo "Test Secure Message..."
+          alice=($(node secure_keygen.mjs | cut -c 14-))
+          bob=($(node secure_keygen.mjs | cut -c 14-))
+          enc=$(node secure_message.mjs enc "${alice[0]}" "${bob[1]}" message)
+          dec=$(node secure_message.mjs dec "${bob[0]}" "${alice[1]}" "$enc")
           test "$dec" = "message"
           echo "ok"
       - name: Test examples (Secure Session, ES5)
@@ -153,6 +178,18 @@ jobs:
           grep -q 'Hello' server-output.txt
           grep -q 'Hello' client-output.txt
           echo "ok"
+      - name: Test examples (Secure Session, ES6)
+        if: always()
+        run: |
+          cd $GITHUB_WORKSPACE/docs/examples/wasm/node.js-es6
+          echo "Test Secure Session..."
+          node secure_session_server.mjs | tee server-output.txt &
+          sleep 1 # give the server time to launch
+          node secure_session_client.mjs | tee client-output.txt
+          killall node
+          grep -q 'Hello' server-output.txt
+          grep -q 'Hello' client-output.txt
+          echo "ok"
       - name: Test examples (Secure Comparator, ES5)
         if: always()
         run: |
@@ -161,6 +198,18 @@ jobs:
           node secure_comparator_server.js | tee server-output.txt &
           sleep 1 # give the server time to launch
           node secure_comparator_client.js | tee client-output.txt
+          killall node
+          grep -q 'compare equal: true' server-output.txt
+          grep -q 'compare equal: true' client-output.txt
+          echo "ok"
+      - name: Test examples (Secure Comparator, ES6)
+        if: always()
+        run: |
+          cd $GITHUB_WORKSPACE/docs/examples/wasm/node.js-es6
+          echo "Test Secure Comparator..."
+          node secure_comparator_server.mjs | tee server-output.txt &
+          sleep 1 # give the server time to launch
+          node secure_comparator_client.mjs | tee client-output.txt
           killall node
           grep -q 'compare equal: true' server-output.txt
           grep -q 'compare equal: true' client-output.txt

--- a/.github/workflows/test-wasm.yaml
+++ b/.github/workflows/test-wasm.yaml
@@ -30,28 +30,15 @@ env:
   NO_NIST_STS: 1
 
 jobs:
-  unit-tests:
-    name: Unit tests
+  build-wasmthemis:
+    name: Build WasmThemis
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version:
-          - 8.x   # legacy
-          - 10.x  # legacy
-          - 12.x  # old LTS
-          - 14.x  # current LTS
-          - 16.x  # current stable
-      fail-fast: false
     steps:
       - name: Install system dependencies
         run: |
           sudo sh -c 'echo "DEBIAN_FRONTEND=noninteractive" >> /etc/environment'
           sudo apt update
           sudo apt install --yes gcc make libssl-dev ninja-build
-      - name: Install Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
       - name: Install Emscripten
         run: |
           # Install Emscripten toolchain as described in documentation:
@@ -73,12 +60,52 @@ jobs:
         run: |
           source "$HOME/emsdk/emsdk_env.sh"
           emmake make test
+      - name: Pack build directory
+        run: tar cz build src/wrappers/themis/wasm > build.tgz
+      - name: Upload build directory
+        uses: actions/upload-artifact@v2
+        with:
+          name: build
+          path: build.tgz
+          retention-days: 1 # can be dropped after this build is complete
+
+  unit-tests:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    needs: build-wasmthemis
+    strategy:
+      matrix:
+        node-version:
+          - 8.x   # legacy
+          - 10.x  # legacy
+          - 12.x  # old LTS
+          - 14.x  # current LTS
+          - 16.x  # current stable
+      fail-fast: false
+    steps:
+      - name: Install Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Download build directory
+        uses: actions/download-artifact@v2
+        with:
+          name: build
+      - name: Unpack build directory
+        run: |
+          tar xf build.tgz
+          # Remove configuration of "build-wasmthemis" job.
+          # We have a different Node.js here and we're not in Emscripten env.
+          rm build/configure.mk
       - name: Run test suite (WasmThemis)
         run: make test_wasm
 
   examples:
     name: Code examples
     runs-on: ubuntu-latest
+    needs: build-wasmthemis
     strategy:
       matrix:
         node-version:
@@ -87,32 +114,18 @@ jobs:
           - 16.x  # current stable
       fail-fast: false
     steps:
-      - name: Install system dependencies
-        run: |
-          sudo sh -c 'echo "DEBIAN_FRONTEND=noninteractive" >> /etc/environment'
-          sudo apt update
-          sudo apt install --yes gcc make libssl-dev ninja-build
       - name: Install Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install Emscripten
-        run: |
-          # Install Emscripten toolchain as described in documentation:
-          # https://emscripten.org/docs/getting_started/downloads.html
-          cd $HOME
-          git clone https://github.com/emscripten-core/emsdk.git
-          cd $HOME/emsdk
-          ./emsdk install  2.0.13
-          ./emsdk activate 2.0.13
       - name: Check out code
         uses: actions/checkout@v2
+      - name: Download build directory
+        uses: actions/download-artifact@v2
         with:
-          submodules: true
-      - name: Build WasmThemis
-        run: |
-          source "$HOME/emsdk/emsdk_env.sh"
-          emmake make wasmthemis
+          name: build
+      - name: Unpack build directory
+        run: tar xf build.tgz
       - name: Install WasmThemis
         run: |
           npm install ./build/wasm-themis.tgz

--- a/.github/workflows/test-wasm.yaml
+++ b/.github/workflows/test-wasm.yaml
@@ -29,10 +29,6 @@ env:
   # RNG tests tend to fail in virtualized environment due to /dev/random
   # not behaving properly. Disable them to avoid spurious failures.
   NO_NIST_STS: 1
-  # WasmThemis uses promises to handle asynchronous WebAssmebly compilation.
-  # Node.js by default prints a warning if the top-level promise is rejected.
-  # Make it rethrow the exception failing the tests in this case.
-  NODE_OPTIONS: --unhandled-rejections=strict
 
 jobs:
   build-wasmthemis:

--- a/.github/workflows/test-wasm.yaml
+++ b/.github/workflows/test-wasm.yaml
@@ -125,6 +125,15 @@ jobs:
           test -e key.pub
           rm key key.pub
           echo "ok"
+      - name: Test tools (keygen, ES6)
+        if: always()
+        run: |
+          echo "Test keygen..."
+          node ./tools/js/wasm-themis/keygen.mjs
+          test -e key
+          test -e key.pub
+          rm key key.pub
+          echo "ok"
       - name: Test tools (Secure Cell, ES5)
         if: always()
         run: |
@@ -159,6 +168,40 @@ jobs:
                     dec "master-key" "$enc" "associated context")
           test "$dec" = "message"
           echo "ok"
+      - name: Test tools (Secure Cell, ES6)
+        if: always()
+        run: |
+          echo "Test Secure Cell (Seal)..."
+          enc=$(node ./tools/js/wasm-themis/scell_seal_string_echo.mjs \
+                    enc "master-key" "message" "associated context")
+          dec=$(node ./tools/js/wasm-themis/scell_seal_string_echo.mjs \
+                    dec "master-key" "$enc" "associated context")
+          test "$dec" = "message"
+          echo "ok"
+
+          echo "Test Secure Cell (Seal + passphrase)..."
+          enc=$(node ./tools/js/wasm-themis/scell_seal_string_echo_pw.mjs \
+                    enc "passphrase" "message" "associated context")
+          dec=$(node ./tools/js/wasm-themis/scell_seal_string_echo_pw.mjs \
+                    dec "passphrase" "$enc" "associated context")
+          test "$dec" = "message"
+          echo "ok"
+
+          echo "Test Secure Cell (Token Protect)..."
+          enc=$(node ./tools/js/wasm-themis/scell_token_string_echo.mjs \
+                    enc "master-key" "message" "associated context")
+          dec=$(node ./tools/js/wasm-themis/scell_token_string_echo.mjs \
+                    dec "master-key" "$enc" "associated context")
+          test "$dec" = "message"
+          echo "ok"
+
+          echo "Test Secure Cell (Context Imprint)..."
+          enc=$(node ./tools/js/wasm-themis/scell_context_string_echo.mjs \
+                    enc "master-key" "message" "associated context")
+          dec=$(node ./tools/js/wasm-themis/scell_context_string_echo.mjs \
+                    dec "master-key" "$enc" "associated context")
+          test "$dec" = "message"
+          echo "ok"
       - name: Test tools (Secure Message, ES5)
         if: always()
         run: |
@@ -168,6 +211,20 @@ jobs:
                         ./tests/_integration/keys/server.pub \
                     "your secure message")
           dec=$(node ./tools/js/wasm-themis/smessage_encryption.js \
+                    dec ./tests/_integration/keys/client.priv \
+                        ./tests/_integration/keys/server.pub \
+                    "$enc")
+          test "$dec" = "your secure message"
+          echo "ok"
+      - name: Test tools (Secure Message, ES6)
+        if: always()
+        run: |
+          echo "Test Secure Message (encryption)..."
+          enc=$(node ./tools/js/wasm-themis/smessage_encryption.mjs \
+                    enc ./tests/_integration/keys/client.priv \
+                        ./tests/_integration/keys/server.pub \
+                    "your secure message")
+          dec=$(node ./tools/js/wasm-themis/smessage_encryption.mjs \
                     dec ./tests/_integration/keys/client.priv \
                         ./tests/_integration/keys/server.pub \
                     "$enc")

--- a/docs/examples/wasm/node.js-es5/secure_cell.js
+++ b/docs/examples/wasm/node.js-es5/secure_cell.js
@@ -1,0 +1,70 @@
+const themis = require('wasm-themis')
+
+themis.initialized.then(function() {
+    let message = 'Test Message Please Ignore'
+    let context = 'Secure Cell example code'
+    let master_key = Buffer.from('bm8sIHRoaXMgaXMgbm90IGEgdmFsaWQgbWFzdGVyIGtleQ==', 'base64')
+    let passphrase = 'My Litte Secret: Passphrase Is Magic'
+
+    let encrypted_message, decrypted_message
+
+    console.log('# Secure Cell in Seal mode\n')
+
+    console.log('## Master key API\n')
+
+    let scellMK = themis.SecureCellSeal.withKey(master_key)
+
+    encrypted_message = scellMK.encrypt(Buffer.from(message, 'UTF-8'))
+    console.log('Encrypted: ' + Buffer.from(encrypted_message).toString('base64'))
+
+    decrypted_message = scellMK.decrypt(encrypted_message)
+    console.log('Decrypted: ' + Buffer.from(decrypted_message).toString('UTF-8'))
+
+    // Visit https://docs.cossacklabs.com/simulator/data-cell/
+    console.log()
+    encrypted_message = Buffer.from('AAEBQAwAAAAQAAAAEQAAAC0fCd2mOIxlDUORXz8+qCKuHCXcDii4bMF8OjOCOqsKEdV4+Ga2xTHPMupFvg==', 'base64')
+    decrypted_message = scellMK.decrypt(encrypted_message)
+    console.log('Decrypted (simulator): ' + Buffer.from(decrypted_message).toString('UTF-8'))
+
+    console.log()
+
+
+    console.log('## Passphrase API\n')
+
+    let scellPW = themis.SecureCellSeal.withPassphrase(passphrase)
+
+    encrypted_message = scellPW.encrypt(Buffer.from(message, 'UTF-8'))
+    console.log('Encrypted: ' + Buffer.from(encrypted_message).toString('base64'))
+
+    decrypted_message = scellPW.decrypt(encrypted_message)
+    console.log('Decrypted: ' + Buffer.from(decrypted_message).toString('UTF-8'))
+
+    console.log('')
+
+
+    console.log('# Secure Cell in Token Protect mode\n')
+
+    let scellTP = themis.SecureCellTokenProtect.withKey(master_key)
+
+    encrypted_message = scellTP.encrypt(Buffer.from(message, 'UTF-8'))
+    console.log('Encrypted:  ' + Buffer.from(encrypted_message.data).toString('base64'))
+    console.log('Auth token: ' + Buffer.from(encrypted_message.token).toString('base64'))
+
+    decrypted_message = scellTP.decrypt(encrypted_message.data, encrypted_message.token)
+    console.log('Decrypted:  ' + Buffer.from(decrypted_message).toString('UTF-8'))
+
+    console.log('')
+
+
+    console.log('# Secure Cell in Context Imprint mode\n')
+
+    let scellCI = themis.SecureCellContextImprint.withKey(master_key)
+
+    encrypted_message = scellCI.encrypt(Buffer.from(message, 'UTF-8'), Buffer.from(context, 'UTF-8'))
+    console.log('Encrypted: ' + Buffer.from(encrypted_message).toString('base64'))
+
+    decrypted_message = scellCI.decrypt(encrypted_message, Buffer.from(context, 'UTF-8'))
+    console.log('Decrypted: ' + Buffer.from(decrypted_message).toString('UTF-8'))
+
+    console.log('')
+})

--- a/docs/examples/wasm/node.js-es5/secure_cell.js
+++ b/docs/examples/wasm/node.js-es5/secure_cell.js
@@ -1,18 +1,18 @@
-const themis = require('wasm-themis')
+var themis = require('wasm-themis')
 
 themis.initialized.then(function() {
-    let message = 'Test Message Please Ignore'
-    let context = 'Secure Cell example code'
-    let master_key = Buffer.from('bm8sIHRoaXMgaXMgbm90IGEgdmFsaWQgbWFzdGVyIGtleQ==', 'base64')
-    let passphrase = 'My Litte Secret: Passphrase Is Magic'
+    var message = 'Test Message Please Ignore'
+    var context = 'Secure Cell example code'
+    var master_key = Buffer.from('bm8sIHRoaXMgaXMgbm90IGEgdmFsaWQgbWFzdGVyIGtleQ==', 'base64')
+    var passphrase = 'My Litte Secret: Passphrase Is Magic'
 
-    let encrypted_message, decrypted_message
+    var encrypted_message, decrypted_message
 
     console.log('# Secure Cell in Seal mode\n')
 
     console.log('## Master key API\n')
 
-    let scellMK = themis.SecureCellSeal.withKey(master_key)
+    var scellMK = themis.SecureCellSeal.withKey(master_key)
 
     encrypted_message = scellMK.encrypt(Buffer.from(message, 'UTF-8'))
     console.log('Encrypted: ' + Buffer.from(encrypted_message).toString('base64'))
@@ -31,7 +31,7 @@ themis.initialized.then(function() {
 
     console.log('## Passphrase API\n')
 
-    let scellPW = themis.SecureCellSeal.withPassphrase(passphrase)
+    var scellPW = themis.SecureCellSeal.withPassphrase(passphrase)
 
     encrypted_message = scellPW.encrypt(Buffer.from(message, 'UTF-8'))
     console.log('Encrypted: ' + Buffer.from(encrypted_message).toString('base64'))
@@ -44,7 +44,7 @@ themis.initialized.then(function() {
 
     console.log('# Secure Cell in Token Protect mode\n')
 
-    let scellTP = themis.SecureCellTokenProtect.withKey(master_key)
+    var scellTP = themis.SecureCellTokenProtect.withKey(master_key)
 
     encrypted_message = scellTP.encrypt(Buffer.from(message, 'UTF-8'))
     console.log('Encrypted:  ' + Buffer.from(encrypted_message.data).toString('base64'))
@@ -58,7 +58,7 @@ themis.initialized.then(function() {
 
     console.log('# Secure Cell in Context Imprint mode\n')
 
-    let scellCI = themis.SecureCellContextImprint.withKey(master_key)
+    var scellCI = themis.SecureCellContextImprint.withKey(master_key)
 
     encrypted_message = scellCI.encrypt(Buffer.from(message, 'UTF-8'), Buffer.from(context, 'UTF-8'))
     console.log('Encrypted: ' + Buffer.from(encrypted_message).toString('base64'))

--- a/docs/examples/wasm/node.js-es5/secure_comparator_client.js
+++ b/docs/examples/wasm/node.js-es5/secure_comparator_client.js
@@ -1,17 +1,17 @@
-const net = require('net')
-const themis = require('wasm-themis')
+var net = require('net')
+var themis = require('wasm-themis')
 
 themis.initialized.then(function() {
-    let comparator = new themis.SecureComparator(Buffer.from('secret'))
+    var comparator = new themis.SecureComparator(Buffer.from('secret'))
 
-    let socket = new net.Socket()
+    var socket = new net.Socket()
     socket.connect(1337, '127.0.0.1', function() {
         console.log('Client: connected');
         socket.write(comparator.begin())
     })
 
     socket.on('data', function(dataFromServer) {
-        let dataToServer = comparator.proceed(dataFromServer)
+        var dataToServer = comparator.proceed(dataFromServer)
         if (!comparator.complete()) {
             socket.write(dataToServer)
         } else {

--- a/docs/examples/wasm/node.js-es5/secure_comparator_client.js
+++ b/docs/examples/wasm/node.js-es5/secure_comparator_client.js
@@ -1,0 +1,27 @@
+const net = require('net')
+const themis = require('wasm-themis')
+
+themis.initialized.then(function() {
+    let comparator = new themis.SecureComparator(Buffer.from('secret'))
+
+    let socket = new net.Socket()
+    socket.connect(1337, '127.0.0.1', function() {
+        console.log('Client: connected');
+        socket.write(comparator.begin())
+    })
+
+    socket.on('data', function(dataFromServer) {
+        let dataToServer = comparator.proceed(dataFromServer)
+        if (!comparator.complete()) {
+            socket.write(dataToServer)
+        } else {
+            console.log('Client: compare equal: ' + comparator.compareEqual())
+            comparator.destroy()
+            socket.destroy()
+        }
+    })
+
+    socket.on('close', function() {
+        console.log('Client: connection closed')
+    })
+})

--- a/docs/examples/wasm/node.js-es5/secure_comparator_server.js
+++ b/docs/examples/wasm/node.js-es5/secure_comparator_server.js
@@ -1,14 +1,14 @@
-const net = require('net')
-const themis = require('wasm-themis')
+var net = require('net')
+var themis = require('wasm-themis')
 
 themis.initialized.then(function() {
-    let server = net.createServer(function(socket) {
+    var server = net.createServer(function(socket) {
         console.log('Server: accepted connection')
 
-        let comparator = new themis.SecureComparator(Buffer.from('secret'))
+        var comparator = new themis.SecureComparator(Buffer.from('secret'))
 
         socket.on('data', function(dataFromClient) {
-            let dataToClient = comparator.proceed(dataFromClient)
+            var dataToClient = comparator.proceed(dataFromClient)
             socket.write(dataToClient)
             if (comparator.complete()) {
                 console.log('Server: compare equal: ' + comparator.compareEqual())

--- a/docs/examples/wasm/node.js-es5/secure_comparator_server.js
+++ b/docs/examples/wasm/node.js-es5/secure_comparator_server.js
@@ -1,0 +1,27 @@
+const net = require('net')
+const themis = require('wasm-themis')
+
+themis.initialized.then(function() {
+    let server = net.createServer(function(socket) {
+        console.log('Server: accepted connection')
+
+        let comparator = new themis.SecureComparator(Buffer.from('secret'))
+
+        socket.on('data', function(dataFromClient) {
+            let dataToClient = comparator.proceed(dataFromClient)
+            socket.write(dataToClient)
+            if (comparator.complete()) {
+                console.log('Server: compare equal: ' + comparator.compareEqual())
+                comparator.destroy()
+                socket.destroy()
+            }
+        })
+
+        socket.on('close', function() {
+            console.log('Server: connection closed')
+        })
+    })
+
+    server.listen(1337, '127.0.0.1')
+    console.log('Server: waiting for connections')
+})

--- a/docs/examples/wasm/node.js-es5/secure_keygen.js
+++ b/docs/examples/wasm/node.js-es5/secure_keygen.js
@@ -1,0 +1,8 @@
+const themis = require('wasm-themis')
+
+themis.initialized.then(function() {
+    let keypair = new themis.KeyPair()
+
+    console.log('private key: ' + Buffer.from(keypair.privateKey).toString('base64'))
+    console.log('public key : ' + Buffer.from(keypair.publicKey).toString('base64'))
+})

--- a/docs/examples/wasm/node.js-es5/secure_keygen.js
+++ b/docs/examples/wasm/node.js-es5/secure_keygen.js
@@ -1,7 +1,7 @@
-const themis = require('wasm-themis')
+var themis = require('wasm-themis')
 
 themis.initialized.then(function() {
-    let keypair = new themis.KeyPair()
+    var keypair = new themis.KeyPair()
 
     console.log('private key: ' + Buffer.from(keypair.privateKey).toString('base64'))
     console.log('public key : ' + Buffer.from(keypair.publicKey).toString('base64'))

--- a/docs/examples/wasm/node.js-es5/secure_message.js
+++ b/docs/examples/wasm/node.js-es5/secure_message.js
@@ -1,6 +1,6 @@
-const themis = require('wasm-themis')
+var themis = require('wasm-themis')
 
-let command, privateKeyText, publicKeyText, message
+var command, privateKeyText, publicKeyText, message
 if (process.argv.length == 6) {
     command        = process.argv[2]
     privateKeyText = process.argv[3]
@@ -12,18 +12,18 @@ if (process.argv.length == 6) {
 }
 
 themis.initialized.then(function() {
-    let privateKey = new themis.PrivateKey(Buffer.from(privateKeyText, 'base64'))
-    let publicKey = new themis.PublicKey(Buffer.from(publicKeyText, 'base64'))
+    var privateKey = new themis.PrivateKey(Buffer.from(privateKeyText, 'base64'))
+    var publicKey = new themis.PublicKey(Buffer.from(publicKeyText, 'base64'))
 
-    let secureMessage = new themis.SecureMessage(privateKey, publicKey)
+    var secureMessage = new themis.SecureMessage(privateKey, publicKey)
 
     switch (command) {
     case 'enc':
-        let encrypted = secureMessage.encrypt(Buffer.from(message, 'UTF-8'))
+        var encrypted = secureMessage.encrypt(Buffer.from(message, 'UTF-8'))
         console.log(Buffer.from(encrypted).toString('base64'))
         break
     case 'dec':
-        let decrypted = secureMessage.decrypt(Buffer.from(message, 'base64'))
+        var decrypted = secureMessage.decrypt(Buffer.from(message, 'base64'))
         console.log(Buffer.from(decrypted).toString('UTF-8'))
         break
     default:

--- a/docs/examples/wasm/node.js-es5/secure_message.js
+++ b/docs/examples/wasm/node.js-es5/secure_message.js
@@ -1,0 +1,33 @@
+const themis = require('wasm-themis')
+
+let command, privateKeyText, publicKeyText, message
+if (process.argv.length == 6) {
+    command        = process.argv[2]
+    privateKeyText = process.argv[3]
+    publicKeyText  = process.argv[4]
+    message        = process.argv[5]
+} else {
+    console.error('usage:\n\tnode ' + process.argv[1] + '{enc|dec} <private-key> <public-key> <message>')
+    process.exit(1)
+}
+
+themis.initialized.then(function() {
+    let privateKey = new themis.PrivateKey(Buffer.from(privateKeyText, 'base64'))
+    let publicKey = new themis.PublicKey(Buffer.from(publicKeyText, 'base64'))
+
+    let secureMessage = new themis.SecureMessage(privateKey, publicKey)
+
+    switch (command) {
+    case 'enc':
+        let encrypted = secureMessage.encrypt(Buffer.from(message, 'UTF-8'))
+        console.log(Buffer.from(encrypted).toString('base64'))
+        break
+    case 'dec':
+        let decrypted = secureMessage.decrypt(Buffer.from(message, 'base64'))
+        console.log(Buffer.from(decrypted).toString('UTF-8'))
+        break
+    default:
+        console.error('usage:\n\tnode ' + process.argv[1] + '{enc|dec} <private-key> <public-key> <message>')
+        process.exit(1)
+    }
+})

--- a/docs/examples/wasm/node.js-es5/secure_session_client.js
+++ b/docs/examples/wasm/node.js-es5/secure_session_client.js
@@ -1,17 +1,17 @@
-const net = require('net')
-const themis = require('wasm-themis')
+var net = require('net')
+var themis = require('wasm-themis')
 
-const clientPrivateKeyBuffer = Buffer.from('UkVDMgAAAC3DZR2qAEbvO092R/IKXBttnf9dVSU65R+Fb4eNoyxxlzn2n4GR', 'base64')
-const serverPublicKeyBuffer = Buffer.from('VUVDMgAAAC30/vs+AwciK6egi82A9TkTydVuOzMFsJ9AkA0gMGyNH0tSu5Bk', 'base64')
+var clientPrivateKeyBuffer = Buffer.from('UkVDMgAAAC3DZR2qAEbvO092R/IKXBttnf9dVSU65R+Fb4eNoyxxlzn2n4GR', 'base64')
+var serverPublicKeyBuffer = Buffer.from('VUVDMgAAAC30/vs+AwciK6egi82A9TkTydVuOzMFsJ9AkA0gMGyNH0tSu5Bk', 'base64')
 
-const clientID = Buffer.from('client')
-const serverID = Buffer.from('server')
+var clientID = Buffer.from('client')
+var serverID = Buffer.from('server')
 
 themis.initialized.then(function() {
-    let clientPrivateKey = new themis.PrivateKey(clientPrivateKeyBuffer)
-    let serverPublicKey = new themis.PublicKey(serverPublicKeyBuffer)
+    var clientPrivateKey = new themis.PrivateKey(clientPrivateKeyBuffer)
+    var serverPublicKey = new themis.PublicKey(serverPublicKeyBuffer)
 
-    let session = new themis.SecureSession(clientID, clientPrivateKey, function(id) {
+    var session = new themis.SecureSession(clientID, clientPrivateKey, function(id) {
         if (serverID.equals(id)) {
             return serverPublicKey
         }
@@ -19,29 +19,29 @@ themis.initialized.then(function() {
         return null
     })
 
-    let counter = 5
+    var counter = 5
 
-    let socket = new net.Socket()
+    var socket = new net.Socket()
     socket.connect(1337, '127.0.0.1', function() {
         console.log('Client: connected')
-        let request = session.connectionRequest()
+        var request = session.connectionRequest()
         socket.write(request)
     })
 
     socket.on('data', function(dataFromServer) {
         if (!session.established()) {
-            let dataToServer = session.negotiateReply(dataFromServer)
+            var dataToServer = session.negotiateReply(dataFromServer)
             socket.write(dataToServer)
             if (session.established()) {
                 console.log('Client: Secure Session established')
-                let dataToServer = session.wrap(Buffer.from('Hello ' + counter))
+                var dataToServer = session.wrap(Buffer.from('Hello ' + counter))
                 socket.write(dataToServer)
             }
         } else {
-            let message = session.unwrap(dataFromServer)
+            var message = session.unwrap(dataFromServer)
             console.log('Client: server says: ' + Buffer.from(message).toString())
             if (counter--) {
-                let dataToServer = session.wrap(Buffer.from('Hello ' + counter))
+                var dataToServer = session.wrap(Buffer.from('Hello ' + counter))
                 socket.write(dataToServer)
             } else {
                 session.destroy()

--- a/docs/examples/wasm/node.js-es5/secure_session_client.js
+++ b/docs/examples/wasm/node.js-es5/secure_session_client.js
@@ -1,0 +1,56 @@
+const net = require('net')
+const themis = require('wasm-themis')
+
+const clientPrivateKeyBuffer = Buffer.from('UkVDMgAAAC3DZR2qAEbvO092R/IKXBttnf9dVSU65R+Fb4eNoyxxlzn2n4GR', 'base64')
+const serverPublicKeyBuffer = Buffer.from('VUVDMgAAAC30/vs+AwciK6egi82A9TkTydVuOzMFsJ9AkA0gMGyNH0tSu5Bk', 'base64')
+
+const clientID = Buffer.from('client')
+const serverID = Buffer.from('server')
+
+themis.initialized.then(function() {
+    let clientPrivateKey = new themis.PrivateKey(clientPrivateKeyBuffer)
+    let serverPublicKey = new themis.PublicKey(serverPublicKeyBuffer)
+
+    let session = new themis.SecureSession(clientID, clientPrivateKey, function(id) {
+        if (serverID.equals(id)) {
+            return serverPublicKey
+        }
+        console.error('Client: unknown peer ID: ' + Buffer.from(id).toString())
+        return null
+    })
+
+    let counter = 5
+
+    let socket = new net.Socket()
+    socket.connect(1337, '127.0.0.1', function() {
+        console.log('Client: connected')
+        let request = session.connectionRequest()
+        socket.write(request)
+    })
+
+    socket.on('data', function(dataFromServer) {
+        if (!session.established()) {
+            let dataToServer = session.negotiateReply(dataFromServer)
+            socket.write(dataToServer)
+            if (session.established()) {
+                console.log('Client: Secure Session established')
+                let dataToServer = session.wrap(Buffer.from('Hello ' + counter))
+                socket.write(dataToServer)
+            }
+        } else {
+            let message = session.unwrap(dataFromServer)
+            console.log('Client: server says: ' + Buffer.from(message).toString())
+            if (counter--) {
+                let dataToServer = session.wrap(Buffer.from('Hello ' + counter))
+                socket.write(dataToServer)
+            } else {
+                session.destroy()
+                socket.destroy()
+            }
+        }
+    })
+
+    socket.on('close', function() {
+        console.log('Client: connection closed')
+    })
+})

--- a/docs/examples/wasm/node.js-es5/secure_session_server.js
+++ b/docs/examples/wasm/node.js-es5/secure_session_server.js
@@ -1,20 +1,20 @@
-const net = require('net')
-const themis = require('wasm-themis')
+var net = require('net')
+var themis = require('wasm-themis')
 
-const serverPrivateKeyBuffer = Buffer.from('UkVDMgAAAC0U6AK7AAm6ha0cgHmovSTpZax01+icg9xwFlZAqqGWeGTqbHUt', 'base64')
-const clientPublicKeyBuffer = Buffer.from('VUVDMgAAAC15KNjgAr1DQEw+So1oztUarO4Jw/CGgyehBRCbOxbpHrPBKO7s', 'base64')
+var serverPrivateKeyBuffer = Buffer.from('UkVDMgAAAC0U6AK7AAm6ha0cgHmovSTpZax01+icg9xwFlZAqqGWeGTqbHUt', 'base64')
+var clientPublicKeyBuffer = Buffer.from('VUVDMgAAAC15KNjgAr1DQEw+So1oztUarO4Jw/CGgyehBRCbOxbpHrPBKO7s', 'base64')
 
-const clientID = Buffer.from('client')
-const serverID = Buffer.from('server')
+var clientID = Buffer.from('client')
+var serverID = Buffer.from('server')
 
 themis.initialized.then(function() {
-    let serverPrivateKey = new themis.PrivateKey(serverPrivateKeyBuffer)
-    let clientPublicKey = new themis.PublicKey(clientPublicKeyBuffer)
+    var serverPrivateKey = new themis.PrivateKey(serverPrivateKeyBuffer)
+    var clientPublicKey = new themis.PublicKey(clientPublicKeyBuffer)
 
-    let server = net.createServer(function(socket) {
+    var server = net.createServer(function(socket) {
         console.log('Server: accepted connection')
 
-        let session = new themis.SecureSession(serverID, serverPrivateKey, function(id) {
+        var session = new themis.SecureSession(serverID, serverPrivateKey, function(id) {
             if (clientID.equals(id)) {
                 return clientPublicKey
             }
@@ -24,15 +24,15 @@ themis.initialized.then(function() {
 
         socket.on('data', function(dataFromClient) {
             if (!session.established()) {
-                let dataToClient = session.negotiateReply(dataFromClient)
+                var dataToClient = session.negotiateReply(dataFromClient)
                 socket.write(dataToClient)
                 if (session.established()) {
                     console.log('Server: Secure Session established')
                 }
             } else {
-                let message = session.unwrap(dataFromClient)
+                var message = session.unwrap(dataFromClient)
                 console.log('Server: client says: ' + Buffer.from(message).toString())
-                let reply = session.wrap(message)
+                var reply = session.wrap(message)
                 socket.write(reply)
             }
         })

--- a/docs/examples/wasm/node.js-es5/secure_session_server.js
+++ b/docs/examples/wasm/node.js-es5/secure_session_server.js
@@ -1,0 +1,48 @@
+const net = require('net')
+const themis = require('wasm-themis')
+
+const serverPrivateKeyBuffer = Buffer.from('UkVDMgAAAC0U6AK7AAm6ha0cgHmovSTpZax01+icg9xwFlZAqqGWeGTqbHUt', 'base64')
+const clientPublicKeyBuffer = Buffer.from('VUVDMgAAAC15KNjgAr1DQEw+So1oztUarO4Jw/CGgyehBRCbOxbpHrPBKO7s', 'base64')
+
+const clientID = Buffer.from('client')
+const serverID = Buffer.from('server')
+
+themis.initialized.then(function() {
+    let serverPrivateKey = new themis.PrivateKey(serverPrivateKeyBuffer)
+    let clientPublicKey = new themis.PublicKey(clientPublicKeyBuffer)
+
+    let server = net.createServer(function(socket) {
+        console.log('Server: accepted connection')
+
+        let session = new themis.SecureSession(serverID, serverPrivateKey, function(id) {
+            if (clientID.equals(id)) {
+                return clientPublicKey
+            }
+            console.error('Server: unknown peer ID: ' + Buffer.from(id).toString())
+            return null
+        })
+
+        socket.on('data', function(dataFromClient) {
+            if (!session.established()) {
+                let dataToClient = session.negotiateReply(dataFromClient)
+                socket.write(dataToClient)
+                if (session.established()) {
+                    console.log('Server: Secure Session established')
+                }
+            } else {
+                let message = session.unwrap(dataFromClient)
+                console.log('Server: client says: ' + Buffer.from(message).toString())
+                let reply = session.wrap(message)
+                socket.write(reply)
+            }
+        })
+
+        socket.on('close', function() {
+            console.log('Server: connection closed')
+            session.destroy()
+        })
+    })
+
+    server.listen(1337, '127.0.0.1')
+    console.log('Server: waiting for connections')
+})

--- a/docs/examples/wasm/node.js-es6/secure_cell.mjs
+++ b/docs/examples/wasm/node.js-es6/secure_cell.mjs
@@ -1,0 +1,74 @@
+import themis from 'wasm-themis'
+
+async function main() {
+    await themis.initialized
+
+    let message = 'Test Message Please Ignore'
+    let context = 'Secure Cell example code'
+    let master_key = Buffer.from('bm8sIHRoaXMgaXMgbm90IGEgdmFsaWQgbWFzdGVyIGtleQ==', 'base64')
+    let passphrase = 'My Litte Secret: Passphrase Is Magic'
+
+    let encrypted_message, decrypted_message
+
+    console.log('# Secure Cell in Seal mode\n')
+
+    console.log('## Master key API\n')
+
+    let scellMK = themis.SecureCellSeal.withKey(master_key)
+
+    encrypted_message = scellMK.encrypt(Buffer.from(message, 'UTF-8'))
+    console.log('Encrypted: ' + Buffer.from(encrypted_message).toString('base64'))
+
+    decrypted_message = scellMK.decrypt(encrypted_message)
+    console.log('Decrypted: ' + Buffer.from(decrypted_message).toString('UTF-8'))
+
+    // Visit https://docs.cossacklabs.com/simulator/data-cell/
+    console.log()
+    encrypted_message = Buffer.from('AAEBQAwAAAAQAAAAEQAAAC0fCd2mOIxlDUORXz8+qCKuHCXcDii4bMF8OjOCOqsKEdV4+Ga2xTHPMupFvg==', 'base64')
+    decrypted_message = scellMK.decrypt(encrypted_message)
+    console.log('Decrypted (simulator): ' + Buffer.from(decrypted_message).toString('UTF-8'))
+
+    console.log()
+
+
+    console.log('## Passphrase API\n')
+
+    let scellPW = themis.SecureCellSeal.withPassphrase(passphrase)
+
+    encrypted_message = scellPW.encrypt(Buffer.from(message, 'UTF-8'))
+    console.log('Encrypted: ' + Buffer.from(encrypted_message).toString('base64'))
+
+    decrypted_message = scellPW.decrypt(encrypted_message)
+    console.log('Decrypted: ' + Buffer.from(decrypted_message).toString('UTF-8'))
+
+    console.log('')
+
+
+    console.log('# Secure Cell in Token Protect mode\n')
+
+    let scellTP = themis.SecureCellTokenProtect.withKey(master_key)
+
+    encrypted_message = scellTP.encrypt(Buffer.from(message, 'UTF-8'))
+    console.log('Encrypted:  ' + Buffer.from(encrypted_message.data).toString('base64'))
+    console.log('Auth token: ' + Buffer.from(encrypted_message.token).toString('base64'))
+
+    decrypted_message = scellTP.decrypt(encrypted_message.data, encrypted_message.token)
+    console.log('Decrypted:  ' + Buffer.from(decrypted_message).toString('UTF-8'))
+
+    console.log('')
+
+
+    console.log('# Secure Cell in Context Imprint mode\n')
+
+    let scellCI = themis.SecureCellContextImprint.withKey(master_key)
+
+    encrypted_message = scellCI.encrypt(Buffer.from(message, 'UTF-8'), Buffer.from(context, 'UTF-8'))
+    console.log('Encrypted: ' + Buffer.from(encrypted_message).toString('base64'))
+
+    decrypted_message = scellCI.decrypt(encrypted_message, Buffer.from(context, 'UTF-8'))
+    console.log('Decrypted: ' + Buffer.from(decrypted_message).toString('UTF-8'))
+
+    console.log('')
+}
+
+main()

--- a/docs/examples/wasm/node.js-es6/secure_comparator_client.mjs
+++ b/docs/examples/wasm/node.js-es6/secure_comparator_client.mjs
@@ -1,0 +1,31 @@
+import net from 'net'
+import themis from 'wasm-themis'
+
+async function main() {
+    await themis.initialized
+
+    let comparator = new themis.SecureComparator(Buffer.from('secret'))
+
+    let socket = new net.Socket()
+    socket.connect(1337, '127.0.0.1', function() {
+        console.log('Client: connected');
+        socket.write(comparator.begin())
+    })
+
+    socket.on('data', function(dataFromServer) {
+        let dataToServer = comparator.proceed(dataFromServer)
+        if (!comparator.complete()) {
+            socket.write(dataToServer)
+        } else {
+            console.log('Client: compare equal: ' + comparator.compareEqual())
+            comparator.destroy()
+            socket.destroy()
+        }
+    })
+
+    socket.on('close', function() {
+        console.log('Client: connection closed')
+    })
+}
+
+main()

--- a/docs/examples/wasm/node.js-es6/secure_comparator_server.mjs
+++ b/docs/examples/wasm/node.js-es6/secure_comparator_server.mjs
@@ -1,0 +1,31 @@
+import net from 'net'
+import themis from 'wasm-themis'
+
+async function main() {
+    await themis.initialized
+
+    let server = net.createServer(function(socket) {
+        console.log('Server: accepted connection')
+
+        let comparator = new themis.SecureComparator(Buffer.from('secret'))
+
+        socket.on('data', function(dataFromClient) {
+            let dataToClient = comparator.proceed(dataFromClient)
+            socket.write(dataToClient)
+            if (comparator.complete()) {
+                console.log('Server: compare equal: ' + comparator.compareEqual())
+                comparator.destroy()
+                socket.destroy()
+            }
+        })
+
+        socket.on('close', function() {
+            console.log('Server: connection closed')
+        })
+    })
+
+    server.listen(1337, '127.0.0.1')
+    console.log('Server: waiting for connections')
+}
+
+main()

--- a/docs/examples/wasm/node.js-es6/secure_keygen.mjs
+++ b/docs/examples/wasm/node.js-es6/secure_keygen.mjs
@@ -1,0 +1,12 @@
+import themis from 'wasm-themis'
+
+async function main() {
+    await themis.initialized
+
+    let keypair = new themis.KeyPair()
+
+    console.log(`private key: ${Buffer.from(keypair.privateKey).toString('base64')}`)
+    console.log(`public key : ${Buffer.from(keypair.publicKey).toString('base64')}`)
+}
+
+main()

--- a/docs/examples/wasm/node.js-es6/secure_message.mjs
+++ b/docs/examples/wasm/node.js-es6/secure_message.mjs
@@ -1,0 +1,37 @@
+import themis from 'wasm-themis'
+
+let command, privateKeyText, publicKeyText, message
+if (process.argv.length == 6) {
+    command        = process.argv[2]
+    privateKeyText = process.argv[3]
+    publicKeyText  = process.argv[4]
+    message        = process.argv[5]
+} else {
+    console.error(`usage:\n\tnode ${process.argv[1]} {enc|dec} <private-key> <public-key> <message>`)
+    process.exit(1)
+}
+
+async function main() {
+    await themis.initialized
+
+    let privateKey = new themis.PrivateKey(Buffer.from(privateKeyText, 'base64'))
+    let publicKey = new themis.PublicKey(Buffer.from(publicKeyText, 'base64'))
+
+    let secureMessage = new themis.SecureMessage(privateKey, publicKey)
+
+    switch (command) {
+    case 'enc':
+        let encrypted = secureMessage.encrypt(Buffer.from(message, 'UTF-8'))
+        console.log(Buffer.from(encrypted).toString('base64'))
+        break
+    case 'dec':
+        let decrypted = secureMessage.decrypt(Buffer.from(message, 'base64'))
+        console.log(Buffer.from(decrypted).toString('UTF-8'))
+        break
+    default:
+        console.error(`usage:\n\tnode ${process.argv[1]} {enc|dec} <private-key> <public-key> <message>`)
+        process.exit(1)
+    }
+}
+
+main()

--- a/docs/examples/wasm/node.js-es6/secure_session_client.mjs
+++ b/docs/examples/wasm/node.js-es6/secure_session_client.mjs
@@ -1,0 +1,60 @@
+import net from 'net'
+import themis from 'wasm-themis'
+
+const clientPrivateKeyBuffer = Buffer.from('UkVDMgAAAC3DZR2qAEbvO092R/IKXBttnf9dVSU65R+Fb4eNoyxxlzn2n4GR', 'base64')
+const serverPublicKeyBuffer = Buffer.from('VUVDMgAAAC30/vs+AwciK6egi82A9TkTydVuOzMFsJ9AkA0gMGyNH0tSu5Bk', 'base64')
+
+const clientID = Buffer.from('client')
+const serverID = Buffer.from('server')
+
+async function main() {
+    await themis.initialized
+
+    let clientPrivateKey = new themis.PrivateKey(clientPrivateKeyBuffer)
+    let serverPublicKey = new themis.PublicKey(serverPublicKeyBuffer)
+
+    let session = new themis.SecureSession(clientID, clientPrivateKey, function(id) {
+        if (serverID.equals(id)) {
+            return serverPublicKey
+        }
+        console.error('Client: unknown peer ID: ' + Buffer.from(id).toString())
+        return null
+    })
+
+    let counter = 5
+
+    let socket = new net.Socket()
+    socket.connect(1337, '127.0.0.1', function() {
+        console.log('Client: connected')
+        let request = session.connectionRequest()
+        socket.write(request)
+    })
+
+    socket.on('data', function(dataFromServer) {
+        if (!session.established()) {
+            let dataToServer = session.negotiateReply(dataFromServer)
+            socket.write(dataToServer)
+            if (session.established()) {
+                console.log('Client: Secure Session established')
+                let dataToServer = session.wrap(Buffer.from('Hello ' + counter))
+                socket.write(dataToServer)
+            }
+        } else {
+            let message = session.unwrap(dataFromServer)
+            console.log('Client: server says: ' + Buffer.from(message).toString())
+            if (counter--) {
+                let dataToServer = session.wrap(Buffer.from('Hello ' + counter))
+                socket.write(dataToServer)
+            } else {
+                session.destroy()
+                socket.destroy()
+            }
+        }
+    })
+
+    socket.on('close', function() {
+        console.log('Client: connection closed')
+    })
+}
+
+main()

--- a/docs/examples/wasm/node.js-es6/secure_session_server.mjs
+++ b/docs/examples/wasm/node.js-es6/secure_session_server.mjs
@@ -1,0 +1,52 @@
+import net from 'net'
+import themis from 'wasm-themis'
+
+const serverPrivateKeyBuffer = Buffer.from('UkVDMgAAAC0U6AK7AAm6ha0cgHmovSTpZax01+icg9xwFlZAqqGWeGTqbHUt', 'base64')
+const clientPublicKeyBuffer = Buffer.from('VUVDMgAAAC15KNjgAr1DQEw+So1oztUarO4Jw/CGgyehBRCbOxbpHrPBKO7s', 'base64')
+
+const clientID = Buffer.from('client')
+const serverID = Buffer.from('server')
+
+async function main() {
+    await themis.initialized
+
+    let serverPrivateKey = new themis.PrivateKey(serverPrivateKeyBuffer)
+    let clientPublicKey = new themis.PublicKey(clientPublicKeyBuffer)
+
+    let server = net.createServer(function(socket) {
+        console.log('Server: accepted connection')
+
+        let session = new themis.SecureSession(serverID, serverPrivateKey, function(id) {
+            if (clientID.equals(id)) {
+                return clientPublicKey
+            }
+            console.error('Server: unknown peer ID: ' + Buffer.from(id).toString())
+            return null
+        })
+
+        socket.on('data', function(dataFromClient) {
+            if (!session.established()) {
+                let dataToClient = session.negotiateReply(dataFromClient)
+                socket.write(dataToClient)
+                if (session.established()) {
+                    console.log('Server: Secure Session established')
+                }
+            } else {
+                let message = session.unwrap(dataFromClient)
+                console.log('Server: client says: ' + Buffer.from(message).toString())
+                let reply = session.wrap(message)
+                socket.write(reply)
+            }
+        })
+
+        socket.on('close', function() {
+            console.log('Server: connection closed')
+            session.destroy()
+        })
+    })
+
+    server.listen(1337, '127.0.0.1')
+    console.log('Server: waiting for connections')
+}
+
+main()

--- a/tools/js/wasm-themis/keygen.js
+++ b/tools/js/wasm-themis/keygen.js
@@ -1,7 +1,7 @@
-const fs = require('fs')
-const themis = require('wasm-themis')
+var fs = require('fs')
+var themis = require('wasm-themis')
 
-let private_key_path, public_key_path
+var private_key_path, public_key_path
 switch (process.argv.length) {
     case 2:
         private_key_path = 'key'
@@ -17,7 +17,7 @@ switch (process.argv.length) {
 }
 
 themis.initialized.then(function() {
-    let keypair = new themis.KeyPair()
+    var keypair = new themis.KeyPair()
 
     fs.writeFile(private_key_path, keypair.privateKey, {'mode': 0o600}, function(err) {
         if (err) {

--- a/tools/js/wasm-themis/keygen.mjs
+++ b/tools/js/wasm-themis/keygen.mjs
@@ -1,0 +1,32 @@
+import fs from 'fs'
+import themis from 'wasm-themis'
+
+let private_key_path, public_key_path
+switch (process.argv.length) {
+    case 2:
+        private_key_path = 'key'
+        public_key_path = 'key.pub'
+        break
+    case 4:
+        private_key_path = process.argv[2]
+        public_key_path = process.argv[3]
+        break
+    default:
+        console.log('usage: node keygen.js [<path/to/key> <path/to/key.pub>]')
+        process.exit(1)
+}
+
+themis.initialized.then(function() {
+    let keypair = new themis.KeyPair()
+
+    fs.writeFile(private_key_path, keypair.privateKey, {'mode': 0o600}, function(err) {
+        if (err) {
+            console.log('failed to write ' + private_key_path + ': ' + err)
+        }
+    })
+    fs.writeFile(public_key_path, keypair.publicKey, function(err) {
+        if (err) {
+            console.log('failed to write ' + public_key_path + ': ' + err)
+        }
+    })
+})

--- a/tools/js/wasm-themis/scell_context_string_echo.js
+++ b/tools/js/wasm-themis/scell_context_string_echo.js
@@ -1,6 +1,6 @@
-const themis = require('wasm-themis')
+var themis = require('wasm-themis')
 
-let command, key, message, context
+var command, key, message, context
 if (process.argv.length == 6) {
     command = process.argv[2]
     key     = process.argv[3]
@@ -12,8 +12,8 @@ if (process.argv.length == 6) {
 }
 
 themis.initialized.then(function() {
-    let cell = themis.SecureCellContextImprint.withKey(Buffer.from(key))
-    let result
+    var cell = themis.SecureCellContextImprint.withKey(Buffer.from(key))
+    var result
     switch (command) {
         case 'enc':
             result = cell.encrypt(Buffer.from(message), Buffer.from(context))

--- a/tools/js/wasm-themis/scell_context_string_echo.mjs
+++ b/tools/js/wasm-themis/scell_context_string_echo.mjs
@@ -1,0 +1,30 @@
+import themis from 'wasm-themis'
+
+let command, key, message, context
+if (process.argv.length == 6) {
+    command = process.argv[2]
+    key     = process.argv[3]
+    message = process.argv[4]
+    context = process.argv[5]
+} else {
+    console.log('usage: node scell_context_string_echo.js <enc|dec> <key> <message> <context>')
+    process.exit(1);
+}
+
+themis.initialized.then(function() {
+    let cell = themis.SecureCellContextImprint.withKey(Buffer.from(key))
+    let result
+    switch (command) {
+        case 'enc':
+            result = cell.encrypt(Buffer.from(message), Buffer.from(context))
+            console.log(Buffer.from(result).toString('base64'))
+            break
+        case 'dec':
+            result = cell.decrypt(Buffer.from(message, 'base64'), Buffer.from(context))
+            console.log(Buffer.from(result).toString('utf-8'))
+            break
+        default:
+            console.log('invalid command "' + command + '": use "enc" or "dec"')
+            process.exit(1)
+    }
+})

--- a/tools/js/wasm-themis/scell_seal_string_echo.js
+++ b/tools/js/wasm-themis/scell_seal_string_echo.js
@@ -1,6 +1,6 @@
-const themis = require('wasm-themis')
+var themis = require('wasm-themis')
 
-let command, key, message, context
+var command, key, message, context
 if (5 <= process.argv.length && process.argv.length <= 6) {
     command = process.argv[2]
     key     = process.argv[3]
@@ -14,8 +14,8 @@ if (5 <= process.argv.length && process.argv.length <= 6) {
 }
 
 themis.initialized.then(function() {
-    let cell = themis.SecureCellSeal.withKey(Buffer.from(key))
-    let result
+    var cell = themis.SecureCellSeal.withKey(Buffer.from(key))
+    var result
     switch (command) {
         case 'enc':
             if (context) {

--- a/tools/js/wasm-themis/scell_seal_string_echo.mjs
+++ b/tools/js/wasm-themis/scell_seal_string_echo.mjs
@@ -1,0 +1,40 @@
+import themis from 'wasm-themis'
+
+let command, key, message, context
+if (5 <= process.argv.length && process.argv.length <= 6) {
+    command = process.argv[2]
+    key     = process.argv[3]
+    message = process.argv[4]
+    if (process.argv.length == 6) {
+        context = process.argv[5]
+    }
+} else {
+    console.log('usage: node scell_seal_string_echo.js <enc|dec> <key> <message> [<context>]')
+    process.exit(1);
+}
+
+themis.initialized.then(function() {
+    let cell = themis.SecureCellSeal.withKey(Buffer.from(key))
+    let result
+    switch (command) {
+        case 'enc':
+            if (context) {
+                result = cell.encrypt(Buffer.from(message), Buffer.from(context))
+            } else {
+                result = cell.encrypt(Buffer.from(message))
+            }
+            console.log(Buffer.from(result).toString('base64'))
+            break
+        case 'dec':
+            if (context) {
+                result = cell.decrypt(Buffer.from(message, 'base64'), Buffer.from(context))
+            } else {
+                result = cell.decrypt(Buffer.from(message, 'base64'))
+            }
+            console.log(Buffer.from(result).toString('utf-8'))
+            break
+        default:
+            console.log('invalid command "' + command + '": use "enc" or "dec"')
+            process.exit(1)
+    }
+})

--- a/tools/js/wasm-themis/scell_seal_string_echo_pw.js
+++ b/tools/js/wasm-themis/scell_seal_string_echo_pw.js
@@ -1,6 +1,6 @@
 const themis = require('wasm-themis')
 
-let command, key, message, context
+let command, passphrase, message, context
 if (5 <= process.argv.length && process.argv.length <= 6) {
     command = process.argv[2]
     passphrase = process.argv[3]

--- a/tools/js/wasm-themis/scell_seal_string_echo_pw.js
+++ b/tools/js/wasm-themis/scell_seal_string_echo_pw.js
@@ -1,6 +1,6 @@
-const themis = require('wasm-themis')
+var themis = require('wasm-themis')
 
-let command, passphrase, message, context
+var command, passphrase, message, context
 if (5 <= process.argv.length && process.argv.length <= 6) {
     command = process.argv[2]
     passphrase = process.argv[3]
@@ -14,8 +14,8 @@ if (5 <= process.argv.length && process.argv.length <= 6) {
 }
 
 themis.initialized.then(function() {
-    let cell = themis.SecureCellSeal.withPassphrase(passphrase)
-    let result
+    var cell = themis.SecureCellSeal.withPassphrase(passphrase)
+    var result
     switch (command) {
         case 'enc':
             if (context) {

--- a/tools/js/wasm-themis/scell_seal_string_echo_pw.mjs
+++ b/tools/js/wasm-themis/scell_seal_string_echo_pw.mjs
@@ -1,6 +1,6 @@
 import themis from 'wasm-themis'
 
-let command, key, message, context
+let command, passphrase, message, context
 if (5 <= process.argv.length && process.argv.length <= 6) {
     command = process.argv[2]
     passphrase = process.argv[3]

--- a/tools/js/wasm-themis/scell_seal_string_echo_pw.mjs
+++ b/tools/js/wasm-themis/scell_seal_string_echo_pw.mjs
@@ -1,0 +1,40 @@
+import themis from 'wasm-themis'
+
+let command, key, message, context
+if (5 <= process.argv.length && process.argv.length <= 6) {
+    command = process.argv[2]
+    passphrase = process.argv[3]
+    message = process.argv[4]
+    if (process.argv.length == 6) {
+        context = process.argv[5]
+    }
+} else {
+    console.log('usage: node scell_seal_string_echo.js {enc|dec} <passphrase> <message> [<context>]')
+    process.exit(1);
+}
+
+themis.initialized.then(function() {
+    let cell = themis.SecureCellSeal.withPassphrase(passphrase)
+    let result
+    switch (command) {
+        case 'enc':
+            if (context) {
+                result = cell.encrypt(Buffer.from(message), Buffer.from(context))
+            } else {
+                result = cell.encrypt(Buffer.from(message))
+            }
+            console.log(Buffer.from(result).toString('base64'))
+            break
+        case 'dec':
+            if (context) {
+                result = cell.decrypt(Buffer.from(message, 'base64'), Buffer.from(context))
+            } else {
+                result = cell.decrypt(Buffer.from(message, 'base64'))
+            }
+            console.log(Buffer.from(result).toString('utf-8'))
+            break
+        default:
+            console.log('invalid command "' + command + '": use "enc" or "dec"')
+            process.exit(1)
+    }
+})

--- a/tools/js/wasm-themis/scell_token_string_echo.js
+++ b/tools/js/wasm-themis/scell_token_string_echo.js
@@ -1,6 +1,6 @@
-const themis = require('wasm-themis')
+var themis = require('wasm-themis')
 
-let command, key, message, context
+var command, key, message, context
 if (5 <= process.argv.length && process.argv.length <= 6) {
     command = process.argv[2]
     key     = process.argv[3]
@@ -14,8 +14,8 @@ if (5 <= process.argv.length && process.argv.length <= 6) {
 }
 
 themis.initialized.then(function() {
-    let cell = themis.SecureCellTokenProtect.withKey(Buffer.from(key))
-    let result
+    var cell = themis.SecureCellTokenProtect.withKey(Buffer.from(key))
+    var result
     switch (command) {
         case 'enc':
             if (context) {
@@ -27,7 +27,7 @@ themis.initialized.then(function() {
                       + Buffer.from(result.token).toString('base64'))
             break
         case 'dec':
-            let [the_message, token] = message.split(',')
+            var [the_message, token] = message.split(',')
             if (context) {
                 result = cell.decrypt(Buffer.from(the_message, 'base64'),
                                       Buffer.from(token, 'base64'), Buffer.from(context))

--- a/tools/js/wasm-themis/scell_token_string_echo.mjs
+++ b/tools/js/wasm-themis/scell_token_string_echo.mjs
@@ -1,0 +1,44 @@
+import themis from 'wasm-themis'
+
+let command, key, message, context
+if (5 <= process.argv.length && process.argv.length <= 6) {
+    command = process.argv[2]
+    key     = process.argv[3]
+    message = process.argv[4]
+    if (process.argv.length == 6) {
+        context = process.argv[5]
+    }
+} else {
+    console.log('usage: node scell_token_string_echo.js <enc|dec> <key> <message[,token]> [<context>]')
+    process.exit(1);
+}
+
+themis.initialized.then(function() {
+    let cell = themis.SecureCellTokenProtect.withKey(Buffer.from(key))
+    let result
+    switch (command) {
+        case 'enc':
+            if (context) {
+                result = cell.encrypt(Buffer.from(message), Buffer.from(context))
+            } else {
+                result = cell.encrypt(Buffer.from(message))
+            }
+            console.log(Buffer.from(result.data).toString('base64') + ','
+                      + Buffer.from(result.token).toString('base64'))
+            break
+        case 'dec':
+            let [the_message, token] = message.split(',')
+            if (context) {
+                result = cell.decrypt(Buffer.from(the_message, 'base64'),
+                                      Buffer.from(token, 'base64'), Buffer.from(context))
+            } else {
+                result = cell.decrypt(Buffer.from(the_message, 'base64'),
+                                      Buffer.from(token, 'base64'))
+            }
+            console.log(Buffer.from(result).toString('utf-8'))
+            break
+        default:
+            console.log('invalid command "' + command + '": use "enc" or "dec"')
+            process.exit(1)
+    }
+})

--- a/tools/js/wasm-themis/smessage_encryption.js
+++ b/tools/js/wasm-themis/smessage_encryption.js
@@ -1,7 +1,7 @@
-const fs = require('fs')
-const themis = require('wasm-themis')
+var fs = require('fs')
+var themis = require('wasm-themis')
 
-let command, privateKeyPath, publicKeyPath, message
+var command, privateKeyPath, publicKeyPath, message
 if (process.argv.length == 6) {
     command = process.argv[2]
     privateKeyPath = process.argv[3]
@@ -25,10 +25,10 @@ fs.readFile(privateKeyPath, function(err, privateKey) {
         themis.initialized.then(function() {
             privateKey = new themis.PrivateKey(privateKey)
             publicKey = new themis.PublicKey(publicKey)
-            let smessage = new themis.SecureMessage(privateKey, publicKey)
-            let smessage_sign = new themis.SecureMessageSign(privateKey)
-            let smessage_verify = new themis.SecureMessageVerify(publicKey)
-            let result
+            var smessage = new themis.SecureMessage(privateKey, publicKey)
+            var smessage_sign = new themis.SecureMessageSign(privateKey)
+            var smessage_verify = new themis.SecureMessageVerify(publicKey)
+            var result
             switch (command) {
                 case 'enc':
                     result = smessage.encrypt(Buffer.from(message))

--- a/tools/js/wasm-themis/smessage_encryption.mjs
+++ b/tools/js/wasm-themis/smessage_encryption.mjs
@@ -1,0 +1,55 @@
+import fs from 'fs'
+import themis from 'wasm-themis'
+
+let command, privateKeyPath, publicKeyPath, message
+if (process.argv.length == 6) {
+    command = process.argv[2]
+    privateKeyPath = process.argv[3]
+    publicKeyPath  = process.argv[4]
+    message = process.argv[5]
+} else {
+    console.log('usage: node smessage_encryption.js <enc|dec|sign|verify> <sender/private.key> <recipient/public.key> <message>')
+    process.exit(1);
+}
+
+fs.readFile(privateKeyPath, function(err, privateKey) {
+    if (err) {
+        console.log('failed to read ' + privateKeyPath + ': ' + err)
+        process.exit(1)
+    }
+    fs.readFile(publicKeyPath, function(err, publicKey) {
+        if (err) {
+            console.log('failed to read ' + publicKeyPath + ': ' + err)
+            process.exit(1)
+        }
+        themis.initialized.then(function() {
+            privateKey = new themis.PrivateKey(privateKey)
+            publicKey = new themis.PublicKey(publicKey)
+            let smessage = new themis.SecureMessage(privateKey, publicKey)
+            let smessage_sign = new themis.SecureMessageSign(privateKey)
+            let smessage_verify = new themis.SecureMessageVerify(publicKey)
+            let result
+            switch (command) {
+                case 'enc':
+                    result = smessage.encrypt(Buffer.from(message))
+                    console.log(Buffer.from(result).toString('base64'))
+                    break
+                case 'dec':
+                    result = smessage.decrypt(Buffer.from(message, 'base64'))
+                    console.log(Buffer.from(result).toString('utf-8'))
+                    break
+                case 'sign':
+                    result = smessage_sign.sign(Buffer.from(message))
+                    console.log(Buffer.from(result).toString('base64'))
+                    break
+                case 'verify':
+                    result = smessage_verify.verify(Buffer.from(message, 'base64'))
+                    console.log(Buffer.from(result).toString('utf-8'))
+                    break
+                default:
+                    console.log('invalid command "' + command + '": use "enc", "dec", "sign", "verify"')
+                    process.exit(1)
+            }
+        })
+    })
+})


### PR DESCRIPTION
Add proper code examples for WasmThemis (for now, only with Node.js).

WasmThemis is basically the only one without code examples and without *any* examples verified on CI. This bother me because there is this `wasm-typescript` branch that's going to change a lot once it's merged. In particular, it's probably going to drop ES5 support (which kinda-sorta worked because I don't know JavaScript and the current WasmThemis is a weird chimera of ES5 and ES6 code that works only because Node is very lax in standards compliance).

Now there are proper examples that test both ES5 and ES6 imports of `wasm-themis`. And they are actually tested now. This has uncovered some bugs in the example code.

Finally, it bothers me that we're running the exact same WasmThemis build eight times in parallel when running tests with various Node.js versions. GitHub Actions compute time is kinda “free” for us, but wasting it is not nice.

It would be cool to make and test WasmThemis examples with Electron and browsers, but I'm out of spoons for this week. Currently I presume that Electron should be working (given that Node does), but browsers are most likely broken.

Though, even with these examples I believe we're ready to announce ES5 deprecation in 0.14 because `wasm-typescript` branch does break ES5 examples. So that branch will be moved to 0.15, it seems. (Let's discuss it elsewhere, I guess.)

@maxammann, if you could give this changeset a look, that would be sweet 🙏

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Example projects and code samples are up-to-date (oh yeah)
- [x] ~~Changelog is updated~~ (don't need, I guess?)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
