### PR TITLE
rust: Avoid double references

### DIFF
--- a/docs/examples/rust/keygen.rs
+++ b/docs/examples/rust/keygen.rs
@@ -31,11 +31,11 @@ fn main() {
 
     let (private_key, public_key) = gen_ec_key_pair().split();
 
-    match write_file(&private_key, &private_path) {
+    match write_file(&private_key, private_path) {
         Ok(_) => eprintln!("wrote private key to {}", private_path),
         Err(e) => eprintln!("failed to write private key to {}: {}", private_path, e),
     }
-    match write_file(&public_key, &public_path) {
+    match write_file(&public_key, public_path) {
         Ok(_) => eprintln!("wrote public key to {}", public_path),
         Err(e) => eprintln!("failed to write public key to {}: {}", public_path, e),
     }

--- a/docs/examples/rust/secure_compare.rs
+++ b/docs/examples/rust/secure_compare.rs
@@ -101,7 +101,7 @@ fn send_msg(message: &[u8], peer: &mut TcpStream) -> io::Result<()> {
         ));
     }
     peer.write_u32::<LittleEndian>(message.len() as u32)?;
-    peer.write_all(&message)
+    peer.write_all(message)
 }
 
 fn receive_msg(peer: &mut TcpStream) -> io::Result<Vec<u8>> {

--- a/docs/examples/rust/secure_message_client_encrypt.rs
+++ b/docs/examples/rust/secure_message_client_encrypt.rs
@@ -42,9 +42,9 @@ fn main() {
     let public_path = matches.value_of("public").unwrap_or("public.key");
     let remote_addr = matches.value_of("address").unwrap_or("localhost:7573");
 
-    let private_key = read_file(&private_path).expect("read private key");
+    let private_key = read_file(private_path).expect("read private key");
     let private_key = PrivateKey::try_from_slice(private_key).expect("parse private key");
-    let public_key = read_file(&public_path).expect("read public key");
+    let public_key = read_file(public_path).expect("read public key");
     let public_key = PublicKey::try_from_slice(public_key).expect("parse public key");
     let key_pair = KeyPair::try_join(private_key, public_key).expect("matching keys");
 

--- a/docs/examples/rust/secure_message_client_verify.rs
+++ b/docs/examples/rust/secure_message_client_verify.rs
@@ -41,9 +41,9 @@ fn main() {
     let public_path = matches.value_of("public").unwrap_or("public.key");
     let remote_addr = matches.value_of("address").unwrap_or("localhost:7573");
 
-    let private_key = read_file(&private_path).expect("read private key");
+    let private_key = read_file(private_path).expect("read private key");
     let private_key = PrivateKey::try_from_slice(private_key).expect("parse private key");
-    let public_key = read_file(&public_path).expect("read public key");
+    let public_key = read_file(public_path).expect("read public key");
     let public_key = PublicKey::try_from_slice(public_key).expect("parse public key");
 
     let socket = UdpSocket::bind("localhost:0").expect("client socket");

--- a/tools/rust/keygen_tool.rs
+++ b/tools/rust/keygen_tool.rs
@@ -34,11 +34,11 @@ fn main() {
 
     let (private_key, public_key) = gen_ec_key_pair().split();
 
-    match write_file(&private_key, &private_path, 0o400) {
+    match write_file(&private_key, private_path, 0o400) {
         Ok(_) => {}
         Err(e) => eprintln!("failed to write private key to {}: {}", private_path, e),
     }
-    match write_file(&public_key, &public_path, 0o666) {
+    match write_file(&public_key, public_path, 0o666) {
         Ok(_) => {}
         Err(e) => eprintln!("failed to write public key to {}: {}", public_path, e),
     }

--- a/tools/rust/smessage_encryption.rs
+++ b/tools/rust/smessage_encryption.rs
@@ -36,9 +36,9 @@ fn main() {
     let public_key_path = matches.value_of("public_key").unwrap();
     let message = matches.value_of("message").unwrap();
 
-    let private_key = read_file(&private_key_path).expect("read private key");
+    let private_key = read_file(private_key_path).expect("read private key");
     let private_key = PrivateKey::try_from_slice(private_key).expect("parse private key");
-    let public_key = read_file(&public_key_path).expect("read public key");
+    let public_key = read_file(public_key_path).expect("read public key");
     let public_key = PublicKey::try_from_slice(public_key).expect("parse public key");
 
     match command {


### PR DESCRIPTION
Recent Clippy started complaining when you pass a reference to reference.  Compiler will automatically dereference those, but the warnings suggest it's redundant. Remove those. Originally, I wrote it like that for consistency with other arguments, but that would better be solved with a different argument parser.

Anyhow, stop offending our dear stationery and unbreak the build.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] Example projects and code samples are up-to-date
- [X] ~~Changelog is updated~~ (not a user-visible change)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
