### PR TITLE
Remove TextEncoder polyfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 Changes that are currently in development and have not been released yet.
 
+- **WebAssembly**
+
+  - Fixed issue with `TypeError: TextEncoder is not a constructor` when bundling WasmThemis with webpack ([#779](https://github.com/cossacklabs/themis/issue/779)).
+
+
 ## [0.13.10](https://github.com/cossacklabs/themis/releases/tag/0.13.10), May 26th 2021
 
 **Deprecation Notice for CocoaPods users:**

--- a/src/wrappers/themis/wasm/package-lock.json
+++ b/src/wrappers/themis/wasm/package-lock.json
@@ -263,11 +263,6 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
-    "fastestsmallesttextencoderdecoder": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.14.tgz",
-      "integrity": "sha512-ov+uDh4DMZHpZvcGwlCb9tfntaHwRI7SK+/6XkdXhksZLJcMoTJ20FZx3GvujnsGjMvJVQ71LkduEUEPwX1BvQ=="
-    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",

--- a/src/wrappers/themis/wasm/package.json
+++ b/src/wrappers/themis/wasm/package.json
@@ -22,9 +22,7 @@
     "url": "https://github.com/cossacklabs/themis/issues"
   },
   "homepage": "https://www.cossacklabs.com/themis/",
-  "dependencies": {
-    "fastestsmallesttextencoderdecoder": "^1.0.14"
-  },
+  "dependencies": {},
   "devDependencies": {
     "mocha": "^7.1.1"
   }

--- a/src/wrappers/themis/wasm/src/utils.js
+++ b/src/wrappers/themis/wasm/src/utils.js
@@ -18,7 +18,6 @@
  */
 
 const libthemis = require('./libthemis.js')
-const {TextEncoder} = require('fastestsmallesttextencoderdecoder')
 
 /**
  * Convert an object into a byte buffer.
@@ -35,10 +34,25 @@ module.exports.coerceToBytes = function(buffer) {
     throw new TypeError('type mismatch, expect "Uint8Array" or "ArrayBuffer"')
 }
 
-const utf8Encoder = new TextEncoder()
+function getTextEncoder() {
+    if (typeof window !== 'undefined' && window.TextEncoder) {
+        return new window.TextEncoder()
+    }
+
+    if (typeof TextEncoder !== 'undefined') {
+        return new TextEncoder()
+    }
+    
+    // we are using a browser which does not support TextEncoder or in a Node process which has TextEncoder
+    // available through the util package.
+    const NodeTextEncoder = require('util').TextEncoder
+    return new NodeTextEncoder()
+}
+
+const textEncoder = getTextEncoder()
 
 function stringToUTF8(str) {
-    return utf8Encoder.encode(str)
+    return textEncoder.encode(str)
 }
 
 /**


### PR DESCRIPTION
Cherry-pick @maxammann's PR #783 onto `release/0.13`.

I'm trying to automate testing WasmThemis with webpack in browsers and issue #779 interferes with this.

It would be nice to see `wasm-themis@0.13.11` later with this. This seems to be the only issue that breaks WasmThemis in my browser when packaged with webpack.

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md