### PR TITLE
Bring back `initialized` promise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,7 @@ _Code:_
 
   - Updated Emscripten toolchain to the latest version ([#760](https://github.com/cossacklabs/themis/pull/760)).
   - Node.js v16 is now supported ([#801](https://github.com/cossacklabs/themis/pull/801)).
+  - New initialization API: `initialize()`, allowing to specify custom URL for `libthemis.wasm` ([#792](https://github.com/cossacklabs/themis/pull/792), [#854](https://github.com/cossacklabs/themis/pull/854)).
 
 _Infrastructure:_
 

--- a/docs/examples/wasm/node.js-es5/secure_cell.js
+++ b/docs/examples/wasm/node.js-es5/secure_cell.js
@@ -1,6 +1,6 @@
 var themis = require('wasm-themis')
 
-themis.initialize().then(function() {
+themis.initialized.then(function() {
     var message = 'Test Message Please Ignore'
     var context = 'Secure Cell example code'
     var master_key = Buffer.from('bm8sIHRoaXMgaXMgbm90IGEgdmFsaWQgbWFzdGVyIGtleQ==', 'base64')

--- a/docs/examples/wasm/node.js-es5/secure_comparator_client.js
+++ b/docs/examples/wasm/node.js-es5/secure_comparator_client.js
@@ -1,7 +1,7 @@
 var net = require('net')
 var themis = require('wasm-themis')
 
-themis.initialize().then(function() {
+themis.initialized.then(function() {
     var comparator = new themis.SecureComparator(Buffer.from('secret'))
 
     var socket = new net.Socket()

--- a/docs/examples/wasm/node.js-es5/secure_comparator_server.js
+++ b/docs/examples/wasm/node.js-es5/secure_comparator_server.js
@@ -1,7 +1,7 @@
 var net = require('net')
 var themis = require('wasm-themis')
 
-themis.initialize().then(function() {
+themis.initialized.then(function() {
     var server = net.createServer(function(socket) {
         console.log('Server: accepted connection')
 

--- a/docs/examples/wasm/node.js-es5/secure_keygen.js
+++ b/docs/examples/wasm/node.js-es5/secure_keygen.js
@@ -1,6 +1,6 @@
 var themis = require('wasm-themis')
 
-themis.initialize().then(function() {
+themis.initialized.then(function() {
     var keypair = new themis.KeyPair()
 
     console.log('private key: ' + Buffer.from(keypair.privateKey.data).toString('base64'))

--- a/docs/examples/wasm/node.js-es5/secure_message.js
+++ b/docs/examples/wasm/node.js-es5/secure_message.js
@@ -11,7 +11,7 @@ if (process.argv.length == 6) {
     process.exit(1)
 }
 
-themis.initialize().then(function() {
+themis.initialized.then(function() {
     var privateKey = new themis.PrivateKey(Buffer.from(privateKeyText, 'base64'))
     var publicKey = new themis.PublicKey(Buffer.from(publicKeyText, 'base64'))
 

--- a/docs/examples/wasm/node.js-es5/secure_session_client.js
+++ b/docs/examples/wasm/node.js-es5/secure_session_client.js
@@ -7,7 +7,7 @@ var serverPublicKeyBuffer = Buffer.from('VUVDMgAAAC30/vs+AwciK6egi82A9TkTydVuOzM
 var clientID = Buffer.from('client')
 var serverID = Buffer.from('server')
 
-themis.initialize().then(function() {
+themis.initialized.then(function() {
     var clientPrivateKey = new themis.PrivateKey(clientPrivateKeyBuffer)
     var serverPublicKey = new themis.PublicKey(serverPublicKeyBuffer)
 

--- a/docs/examples/wasm/node.js-es5/secure_session_server.js
+++ b/docs/examples/wasm/node.js-es5/secure_session_server.js
@@ -7,7 +7,7 @@ var clientPublicKeyBuffer = Buffer.from('VUVDMgAAAC15KNjgAr1DQEw+So1oztUarO4Jw/C
 var clientID = Buffer.from('client')
 var serverID = Buffer.from('server')
 
-themis.initialize().then(function() {
+themis.initialized.then(function() {
     var serverPrivateKey = new themis.PrivateKey(serverPrivateKeyBuffer)
     var clientPublicKey = new themis.PublicKey(clientPublicKeyBuffer)
 

--- a/docs/examples/wasm/node.js-es6/secure_cell.mjs
+++ b/docs/examples/wasm/node.js-es6/secure_cell.mjs
@@ -1,7 +1,7 @@
 import themis from 'wasm-themis'
 
 async function main() {
-    await themis.initialize()
+    await themis.initialized
 
     let message = 'Test Message Please Ignore'
     let context = 'Secure Cell example code'

--- a/docs/examples/wasm/node.js-es6/secure_comparator_client.mjs
+++ b/docs/examples/wasm/node.js-es6/secure_comparator_client.mjs
@@ -2,7 +2,7 @@ import net from 'net'
 import themis from 'wasm-themis'
 
 async function main() {
-    await themis.initialize()
+    await themis.initialized
 
     let comparator = new themis.SecureComparator(Buffer.from('secret'))
 

--- a/docs/examples/wasm/node.js-es6/secure_comparator_server.mjs
+++ b/docs/examples/wasm/node.js-es6/secure_comparator_server.mjs
@@ -2,7 +2,7 @@ import net from 'net'
 import themis from 'wasm-themis'
 
 async function main() {
-    await themis.initialize()
+    await themis.initialized
 
     let server = net.createServer(function(socket) {
         console.log('Server: accepted connection')

--- a/docs/examples/wasm/node.js-es6/secure_keygen.mjs
+++ b/docs/examples/wasm/node.js-es6/secure_keygen.mjs
@@ -1,7 +1,7 @@
 import themis from 'wasm-themis'
 
 async function main() {
-    await themis.initialize()
+    await themis.initialized
 
     let keypair = new themis.KeyPair()
 

--- a/docs/examples/wasm/node.js-es6/secure_message.mjs
+++ b/docs/examples/wasm/node.js-es6/secure_message.mjs
@@ -12,7 +12,7 @@ if (process.argv.length == 6) {
 }
 
 async function main() {
-    await themis.initialize()
+    await themis.initialized
 
     let privateKey = new themis.PrivateKey(Buffer.from(privateKeyText, 'base64'))
     let publicKey = new themis.PublicKey(Buffer.from(publicKeyText, 'base64'))

--- a/docs/examples/wasm/node.js-es6/secure_session_client.mjs
+++ b/docs/examples/wasm/node.js-es6/secure_session_client.mjs
@@ -8,7 +8,7 @@ const clientID = Buffer.from('client')
 const serverID = Buffer.from('server')
 
 async function main() {
-    await themis.initialize()
+    await themis.initialized
 
     let clientPrivateKey = new themis.PrivateKey(clientPrivateKeyBuffer)
     let serverPublicKey = new themis.PublicKey(serverPublicKeyBuffer)

--- a/docs/examples/wasm/node.js-es6/secure_session_server.mjs
+++ b/docs/examples/wasm/node.js-es6/secure_session_server.mjs
@@ -8,7 +8,7 @@ const clientID = Buffer.from('client')
 const serverID = Buffer.from('server')
 
 async function main() {
-    await themis.initialize()
+    await themis.initialized
 
     let serverPrivateKey = new themis.PrivateKey(serverPrivateKeyBuffer)
     let clientPublicKey = new themis.PublicKey(clientPublicKeyBuffer)

--- a/docs/examples/wasm/webpack/src/index.js
+++ b/docs/examples/wasm/webpack/src/index.js
@@ -2,7 +2,7 @@ import themis from 'wasm-themis'
 import { setupSecureCell } from './secure-cell.js'
 
 window.onload = function() {
-    themis.initialize().then(function() {
+    themis.initialized.then(function() {
         const loaded = document.getElementById('wasm-loaded')
         loaded.textContent = 'WasmThemis loaded!'
         loaded.classList.add('dimmed')

--- a/src/wrappers/themis/wasm/package.json
+++ b/src/wrappers/themis/wasm/package.json
@@ -14,7 +14,7 @@
     "dist-es6/libthemis.wasm"
   ],
   "scripts": {
-    "test": "ts-mocha -p tsconfig.json test/test.js",
+    "test": "find test -name *.js | sort | xargs -L1 ts-mocha -p tsconfig.json",
     "tsc-es5": "tsc -t es5 -m commonjs --outDir dist && cp src/libthemis* src/.npmignore dist/",
     "tsc-es6": "tsc -t es6 -m es6 --outDir dist-es6 && cp src/libthemis* src/.npmignore dist-es6/",
     "prepare": "npm run tsc-es5 && npm run tsc-es6"

--- a/src/wrappers/themis/wasm/src/index.ts
+++ b/src/wrappers/themis/wasm/src/index.ts
@@ -28,9 +28,36 @@ export { SecureSession } from "./secure_session";
 export { KeyPair, PrivateKey, PublicKey, SymmetricKey } from "./secure_keygen";
 export { SecureComparator } from "./secure_comparator";
 
+// WebAssembly code is not directly included with compiled JavaScript code.
+// Emscripten generates a stub that will download and compile WebAssembly
+// after this module is loaded. This initialization is necessary before
+// any WasmThemis function can be called.
+//
+// Due to historical reasons, WasmThemis has multiple ways to initialize.
+
+let onRuntimeInitialized: () => void
+
+// The current facility is "async initialize()" function which user code
+// is expected to call, then await the result to resolve before using
+// other WasmThemis functions.
+
+/**
+ * Initialize WasmThemis.
+ *
+ * This function **must** be called and awaited before using any WasmThemis interfaces.
+ * It will download and compile WebAssembly code of WasmThemis.
+ *
+ * If you are hosting WebAssembly code on a CDN or at a non-standard location,
+ * you should pass the URL as an argument.
+ * Otherwise, `libthemis.wasm` will be downloaded, relative to the script.
+ *
+ * @param wasmPath URL of `libthemis.wasm` to download.
+ *
+ * @since WasmThemis 0.14.0
+ */
 export const initialize = async (wasmPath?: string) => {
   context.libthemis = await libthemisFn({
-    onRuntimeInitialized: function () {},
+    onRuntimeInitialized: () => onRuntimeInitialized(),
     locateFile: wasmPath ? function () {
       return wasmPath;
     } : undefined,
@@ -38,3 +65,85 @@ export const initialize = async (wasmPath?: string) => {
 
   return context.libthemis;
 };
+
+// However, it was not always the case. Previously, WasmThemis has exported
+// just "initialzed" promise which is resolved once WASM code is downloaded
+// and compiled. User code is expected to await for that promise to resolve,
+// then proceed using WasmThemis functions.
+//
+// Back in the day, WasmThemis was not modularized, so the download & compile
+// was initialized immediately once JS code of WasmThemis got loaded and the
+// module was evalated.
+//
+// Obviously, there is no way to pass any parameters to this promise either.
+//
+// In order to keep "initialized" working, we do some trickery, exporting
+// a promise that will make sure that initialize() is called before this
+// promise is resolved. This kickstarts WebAssmebly loading and ensures
+// that WasmThemis is initialized once "initialized" promise is resolved.
+//
+// This approach does not cover the case where the user code does not use
+// "initialized" promise at all. That is, if the application just hopes
+// that WasmThemis is loaded by the time it's needed. This should be rare.
+// Users have been warned.
+
+// TypeScript does not allow to extend Promise nicely [1], but since JavaScript
+// is actually duck-typed, we can just mimick the API and get away with it.
+// [1]: https://github.com/microsoft/TypeScript/issues/15202
+class InitializedPromise {
+  private initialized: boolean = false;
+  private readonly promise: Promise<void>;
+
+  constructor(executor: (resolve: (value: void | PromiseLike<void>) => void,
+                         reject: (reason?: any) => void) => void)
+  {
+    this.promise = new Promise(executor);
+  }
+
+  private initialize() {
+    // Make sure that initialize() -- the exported one -- is only called once.
+    // Promises can have their then() and catch() methods called multiple times
+    // to register multiple callbacks. Register callbacks, but call initialize()
+    // only once. Also, it's okay to ignore its result. For the "initialized"
+    // code path we register "onRuntimeInitialized" callback that will resolve
+    // *this* promise when it is time.
+    if (!this.initialized) {
+      initialize();
+      this.initialized = true;
+    }
+  }
+
+  then<T = any, E = never>(
+    fulfilled?: ((value: any) => T | PromiseLike<T>) | null | undefined,
+    rejected?: ((reason: any) => E | PromiseLike<E>) | null | undefined,
+  ) : Promise<T | E>
+  {
+    this.initialize();
+    return this.promise.then(fulfilled, rejected);
+  }
+
+  catch<T = never>(
+    rejected?: ((reason: any) => T | PromiseLike<T>) | undefined | null,
+  ): Promise<void | T>
+  {
+    this.initialize();
+    return this.promise.catch(rejected);
+  }
+}
+
+/**
+ * Await WasmThemis initialisation.
+ *
+ * This promise is resolved once WebAssembly code has been downloaded and compiled
+ * and WasmThemis is ready to use.
+ *
+ * You **must** await either this promise, or `initialize()` to use WasmThemis.
+ *
+ * WebAssembly code is expected to be located at `libthemis.wasm` relative to the script.
+ * If you need to use a custom location, call `initialize()`.
+ *
+ * @see initialize
+ */
+export const initialized = new InitializedPromise((resolve) => {
+  onRuntimeInitialized = resolve;
+});

--- a/src/wrappers/themis/wasm/src/index.ts
+++ b/src/wrappers/themis/wasm/src/index.ts
@@ -47,9 +47,10 @@ let onRuntimeInitialized: () => void
  * This function **must** be called and awaited before using any WasmThemis interfaces.
  * It will download and compile WebAssembly code of WasmThemis.
  *
- * If you are hosting WebAssembly code on a CDN or at a non-standard location,
- * you should pass the URL as an argument.
- * Otherwise, `libthemis.wasm` will be downloaded, relative to the script.
+ * If you are hosting `libthemis.wasm` on a CDN or at a non-standard location,
+ * pass URL to `libthemis.wasm` as an argument.
+ * If URL is omitted, `libthemis.wasm` is expected to be located in the same directory
+ * as the executing script.
  *
  * @param wasmPath URL of `libthemis.wasm` to download.
  *
@@ -67,13 +68,13 @@ export const initialize = async (wasmPath?: string) => {
 };
 
 // However, it was not always the case. Previously, WasmThemis has exported
-// just "initialzed" promise which is resolved once WASM code is downloaded
+// just "initialized" promise which is resolved once WASM code is downloaded
 // and compiled. User code is expected to await for that promise to resolve,
 // then proceed using WasmThemis functions.
 //
 // Back in the day, WasmThemis was not modularized, so the download & compile
-// was initialized immediately once JS code of WasmThemis got loaded and the
-// module was evalated.
+// was initiated immediately once JS code of WasmThemis got loaded and the
+// module was evaluated.
 //
 // Obviously, there is no way to pass any parameters to this promise either.
 //
@@ -87,8 +88,8 @@ export const initialize = async (wasmPath?: string) => {
 // that WasmThemis is loaded by the time it's needed. This should be rare.
 // Users have been warned.
 
-// TypeScript does not allow to extend Promise nicely [1], but since JavaScript
-// is actually duck-typed, we can just mimick the API and get away with it.
+// TypeScript does not allow to extend Promise nicely in ES5 [1], but since
+// JavaScript is actually duck-typed, we can just mimick the API.
 // [1]: https://github.com/microsoft/TypeScript/issues/15202
 class InitializedPromise {
   private initialized: boolean = false;
@@ -132,14 +133,15 @@ class InitializedPromise {
 }
 
 /**
- * Await WasmThemis initialisation.
+ * Await WasmThemis initialization.
  *
  * This promise is resolved once WebAssembly code has been downloaded and compiled
  * and WasmThemis is ready to use.
  *
- * You **must** await either this promise, or `initialize()` to use WasmThemis.
+ * You **must** await either this promise or `initialize()` to use WasmThemis.
  *
- * WebAssembly code is expected to be located at `libthemis.wasm` relative to the script.
+ * WebAssembly code is expected to be located in `libthemis.wasm` file
+ * in the same directory as the executing script.
  * If you need to use a custom location, call `initialize()`.
  *
  * @see initialize

--- a/src/wrappers/themis/wasm/test/initialization/README.md
+++ b/src/wrappers/themis/wasm/test/initialization/README.md
@@ -1,0 +1,6 @@
+WasmThemis initialization tests
+===============================
+
+There are multiple way to initialize WasmThemis.
+
+These tests must be kept as separate files, since you can only initialize once.

--- a/src/wrappers/themis/wasm/test/initialization/initialize-path.js
+++ b/src/wrappers/themis/wasm/test/initialization/initialize-path.js
@@ -1,0 +1,20 @@
+const themis = require('../../src/index.ts')
+const assert = require('assert')
+
+describe('wasm-themis', function() {
+    describe('initialization', function() {
+        it('catches error for invalid paths in initialize()', function(done) {
+            themis.initialize('/does/not/exist').catch(function() {
+                done()
+            })
+        })
+        it('resolves "initialize()" promise with path', function(done) {
+            // Assuming we're run via "npm test" from wrapper's directory.
+            themis.initialize('src/libthemis.wasm').then(function() {
+                let key = new themis.SymmetricKey()
+                assert.ok(key.length > 0)
+                done()
+            })
+        })
+    })
+})

--- a/src/wrappers/themis/wasm/test/initialization/initialize.js
+++ b/src/wrappers/themis/wasm/test/initialization/initialize.js
@@ -1,0 +1,14 @@
+const themis = require('../../src/index.ts')
+const assert = require('assert')
+
+describe('wasm-themis', function() {
+    describe('initialization', function() {
+        it('resolves "initialize()" promise', function(done) {
+            themis.initialize().then(function() {
+                let key = new themis.SymmetricKey()
+                assert.ok(key.length > 0)
+                done()
+            })
+        })
+    })
+})

--- a/src/wrappers/themis/wasm/test/initialization/initialized.js
+++ b/src/wrappers/themis/wasm/test/initialization/initialized.js
@@ -1,0 +1,14 @@
+const themis = require('../../src/index.ts')
+const assert = require('assert')
+
+describe('wasm-themis', function() {
+    describe('initialization', function() {
+        it('resolves "initialized" promise', function(done) {
+            themis.initialized.then(function() {
+                let key = new themis.SymmetricKey()
+                assert.ok(key.length > 0)
+                done()
+            })
+        })
+    })
+})

--- a/src/wrappers/themis/wasm/test/test.js
+++ b/src/wrappers/themis/wasm/test/test.js
@@ -43,7 +43,7 @@ describe('wasm-themis', function() {
     ]
     describe('initialization', function() {
         it('resolves "initialized" promise', function(done) {
-            themis.initialize().then(function() {
+            themis.initialized.then(function() {
                 done()
             })
         })

--- a/tools/js/wasm-themis/keygen.js
+++ b/tools/js/wasm-themis/keygen.js
@@ -16,7 +16,7 @@ switch (process.argv.length) {
         process.exit(1)
 }
 
-themis.initialize().then(function() {
+themis.initialized.then(function() {
     var keypair = new themis.KeyPair()
 
     fs.writeFile(private_key_path, keypair.privateKey.data, {'mode': 0o600}, function(err) {

--- a/tools/js/wasm-themis/keygen.mjs
+++ b/tools/js/wasm-themis/keygen.mjs
@@ -16,7 +16,7 @@ switch (process.argv.length) {
         process.exit(1)
 }
 
-themis.initialize().then(function() {
+themis.initialized.then(function() {
     let keypair = new themis.KeyPair()
 
     fs.writeFile(private_key_path, keypair.privateKey.data, {'mode': 0o600}, function(err) {

--- a/tools/js/wasm-themis/scell_context_string_echo.js
+++ b/tools/js/wasm-themis/scell_context_string_echo.js
@@ -11,7 +11,7 @@ if (process.argv.length == 6) {
     process.exit(1);
 }
 
-themis.initialize().then(function() {
+themis.initialized.then(function() {
     var cell = themis.SecureCellContextImprint.withKey(Buffer.from(key))
     var result
     switch (command) {

--- a/tools/js/wasm-themis/scell_context_string_echo.mjs
+++ b/tools/js/wasm-themis/scell_context_string_echo.mjs
@@ -11,7 +11,7 @@ if (process.argv.length == 6) {
     process.exit(1);
 }
 
-themis.initialize().then(function() {
+themis.initialized.then(function() {
     let cell = themis.SecureCellContextImprint.withKey(Buffer.from(key))
     let result
     switch (command) {

--- a/tools/js/wasm-themis/scell_seal_string_echo.js
+++ b/tools/js/wasm-themis/scell_seal_string_echo.js
@@ -13,7 +13,7 @@ if (5 <= process.argv.length && process.argv.length <= 6) {
     process.exit(1);
 }
 
-themis.initialize().then(function() {
+themis.initialized.then(function() {
     var cell = themis.SecureCellSeal.withKey(Buffer.from(key))
     var result
     switch (command) {

--- a/tools/js/wasm-themis/scell_seal_string_echo.mjs
+++ b/tools/js/wasm-themis/scell_seal_string_echo.mjs
@@ -13,7 +13,7 @@ if (5 <= process.argv.length && process.argv.length <= 6) {
     process.exit(1);
 }
 
-themis.initialize().then(function() {
+themis.initialized.then(function() {
     let cell = themis.SecureCellSeal.withKey(Buffer.from(key))
     let result
     switch (command) {

--- a/tools/js/wasm-themis/scell_seal_string_echo_pw.js
+++ b/tools/js/wasm-themis/scell_seal_string_echo_pw.js
@@ -13,7 +13,7 @@ if (5 <= process.argv.length && process.argv.length <= 6) {
     process.exit(1);
 }
 
-themis.initialize().then(function() {
+themis.initialized.then(function() {
     var cell = themis.SecureCellSeal.withPassphrase(passphrase)
     var result
     switch (command) {

--- a/tools/js/wasm-themis/scell_seal_string_echo_pw.mjs
+++ b/tools/js/wasm-themis/scell_seal_string_echo_pw.mjs
@@ -13,7 +13,7 @@ if (5 <= process.argv.length && process.argv.length <= 6) {
     process.exit(1);
 }
 
-themis.initialize().then(function() {
+themis.initialized.then(function() {
     let cell = themis.SecureCellSeal.withPassphrase(passphrase)
     let result
     switch (command) {

--- a/tools/js/wasm-themis/scell_token_string_echo.js
+++ b/tools/js/wasm-themis/scell_token_string_echo.js
@@ -13,7 +13,7 @@ if (5 <= process.argv.length && process.argv.length <= 6) {
     process.exit(1);
 }
 
-themis.initialize().then(function() {
+themis.initialized.then(function() {
     var cell = themis.SecureCellTokenProtect.withKey(Buffer.from(key))
     var result
     switch (command) {

--- a/tools/js/wasm-themis/scell_token_string_echo.mjs
+++ b/tools/js/wasm-themis/scell_token_string_echo.mjs
@@ -13,7 +13,7 @@ if (5 <= process.argv.length && process.argv.length <= 6) {
     process.exit(1);
 }
 
-themis.initialize().then(function() {
+themis.initialized.then(function() {
     let cell = themis.SecureCellTokenProtect.withKey(Buffer.from(key))
     let result
     switch (command) {

--- a/tools/js/wasm-themis/smessage_encryption.js
+++ b/tools/js/wasm-themis/smessage_encryption.js
@@ -22,7 +22,7 @@ fs.readFile(privateKeyPath, function(err, privateKey) {
             console.log('failed to read ' + publicKeyPath + ': ' + err)
             process.exit(1)
         }
-        themis.initialize().then(function() {
+        themis.initialized.then(function() {
             privateKey = new themis.PrivateKey(privateKey)
             publicKey = new themis.PublicKey(publicKey)
             var smessage = new themis.SecureMessage(privateKey, publicKey)

--- a/tools/js/wasm-themis/smessage_encryption.mjs
+++ b/tools/js/wasm-themis/smessage_encryption.mjs
@@ -22,7 +22,7 @@ fs.readFile(privateKeyPath, function(err, privateKey) {
             console.log('failed to read ' + publicKeyPath + ': ' + err)
             process.exit(1)
         }
-        themis.initialize().then(function() {
+        themis.initialized.then(function() {
             privateKey = new themis.PrivateKey(privateKey)
             publicKey = new themis.PublicKey(publicKey)
             let smessage = new themis.SecureMessage(privateKey, publicKey)


### PR DESCRIPTION
Restoring compatibility, one step at a time.

### Background

Historically, WasmThemis has exported only the `initialized` promise. WasmThemis was not modularized and kicked off `libthemis.wasm` download right after the module is loaded. Moreover, there was no way to use a different path to WebAssembly code: it had to be located in a file named `libthemis.wasm` next to the JavaScript code bundle.

[TypeScript rewrite](https://github.com/cossacklabs/themis/pull/792) introduced an alternative interface `initialize()` which allows to specify the URL. However, this required WasmThemis modularization. That is, WasmThemis *will not* be initialized unless `initialize()` is called.

This introduces two issues with backwards compatibility:

  1. `initialize` promise was gone.
  2. You can no longer expect that WasmThemis will be downloaded in background without awaiting any promise.

Due to modularization, there is no (practical) way to fix the second issue. Just don't do, it's a bad practice.

However, absence of `initialized` is a real breaking change that will break well-formed applications.

Reintroduce the `initialized` promise and make sure it works by calling the `initialize()` function behind the scenes. It's a bit of a hack, but it works, so whatever.

Note that `initialize` is *not* deprecated or anything. It's a perfectly valid API if you don't need to specify a custom path to `libthemis.wasm`

### Initialization APIs

So basically, now WasmThemis has two initialization APIs.

- Historically first:

  ```js
  await themis.initialized
  ```

  which will download `libthemis.wasm` relative to the executing JS bundle.

- Explicit — available since WasmThemis 0.14.0:

  ```js
  await themis.initialize()
  // OR
  await themis.initialize('https://your.CND.example.com/storage/libthemis.wasm')
  ```

  which allows you to specify the exact URL for downloading WebAssembly code.

Maybe later it will accept more parameters that can be passed to Emscripten ([see their docs](https://emscripten.org/docs/api_reference/module.html)), but I don't want to expand the API unless there are users for it.

### Ancillary changes

Existing unit tests, examples, and tools are rolled back to using `initialized`.

New tests verify the all initialization APIs work as expected.

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Public API has proper documentation
- [x] Example projects and code samples are up-to-date
- [x] Changelog is updated
- [x] #845 is merged

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
