### PR TITLE
Fix Carthage example project: update Themis XCF location

### DIFF
--- a/docs/examples/objc/iOS-Carthage/Cartfile
+++ b/docs/examples/objc/iOS-Carthage/Cartfile
@@ -1,1 +1,1 @@
-github "cossacklabs/themis" ~> 0.13.9
+github "cossacklabs/themis" ~> 0.13.13

--- a/docs/examples/objc/iOS-Carthage/Cartfile.resolved
+++ b/docs/examples/objc/iOS-Carthage/Cartfile.resolved
@@ -1,2 +1,2 @@
 binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-xcframework.json" "1.1.11101"
-github "cossacklabs/themis" "0.13.9"
+github "cossacklabs/themis" "0.13.13"

--- a/docs/examples/objc/iOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
+++ b/docs/examples/objc/iOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
@@ -7,8 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		6DEC19AF265BDD180042EA63 /* themis.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DCCB20D264EFFE8008072EF /* themis.xcframework */; };
-		6DEC19B0265BDD180042EA63 /* themis.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6DCCB20D264EFFE8008072EF /* themis.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6D50C564270CA26D00C8C30F /* themis.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DCCB20D264EFFE8008072EF /* themis.xcframework */; };
+		6D50C565270CA26D00C8C30F /* themis.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6DCCB20D264EFFE8008072EF /* themis.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F00EA2E2241539600EC1EF3 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F00EA2D2241539600EC1EF3 /* AppDelegate.m */; };
 		9F00EA312241539600EC1EF3 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F00EA302241539600EC1EF3 /* ViewController.m */; };
 		9F00EA342241539600EC1EF3 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9F00EA322241539600EC1EF3 /* Main.storyboard */; };
@@ -22,13 +22,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		6DEC19B1265BDD180042EA63 /* Embed Frameworks */ = {
+		6D50C566270CA26D00C8C30F /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				6DEC19B0265BDD180042EA63 /* themis.xcframework in Embed Frameworks */,
+				6D50C565270CA26D00C8C30F /* themis.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -58,7 +58,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6DEC19AF265BDD180042EA63 /* themis.xcframework in Frameworks */,
+				6D50C564270CA26D00C8C30F /* themis.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -128,7 +128,7 @@
 				9F00EA252241539600EC1EF3 /* Sources */,
 				9F00EA262241539600EC1EF3 /* Frameworks */,
 				9F00EA272241539600EC1EF3 /* Resources */,
-				6DEC19B1265BDD180042EA63 /* Embed Frameworks */,
+				6D50C566270CA26D00C8C30F /* Embed Frameworks */,
 			);
 			buildRules = (
 			);

--- a/docs/examples/swift/iOS-Carthage/Cartfile
+++ b/docs/examples/swift/iOS-Carthage/Cartfile
@@ -1,1 +1,1 @@
-github "cossacklabs/themis" ~> 0.13.9
+github "cossacklabs/themis" ~> 0.13.13

--- a/docs/examples/swift/iOS-Carthage/Cartfile.resolved
+++ b/docs/examples/swift/iOS-Carthage/Cartfile.resolved
@@ -1,2 +1,2 @@
 binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-xcframework.json" "1.1.11101"
-github "cossacklabs/themis" "0.13.9"
+github "cossacklabs/themis" "0.13.13"

--- a/docs/examples/swift/iOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
+++ b/docs/examples/swift/iOS-Carthage/ThemisTest.xcodeproj/project.pbxproj
@@ -7,8 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		6DEC19AB265BD0360042EA63 /* themis.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DCCB200264EFDC0008072EF /* themis.xcframework */; };
-		6DEC19AC265BD0360042EA63 /* themis.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6DCCB200264EFDC0008072EF /* themis.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6D50C560270C9B0800C8C30F /* themis.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DCCB200264EFDC0008072EF /* themis.xcframework */; };
+		6D50C561270C9B0800C8C30F /* themis.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6DCCB200264EFDC0008072EF /* themis.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F00E99A22410F7600EC1EF3 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F00E99922410F7600EC1EF3 /* AppDelegate.swift */; };
 		9F00E99C22410F7600EC1EF3 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F00E99B22410F7600EC1EF3 /* ViewController.swift */; };
 		9F00E99F22410F7600EC1EF3 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9F00E99D22410F7600EC1EF3 /* Main.storyboard */; };
@@ -21,13 +21,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		6DEC19AD265BD0360042EA63 /* Embed Frameworks */ = {
+		6D50C562270C9B0800C8C30F /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				6DEC19AC265BD0360042EA63 /* themis.xcframework in Embed Frameworks */,
+				6D50C561270C9B0800C8C30F /* themis.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -54,7 +54,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6DEC19AB265BD0360042EA63 /* themis.xcframework in Frameworks */,
+				6D50C560270C9B0800C8C30F /* themis.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -121,7 +121,7 @@
 				9F00E99222410F7600EC1EF3 /* Sources */,
 				9F00E99322410F7600EC1EF3 /* Frameworks */,
 				9F00E99422410F7600EC1EF3 /* Resources */,
-				6DEC19AD265BD0360042EA63 /* Embed Frameworks */,
+				6D50C562270C9B0800C8C30F /* Embed Frameworks */,
 			);
 			buildRules = (
 			);


### PR DESCRIPTION
After the recent iOS hotfix of arm64 simulator builds in 0.13.12 we haven't updated our example projects. Our CI tests are running from `master` on the latest version (tag 0.13.13). Carthage started building for arm64 simulator and changed the folder name of Themis XCF from `ios-i386_x86_64-simulator` to `ios-arm64_i386_x86_64-simulator`. That's why example project tests are failing. 

Updating the XCF path should fix an issue. I've also updated the version to the latest and checked that example projects (both Swift and Objective-C) are running locally.

After the PR is merged, I'm going to update tests on Bitrise with a workaround similar to what we have in github actions. 

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Example projects and code samples are up-to-date (in case of API changes)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
