### PR TITLE
Bring back `undefined` into TypeError tests

### DIFF
--- a/src/wrappers/themis/wasm/test/test.js
+++ b/src/wrappers/themis/wasm/test/test.js
@@ -36,7 +36,7 @@ function measureTime(thunk) {
 
 describe('wasm-themis', function() {
     let generallyInvalidArguments = [
-        null, 'string',
+        null, undefined, 'string',
         new Int16Array([1, 2, 3]), [4, 5, 6],
         () => new Uint8Array([27, 18, 28, 18, 28]),
         { value: [3, 14, 15, 92, 6] }
@@ -132,6 +132,11 @@ describe('wasm-themis', function() {
             })
             it('fails with invalid types', function() {
                 generallyInvalidArguments.forEach(function(invalid) {
+                    // TypeScript implementation handles "undefined" as "no argument".
+                    // themis.SymmetricKey() is a valid constructor, so allow this.
+                    if (invalid === undefined) {
+                        return
+                    }
                     assert.throws(() => new themis.SymmetricKey(invalid),
                         TypeError
                     )
@@ -218,7 +223,8 @@ describe('wasm-themis', function() {
                     assert.throws(() => cell.encrypt(invalid), TypeError)
                     assert.throws(() => cell.decrypt(invalid), TypeError)
                     // null context is okay, it should not throw
-                    if (invalid !== null) {
+                    // undefined is interpreted as omitted context, it's okay too
+                    if (invalid !== null && invalid !== undefined) {
                         assert.throws(() => cell.encrypt(testInput, invalid), TypeError)
                         assert.throws(() => cell.decrypt(encrypted, invalid), TypeError)
                     }


### PR DESCRIPTION
Previous change has removed it from the list of 'invalid values' because in TypeScript `undefined` is interpreted as literally "omitted argument" which is actually allowed in some places and does not cause failures.

However, test tests are actually written in JavaScript, so we can pass `undefined` there just fine.

Instead of removing `undefined`, skip it for those APIs that accept omitted arguments, but still test other APIs with `undefined`.

This brings WasmThemis test coverage more in sync with master branch.

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] #845 is merged

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md