### PR TITLE
Run scheduled builds only on Mondays

### DIFF
--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -24,7 +24,7 @@ on:
       - stable
       - release/*
   schedule:
-    - cron: '0 6 * * *' # every day at 6:00 UTC
+    - cron: '20 6 * * 1' # every Monday at 6:20 UTC
 
 env:
   WITH_FATAL_WARNINGS: yes

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -26,7 +26,7 @@ on:
       - stable
       - release/*
   schedule:
-    - cron: '0 6 * * *' # every day at 6:00 UTC
+    - cron: '20 6 * * 1' # every Monday at 6:20 UTC
 
 env:
   WITH_FATAL_WARNINGS: yes

--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -23,7 +23,7 @@ on:
       - stable
       - release/*
   schedule:
-    - cron: '0 6 * * *' # every day at 6:00 UTC
+    - cron: '20 6 * * 1' # every Monday at 6:20 UTC
 
 env:
   WITH_FATAL_WARNINGS: yes

--- a/.github/workflows/test-cpp.yaml
+++ b/.github/workflows/test-cpp.yaml
@@ -20,7 +20,7 @@ on:
       - stable
       - release/*
   schedule:
-    - cron: '0 6 * * *' # every day at 6:00 UTC
+    - cron: '20 6 * * 1' # every Monday at 6:20 UTC
 
 env:
   WITH_FATAL_WARNINGS: yes

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -20,7 +20,7 @@ on:
       - stable
       - release/*
   schedule:
-    - cron: '0 6 * * *' # every day at 6:00 UTC
+    - cron: '20 6 * * 1' # every Monday at 6:20 UTC
 
 env:
   GOTHEMIS_IMPORT: github.com/cossacklabs/themis/gothemis

--- a/.github/workflows/test-java.yaml
+++ b/.github/workflows/test-java.yaml
@@ -21,7 +21,7 @@ on:
       - stable
       - release/*
   schedule:
-    - cron: '0 6 * * *' # every day at 6:00 UTC
+    - cron: '20 6 * * 1' # every Monday at 6:20 UTC
 
 env:
   WITH_FATAL_WARNINGS: yes

--- a/.github/workflows/test-nodejs.yaml
+++ b/.github/workflows/test-nodejs.yaml
@@ -18,7 +18,7 @@ on:
       - stable
       - release/*
   schedule:
-    - cron: '0 6 * * *' # every day at 6:00 UTC
+    - cron: '20 6 * * 1' # every Monday at 6:20 UTC
 
 env:
   WITH_FATAL_WARNINGS: yes

--- a/.github/workflows/test-objc.yaml
+++ b/.github/workflows/test-objc.yaml
@@ -23,7 +23,7 @@ on:
       - stable
       - release/*
   schedule:
-    - cron: '0 6 * * *' # every day at 6:00 UTC
+    - cron: '20 6 * * 1' # every Monday at 6:20 UTC
 
 env:
   WITH_FATAL_WARNINGS: yes

--- a/.github/workflows/test-php.yaml
+++ b/.github/workflows/test-php.yaml
@@ -18,7 +18,7 @@ on:
       - stable
       - release/*
   schedule:
-    - cron: '0 6 * * *' # every day at 6:00 UTC
+    - cron: '20 6 * * 1' # every Monday at 6:20 UTC
 
 env:
   WITH_FATAL_WARNINGS: yes

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -19,7 +19,7 @@ on:
       - stable
       - release/*
   schedule:
-    - cron: '0 6 * * *' # every day at 6:00 UTC
+    - cron: '20 6 * * 1' # every Monday at 6:20 UTC
 
 env:
   WITH_FATAL_WARNINGS: yes

--- a/.github/workflows/test-ruby.yaml
+++ b/.github/workflows/test-ruby.yaml
@@ -19,7 +19,7 @@ on:
       - stable
       - release/*
   schedule:
-    - cron: '0 6 * * *' # every day at 6:00 UTC
+    - cron: '20 6 * * 1' # every Monday at 6:20 UTC
 
 env:
   WITH_FATAL_WARNINGS: yes

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -19,7 +19,7 @@ on:
       - stable
       - release/*
   schedule:
-    - cron: '0 6 * * *' # every day at 6:00 UTC
+    - cron: '20 6 * * 1' # every Monday at 6:20 UTC
 
 env:
   WITH_FATAL_WARNINGS: yes

--- a/.github/workflows/test-wasm.yaml
+++ b/.github/workflows/test-wasm.yaml
@@ -21,7 +21,7 @@ on:
       - stable
       - release/*
   schedule:
-    - cron: '0 6 * * *' # every day at 6:00 UTC
+    - cron: '20 6 * * 1' # every Monday at 6:20 UTC
 
 env:
   WITH_FATAL_WARNINGS: yes


### PR DESCRIPTION
Instead of running all builds every day, run them only once a week. Also, since there are a lot of builds across the entire ecosystem started at the beginning of an hour, offset our builds a bit.

We have quite a few builds and I feel a bit sorry for GitHub Actions that have to work so much. No, actually, I'm not. Microsoft has the $.

What I do care about is amount of email I get about broken builds. For the past 30 days I have received 19 notifications about something being broken in Objective-C examples or other tasks. Out of which 0 (zero) have been actual, actionable issues, not cloud farts. Now I'm going to receive maybe three emails a week at worst. I can live with this.

## Checklist

- [x] Change is covered by automated tests