### PR TITLE
RSA: keygen: Preparatory cleanups

### DIFF
--- a/src/soter/openssl/soter_rsa_key_pair_gen.c
+++ b/src/soter/openssl/soter_rsa_key_pair_gen.c
@@ -191,11 +191,17 @@ soter_status_t soter_rsa_key_pair_gen_export_key(soter_rsa_key_pair_gen_t* ctx,
 {
     EVP_PKEY* pkey = NULL;
 
-    SOTER_CHECK_PARAM(ctx);
+    if (!ctx) {
+        return SOTER_INVALID_PARAMETER;
+    }
 
     pkey = EVP_PKEY_CTX_get0_pkey(ctx->pkey_ctx);
-    SOTER_CHECK_PARAM(pkey);
-    SOTER_CHECK_PARAM(EVP_PKEY_RSA == EVP_PKEY_id(pkey));
+    if (!pkey) {
+        return SOTER_INVALID_PARAMETER;
+    }
+    if (EVP_PKEY_id(pkey) != EVP_PKEY_RSA) {
+        return SOTER_INVALID_PARAMETER;
+    }
 
     if (isprivate) {
         return soter_engine_specific_to_rsa_priv_key((const soter_engine_specific_rsa_key_t*)pkey,

--- a/src/soter/openssl/soter_rsa_key_pair_gen.c
+++ b/src/soter/openssl/soter_rsa_key_pair_gen.c
@@ -159,7 +159,9 @@ free_pkey:
 
 soter_status_t soter_rsa_key_pair_gen_cleanup(soter_rsa_key_pair_gen_t* ctx)
 {
-    SOTER_CHECK_PARAM(ctx);
+    if (!ctx) {
+        return SOTER_INVALID_PARAMETER;
+    }
     if (ctx->pkey_ctx) {
         EVP_PKEY_CTX_free(ctx->pkey_ctx);
         ctx->pkey_ctx = NULL;

--- a/src/soter/openssl/soter_rsa_key_pair_gen.c
+++ b/src/soter/openssl/soter_rsa_key_pair_gen.c
@@ -189,6 +189,7 @@ soter_status_t soter_rsa_key_pair_gen_export_key(soter_rsa_key_pair_gen_t* ctx,
                                                  size_t* key_length,
                                                  bool isprivate)
 {
+    soter_status_t res = SOTER_FAIL;
     EVP_PKEY* pkey = NULL;
 
     if (!ctx) {
@@ -204,12 +205,13 @@ soter_status_t soter_rsa_key_pair_gen_export_key(soter_rsa_key_pair_gen_t* ctx,
     }
 
     if (isprivate) {
-        return soter_engine_specific_to_rsa_priv_key((const soter_engine_specific_rsa_key_t*)pkey,
-                                                     (soter_container_hdr_t*)key,
-                                                     key_length);
+        res = soter_engine_specific_to_rsa_priv_key((const soter_engine_specific_rsa_key_t*)pkey,
+                                                    (soter_container_hdr_t*)key,
+                                                    key_length);
+    } else {
+        res = soter_engine_specific_to_rsa_pub_key((const soter_engine_specific_rsa_key_t*)pkey,
+                                                   (soter_container_hdr_t*)key,
+                                                   key_length);
     }
-
-    return soter_engine_specific_to_rsa_pub_key((const soter_engine_specific_rsa_key_t*)pkey,
-                                                (soter_container_hdr_t*)key,
-                                                key_length);
+    return res;
 }

--- a/src/soter/openssl/soter_rsa_key_pair_gen.c
+++ b/src/soter/openssl/soter_rsa_key_pair_gen.c
@@ -46,7 +46,9 @@ soter_rsa_key_pair_gen_t* soter_rsa_key_pair_gen_create(const unsigned key_lengt
 {
     soter_rsa_key_pair_gen_t* ctx = NULL;
 
-    SOTER_CHECK_PARAM_(rsa_key_length(key_length) > 0);
+    if (rsa_key_length(key_length) <= 0) {
+        return NULL;
+    }
 
     ctx = malloc(sizeof(soter_rsa_key_pair_gen_t));
     SOTER_CHECK_MALLOC_(ctx);

--- a/src/soter/openssl/soter_rsa_key_pair_gen.c
+++ b/src/soter/openssl/soter_rsa_key_pair_gen.c
@@ -173,7 +173,9 @@ soter_status_t soter_rsa_key_pair_gen_destroy(soter_rsa_key_pair_gen_t* ctx)
 {
     soter_status_t res = SOTER_FAIL;
 
-    SOTER_CHECK_PARAM(ctx);
+    if (!ctx) {
+        return SOTER_INVALID_PARAMETER;
+    }
 
     res = soter_rsa_key_pair_gen_cleanup(ctx);
 

--- a/src/soter/openssl/soter_rsa_key_pair_gen.c
+++ b/src/soter/openssl/soter_rsa_key_pair_gen.c
@@ -44,6 +44,7 @@ static int rsa_key_length(unsigned size)
 
 soter_rsa_key_pair_gen_t* soter_rsa_key_pair_gen_create(const unsigned key_length)
 {
+    soter_status_t res = SOTER_FAIL;
     soter_rsa_key_pair_gen_t* ctx = NULL;
 
     if (rsa_key_length(key_length) <= 0) {
@@ -55,7 +56,12 @@ soter_rsa_key_pair_gen_t* soter_rsa_key_pair_gen_create(const unsigned key_lengt
         return NULL;
     }
 
-    SOTER_IF_FAIL_(soter_rsa_key_pair_gen_init(ctx, key_length) == SOTER_SUCCESS, free(ctx));
+    res = soter_rsa_key_pair_gen_init(ctx, key_length);
+    if (res != SOTER_SUCCESS) {
+        free(ctx);
+        return NULL;
+    }
+
     return ctx;
 }
 

--- a/src/soter/openssl/soter_rsa_key_pair_gen.c
+++ b/src/soter/openssl/soter_rsa_key_pair_gen.c
@@ -50,7 +50,7 @@ soter_rsa_key_pair_gen_t* soter_rsa_key_pair_gen_create(const unsigned key_lengt
         return NULL;
     }
 
-    ctx = malloc(sizeof(soter_rsa_key_pair_gen_t));
+    ctx = calloc(1, sizeof(*ctx));
     SOTER_CHECK_MALLOC_(ctx);
     SOTER_IF_FAIL_(soter_rsa_key_pair_gen_init(ctx, key_length) == SOTER_SUCCESS, free(ctx));
     return ctx;

--- a/src/soter/openssl/soter_rsa_key_pair_gen.c
+++ b/src/soter/openssl/soter_rsa_key_pair_gen.c
@@ -189,11 +189,14 @@ soter_status_t soter_rsa_key_pair_gen_export_key(soter_rsa_key_pair_gen_t* ctx,
                                                  size_t* key_length,
                                                  bool isprivate)
 {
-    EVP_PKEY* pkey;
+    EVP_PKEY* pkey = NULL;
+
     SOTER_CHECK_PARAM(ctx);
+
     pkey = EVP_PKEY_CTX_get0_pkey(ctx->pkey_ctx);
     SOTER_CHECK_PARAM(pkey);
     SOTER_CHECK_PARAM(EVP_PKEY_RSA == EVP_PKEY_id(pkey));
+
     if (isprivate) {
         return soter_engine_specific_to_rsa_priv_key((const soter_engine_specific_rsa_key_t*)pkey,
                                                      (soter_container_hdr_t*)key,

--- a/src/soter/openssl/soter_rsa_key_pair_gen.c
+++ b/src/soter/openssl/soter_rsa_key_pair_gen.c
@@ -51,7 +51,10 @@ soter_rsa_key_pair_gen_t* soter_rsa_key_pair_gen_create(const unsigned key_lengt
     }
 
     ctx = calloc(1, sizeof(*ctx));
-    SOTER_CHECK_MALLOC_(ctx);
+    if (!ctx) {
+        return NULL;
+    }
+
     SOTER_IF_FAIL_(soter_rsa_key_pair_gen_init(ctx, key_length) == SOTER_SUCCESS, free(ctx));
     return ctx;
 }

--- a/src/soter/openssl/soter_rsa_key_pair_gen.c
+++ b/src/soter/openssl/soter_rsa_key_pair_gen.c
@@ -171,10 +171,15 @@ soter_status_t soter_rsa_key_pair_gen_cleanup(soter_rsa_key_pair_gen_t* ctx)
 
 soter_status_t soter_rsa_key_pair_gen_destroy(soter_rsa_key_pair_gen_t* ctx)
 {
+    soter_status_t res = SOTER_FAIL;
+
     SOTER_CHECK_PARAM(ctx);
-    SOTER_CHECK(soter_rsa_key_pair_gen_cleanup(ctx) == SOTER_SUCCESS);
+
+    res = soter_rsa_key_pair_gen_cleanup(ctx);
+
     free(ctx);
-    return SOTER_SUCCESS;
+
+    return res;
 }
 
 soter_status_t soter_rsa_key_pair_gen_export_key(soter_rsa_key_pair_gen_t* ctx,

--- a/src/soter/openssl/soter_rsa_key_pair_gen.c
+++ b/src/soter/openssl/soter_rsa_key_pair_gen.c
@@ -98,7 +98,7 @@ static soter_status_t soter_set_rsa_key_length(EVP_PKEY_CTX* pkey_ctx, int lengt
 
 soter_status_t soter_rsa_key_pair_gen_init(soter_rsa_key_pair_gen_t* ctx, const unsigned key_length)
 {
-    soter_status_t err = SOTER_FAIL;
+    soter_status_t res = SOTER_FAIL;
     EVP_PKEY* pkey = NULL;
 
     pkey = EVP_PKEY_new();
@@ -113,7 +113,7 @@ soter_status_t soter_rsa_key_pair_gen_init(soter_rsa_key_pair_gen_t* ctx, const 
 
     ctx->pkey_ctx = EVP_PKEY_CTX_new(pkey, NULL);
     if (!ctx->pkey_ctx) {
-        err = SOTER_NO_MEMORY;
+        res = SOTER_NO_MEMORY;
         goto free_pkey;
     }
 
@@ -125,8 +125,8 @@ soter_status_t soter_rsa_key_pair_gen_init(soter_rsa_key_pair_gen_t* ctx, const 
      * Although it seems that OpenSSL/LibreSSL use 0x10001 as default public exponent,
      * we will set it explicitly just in case.
      */
-    err = soter_set_default_rsa_pub_exp(ctx->pkey_ctx);
-    if (err != SOTER_SUCCESS) {
+    res = soter_set_default_rsa_pub_exp(ctx->pkey_ctx);
+    if (res != SOTER_SUCCESS) {
         goto free_pkey_ctx;
     }
 
@@ -134,8 +134,8 @@ soter_status_t soter_rsa_key_pair_gen_init(soter_rsa_key_pair_gen_t* ctx, const 
      * Override default key length for RSA key. Currently OpenSSL has default
      * key length of 1024. LibreSSL has 2048. We will set length explicitly.
      */
-    err = soter_set_rsa_key_length(ctx->pkey_ctx, rsa_key_length(key_length));
-    if (err != SOTER_SUCCESS) {
+    res = soter_set_rsa_key_length(ctx->pkey_ctx, rsa_key_length(key_length));
+    if (res != SOTER_SUCCESS) {
         goto free_pkey_ctx;
     }
 
@@ -151,7 +151,7 @@ free_pkey_ctx:
     ctx->pkey_ctx = NULL;
 free_pkey:
     EVP_PKEY_free(pkey);
-    return err;
+    return res;
 }
 
 soter_status_t soter_rsa_key_pair_gen_cleanup(soter_rsa_key_pair_gen_t* ctx)

--- a/src/soter/openssl/soter_rsa_key_pair_gen.c
+++ b/src/soter/openssl/soter_rsa_key_pair_gen.c
@@ -44,8 +44,11 @@ static int rsa_key_length(unsigned size)
 
 soter_rsa_key_pair_gen_t* soter_rsa_key_pair_gen_create(const unsigned key_length)
 {
+    soter_rsa_key_pair_gen_t* ctx = NULL;
+
     SOTER_CHECK_PARAM_(rsa_key_length(key_length) > 0);
-    soter_rsa_key_pair_gen_t* ctx = malloc(sizeof(soter_rsa_key_pair_gen_t));
+
+    ctx = malloc(sizeof(soter_rsa_key_pair_gen_t));
     SOTER_CHECK_MALLOC_(ctx);
     SOTER_IF_FAIL_(soter_rsa_key_pair_gen_init(ctx, key_length) == SOTER_SUCCESS, free(ctx));
     return ctx;

--- a/src/soter/openssl/soter_rsa_key_pair_gen.c
+++ b/src/soter/openssl/soter_rsa_key_pair_gen.c
@@ -108,6 +108,7 @@ soter_status_t soter_rsa_key_pair_gen_init(soter_rsa_key_pair_gen_t* ctx, const 
 
     /* Only RSA supports asymmetric encryption */
     if (EVP_PKEY_set_type(pkey, EVP_PKEY_RSA) != 1) {
+        res = SOTER_FAIL;
         goto free_pkey;
     }
 
@@ -118,6 +119,7 @@ soter_status_t soter_rsa_key_pair_gen_init(soter_rsa_key_pair_gen_t* ctx, const 
     }
 
     if (EVP_PKEY_keygen_init(ctx->pkey_ctx) != 1) {
+        res = SOTER_FAIL;
         goto free_pkey_ctx;
     }
 
@@ -140,6 +142,7 @@ soter_status_t soter_rsa_key_pair_gen_init(soter_rsa_key_pair_gen_t* ctx, const 
     }
 
     if (EVP_PKEY_keygen(ctx->pkey_ctx, &pkey) != 1) {
+        res = SOTER_FAIL;
         goto free_pkey_ctx;
     }
 


### PR DESCRIPTION
So I tried fixing deprecation warnings related to OpenSSL 3.0. That resulted in 60+ commits just for one file handling RSA key exporting and importing. And it started crashing because apparently to use new RSA key manipulation functions, you first need to generate RSA keys using new key generation functions. That will be taken care of later.

This PR is some preparatory cleanups in generic OpenSSL code. Initially I wanted to submit just one PR with OpenSSL 3.0 migration, thinking that it would be just a couple of conversions here and there. However, now it seems *almost all* code will need to be rewritten to use OpenSSL 3.0 API. And that will be a lot of changes. So to avoid dropping a patch bomb, I'm going to move incrementally: file by file, function by function.

It's a bummer that so much code will need attention. I mean, we could probably not do that – a warning is still a warning, the code still compiles. And I believe in OpenSSL team being responsible adults and not removing these APIs at least in 3.0. However, depending on deprecated APIs is bad, and *some* new APIs are genuinely easier and more secure to use, and have better compatibility with new things added in OpenSSL 3.0. Moreover, it seems that we are using the old APIs in some broken way that compatibility bridge in OpenSSL 3.0 cannot handle, resulting in actual test failures that I have not yet debugged thoroughly (I just know that OpenSSL refuses to generate us EC keys).

Anyhows. This PR is some preparatory cleanups in generic OpenSSL code for RSA key generation. This is not the only place where we generate RSA keys – the other one is in RSA signature handling. But this one is what generates keys which are then exported and given to the users.

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] ~~Changelog is updated~~ (no functional changes)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
