### PR TITLE
core: Choose `openssl@1.1` from Homebrew by default

### DIFF
--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -46,7 +46,7 @@ jobs:
         run: |
           if [[ "$(uname)" = "Darwin" ]]
           then
-            brew install cmake ninja openssl
+            brew install cmake ninja openssl@1.1
           else
             sudo sh -c 'echo "DEBIAN_FRONTEND=noninteractive" >> /etc/environment'
             sudo apt update

--- a/.github/workflows/test-java.yaml
+++ b/.github/workflows/test-java.yaml
@@ -39,7 +39,7 @@ jobs:
         run: |
           if [[ "$(uname)" = "Darwin" ]]
           then
-            brew install openssl
+            brew install openssl@1.1
           else
             sudo sh -c 'echo "DEBIAN_FRONTEND=noninteractive" >> /etc/environment'
             sudo apt update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,7 @@ _Infrastructure:_
 - Added automated tests for desktop Java example project ([#816](https://github.com/cossacklabs/themis/pull/816)).
 - Embedded BoringSSL now builds faster if Ninja is available ([#837](https://github.com/cossacklabs/themis/pull/837)).
 - Embedded BoringSSL can now be cross-compiled on macOS by setting `ARCH` and `SDK` variables ([#849](https://github.com/cossacklabs/themis/pull/849)).
+- Builds on macOS use OpenSSL 1.1 from Homebrew by default ([#871](https://github.com/cossacklabs/themis/pull/871)).
 
 
 ## [0.13.12](https://github.com/cossacklabs/themis/releases/tag/0.13.12), July 26th 2021

--- a/configure
+++ b/configure
@@ -232,7 +232,7 @@ configure_macos_toolchain() {
 
 find_macos_openssl() {
     [ -z "${IS_MACOS:-}" ] && return
-    local path="$(brew --prefix openssl 2> /dev/null || true)"
+    local path="$(brew --prefix openssl@1.1 2> /dev/null || true)"
     if [ -n "$path" ]
     then
         set_variable HOMEBREW_OPENSSL_PATH "$path"


### PR DESCRIPTION
Homebrew formula `openssl` now defaults to `openssl@3` which is not currently supported by Themis (so much that the tests are broken). While we certainly can compile Themis, it doesn't look like it's working properly. First of all, start installing OpenSSL 1.1 on macOS where it's already the default (with Homebrew, that is).

When automatically detecting OpenSSL location, choose OpenSSL 1.1 as well. This is applicable only for from-source builds. Technically, all previously released source tarballs fail to build right now, but that's not much of an issue since not many macOS users build Themis from source. The currently published Homebrew formula is broken too. That will be patched up separately.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
