### PR TITLE
Allow calling `initialize()` only once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,7 +154,7 @@ _Code:_
 
   - Updated Emscripten toolchain to the latest version ([#760](https://github.com/cossacklabs/themis/pull/760)).
   - Node.js v16 is now supported ([#801](https://github.com/cossacklabs/themis/pull/801)).
-  - New initialization API: `initialize()`, allowing to specify custom URL for `libthemis.wasm` ([#792](https://github.com/cossacklabs/themis/pull/792), [#854](https://github.com/cossacklabs/themis/pull/854)).
+  - New initialization API: `initialize()`, allowing to specify custom URL for `libthemis.wasm` ([#792](https://github.com/cossacklabs/themis/pull/792), [#854](https://github.com/cossacklabs/themis/pull/854), [#857](https://github.com/cossacklabs/themis/pull/857)).
 
 _Infrastructure:_
 

--- a/src/wrappers/themis/wasm/test/initialization/initialize-path.js
+++ b/src/wrappers/themis/wasm/test/initialization/initialize-path.js
@@ -1,4 +1,5 @@
 const themis = require('../../src/index.ts')
+const ThemisErrorCode = themis.ThemisErrorCode
 const assert = require('assert')
 
 describe('wasm-themis', function() {
@@ -13,6 +14,12 @@ describe('wasm-themis', function() {
             themis.initialize('src/libthemis.wasm').then(function() {
                 let key = new themis.SymmetricKey()
                 assert.ok(key.length > 0)
+                done()
+            })
+        })
+        it('can only be initialized once', function(done) {
+            themis.initialize('src/libthemis.wasm').catch(function(e) {
+                assert.strictEqual(e.errorCode, ThemisErrorCode.FAIL)
                 done()
             })
         })

--- a/src/wrappers/themis/wasm/test/initialization/initialize.js
+++ b/src/wrappers/themis/wasm/test/initialization/initialize.js
@@ -1,4 +1,5 @@
 const themis = require('../../src/index.ts')
+const ThemisErrorCode = themis.ThemisErrorCode
 const assert = require('assert')
 
 describe('wasm-themis', function() {
@@ -7,6 +8,12 @@ describe('wasm-themis', function() {
             themis.initialize().then(function() {
                 let key = new themis.SymmetricKey()
                 assert.ok(key.length > 0)
+                done()
+            })
+        })
+        it('can only be initialized once', function(done) {
+            themis.initialize().catch(function(e) {
+                assert.strictEqual(e.errorCode, ThemisErrorCode.FAIL)
                 done()
             })
         })

--- a/src/wrappers/themis/wasm/test/initialization/initialized.js
+++ b/src/wrappers/themis/wasm/test/initialization/initialized.js
@@ -1,4 +1,5 @@
 const themis = require('../../src/index.ts')
+const ThemisErrorCode = themis.ThemisErrorCode
 const assert = require('assert')
 
 describe('wasm-themis', function() {
@@ -7,6 +8,13 @@ describe('wasm-themis', function() {
             themis.initialized.then(function() {
                 let key = new themis.SymmetricKey()
                 assert.ok(key.length > 0)
+                done()
+            })
+        })
+        // "themis.initialized" stays resolved but you cannot initialize again.
+        it('can only be initialized once', function(done) {
+            themis.initialize().catch(function(e) {
+                assert.strictEqual(e.errorCode, ThemisErrorCode.FAIL)
                 done()
             })
         })


### PR DESCRIPTION
WasmThemis initialization fills in the `context.libthemis` singleton that is actually used by all WasmThemis functions. That is, calling `initialize()` multiple times is technically permitted, but it might not have an effect that you expect. WasmThemis will always use WebAssembly context from the last initialization.

While reinitialization might be useful, it does not seem to be now. Let's allow calling `initialize()` only once. (This includes calling it indirectly via the `initialized` promise.) We can always allow it later, once the semantics of this are clarified.

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Public API has proper documentation
- [x] Changelog is updated (gotta add this PR to the line...)
- [x] #854 is merged

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
