### PR TITLE
WasmThemis 0.13.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 Changes that are currently in development and have not been released yet.
 
+
+## [0.13.11](https://github.com/cossacklabs/themis/releases/tag/0.13.11), June 30th 2021
+
+**Hotfix for WasmThemis:**
+
+- Fixed issue when bundling WasmThemis with webpack ([#779](https://github.com/cossacklabs/themis/issue/779)).
+
+_Code:_
+
 - **WebAssembly**
 
   - Fixed issue with `TypeError: TextEncoder is not a constructor` when bundling WasmThemis with webpack ([#779](https://github.com/cossacklabs/themis/issue/779)).

--- a/src/wrappers/themis/wasm/package-lock.json
+++ b/src/wrappers/themis/wasm/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wasm-themis",
-  "version": "0.13.1",
+  "version": "0.13.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/wrappers/themis/wasm/package.json
+++ b/src/wrappers/themis/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wasm-themis",
-  "version": "0.13.1",
+  "version": "0.13.11",
   "description": "Themis is a convenient cryptographic library for data protection.",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
Cut a hotfix release that should make WasmThemis actually usable in browsers (at least when bundled by webpack, at least for 2 users).

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
