### PR TITLE
CI: Use Xcode 12.4 for building Apple things

### DIFF
--- a/.github/workflows/test-objc.yaml
+++ b/.github/workflows/test-objc.yaml
@@ -59,10 +59,9 @@ env:
   HACK_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
   # let's use Xcode 12 to test Xcode12-specifics
-  # TODO: change on default Xcode later
   # the list is here
   # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md
-  DEVELOPER_DIR: /Applications/Xcode_12.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
 
 jobs:
   unit-tests-cocoapods:


### PR DESCRIPTION
#722 downgraded Xcode from 12.2 to 12.0 because reasons, but it seems 12.0 is broken somehow on CI, let's upgrade! #YOLO

In any case, Apple does not support anything but the latest version, and GitHub Actions will soon be ready to support macOS 11 for non-paying plebs and we will have to upgrade something somewhere eventually too.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] Example projects and code samples are up-to-date
- [X] ~~Changelog is updated~~ (CI only)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
