### PR TITLE
Make keys `Uint8Arrays` again (by killing ES5 support)

### DIFF
--- a/docs/examples/wasm/node.js-es5/secure_keygen.js
+++ b/docs/examples/wasm/node.js-es5/secure_keygen.js
@@ -3,6 +3,6 @@ var themis = require('wasm-themis')
 themis.initialize().then(function() {
     var keypair = new themis.KeyPair()
 
-    console.log('private key: ' + Buffer.from(keypair.privateKey.data).toString('base64'))
-    console.log('public key : ' + Buffer.from(keypair.publicKey.data).toString('base64'))
+    console.log('private key: ' + Buffer.from(keypair.privateKey).toString('base64'))
+    console.log('public key : ' + Buffer.from(keypair.publicKey).toString('base64'))
 })

--- a/docs/examples/wasm/node.js-es6/secure_keygen.mjs
+++ b/docs/examples/wasm/node.js-es6/secure_keygen.mjs
@@ -5,8 +5,8 @@ async function main() {
 
     let keypair = new themis.KeyPair()
 
-    console.log(`private key: ${Buffer.from(keypair.privateKey.data).toString('base64')}`)
-    console.log(`public key : ${Buffer.from(keypair.publicKey.data).toString('base64')}`)
+    console.log(`private key: ${Buffer.from(keypair.privateKey).toString('base64')}`)
+    console.log(`public key : ${Buffer.from(keypair.publicKey).toString('base64')}`)
 }
 
 main()

--- a/docs/examples/wasm/webpack/src/secure-cell.js
+++ b/docs/examples/wasm/webpack/src/secure-cell.js
@@ -293,8 +293,8 @@ export function setupSecureCell() {
 
     generateButton.addEventListener('click', function() {
         const key = new themis.SymmetricKey()
-        symmetricKeyInput.value = BytesToBase64(key.data)
-        symmetricKeyLength.textContent = `${key.data.length} bytes`
+        symmetricKeyInput.value = BytesToBase64(key)
+        symmetricKeyLength.textContent = `${key.length} bytes`
         update()
     })
 

--- a/src/wrappers/themis/wasm/package.json
+++ b/src/wrappers/themis/wasm/package.json
@@ -15,9 +15,9 @@
   ],
   "scripts": {
     "test": "ts-mocha -p tsconfig.json test/test.js",
-    "tsc-es5": "tsc -t es5 -m commonjs --outDir dist && cp src/libthemis* src/.npmignore dist/",
+    "tsc-cjs": "tsc -t es6 -m commonjs --outDir dist && cp src/libthemis* src/.npmignore dist/",
     "tsc-es6": "tsc -t es6 -m es6 --outDir dist-es6 && cp src/libthemis* src/.npmignore dist-es6/",
-    "prepare": "npm run tsc-es5 && npm run tsc-es6"
+    "prepare": "npm run tsc-cjs && npm run tsc-es6"
   },
   "repository": {
     "type": "git",

--- a/src/wrappers/themis/wasm/src/secure_keygen.ts
+++ b/src/wrappers/themis/wasm/src/secure_keygen.ts
@@ -42,27 +42,19 @@ export enum KeyKind {
   EC_PUBLIC = 4,
 }
 
-export class PrivateKey {
-  data: Uint8Array
+export class PrivateKey extends Uint8Array {
   constructor(array: Uint8Array | ArrayBuffer) {
-    this.data = coerceToBytes(array);
-    validateKeyBuffer(this.data, [KeyKind.EC_PRIVATE, KeyKind.RSA_PRIVATE]);
-  }
-
-  get length() {
-    return this.data.length
+    const data = coerceToBytes(array);
+    validateKeyBuffer(data, [KeyKind.EC_PRIVATE, KeyKind.RSA_PRIVATE]);
+    super(data);
   }
 }
 
-export class PublicKey {
-  data: Uint8Array
+export class PublicKey extends Uint8Array {
   constructor(array: Uint8Array | ArrayBuffer) {
-    this.data = coerceToBytes(array);
-    validateKeyBuffer(this.data, [KeyKind.EC_PUBLIC, KeyKind.RSA_PUBLIC]);
-  }
-
-  get length() {
-    return this.data.length
+    const data = coerceToBytes(array);
+    validateKeyBuffer(data, [KeyKind.EC_PUBLIC, KeyKind.RSA_PUBLIC]);
+    super(data);
   }
 }
 
@@ -119,8 +111,8 @@ export class KeyPair {
 
   constructor(privateKey?: PrivateKey, publicKey?: PublicKey) {
     if (arguments.length === 2) {
-      this._privateKey = new PrivateKey(privateKey?.data!!); // Throw TypeError when passing null
-      this._publicKey = new PublicKey(publicKey?.data!!);
+      this._privateKey = new PrivateKey(privateKey!); // Throw TypeError when passing null
+      this._publicKey = new PublicKey(publicKey!);
     } else if (arguments.length === 0) {
       let keyPair = generateECKeyPair();
       this._privateKey = new PrivateKey(keyPair.private);
@@ -203,8 +195,7 @@ const generateECKeyPair = (): {private: Uint8Array, public: Uint8Array} => {
   }
 };
 
-export class SymmetricKey {
-  data: Uint8Array
+export class SymmetricKey extends Uint8Array {
   constructor(array: Uint8Array | ArrayBuffer = generateSymmetricKey()) {
     if (array.byteLength === 0) {
       throw new ThemisError(
@@ -213,11 +204,7 @@ export class SymmetricKey {
         "key must not be empty"
       );
     }
-    this.data = coerceToBytes(array);
-  }
-
-  get length() {
-    return this.data.length
+    super(coerceToBytes(array));
   }
 }
 

--- a/src/wrappers/themis/wasm/src/secure_message.ts
+++ b/src/wrappers/themis/wasm/src/secure_message.ts
@@ -104,8 +104,8 @@ export class SecureMessage {
         throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY);
       }
 
-      heapPutArray(this.privateKey.data, private_key_ptr);
-      heapPutArray(this.publicKey.data, public_key_ptr);
+      heapPutArray(this.privateKey, private_key_ptr);
+      heapPutArray(this.publicKey, public_key_ptr);
       heapPutArray(message, message_ptr);
 
       status = context.libthemis!!._themis_secure_message_encrypt(
@@ -178,8 +178,8 @@ export class SecureMessage {
         throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY);
       }
 
-      heapPutArray(this.privateKey.data, private_key_ptr);
-      heapPutArray(this.publicKey.data, public_key_ptr);
+      heapPutArray(this.privateKey, private_key_ptr);
+      heapPutArray(this.publicKey, public_key_ptr);
       heapPutArray(message, message_ptr);
 
       status = context.libthemis!!._themis_secure_message_decrypt(
@@ -266,7 +266,7 @@ export class SecureMessageSign {
         throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY);
       }
 
-      heapPutArray(this.privateKey.data, private_key_ptr);
+      heapPutArray(this.privateKey, private_key_ptr);
       heapPutArray(message, message_ptr);
 
       status = context.libthemis!!._themis_secure_message_sign(
@@ -347,7 +347,7 @@ export class SecureMessageVerify {
         throw new ThemisError(cryptosystem_name, ThemisErrorCode.NO_MEMORY);
       }
 
-      heapPutArray(this.publicKey.data, public_key_ptr);
+      heapPutArray(this.publicKey, public_key_ptr);
       heapPutArray(message, message_ptr);
 
       status = context.libthemis!!._themis_secure_message_verify(

--- a/src/wrappers/themis/wasm/src/secure_session.ts
+++ b/src/wrappers/themis/wasm/src/secure_session.ts
@@ -172,7 +172,7 @@ const getPublicKeyForIdThunk = (
       "public key cannot fit into provided buffer"
     );
   }
-  heapPutArray(publicKey.data, keyPtr);
+  heapPutArray(publicKey, keyPtr);
 
   return GetPublicKeySuccess;
 };
@@ -222,7 +222,7 @@ export class SecureSession {
       }
 
       heapPutArray(sessionID, session_id_ptr);
-      heapPutArray(privateKey.data, private_key_ptr);
+      heapPutArray(privateKey, private_key_ptr);
 
       this.keyCallback = keyCallback;
       initUserCallbacks(callbacks_ptr);

--- a/src/wrappers/themis/wasm/test/test.js
+++ b/src/wrappers/themis/wasm/test/test.js
@@ -111,6 +111,13 @@ describe('wasm-themis', function() {
                     assert.throws(() => new themis.PublicKey(invalid), TypeError)
                 })
             })
+            it('keys are Uint8Arrays', function() {
+                let pair = new themis.KeyPair()
+                assert.ok(pair.privateKey instanceof themis.PrivateKey)
+                assert.ok(pair.privateKey instanceof Uint8Array)
+                assert.ok(pair.publicKey instanceof themis.PublicKey)
+                assert.ok(pair.publicKey instanceof Uint8Array)
+            })
         })
     })
     describe('SecureCell', function() {
@@ -136,6 +143,11 @@ describe('wasm-themis', function() {
                         TypeError
                     )
                 })
+            })
+            it('keys are Uint8Arrays', function() {
+                let key = new themis.SymmetricKey()
+                assert.ok(key instanceof themis.SymmetricKey)
+                assert.ok(key instanceof Uint8Array)
             })
         })
         let masterKey1 = new Uint8Array([1, 2, 3, 4])

--- a/src/wrappers/themis/wasm/test/test.js
+++ b/src/wrappers/themis/wasm/test/test.js
@@ -92,16 +92,16 @@ describe('wasm-themis', function() {
             })
             it('check strict types', function() {
                 let key = new themis.KeyPair().publicKey
-                assert.deepStrictEqual(key, new themis.PublicKey(new Uint8Array(key.data)))
-                assert.deepStrictEqual(key, new themis.PublicKey(key.data.buffer))
-                assert.throws(() => new themis.PublicKey(new Int8Array(key.data)))
+                assert.deepStrictEqual(key, new themis.PublicKey(new Uint8Array(key)))
+                assert.deepStrictEqual(key, new themis.PublicKey(key.buffer))
+                assert.throws(() => new themis.PublicKey(new Int8Array(key)))
             })
             it('do not accept strings', function() {
                 let base64key = 'UkVDMgAAAC1JhwRrAPIGB33HHFmhjzn8lIE/nsW6cG+TCI3jhYJb+D/Gnwvf'
                 assert.throws(() => new themis.PrivateKey(base64key))
             })
             it('detect data corruption', function() {
-                let key = new themis.KeyPair().privateKey.data
+                let key = new themis.KeyPair().privateKey
                 key[20] = ~key[20]
                 assert.throws(() => new themis.PrivateKey(key))
             })
@@ -123,7 +123,7 @@ describe('wasm-themis', function() {
             it('wraps existing keys', function() {
                 let buffer = new Uint8Array([1, 2, 3, 4])
                 let key = new themis.SymmetricKey(buffer)
-                assert.deepEqual(key.data, buffer)
+                assert.deepEqual(key, buffer)
             })
             it('fails with empty buffer', function() {
                 assert.throws(() => new themis.SymmetricKey(new Uint8Array()),

--- a/src/wrappers/themis/wasm/tsconfig.json
+++ b/src/wrappers/themis/wasm/tsconfig.json
@@ -2,14 +2,14 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
     "declaration": true,
-    "target": "es5",
+    "target": "es6",
     "lib": [ "es2015", "dom" ],
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "outDir": "dist/"
+    "outDir": "dist-es6/"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "**/*.spec.ts"]

--- a/tools/js/wasm-themis/keygen.js
+++ b/tools/js/wasm-themis/keygen.js
@@ -19,12 +19,12 @@ switch (process.argv.length) {
 themis.initialize().then(function() {
     var keypair = new themis.KeyPair()
 
-    fs.writeFile(private_key_path, keypair.privateKey.data, {'mode': 0o600}, function(err) {
+    fs.writeFile(private_key_path, keypair.privateKey, {'mode': 0o600}, function(err) {
         if (err) {
             console.log('failed to write ' + private_key_path + ': ' + err)
         }
     })
-    fs.writeFile(public_key_path, keypair.publicKey.data, function(err) {
+    fs.writeFile(public_key_path, keypair.publicKey, function(err) {
         if (err) {
             console.log('failed to write ' + public_key_path + ': ' + err)
         }

--- a/tools/js/wasm-themis/keygen.mjs
+++ b/tools/js/wasm-themis/keygen.mjs
@@ -19,12 +19,12 @@ switch (process.argv.length) {
 themis.initialize().then(function() {
     let keypair = new themis.KeyPair()
 
-    fs.writeFile(private_key_path, keypair.privateKey.data, {'mode': 0o600}, function(err) {
+    fs.writeFile(private_key_path, keypair.privateKey, {'mode': 0o600}, function(err) {
         if (err) {
             console.log('failed to write ' + private_key_path + ': ' + err)
         }
     })
-    fs.writeFile(public_key_path, keypair.publicKey.data, function(err) {
+    fs.writeFile(public_key_path, keypair.publicKey, function(err) {
         if (err) {
             console.log('failed to write ' + public_key_path + ': ' + err)
         }


### PR DESCRIPTION
Drop ES5 target for TypeScript compilation. Replace it with ES6 code wrapped into CommonJS modules.

This allows to make `SymmetricKey`, `PublicKey`, `PrivateKey` to extend `Uint8Array` (as they did before TypeScript), and remove backwards-incompatible hack with `data` field.

### Background

TypeScript cannot compile Uint8Array usage into ES5-compatible code. They generate broken code and have no interest in implementing it, probably because its impossible to extend `Uint8Arrays` in ES5 correctly. I was not able to do it while still preserving all type invariants (such as the keys not only *looking* like `Uint8Array`, but *being* that in the sense of `instanceof`, as well as keeping their own type).

### But I need ES5 support...

I *do* want to avoid breaking changes, but this is too much for me.

WasmThemis was never supposed to work in ES5-only environments in the first place. And I'm not sure it *worked* before.

If it did for you, that's unintentional. Please accept my apologies for the suffering that you will go through if you want to transpile into ES5. But you're on your own here. (Backwards-compatible patches are welcome. Updates to documentation with suggested workarounds are welcome.)

### What `wasm-typescript` branch did

Since it's not possible to compile `class SomeKey extends Uint8Array` into ES5, the classes stopped inheriting from `Uint8Array` and got a `data` field instead, via which you could get access to the `Uint8Array` to pass to a function that accepts `Uint8Array`.

That is, if you had
```js
const key = new themis.SymmetricKey();

const cell = themis.SecureCell.withKey(key);
```
you were supposed to rewrite this into
```js
const cell = themis.SecureCell.withKey(key.data);
```
and the previous code would fail to work.

Similarly, if you had
```js
const keypair = new themis.KeyPair();

socket.send(keypair.publicKey);
```
you needed to do
```js
socket.send(keypair.publicKey.data);
```

With this PR applied, `data` is gone. Code written against WasmThemis 0.13 is still valid and works.

### On imports

Instead of compiling TypeScript into ES5 with CommonJS modules and ES6 with ES6 modules, we now compile TypeScript into ES6 with CommonJS modules and ES6 modules.

This means that all previous code that did

```js
const themis = require('wasm-themis');
```

can continue doing so with no changes. They will be getting CommonJS module from `dist`.

New code can now also do

```js
import { SecureCell, SymmetricKey } from 'wasm-themis';
```

and this will also work. They will be getting ES6 module from `dist-es6`.

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Example projects and code samples are up-to-date
- [x] ~~Changelog is updated~~ (it wasn't supposed to change in the first place)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
