### PR TITLE
Fix cross-compilation on macOS with SDK and ARCH

### DIFF
--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -405,3 +405,31 @@ jobs:
           echo "Secure Session: socket interface"
           cc -o session_test client.c server.c session_test.c -lthemis -pthread
           ./session_test
+
+  macos-cross-compile:
+    name: macOS cross toolchain
+    runs-on: macos-10.15
+    steps:
+      - name: Install system dependencies
+        run: |
+          brew install cmake ninja
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      # We can't test OpenSSL builds since this requires OpenSSL libraries
+      # built for the target architecture (and Homebrew doesn't have any).
+      #
+      # GitHub's virtual environemnts can change the default version of Xcode
+      # and that changes the available SDKs. Check the combinations here:
+      # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#xcode
+      - name: Build Themis Core (BoringSSL, arm64)
+        run: make SDK=macosx11.1 ARCH=arm64 ENGINE=boringssl
+      # Of course we can't run unit tests either because there is no emulator.
+      # So I will be satisifed to see the build succeed and produce binaries
+      # with expected architecture.
+      - name: Check binary architecture
+        run: |
+          set -x
+          test $(lipo -archs build/libsoter.0.dylib) = arm64
+          test $(lipo -archs build/libthemis.0.dylib) = arm64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ _Code:_
     </details>
 
   - Fixed multiple buffer overflows in Secure Message ([#763](https://github.com/cossacklabs/themis/pull/763)).
+  - Fixed cross-compilation on macOS by setting `ARCH` and `SDK` variables ([#849](https://github.com/cossacklabs/themis/pull/849)).
 
 - **Android**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,8 @@ _Infrastructure:_
 - Added automated tests for Android example project ([#813](https://github.com/cossacklabs/themis/pull/813)).
 - Added automated tests for desktop Java example project ([#816](https://github.com/cossacklabs/themis/pull/816)).
 - Embedded BoringSSL now builds faster if Ninja is available ([#837](https://github.com/cossacklabs/themis/pull/837)).
+- Embedded BoringSSL can now be cross-compiled on macOS by setting `ARCH` and `SDK` variables ([#849](https://github.com/cossacklabs/themis/pull/849)).
+
 
 ## [0.13.10](https://github.com/cossacklabs/themis/releases/tag/0.13.10), May 26th 2021
 

--- a/configure
+++ b/configure
@@ -220,11 +220,13 @@ configure_macos_toolchain() {
         set_variable FRAMEWORKS   "$SDK_BASE/System/Library/Frameworks/"
         set_variable SDK_INCLUDES "$SDK_BASE/usr/include"
         append_variable CFLAGS "-isysroot \"$SDK_BASE\""
+        append_variable LDFLAGS "-isysroot \"$SDK_BASE\""
     fi
 
     if [ -n "${ARCH:-}" ]
     then
         append_variable CFLAGS "-arch $ARCH"
+        append_variable LDFLAGS "-arch $ARCH"
     fi
 }
 

--- a/src/soter/boringssl/soter.mk
+++ b/src/soter/boringssl/soter.mk
@@ -40,6 +40,16 @@ ifneq ($(NINJA),)
 SOTER_ENGINE_CMAKE_FLAGS += -G Ninja
 endif
 
+# Cross-compilation support for macOS
+ifdef IS_MACOS
+ifdef SDK
+SOTER_ENGINE_CMAKE_FLAGS += -DCMAKE_OSX_SYSROOT=$(SDK)
+endif
+ifdef ARCH
+SOTER_ENGINE_CMAKE_FLAGS += -DCMAKE_OSX_ARCHITECTURES=$(ARCH)
+endif
+endif
+
 ifdef IS_LINUX
 RENAME_BORINGSSL_SYMBOLS = yes
 endif


### PR DESCRIPTION
Surprisingly, it's possible to cross-compile Themis Core for different SDKs and architectures using our makefile. For example,

    make SDK=macosx11.0 ARCH=arm64

will compile for Apple Silicon, provided that your Xcode toolchain is actually capable of building that architecture.

You also need to have OpenSSL binaries with desired architecture installed (for which you might need to tweak ENGINE_INCLUDE_PATH and ENGINE_LIB_PATH separately). Or build `ENGINE=boringssl` to use embedded BoringSSL that we can cross-compile too.

There were some missing bits here and there to make it work, but now it works. See commit messages for details.

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Changelog is updated (in case of notable or breaking changes)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md