### PR TITLE
M1 simulator fix: Removed arm64 from excluded archs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 Changes that are currently in development and have not been released yet.
 
+## [0.13.12](https://github.com/cossacklabs/themis/releases/tag/0.13.12), July 26th 2021
+
+**Hotfix for Apple arm64 simulators for M1**
+
+- Fixed issue [864](https://github.com/cossacklabs/themis/issues/864): Themis XCFramework now includes arm64 slice for simulators ([865](https://github.com/cossacklabs/themis/pull/865)).
+
+_Code:_
+
+  - Fixed `Themis.xcodeproj` build settings: removed arm64 from exluded architectures ([865](https://github.com/cossacklabs/themis/pull/865)).
+
 
 ## [0.13.11](https://github.com/cossacklabs/themis/releases/tag/0.13.11), July 6th 2021
 

--- a/Package.swift
+++ b/Package.swift
@@ -15,11 +15,11 @@ let package = Package(
     targets: [
         .binaryTarget(name: "themis",
                       // update version in URL path
-                      url: "https://github.com/cossacklabs/themis/releases/download/0.13.10/themis.xcframework.zip",
+                      url: "https://github.com/cossacklabs/themis/releases/download/0.13.12/themis.xcframework.zip",
                       // The scripts/create_xcframework.sh calculates the checksum when generating the XCF.
                       // Alternatively, run from package directory:
                       // swift package compute-checksum build/xcf_output/themis.xcframework.zip
-                      checksum: "2c77a19be873f306ed0fc997794d564f0ff32633c3596b81e8bb9d684ccfc049"),
+                      checksum: "c74f65d4918884220efe99c3195001fa8aabc8030ad85f8ef30d2bfed11065a3"),
 
     ]
 )

--- a/Themis.xcodeproj/project.pbxproj
+++ b/Themis.xcodeproj/project.pbxproj
@@ -1492,7 +1492,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.13.9;
+				MARKETING_VERSION = 0.13.12;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis;
 				PRODUCT_MODULE_NAME = themis;
 				PRODUCT_NAME = themis;
@@ -1534,7 +1534,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.13.9;
+				MARKETING_VERSION = 0.13.12;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis;
 				PRODUCT_MODULE_NAME = themis;
 				PRODUCT_NAME = themis;
@@ -1558,7 +1558,6 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = YES;
 				EXCLUDED_ARCHS = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				EXPORTED_SYMBOLS_FILE = "$(PROJECT_DIR)/src/wrappers/themis/Obj-C/exported.symbols";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1578,7 +1577,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.13.10;
+				MARKETING_VERSION = 0.13.12;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis;
 				PRODUCT_MODULE_NAME = themis;
 				PRODUCT_NAME = themis;
@@ -1607,7 +1606,6 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = YES;
 				EXCLUDED_ARCHS = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				EXPORTED_SYMBOLS_FILE = "$(PROJECT_DIR)/src/wrappers/themis/Obj-C/exported.symbols";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1627,7 +1625,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.13.10;
+				MARKETING_VERSION = 0.13.12;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cossacklabs.themis;
 				PRODUCT_MODULE_NAME = themis;
 				PRODUCT_NAME = themis;

--- a/themis.podspec
+++ b/themis.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name = "themis"
-    s.version = "0.13.10"
+    s.version = "0.13.12"
     s.summary = "Data security library for network communication and data storage for iOS and mac OS"
     s.description = "Themis is a convenient cryptographic library for data protection. It provides secure messaging with forward secrecy and secure data storage. Themis is aimed at modern development practices and has a unified API across 12 platforms, including iOS/macOS, Ruby, JavaScript, Python, and Java/Android."
     s.homepage = "https://cossacklabs.com"


### PR DESCRIPTION
Themis XCFramework was missing arm64 architecture that is required for M1 simulators.
Reported in #864 

I have removed arm64 from the excluded architectures in `Themis.xcodeproj` to resolve the issue. After that, Themis XCFrameworks is building with the required arm64 simulator slice. 

I'm going to publish a release with the new XCFramework attached. The update with touch all package managers.

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Public API has proper documentation
- [x] Example projects and code samples are up-to-date (in case of API changes)
- [x] Changelog is updated (in case of notable or breaking changes)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
