### PR TITLE
Keep a copy of libthemis.wasm in `src`

### DIFF
--- a/src/wrappers/themis/wasm/package.json
+++ b/src/wrappers/themis/wasm/package.json
@@ -11,7 +11,8 @@
     "dist/libthemis.wasm",
     "dist-es6/*.js",
     "dist-es6/*.ts",
-    "dist-es6/libthemis.wasm"
+    "dist-es6/libthemis.wasm",
+    "src/libthemis.wasm"
   ],
   "scripts": {
     "test": "find test -name *.js | sort | xargs -L1 ts-mocha -p tsconfig.json",


### PR DESCRIPTION
That's where this file is located in WasmThemis 0.13.X and some users might have hardcoded its location (like it's hardcoded in WasmThemis example with webpack, for example). Let's package the original copy of `libthemis.wasm` at its original path, for compatibility.

This makes installed, unpackaged size a bit larger, but JavaScript developers are used to `node_modules` being heavier than their mom so it's okay.

![node_modules in comparison to stellar objects](https://user-images.githubusercontent.com/1256587/125644457-606ee8ca-1997-42e9-ab54-3450c4bbf74d.png)

And this does not affect downloads, since identical files are compressed with deduplication.

## Checklist

- [x] Change is covered by automated tests