### PR TITLE
soter: Fix misuse of OpenSSL API for EC key generation (and more)

### DIFF
--- a/.github/workflows/test-nodejs.yaml
+++ b/.github/workflows/test-nodejs.yaml
@@ -48,10 +48,19 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Check out code
         uses: actions/checkout@v2
+        with:
+          submodules: true
       - name: Install Themis Core
+        env:
+          NODE_VERSION: ${{ matrix.node-version }}
         run: |
+          # Workaround for Node.js 8.x using OpenSSL 1.0.2 when Themis is built against OpenSSL 1.1
+          # https://github.com/cossacklabs/themis/issues/657
+          if [[ "$NODE_VERSION" = "8.x" ]]; then
+            export ENGINE=boringssl
+          fi
           make
-          sudo make install
+          sudo -E make install
       - name: Run test suite
         run: |
           echo Node.js: $(node --version)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ _Code:_
   - Fixed cross-compilation on macOS by setting `ARCH` and `SDK` variables ([#849](https://github.com/cossacklabs/themis/pull/849)).
   - Updated embedded BoringSSL to the latest version ([#812](https://github.com/cossacklabs/themis/pull/812)).
   - Builds with OpenSSL 3.0 will result in a compilation error for the time being ([#872](https://github.com/cossacklabs/themis/pull/872)).
+  - Hardened EC/RSA key generation and Secure Message sign/verify code paths ([#875](https://github.com/cossacklabs/themis/pull/875)).
 
 - **Android**
 

--- a/src/soter/openssl/soter_ecdsa_common.c
+++ b/src/soter/openssl/soter_ecdsa_common.c
@@ -24,6 +24,7 @@
 
 soter_status_t soter_ec_gen_key(EVP_PKEY_CTX* pkey_ctx, EVP_PKEY** ppkey)
 {
+    soter_status_t res = SOTER_FAIL;
     EVP_PKEY* pkey;
     EC_KEY* ec;
     if (!pkey_ctx) {
@@ -43,10 +44,13 @@ soter_status_t soter_ec_gen_key(EVP_PKEY_CTX* pkey_ctx, EVP_PKEY** ppkey)
     if (NULL == ec) {
         return SOTER_INVALID_PARAMETER;
     }
-    if (1 == EC_KEY_generate_key(ec)) {
-        return SOTER_SUCCESS;
+    if (EC_KEY_generate_key(ec) != 1) {
+        return SOTER_FAIL;
     }
-    return SOTER_FAIL;
+
+    res = SOTER_SUCCESS;
+
+    return res;
 }
 
 soter_status_t soter_ec_import_key(EVP_PKEY* pkey, const void* key, const size_t key_length)

--- a/src/soter/openssl/soter_ecdsa_common.c
+++ b/src/soter/openssl/soter_ecdsa_common.c
@@ -76,7 +76,7 @@ soter_status_t soter_ec_import_key(EVP_PKEY* pkey, const void* key, const size_t
 
 soter_status_t soter_ec_export_key(soter_sign_ctx_t* ctx, void* key, size_t* key_length, bool isprivate)
 {
-    EVP_PKEY* pkey = EVP_PKEY_CTX_get0_pkey(ctx->pkey_ctx);
+    EVP_PKEY* pkey = ctx->pkey;
     if (!pkey) {
         return SOTER_INVALID_PARAMETER;
     }

--- a/src/soter/openssl/soter_ecdsa_common.c
+++ b/src/soter/openssl/soter_ecdsa_common.c
@@ -25,8 +25,9 @@
 soter_status_t soter_ec_gen_key(EVP_PKEY_CTX* pkey_ctx, EVP_PKEY** ppkey)
 {
     soter_status_t res = SOTER_FAIL;
-    EVP_PKEY* pkey;
-    EC_KEY* ec;
+    EVP_PKEY* pkey = NULL;
+    EC_KEY* ec = NULL;
+
     if (!pkey_ctx) {
         return SOTER_INVALID_PARAMETER;
     }

--- a/src/soter/openssl/soter_ecdsa_common.c
+++ b/src/soter/openssl/soter_ecdsa_common.c
@@ -22,14 +22,17 @@
 #include "soter/openssl/soter_engine.h"
 #include "soter/soter_ec_key.h"
 
-soter_status_t soter_ec_gen_key(EVP_PKEY_CTX* pkey_ctx)
+soter_status_t soter_ec_gen_key(EVP_PKEY_CTX* pkey_ctx, EVP_PKEY** ppkey)
 {
     EVP_PKEY* pkey;
     EC_KEY* ec;
     if (!pkey_ctx) {
         return SOTER_INVALID_PARAMETER;
     }
-    pkey = EVP_PKEY_CTX_get0_pkey(pkey_ctx);
+    if (!ppkey) {
+        return SOTER_INVALID_PARAMETER;
+    }
+    pkey = *ppkey;
     if (!pkey) {
         return SOTER_INVALID_PARAMETER;
     }

--- a/src/soter/openssl/soter_ecdsa_common.c
+++ b/src/soter/openssl/soter_ecdsa_common.c
@@ -33,17 +33,7 @@ soter_status_t soter_ec_gen_key(EVP_PKEY** ppkey)
         return SOTER_INVALID_PARAMETER;
     }
 
-    param = EVP_PKEY_new();
-    if (!param) {
-        return SOTER_NO_MEMORY;
-    }
-
-    if (!EVP_PKEY_set_type(param, EVP_PKEY_EC)) {
-        res = SOTER_FAIL;
-        goto err;
-    }
-
-    param_ctx = EVP_PKEY_CTX_new(param, NULL);
+    param_ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, NULL);
     if (!param_ctx) {
         res = SOTER_NO_MEMORY;
         goto err;

--- a/src/soter/openssl/soter_ecdsa_common.c
+++ b/src/soter/openssl/soter_ecdsa_common.c
@@ -26,6 +26,7 @@ soter_status_t soter_ec_gen_key(EVP_PKEY** ppkey)
 {
     soter_status_t res = SOTER_FAIL;
     EVP_PKEY* pkey = NULL;
+    EVP_PKEY_CTX* param_ctx = NULL;
     EVP_PKEY_CTX* pkey_ctx = NULL;
 
     if (!ppkey) {
@@ -43,22 +44,28 @@ soter_status_t soter_ec_gen_key(EVP_PKEY** ppkey)
         goto err;
     }
 
-    pkey_ctx = EVP_PKEY_CTX_new(pkey, NULL);
-    if (!pkey_ctx) {
+    param_ctx = EVP_PKEY_CTX_new(pkey, NULL);
+    if (!param_ctx) {
         res = SOTER_NO_MEMORY;
         goto err;
     }
 
-    if (!EVP_PKEY_paramgen_init(pkey_ctx)) {
+    if (!EVP_PKEY_paramgen_init(param_ctx)) {
         res = SOTER_FAIL;
         goto err;
     }
-    if (!EVP_PKEY_CTX_set_ec_paramgen_curve_nid(pkey_ctx, NID_X9_62_prime256v1)) {
+    if (!EVP_PKEY_CTX_set_ec_paramgen_curve_nid(param_ctx, NID_X9_62_prime256v1)) {
         res = SOTER_FAIL;
         goto err;
     }
-    if (!EVP_PKEY_paramgen(pkey_ctx, &pkey)) {
+    if (!EVP_PKEY_paramgen(param_ctx, &pkey)) {
         res = SOTER_FAIL;
+        goto err;
+    }
+
+    pkey_ctx = EVP_PKEY_CTX_new(pkey, NULL);
+    if (!pkey_ctx) {
+        res = SOTER_NO_MEMORY;
         goto err;
     }
 
@@ -74,6 +81,7 @@ soter_status_t soter_ec_gen_key(EVP_PKEY** ppkey)
     res = SOTER_SUCCESS;
 
 err:
+    EVP_PKEY_CTX_free(param_ctx);
     EVP_PKEY_CTX_free(pkey_ctx);
 
     return res;

--- a/src/soter/openssl/soter_ecdsa_common.c
+++ b/src/soter/openssl/soter_ecdsa_common.c
@@ -102,9 +102,8 @@ soter_status_t soter_ec_import_key(EVP_PKEY* pkey, const void* key, const size_t
     return SOTER_INVALID_PARAMETER;
 }
 
-soter_status_t soter_ec_export_key(soter_sign_ctx_t* ctx, void* key, size_t* key_length, bool isprivate)
+soter_status_t soter_ec_export_key(EVP_PKEY* pkey, void* key, size_t* key_length, bool isprivate)
 {
-    EVP_PKEY* pkey = ctx->pkey;
     if (!pkey) {
         return SOTER_INVALID_PARAMETER;
     }

--- a/src/soter/openssl/soter_ecdsa_common.c
+++ b/src/soter/openssl/soter_ecdsa_common.c
@@ -44,12 +44,15 @@ soter_status_t soter_ec_gen_key(EVP_PKEY_CTX* pkey_ctx, EVP_PKEY** ppkey)
     if (NULL == ec) {
         return SOTER_INVALID_PARAMETER;
     }
+
     if (EC_KEY_generate_key(ec) != 1) {
-        return SOTER_FAIL;
+        res = SOTER_FAIL;
+        goto err;
     }
 
     res = SOTER_SUCCESS;
 
+err:
     return res;
 }
 

--- a/src/soter/openssl/soter_ecdsa_common.c
+++ b/src/soter/openssl/soter_ecdsa_common.c
@@ -39,15 +39,15 @@ soter_status_t soter_ec_gen_key(EVP_PKEY** ppkey)
         goto err;
     }
 
-    if (!EVP_PKEY_paramgen_init(param_ctx)) {
+    if (EVP_PKEY_paramgen_init(param_ctx) != 1) {
         res = SOTER_FAIL;
         goto err;
     }
-    if (!EVP_PKEY_CTX_set_ec_paramgen_curve_nid(param_ctx, NID_X9_62_prime256v1)) {
+    if (EVP_PKEY_CTX_set_ec_paramgen_curve_nid(param_ctx, NID_X9_62_prime256v1) != 1) {
         res = SOTER_FAIL;
         goto err;
     }
-    if (!EVP_PKEY_paramgen(param_ctx, &param)) {
+    if (EVP_PKEY_paramgen(param_ctx, &param) != 1) {
         res = SOTER_FAIL;
         goto err;
     }

--- a/src/soter/openssl/soter_ecdsa_common.c
+++ b/src/soter/openssl/soter_ecdsa_common.c
@@ -44,9 +44,6 @@ soter_status_t soter_ec_gen_key(EVP_PKEY** ppkey)
         goto err;
     }
 
-    if (EVP_PKEY_EC != EVP_PKEY_id(pkey)) {
-        return SOTER_INVALID_PARAMETER;
-    }
     ec = EVP_PKEY_get0(pkey);
     if (NULL == ec) {
         return SOTER_INVALID_PARAMETER;

--- a/src/soter/openssl/soter_ecdsa_common.c
+++ b/src/soter/openssl/soter_ecdsa_common.c
@@ -27,7 +27,6 @@ soter_status_t soter_ec_gen_key(EVP_PKEY** ppkey)
     soter_status_t res = SOTER_FAIL;
     EVP_PKEY* pkey = NULL;
     EVP_PKEY_CTX* pkey_ctx = NULL;
-    EC_KEY* ec = NULL;
 
     if (!ppkey) {
         return SOTER_INVALID_PARAMETER;
@@ -42,11 +41,6 @@ soter_status_t soter_ec_gen_key(EVP_PKEY** ppkey)
     if (!EVP_PKEY_set_type(pkey, EVP_PKEY_EC)) {
         res = SOTER_FAIL;
         goto err;
-    }
-
-    ec = EVP_PKEY_get0(pkey);
-    if (NULL == ec) {
-        return SOTER_INVALID_PARAMETER;
     }
 
     pkey_ctx = EVP_PKEY_CTX_new(pkey, NULL);
@@ -68,7 +62,11 @@ soter_status_t soter_ec_gen_key(EVP_PKEY** ppkey)
         goto err;
     }
 
-    if (EC_KEY_generate_key(ec) != 1) {
+    if (EVP_PKEY_keygen_init(pkey_ctx) != 1) {
+        res = SOTER_FAIL;
+        goto err;
+    }
+    if (EVP_PKEY_keygen(pkey_ctx, ppkey) != 1) {
         res = SOTER_FAIL;
         goto err;
     }

--- a/src/soter/openssl/soter_ecdsa_common.c
+++ b/src/soter/openssl/soter_ecdsa_common.c
@@ -25,7 +25,7 @@
 soter_status_t soter_ec_gen_key(EVP_PKEY** ppkey)
 {
     soter_status_t res = SOTER_FAIL;
-    EVP_PKEY* pkey = NULL;
+    EVP_PKEY* param = NULL;
     EVP_PKEY_CTX* param_ctx = NULL;
     EVP_PKEY_CTX* pkey_ctx = NULL;
 
@@ -33,18 +33,17 @@ soter_status_t soter_ec_gen_key(EVP_PKEY** ppkey)
         return SOTER_INVALID_PARAMETER;
     }
 
-    pkey = EVP_PKEY_new();
-    if (!pkey) {
+    param = EVP_PKEY_new();
+    if (!param) {
         return SOTER_NO_MEMORY;
     }
-    *ppkey = pkey;
 
-    if (!EVP_PKEY_set_type(pkey, EVP_PKEY_EC)) {
+    if (!EVP_PKEY_set_type(param, EVP_PKEY_EC)) {
         res = SOTER_FAIL;
         goto err;
     }
 
-    param_ctx = EVP_PKEY_CTX_new(pkey, NULL);
+    param_ctx = EVP_PKEY_CTX_new(param, NULL);
     if (!param_ctx) {
         res = SOTER_NO_MEMORY;
         goto err;
@@ -58,12 +57,12 @@ soter_status_t soter_ec_gen_key(EVP_PKEY** ppkey)
         res = SOTER_FAIL;
         goto err;
     }
-    if (!EVP_PKEY_paramgen(param_ctx, &pkey)) {
+    if (!EVP_PKEY_paramgen(param_ctx, &param)) {
         res = SOTER_FAIL;
         goto err;
     }
 
-    pkey_ctx = EVP_PKEY_CTX_new(pkey, NULL);
+    pkey_ctx = EVP_PKEY_CTX_new(param, NULL);
     if (!pkey_ctx) {
         res = SOTER_NO_MEMORY;
         goto err;
@@ -83,6 +82,7 @@ soter_status_t soter_ec_gen_key(EVP_PKEY** ppkey)
 err:
     EVP_PKEY_CTX_free(param_ctx);
     EVP_PKEY_CTX_free(pkey_ctx);
+    EVP_PKEY_free(param);
 
     return res;
 }

--- a/src/soter/openssl/soter_ecdsa_common.c
+++ b/src/soter/openssl/soter_ecdsa_common.c
@@ -32,10 +32,18 @@ soter_status_t soter_ec_gen_key(EVP_PKEY** ppkey)
     if (!ppkey) {
         return SOTER_INVALID_PARAMETER;
     }
-    pkey = *ppkey;
+
+    pkey = EVP_PKEY_new();
     if (!pkey) {
-        return SOTER_INVALID_PARAMETER;
+        return SOTER_NO_MEMORY;
     }
+    *ppkey = pkey;
+
+    if (!EVP_PKEY_set_type(pkey, EVP_PKEY_EC)) {
+        res = SOTER_FAIL;
+        goto err;
+    }
+
     if (EVP_PKEY_EC != EVP_PKEY_id(pkey)) {
         return SOTER_INVALID_PARAMETER;
     }

--- a/src/soter/openssl/soter_ecdsa_common.h
+++ b/src/soter/openssl/soter_ecdsa_common.h
@@ -23,6 +23,6 @@
 
 soter_status_t soter_ec_gen_key(EVP_PKEY** ppkey);
 soter_status_t soter_ec_import_key(EVP_PKEY* pkey, const void* key, size_t key_length);
-soter_status_t soter_ec_export_key(soter_sign_ctx_t* ctx, void* key, size_t* key_length, bool isprivate);
+soter_status_t soter_ec_export_key(EVP_PKEY* pkey, void* key, size_t* key_length, bool isprivate);
 
 #endif /* SOTER_OPENSSL_ECDSA_COMMON_H */

--- a/src/soter/openssl/soter_ecdsa_common.h
+++ b/src/soter/openssl/soter_ecdsa_common.h
@@ -21,7 +21,7 @@
 #include "soter/soter_ec_key.h"
 #include "soter/soter_error.h"
 
-soter_status_t soter_ec_gen_key(EVP_PKEY_CTX* pkey_ctx, EVP_PKEY** ppkey);
+soter_status_t soter_ec_gen_key(EVP_PKEY** ppkey);
 soter_status_t soter_ec_import_key(EVP_PKEY* pkey, const void* key, size_t key_length);
 soter_status_t soter_ec_export_key(soter_sign_ctx_t* ctx, void* key, size_t* key_length, bool isprivate);
 

--- a/src/soter/openssl/soter_ecdsa_common.h
+++ b/src/soter/openssl/soter_ecdsa_common.h
@@ -21,7 +21,7 @@
 #include "soter/soter_ec_key.h"
 #include "soter/soter_error.h"
 
-soter_status_t soter_ec_gen_key(EVP_PKEY_CTX* pkey_ctx);
+soter_status_t soter_ec_gen_key(EVP_PKEY_CTX* pkey_ctx, EVP_PKEY** ppkey);
 soter_status_t soter_ec_import_key(EVP_PKEY* pkey, const void* key, size_t key_length);
 soter_status_t soter_ec_export_key(soter_sign_ctx_t* ctx, void* key, size_t* key_length, bool isprivate);
 

--- a/src/soter/openssl/soter_engine.h
+++ b/src/soter/openssl/soter_engine.h
@@ -55,7 +55,6 @@ struct soter_asym_ka_type {
 
 struct soter_sign_ctx_type {
     EVP_PKEY* pkey;
-    EVP_PKEY_CTX* pkey_ctx;
     EVP_MD_CTX* md_ctx;
     soter_sign_alg_t alg;
 };

--- a/src/soter/openssl/soter_rsa_common.c
+++ b/src/soter/openssl/soter_rsa_common.c
@@ -28,28 +28,13 @@ soter_status_t soter_rsa_gen_key(EVP_PKEY** ppkey)
 {
     soter_status_t res = SOTER_FAIL;
     BIGNUM* pub_exp = NULL;
-    EVP_PKEY* pkey = NULL;
     EVP_PKEY_CTX* pkey_ctx = NULL;
 
     if (!ppkey) {
         return SOTER_INVALID_PARAMETER;
     }
 
-    pkey = EVP_PKEY_new();
-    if (!pkey) {
-        return SOTER_NO_MEMORY;
-    }
-    *ppkey = pkey;
-
-    if (!EVP_PKEY_set_type(pkey, EVP_PKEY_RSA)) {
-        return SOTER_FAIL;
-    }
-
-    if (EVP_PKEY_RSA != EVP_PKEY_id(pkey)) {
-        return SOTER_INVALID_PARAMETER;
-    }
-
-    pkey_ctx = EVP_PKEY_CTX_new(pkey, NULL);
+    pkey_ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, NULL);
     if (!pkey_ctx) {
         res = SOTER_NO_MEMORY;
         goto err;

--- a/src/soter/openssl/soter_rsa_common.c
+++ b/src/soter/openssl/soter_rsa_common.c
@@ -24,11 +24,12 @@
 #define SOTER_RSA_KEY_LENGTH 2048
 #endif
 
-soter_status_t soter_rsa_gen_key(EVP_PKEY_CTX* pkey_ctx, EVP_PKEY** ppkey)
+soter_status_t soter_rsa_gen_key(EVP_PKEY** ppkey)
 {
     soter_status_t res = SOTER_FAIL;
     BIGNUM* pub_exp = NULL;
     EVP_PKEY* pkey = NULL;
+    EVP_PKEY_CTX* pkey_ctx = NULL;
 
     if (!ppkey) {
         return SOTER_INVALID_PARAMETER;
@@ -42,8 +43,15 @@ soter_status_t soter_rsa_gen_key(EVP_PKEY_CTX* pkey_ctx, EVP_PKEY** ppkey)
         return SOTER_INVALID_PARAMETER;
     }
 
+    pkey_ctx = EVP_PKEY_CTX_new(pkey, NULL);
+    if (!pkey_ctx) {
+        res = SOTER_NO_MEMORY;
+        goto err;
+    }
+
     if (!EVP_PKEY_keygen_init(pkey_ctx)) {
-        return SOTER_INVALID_PARAMETER;
+        res = SOTER_INVALID_PARAMETER;
+        goto err;
     }
 
     /* Although it seems that OpenSSL/LibreSSL use 0x10001 as default public exponent, we will set
@@ -82,6 +90,7 @@ soter_status_t soter_rsa_gen_key(EVP_PKEY_CTX* pkey_ctx, EVP_PKEY** ppkey)
 
 err:
     BN_free(pub_exp);
+    EVP_PKEY_CTX_free(pkey_ctx);
 
     return res;
 }

--- a/src/soter/openssl/soter_rsa_common.c
+++ b/src/soter/openssl/soter_rsa_common.c
@@ -27,6 +27,7 @@
 soter_status_t soter_rsa_gen_key(EVP_PKEY_CTX* pkey_ctx, EVP_PKEY** ppkey)
 {
     /* it is copy-paste from /src/soter/openssl/soter_asym_cipher.c */
+    soter_status_t res = SOTER_FAIL;
     BIGNUM* pub_exp;
     EVP_PKEY* pkey = NULL;
     if (!ppkey) {
@@ -71,7 +72,10 @@ soter_status_t soter_rsa_gen_key(EVP_PKEY_CTX* pkey_ctx, EVP_PKEY** ppkey)
     if (!EVP_PKEY_keygen(pkey_ctx, ppkey)) {
         return SOTER_FAIL;
     }
-    return SOTER_SUCCESS;
+
+    res = SOTER_SUCCESS;
+
+    return res;
     /* end of copy-paste from /src/soter/openssl/soter_asym_cipher.c*/
 }
 

--- a/src/soter/openssl/soter_rsa_common.c
+++ b/src/soter/openssl/soter_rsa_common.c
@@ -27,8 +27,9 @@
 soter_status_t soter_rsa_gen_key(EVP_PKEY_CTX* pkey_ctx, EVP_PKEY** ppkey)
 {
     soter_status_t res = SOTER_FAIL;
-    BIGNUM* pub_exp;
+    BIGNUM* pub_exp = NULL;
     EVP_PKEY* pkey = NULL;
+
     if (!ppkey) {
         return SOTER_INVALID_PARAMETER;
     }

--- a/src/soter/openssl/soter_rsa_common.c
+++ b/src/soter/openssl/soter_rsa_common.c
@@ -109,10 +109,8 @@ soter_status_t soter_rsa_import_key(EVP_PKEY* pkey, const void* key, const size_
     return SOTER_INVALID_PARAMETER;
 }
 
-soter_status_t soter_rsa_export_key(soter_sign_ctx_t* ctx, void* key, size_t* key_length, bool isprivate)
+soter_status_t soter_rsa_export_key(EVP_PKEY* pkey, void* key, size_t* key_length, bool isprivate)
 {
-    EVP_PKEY* pkey = ctx->pkey;
-
     if (!pkey) {
         return SOTER_INVALID_PARAMETER;
     }

--- a/src/soter/openssl/soter_rsa_common.c
+++ b/src/soter/openssl/soter_rsa_common.c
@@ -40,7 +40,7 @@ soter_status_t soter_rsa_gen_key(EVP_PKEY** ppkey)
         goto err;
     }
 
-    if (!EVP_PKEY_keygen_init(pkey_ctx)) {
+    if (EVP_PKEY_keygen_init(pkey_ctx) != 1) {
         res = SOTER_INVALID_PARAMETER;
         goto err;
     }
@@ -72,7 +72,7 @@ soter_status_t soter_rsa_gen_key(EVP_PKEY** ppkey)
         goto err;
     }
 
-    if (!EVP_PKEY_keygen(pkey_ctx, ppkey)) {
+    if (EVP_PKEY_keygen(pkey_ctx, ppkey) != 1) {
         res = SOTER_FAIL;
         goto err;
     }

--- a/src/soter/openssl/soter_rsa_common.c
+++ b/src/soter/openssl/soter_rsa_common.c
@@ -24,11 +24,15 @@
 #define SOTER_RSA_KEY_LENGTH 2048
 #endif
 
-soter_status_t soter_rsa_gen_key(EVP_PKEY_CTX* pkey_ctx)
+soter_status_t soter_rsa_gen_key(EVP_PKEY_CTX* pkey_ctx, EVP_PKEY** ppkey)
 {
     /* it is copy-paste from /src/soter/openssl/soter_asym_cipher.c */
     BIGNUM* pub_exp;
-    EVP_PKEY* pkey = EVP_PKEY_CTX_get0_pkey(pkey_ctx);
+    EVP_PKEY* pkey = NULL;
+    if (!ppkey) {
+        return SOTER_INVALID_PARAMETER;
+    }
+    pkey = *ppkey;
     if (!pkey) {
         return SOTER_INVALID_PARAMETER;
     }
@@ -64,7 +68,7 @@ soter_status_t soter_rsa_gen_key(EVP_PKEY_CTX* pkey_ctx)
         return SOTER_FAIL;
     }
 
-    if (!EVP_PKEY_keygen(pkey_ctx, &pkey)) {
+    if (!EVP_PKEY_keygen(pkey_ctx, ppkey)) {
         return SOTER_FAIL;
     }
     return SOTER_SUCCESS;

--- a/src/soter/openssl/soter_rsa_common.c
+++ b/src/soter/openssl/soter_rsa_common.c
@@ -100,7 +100,7 @@ soter_status_t soter_rsa_import_key(EVP_PKEY* pkey, const void* key, const size_
 
 soter_status_t soter_rsa_export_key(soter_sign_ctx_t* ctx, void* key, size_t* key_length, bool isprivate)
 {
-    EVP_PKEY* pkey = EVP_PKEY_CTX_get0_pkey(ctx->pkey_ctx);
+    EVP_PKEY* pkey = ctx->pkey;
 
     if (!pkey) {
         return SOTER_INVALID_PARAMETER;

--- a/src/soter/openssl/soter_rsa_common.c
+++ b/src/soter/openssl/soter_rsa_common.c
@@ -50,29 +50,32 @@ soter_status_t soter_rsa_gen_key(EVP_PKEY_CTX* pkey_ctx, EVP_PKEY** ppkey)
      * it explicitly just in case */
     pub_exp = BN_new();
     if (!pub_exp) {
-        return SOTER_NO_MEMORY;
+        res = SOTER_NO_MEMORY;
+        goto err;
     }
 
     if (!BN_set_word(pub_exp, RSA_F4)) {
-        BN_free(pub_exp);
-        return SOTER_FAIL;
+        res = SOTER_FAIL;
+        goto err;
     }
 
     /* Passing ownership over pub_exp to EVP_PKEY_CTX */
     if (1 > EVP_PKEY_CTX_ctrl(pkey_ctx, -1, -1, EVP_PKEY_CTRL_RSA_KEYGEN_PUBEXP, 0, pub_exp)) {
-        BN_free(pub_exp);
-        return SOTER_FAIL;
+        res = SOTER_FAIL;
+        goto err;
     }
     pub_exp = NULL;
 
     /* Override default key size for RSA key. Currently OpenSSL has default key size of 1024.
      * LibreSSL has 2048. We will put 2048 explicitly */
     if (1 > EVP_PKEY_CTX_ctrl(pkey_ctx, -1, -1, EVP_PKEY_CTRL_RSA_KEYGEN_BITS, SOTER_RSA_KEY_LENGTH, NULL)) {
-        return SOTER_FAIL;
+        res = SOTER_FAIL;
+        goto err;
     }
 
     if (!EVP_PKEY_keygen(pkey_ctx, ppkey)) {
-        return SOTER_FAIL;
+        res = SOTER_FAIL;
+        goto err;
     }
 
     res = SOTER_SUCCESS;

--- a/src/soter/openssl/soter_rsa_common.c
+++ b/src/soter/openssl/soter_rsa_common.c
@@ -34,9 +34,15 @@ soter_status_t soter_rsa_gen_key(EVP_PKEY** ppkey)
     if (!ppkey) {
         return SOTER_INVALID_PARAMETER;
     }
-    pkey = *ppkey;
+
+    pkey = EVP_PKEY_new();
     if (!pkey) {
-        return SOTER_INVALID_PARAMETER;
+        return SOTER_NO_MEMORY;
+    }
+    *ppkey = pkey;
+
+    if (!EVP_PKEY_set_type(pkey, EVP_PKEY_RSA)) {
+        return SOTER_FAIL;
     }
 
     if (EVP_PKEY_RSA != EVP_PKEY_id(pkey)) {

--- a/src/soter/openssl/soter_rsa_common.c
+++ b/src/soter/openssl/soter_rsa_common.c
@@ -26,7 +26,6 @@
 
 soter_status_t soter_rsa_gen_key(EVP_PKEY_CTX* pkey_ctx, EVP_PKEY** ppkey)
 {
-    /* it is copy-paste from /src/soter/openssl/soter_asym_cipher.c */
     soter_status_t res = SOTER_FAIL;
     BIGNUM* pub_exp;
     EVP_PKEY* pkey = NULL;
@@ -84,7 +83,6 @@ err:
     BN_free(pub_exp);
 
     return res;
-    /* end of copy-paste from /src/soter/openssl/soter_asym_cipher.c*/
 }
 
 soter_status_t soter_rsa_import_key(EVP_PKEY* pkey, const void* key, const size_t key_length)

--- a/src/soter/openssl/soter_rsa_common.c
+++ b/src/soter/openssl/soter_rsa_common.c
@@ -58,10 +58,12 @@ soter_status_t soter_rsa_gen_key(EVP_PKEY_CTX* pkey_ctx, EVP_PKEY** ppkey)
         return SOTER_FAIL;
     }
 
+    /* Passing ownership over pub_exp to EVP_PKEY_CTX */
     if (1 > EVP_PKEY_CTX_ctrl(pkey_ctx, -1, -1, EVP_PKEY_CTRL_RSA_KEYGEN_PUBEXP, 0, pub_exp)) {
         BN_free(pub_exp);
         return SOTER_FAIL;
     }
+    pub_exp = NULL;
 
     /* Override default key size for RSA key. Currently OpenSSL has default key size of 1024.
      * LibreSSL has 2048. We will put 2048 explicitly */
@@ -74,6 +76,9 @@ soter_status_t soter_rsa_gen_key(EVP_PKEY_CTX* pkey_ctx, EVP_PKEY** ppkey)
     }
 
     res = SOTER_SUCCESS;
+
+err:
+    BN_free(pub_exp);
 
     return res;
     /* end of copy-paste from /src/soter/openssl/soter_asym_cipher.c*/

--- a/src/soter/openssl/soter_rsa_common.h
+++ b/src/soter/openssl/soter_rsa_common.h
@@ -23,6 +23,6 @@
 
 soter_status_t soter_rsa_gen_key(EVP_PKEY** ppkey);
 soter_status_t soter_rsa_import_key(EVP_PKEY* pkey, const void* key, size_t key_length);
-soter_status_t soter_rsa_export_key(soter_sign_ctx_t* ctx, void* key, size_t* key_length, bool isprivate);
+soter_status_t soter_rsa_export_key(EVP_PKEY* pkey, void* key, size_t* key_length, bool isprivate);
 
 #endif /* SOTER_OPENSSL_RSA_COMMON_H */

--- a/src/soter/openssl/soter_rsa_common.h
+++ b/src/soter/openssl/soter_rsa_common.h
@@ -21,7 +21,7 @@
 #include "soter/soter_error.h"
 #include "soter/soter_rsa_key.h"
 
-soter_status_t soter_rsa_gen_key(EVP_PKEY_CTX* pkey_ctx);
+soter_status_t soter_rsa_gen_key(EVP_PKEY_CTX* pkey_ctx, EVP_PKEY** ppkey);
 soter_status_t soter_rsa_import_key(EVP_PKEY* pkey, const void* key, size_t key_length);
 soter_status_t soter_rsa_export_key(soter_sign_ctx_t* ctx, void* key, size_t* key_length, bool isprivate);
 

--- a/src/soter/openssl/soter_rsa_common.h
+++ b/src/soter/openssl/soter_rsa_common.h
@@ -21,7 +21,7 @@
 #include "soter/soter_error.h"
 #include "soter/soter_rsa_key.h"
 
-soter_status_t soter_rsa_gen_key(EVP_PKEY_CTX* pkey_ctx, EVP_PKEY** ppkey);
+soter_status_t soter_rsa_gen_key(EVP_PKEY** ppkey);
 soter_status_t soter_rsa_import_key(EVP_PKEY* pkey, const void* key, size_t key_length);
 soter_status_t soter_rsa_export_key(soter_sign_ctx_t* ctx, void* key, size_t* key_length, bool isprivate);
 

--- a/src/soter/openssl/soter_sign_ecdsa.c
+++ b/src/soter/openssl/soter_sign_ecdsa.c
@@ -31,7 +31,6 @@ soter_status_t soter_sign_init_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
                                                 const size_t public_key_length)
 {
     soter_status_t err = SOTER_FAIL;
-    EVP_PKEY_CTX *pkey_ctx = NULL;
 
     ctx->pkey = EVP_PKEY_new();
     if (!ctx->pkey) {
@@ -42,24 +41,8 @@ soter_status_t soter_sign_init_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
         goto free_pkey;
     }
 
-    pkey_ctx = EVP_PKEY_CTX_new(ctx->pkey, NULL);
-    if (!pkey_ctx) {
-        err = SOTER_NO_MEMORY;
-        goto free_pkey;
-    }
-
-    if (!EVP_PKEY_paramgen_init(pkey_ctx)) {
-        goto free_pkey_ctx;
-    }
-    if (!EVP_PKEY_CTX_set_ec_paramgen_curve_nid(pkey_ctx, NID_X9_62_prime256v1)) {
-        goto free_pkey_ctx;
-    }
-    if (!EVP_PKEY_paramgen(pkey_ctx, &ctx->pkey)) {
-        goto free_pkey_ctx;
-    }
-
     if ((!private_key) && (!public_key)) {
-        err = soter_ec_gen_key(pkey_ctx, &ctx->pkey);
+        err = soter_ec_gen_key(&ctx->pkey);
         if (err != SOTER_SUCCESS) {
             goto free_pkey_ctx;
         }
@@ -88,15 +71,12 @@ soter_status_t soter_sign_init_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
         goto free_md_ctx;
     }
 
-    EVP_PKEY_CTX_free(pkey_ctx);
-
     return SOTER_SUCCESS;
 
 free_md_ctx:
     EVP_MD_CTX_destroy(ctx->md_ctx);
     ctx->md_ctx = NULL;
 free_pkey_ctx:
-    EVP_PKEY_CTX_free(pkey_ctx);
 free_pkey:
     EVP_PKEY_free(ctx->pkey);
     ctx->pkey = NULL;

--- a/src/soter/openssl/soter_sign_ecdsa.c
+++ b/src/soter/openssl/soter_sign_ecdsa.c
@@ -44,19 +44,19 @@ soter_status_t soter_sign_init_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
     if ((!private_key) && (!public_key)) {
         err = soter_ec_gen_key(&ctx->pkey);
         if (err != SOTER_SUCCESS) {
-            goto free_pkey_ctx;
+            goto free_pkey;
         }
     } else {
         if (private_key != NULL) {
             err = soter_ec_import_key(ctx->pkey, private_key, private_key_length);
             if (err != SOTER_SUCCESS) {
-                goto free_pkey_ctx;
+                goto free_pkey;
             }
         }
         if (public_key != NULL) {
             err = soter_ec_import_key(ctx->pkey, public_key, public_key_length);
             if (err != SOTER_SUCCESS) {
-                goto free_pkey_ctx;
+                goto free_pkey;
             }
         }
     }
@@ -64,7 +64,7 @@ soter_status_t soter_sign_init_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
     ctx->md_ctx = EVP_MD_CTX_create();
     if (!(ctx->md_ctx)) {
         err = SOTER_NO_MEMORY;
-        goto free_pkey_ctx;
+        goto free_pkey;
     }
 
     if (EVP_DigestSignInit(ctx->md_ctx, NULL, EVP_sha256(), NULL, ctx->pkey) != 1) {
@@ -76,7 +76,6 @@ soter_status_t soter_sign_init_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
 free_md_ctx:
     EVP_MD_CTX_destroy(ctx->md_ctx);
     ctx->md_ctx = NULL;
-free_pkey_ctx:
 free_pkey:
     EVP_PKEY_free(ctx->pkey);
     ctx->pkey = NULL;

--- a/src/soter/openssl/soter_sign_ecdsa.c
+++ b/src/soter/openssl/soter_sign_ecdsa.c
@@ -139,7 +139,7 @@ soter_status_t soter_sign_final_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
     }
 
     key_size = EVP_PKEY_size(ctx->pkey);
-    if (key_size < 0) {
+    if (key_size <= 0) {
         return SOTER_FAIL;
     }
     if (!signature || (*signature_length) < (size_t)key_size) {

--- a/src/soter/openssl/soter_sign_ecdsa.c
+++ b/src/soter/openssl/soter_sign_ecdsa.c
@@ -45,10 +45,12 @@ soter_status_t soter_sign_init_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
     } else {
         ctx->pkey = EVP_PKEY_new();
         if (!ctx->pkey) {
-            return SOTER_NO_MEMORY;
+            err = SOTER_NO_MEMORY;
+            goto free_pkey;
         }
 
         if (!EVP_PKEY_set_type(ctx->pkey, EVP_PKEY_EC)) {
+            err = SOTER_FAIL;
             goto free_pkey;
         }
 

--- a/src/soter/openssl/soter_sign_ecdsa.c
+++ b/src/soter/openssl/soter_sign_ecdsa.c
@@ -128,10 +128,10 @@ soter_status_t soter_sign_final_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
     if (!signature || (*signature_length) < (size_t)key_size) {
         (*signature_length) = (size_t)key_size;
         return SOTER_BUFFER_TOO_SMALL;
-    } else {
-        if (EVP_DigestSignFinal(ctx->md_ctx, signature, signature_length) != 1) {
-            return SOTER_INVALID_SIGNATURE;
-        }
+    }
+
+    if (EVP_DigestSignFinal(ctx->md_ctx, signature, signature_length) != 1) {
+        return SOTER_INVALID_SIGNATURE;
     }
     return SOTER_SUCCESS;
 }

--- a/src/soter/openssl/soter_sign_ecdsa.c
+++ b/src/soter/openssl/soter_sign_ecdsa.c
@@ -33,15 +33,6 @@ soter_status_t soter_sign_init_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
     soter_status_t err = SOTER_FAIL;
 
     if ((!private_key) && (!public_key)) {
-        ctx->pkey = EVP_PKEY_new();
-        if (!ctx->pkey) {
-            return SOTER_NO_MEMORY;
-        }
-
-        if (!EVP_PKEY_set_type(ctx->pkey, EVP_PKEY_EC)) {
-            goto free_pkey;
-        }
-
         err = soter_ec_gen_key(&ctx->pkey);
         if (err != SOTER_SUCCESS) {
             goto free_pkey;

--- a/src/soter/openssl/soter_sign_ecdsa.c
+++ b/src/soter/openssl/soter_sign_ecdsa.c
@@ -123,7 +123,7 @@ soter_status_t soter_sign_final_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
                                                  void* signature,
                                                  size_t* signature_length)
 {
-    EVP_PKEY* pkey = EVP_PKEY_CTX_get0_pkey(ctx->pkey_ctx);
+    EVP_PKEY* pkey = ctx->pkey;
     if (!pkey) {
         return SOTER_INVALID_PARAMETER;
     }

--- a/src/soter/openssl/soter_sign_ecdsa.c
+++ b/src/soter/openssl/soter_sign_ecdsa.c
@@ -166,9 +166,5 @@ soter_status_t soter_sign_cleanup_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx)
         EVP_MD_CTX_destroy(ctx->md_ctx);
         ctx->md_ctx = NULL;
     }
-    if (ctx->pkey_ctx) {
-        EVP_PKEY_CTX_free(ctx->pkey_ctx);
-        ctx->pkey_ctx = NULL;
-    }
     return SOTER_SUCCESS;
 }

--- a/src/soter/openssl/soter_sign_ecdsa.c
+++ b/src/soter/openssl/soter_sign_ecdsa.c
@@ -32,6 +32,11 @@ soter_status_t soter_sign_init_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
 {
     soter_status_t err = SOTER_FAIL;
 
+    /* soter_sign_ctx_t should be initialized only once */
+    if (!ctx || ctx->pkey || ctx->md_ctx) {
+        return SOTER_INVALID_PARAMETER;
+    }
+
     if ((!private_key) && (!public_key)) {
         err = soter_ec_gen_key(&ctx->pkey);
         if (err != SOTER_SUCCESS) {

--- a/src/soter/openssl/soter_sign_ecdsa.c
+++ b/src/soter/openssl/soter_sign_ecdsa.c
@@ -94,7 +94,10 @@ soter_status_t soter_sign_export_key_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
                                                       size_t* key_length,
                                                       bool isprivate)
 {
-    if (!ctx) {
+    if (!ctx || !ctx->pkey) {
+        return SOTER_INVALID_PARAMETER;
+    }
+    if (EVP_PKEY_base_id(ctx->pkey) != EVP_PKEY_EC) {
         return SOTER_INVALID_PARAMETER;
     }
     return soter_ec_export_key(ctx, key, key_length, isprivate);
@@ -104,10 +107,13 @@ soter_status_t soter_sign_update_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
                                                   const void* data,
                                                   const size_t data_length)
 {
-    if (!ctx) {
+    if (!ctx || !ctx->pkey) {
         return SOTER_INVALID_PARAMETER;
     }
     if (!data || data_length == 0) {
+        return SOTER_INVALID_PARAMETER;
+    }
+    if (EVP_PKEY_base_id(ctx->pkey) != EVP_PKEY_EC) {
         return SOTER_INVALID_PARAMETER;
     }
     if (EVP_DigestSignUpdate(ctx->md_ctx, data, data_length) != 1) {

--- a/src/soter/openssl/soter_sign_ecdsa.c
+++ b/src/soter/openssl/soter_sign_ecdsa.c
@@ -100,7 +100,7 @@ soter_status_t soter_sign_export_key_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
     if (EVP_PKEY_base_id(ctx->pkey) != EVP_PKEY_EC) {
         return SOTER_INVALID_PARAMETER;
     }
-    return soter_ec_export_key(ctx, key, key_length, isprivate);
+    return soter_ec_export_key(ctx->pkey, key, key_length, isprivate);
 }
 
 soter_status_t soter_sign_update_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,

--- a/src/soter/openssl/soter_sign_ecdsa.c
+++ b/src/soter/openssl/soter_sign_ecdsa.c
@@ -117,16 +117,15 @@ soter_status_t soter_sign_final_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
     if (EVP_PKEY_base_id(ctx->pkey) != EVP_PKEY_EC) {
         return SOTER_INVALID_PARAMETER;
     } /* TODO: need review */
-    soter_status_t res = SOTER_SUCCESS;
     if (!signature || (*signature_length) < (size_t)EVP_PKEY_size(ctx->pkey)) {
         (*signature_length) = (size_t)EVP_PKEY_size(ctx->pkey);
-        res = SOTER_BUFFER_TOO_SMALL;
+        return SOTER_BUFFER_TOO_SMALL;
     } else {
         if (EVP_DigestSignFinal(ctx->md_ctx, signature, signature_length) != 1) {
-            res = SOTER_INVALID_SIGNATURE;
+            return SOTER_INVALID_SIGNATURE;
         }
     }
-    return res;
+    return SOTER_SUCCESS;
 }
 
 soter_status_t soter_sign_cleanup_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx)

--- a/src/soter/openssl/soter_sign_ecdsa.c
+++ b/src/soter/openssl/soter_sign_ecdsa.c
@@ -31,6 +31,7 @@ soter_status_t soter_sign_init_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
                                                 const size_t public_key_length)
 {
     soter_status_t err = SOTER_FAIL;
+    EVP_PKEY_CTX *pkey_ctx = NULL;
 
     ctx->pkey = EVP_PKEY_new();
     if (!ctx->pkey) {
@@ -41,24 +42,24 @@ soter_status_t soter_sign_init_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
         goto free_pkey;
     }
 
-    ctx->pkey_ctx = EVP_PKEY_CTX_new(ctx->pkey, NULL);
-    if (!(ctx->pkey_ctx)) {
+    pkey_ctx = EVP_PKEY_CTX_new(ctx->pkey, NULL);
+    if (!pkey_ctx) {
         err = SOTER_NO_MEMORY;
         goto free_pkey;
     }
 
-    if (!EVP_PKEY_paramgen_init(ctx->pkey_ctx)) {
+    if (!EVP_PKEY_paramgen_init(pkey_ctx)) {
         goto free_pkey_ctx;
     }
-    if (!EVP_PKEY_CTX_set_ec_paramgen_curve_nid(ctx->pkey_ctx, NID_X9_62_prime256v1)) {
+    if (!EVP_PKEY_CTX_set_ec_paramgen_curve_nid(pkey_ctx, NID_X9_62_prime256v1)) {
         goto free_pkey_ctx;
     }
-    if (!EVP_PKEY_paramgen(ctx->pkey_ctx, &ctx->pkey)) {
+    if (!EVP_PKEY_paramgen(pkey_ctx, &ctx->pkey)) {
         goto free_pkey_ctx;
     }
 
     if ((!private_key) && (!public_key)) {
-        err = soter_ec_gen_key(ctx->pkey_ctx, &ctx->pkey);
+        err = soter_ec_gen_key(pkey_ctx, &ctx->pkey);
         if (err != SOTER_SUCCESS) {
             goto free_pkey_ctx;
         }
@@ -87,14 +88,15 @@ soter_status_t soter_sign_init_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
         goto free_md_ctx;
     }
 
+    EVP_PKEY_CTX_free(pkey_ctx);
+
     return SOTER_SUCCESS;
 
 free_md_ctx:
     EVP_MD_CTX_destroy(ctx->md_ctx);
     ctx->md_ctx = NULL;
 free_pkey_ctx:
-    EVP_PKEY_CTX_free(ctx->pkey_ctx);
-    ctx->pkey_ctx = NULL;
+    EVP_PKEY_CTX_free(pkey_ctx);
 free_pkey:
     EVP_PKEY_free(ctx->pkey);
     ctx->pkey = NULL;

--- a/src/soter/openssl/soter_sign_ecdsa.c
+++ b/src/soter/openssl/soter_sign_ecdsa.c
@@ -58,7 +58,7 @@ soter_status_t soter_sign_init_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
     }
 
     if ((!private_key) && (!public_key)) {
-        err = soter_ec_gen_key(ctx->pkey_ctx);
+        err = soter_ec_gen_key(ctx->pkey_ctx, &ctx->pkey);
         if (err != SOTER_SUCCESS) {
             goto free_pkey_ctx;
         }

--- a/src/soter/openssl/soter_sign_ecdsa.c
+++ b/src/soter/openssl/soter_sign_ecdsa.c
@@ -111,16 +111,15 @@ soter_status_t soter_sign_final_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
                                                  void* signature,
                                                  size_t* signature_length)
 {
-    EVP_PKEY* pkey = ctx->pkey;
-    if (!pkey) {
+    if (!ctx->pkey) {
         return SOTER_INVALID_PARAMETER;
     }
-    if (EVP_PKEY_base_id(pkey) != EVP_PKEY_EC) {
+    if (EVP_PKEY_base_id(ctx->pkey) != EVP_PKEY_EC) {
         return SOTER_INVALID_PARAMETER;
     } /* TODO: need review */
     soter_status_t res = SOTER_SUCCESS;
-    if (!signature || (*signature_length) < (size_t)EVP_PKEY_size(pkey)) {
-        (*signature_length) = (size_t)EVP_PKEY_size(pkey);
+    if (!signature || (*signature_length) < (size_t)EVP_PKEY_size(ctx->pkey)) {
+        (*signature_length) = (size_t)EVP_PKEY_size(ctx->pkey);
         res = SOTER_BUFFER_TOO_SMALL;
     } else {
         if (EVP_DigestSignFinal(ctx->md_ctx, signature, signature_length) != 1) {

--- a/src/soter/openssl/soter_sign_ecdsa.c
+++ b/src/soter/openssl/soter_sign_ecdsa.c
@@ -111,14 +111,22 @@ soter_status_t soter_sign_final_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
                                                  void* signature,
                                                  size_t* signature_length)
 {
+    int key_size = 0;
+
     if (!ctx->pkey) {
         return SOTER_INVALID_PARAMETER;
     }
     if (EVP_PKEY_base_id(ctx->pkey) != EVP_PKEY_EC) {
         return SOTER_INVALID_PARAMETER;
-    } /* TODO: need review */
-    if (!signature || (*signature_length) < (size_t)EVP_PKEY_size(ctx->pkey)) {
-        (*signature_length) = (size_t)EVP_PKEY_size(ctx->pkey);
+    }
+
+    key_size = EVP_PKEY_size(ctx->pkey);
+    if (key_size < 0) {
+        return SOTER_FAIL;
+    }
+
+    if (!signature || (*signature_length) < (size_t)key_size) {
+        (*signature_length) = (size_t)key_size;
         return SOTER_BUFFER_TOO_SMALL;
     } else {
         if (EVP_DigestSignFinal(ctx->md_ctx, signature, signature_length) != 1) {

--- a/src/soter/openssl/soter_sign_ecdsa.c
+++ b/src/soter/openssl/soter_sign_ecdsa.c
@@ -107,6 +107,9 @@ soter_status_t soter_sign_update_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
     if (!ctx) {
         return SOTER_INVALID_PARAMETER;
     }
+    if (!data || data_length == 0) {
+        return SOTER_INVALID_PARAMETER;
+    }
     if (EVP_DigestSignUpdate(ctx->md_ctx, data, data_length) != 1) {
         return SOTER_FAIL;
     }
@@ -122,6 +125,9 @@ soter_status_t soter_sign_final_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
     if (!ctx || !ctx->pkey) {
         return SOTER_INVALID_PARAMETER;
     }
+    if (!signature_length) {
+        return SOTER_INVALID_PARAMETER;
+    }
     if (EVP_PKEY_base_id(ctx->pkey) != EVP_PKEY_EC) {
         return SOTER_INVALID_PARAMETER;
     }
@@ -130,7 +136,6 @@ soter_status_t soter_sign_final_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
     if (key_size < 0) {
         return SOTER_FAIL;
     }
-
     if (!signature || (*signature_length) < (size_t)key_size) {
         (*signature_length) = (size_t)key_size;
         return SOTER_BUFFER_TOO_SMALL;

--- a/src/soter/openssl/soter_sign_ecdsa.c
+++ b/src/soter/openssl/soter_sign_ecdsa.c
@@ -94,6 +94,9 @@ soter_status_t soter_sign_export_key_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
                                                       size_t* key_length,
                                                       bool isprivate)
 {
+    if (!ctx) {
+        return SOTER_INVALID_PARAMETER;
+    }
     return soter_ec_export_key(ctx, key, key_length, isprivate);
 }
 
@@ -101,6 +104,9 @@ soter_status_t soter_sign_update_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
                                                   const void* data,
                                                   const size_t data_length)
 {
+    if (!ctx) {
+        return SOTER_INVALID_PARAMETER;
+    }
     if (EVP_DigestSignUpdate(ctx->md_ctx, data, data_length) != 1) {
         return SOTER_FAIL;
     }
@@ -113,7 +119,7 @@ soter_status_t soter_sign_final_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
 {
     int key_size = 0;
 
-    if (!ctx->pkey) {
+    if (!ctx || !ctx->pkey) {
         return SOTER_INVALID_PARAMETER;
     }
     if (EVP_PKEY_base_id(ctx->pkey) != EVP_PKEY_EC) {

--- a/src/soter/openssl/soter_sign_ecdsa.c
+++ b/src/soter/openssl/soter_sign_ecdsa.c
@@ -32,21 +32,30 @@ soter_status_t soter_sign_init_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
 {
     soter_status_t err = SOTER_FAIL;
 
-    ctx->pkey = EVP_PKEY_new();
-    if (!ctx->pkey) {
-        return SOTER_NO_MEMORY;
-    }
-
-    if (!EVP_PKEY_set_type(ctx->pkey, EVP_PKEY_EC)) {
-        goto free_pkey;
-    }
-
     if ((!private_key) && (!public_key)) {
+        ctx->pkey = EVP_PKEY_new();
+        if (!ctx->pkey) {
+            return SOTER_NO_MEMORY;
+        }
+
+        if (!EVP_PKEY_set_type(ctx->pkey, EVP_PKEY_EC)) {
+            goto free_pkey;
+        }
+
         err = soter_ec_gen_key(&ctx->pkey);
         if (err != SOTER_SUCCESS) {
             goto free_pkey;
         }
     } else {
+        ctx->pkey = EVP_PKEY_new();
+        if (!ctx->pkey) {
+            return SOTER_NO_MEMORY;
+        }
+
+        if (!EVP_PKEY_set_type(ctx->pkey, EVP_PKEY_EC)) {
+            goto free_pkey;
+        }
+
         if (private_key != NULL) {
             err = soter_ec_import_key(ctx->pkey, private_key, private_key_length);
             if (err != SOTER_SUCCESS) {

--- a/src/soter/openssl/soter_sign_rsa.c
+++ b/src/soter/openssl/soter_sign_rsa.c
@@ -114,6 +114,10 @@ soter_status_t soter_sign_update_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
     if (!ctx) {
         return SOTER_INVALID_PARAMETER;
     }
+    if (!data || data_length == 0) {
+        return SOTER_INVALID_PARAMETER;
+    }
+
     if (!EVP_DigestSignUpdate(ctx->md_ctx, data, data_length)) {
         return SOTER_FAIL;
     }
@@ -127,15 +131,19 @@ soter_status_t soter_sign_final_rsa_pss_pkcs8(soter_sign_ctx_t* ctx, void* signa
     if (!ctx || !ctx->pkey) {
         return SOTER_INVALID_PARAMETER;
     }
+    if (!signature_length) {
+        return SOTER_INVALID_PARAMETER;
+    }
 
     key_size = EVP_PKEY_size(ctx->pkey);
     if (key_size < 0) {
         return SOTER_FAIL;
     }
-    if ((*signature_length) < (size_t)key_size) {
+    if (!signature || (*signature_length) < (size_t)key_size) {
         (*signature_length) = (size_t)key_size;
         return SOTER_BUFFER_TOO_SMALL;
     }
+
     if (!EVP_DigestSignFinal(ctx->md_ctx, signature, signature_length)) {
         return SOTER_FAIL;
     }

--- a/src/soter/openssl/soter_sign_rsa.c
+++ b/src/soter/openssl/soter_sign_rsa.c
@@ -107,7 +107,7 @@ soter_status_t soter_sign_export_key_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
     if (EVP_PKEY_base_id(ctx->pkey) != EVP_PKEY_RSA) {
         return SOTER_INVALID_PARAMETER;
     }
-    return soter_rsa_export_key(ctx, key, key_length, isprivate);
+    return soter_rsa_export_key(ctx->pkey, key, key_length, isprivate);
 }
 
 soter_status_t soter_sign_update_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,

--- a/src/soter/openssl/soter_sign_rsa.c
+++ b/src/soter/openssl/soter_sign_rsa.c
@@ -168,10 +168,6 @@ soter_status_t soter_sign_cleanup_rsa_pss_pkcs8(soter_sign_ctx_t* ctx)
         EVP_PKEY_free(ctx->pkey);
         ctx->pkey = NULL;
     }
-    if (ctx->pkey_ctx) {
-        EVP_PKEY_CTX_free(ctx->pkey_ctx);
-        ctx->pkey_ctx = NULL;
-    }
     if (ctx->md_ctx) {
         EVP_MD_CTX_destroy(ctx->md_ctx);
         ctx->md_ctx = NULL;

--- a/src/soter/openssl/soter_sign_rsa.c
+++ b/src/soter/openssl/soter_sign_rsa.c
@@ -49,7 +49,7 @@ soter_status_t soter_sign_init_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
             goto free_pkey;
         }
 
-        if (!EVP_PKEY_set_type(ctx->pkey, EVP_PKEY_RSA)) {
+        if (EVP_PKEY_set_type(ctx->pkey, EVP_PKEY_RSA) != 1) {
             err = SOTER_FAIL;
             goto free_pkey;
         }
@@ -75,13 +75,13 @@ soter_status_t soter_sign_init_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
     }
 
     /* md_pkey_ctx is owned by ctx->md_ctx */
-    if (!EVP_DigestSignInit(ctx->md_ctx, &md_pkey_ctx, EVP_sha256(), NULL, ctx->pkey)) {
+    if (EVP_DigestSignInit(ctx->md_ctx, &md_pkey_ctx, EVP_sha256(), NULL, ctx->pkey) != 1) {
         goto free_md_ctx;
     }
-    if (!EVP_PKEY_CTX_set_rsa_padding(md_pkey_ctx, RSA_PKCS1_PSS_PADDING)) {
+    if (EVP_PKEY_CTX_set_rsa_padding(md_pkey_ctx, RSA_PKCS1_PSS_PADDING) != 1) {
         goto free_md_ctx;
     }
-    if (!EVP_PKEY_CTX_set_rsa_pss_saltlen(md_pkey_ctx, -2)) {
+    if (EVP_PKEY_CTX_set_rsa_pss_saltlen(md_pkey_ctx, -2) != 1) {
         goto free_md_ctx;
     }
 
@@ -124,7 +124,7 @@ soter_status_t soter_sign_update_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
         return SOTER_INVALID_PARAMETER;
     }
 
-    if (!EVP_DigestSignUpdate(ctx->md_ctx, data, data_length)) {
+    if (EVP_DigestSignUpdate(ctx->md_ctx, data, data_length) != 1) {
         return SOTER_FAIL;
     }
     return SOTER_SUCCESS;
@@ -153,7 +153,7 @@ soter_status_t soter_sign_final_rsa_pss_pkcs8(soter_sign_ctx_t* ctx, void* signa
         return SOTER_BUFFER_TOO_SMALL;
     }
 
-    if (!EVP_DigestSignFinal(ctx->md_ctx, signature, signature_length)) {
+    if (EVP_DigestSignFinal(ctx->md_ctx, signature, signature_length) != 1) {
         return SOTER_FAIL;
     }
     return SOTER_SUCCESS;

--- a/src/soter/openssl/soter_sign_rsa.c
+++ b/src/soter/openssl/soter_sign_rsa.c
@@ -45,10 +45,12 @@ soter_status_t soter_sign_init_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
     } else {
         ctx->pkey = EVP_PKEY_new();
         if (!ctx->pkey) {
-            return SOTER_NO_MEMORY;
+            err = SOTER_NO_MEMORY;
+            goto free_pkey;
         }
 
         if (!EVP_PKEY_set_type(ctx->pkey, EVP_PKEY_RSA)) {
+            err = SOTER_FAIL;
             goto free_pkey;
         }
 

--- a/src/soter/openssl/soter_sign_rsa.c
+++ b/src/soter/openssl/soter_sign_rsa.c
@@ -118,7 +118,7 @@ soter_status_t soter_sign_update_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
 
 soter_status_t soter_sign_final_rsa_pss_pkcs8(soter_sign_ctx_t* ctx, void* signature, size_t* signature_length)
 {
-    EVP_PKEY* pkey = EVP_PKEY_CTX_get0_pkey(ctx->pkey_ctx);
+    EVP_PKEY* pkey = ctx->pkey;
     if (!pkey) {
         return SOTER_INVALID_PARAMETER;
     }

--- a/src/soter/openssl/soter_sign_rsa.c
+++ b/src/soter/openssl/soter_sign_rsa.c
@@ -145,7 +145,7 @@ soter_status_t soter_sign_final_rsa_pss_pkcs8(soter_sign_ctx_t* ctx, void* signa
     }
 
     key_size = EVP_PKEY_size(ctx->pkey);
-    if (key_size < 0) {
+    if (key_size <= 0) {
         return SOTER_FAIL;
     }
     if (!signature || (*signature_length) < (size_t)key_size) {

--- a/src/soter/openssl/soter_sign_rsa.c
+++ b/src/soter/openssl/soter_sign_rsa.c
@@ -33,15 +33,6 @@ soter_status_t soter_sign_init_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
     EVP_PKEY_CTX* md_pkey_ctx = NULL;
 
     if ((!private_key) && (!public_key)) {
-        ctx->pkey = EVP_PKEY_new();
-        if (!ctx->pkey) {
-            return SOTER_NO_MEMORY;
-        }
-
-        if (!EVP_PKEY_set_type(ctx->pkey, EVP_PKEY_RSA)) {
-            goto free_pkey;
-        }
-
         err = soter_rsa_gen_key(&ctx->pkey);
         if (err != SOTER_SUCCESS) {
             goto free_pkey;

--- a/src/soter/openssl/soter_sign_rsa.c
+++ b/src/soter/openssl/soter_sign_rsa.c
@@ -116,10 +116,13 @@ soter_status_t soter_sign_update_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
 
 soter_status_t soter_sign_final_rsa_pss_pkcs8(soter_sign_ctx_t* ctx, void* signature, size_t* signature_length)
 {
+    int key_size = 0;
+
     if (!ctx->pkey) {
         return SOTER_INVALID_PARAMETER;
     }
-    int key_size = EVP_PKEY_size(ctx->pkey);
+
+    key_size = EVP_PKEY_size(ctx->pkey);
     if (key_size < 0) {
         return SOTER_FAIL;
     }

--- a/src/soter/openssl/soter_sign_rsa.c
+++ b/src/soter/openssl/soter_sign_rsa.c
@@ -30,6 +30,7 @@ soter_status_t soter_sign_init_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
                                              const size_t public_key_length)
 {
     soter_status_t err = SOTER_FAIL;
+    EVP_PKEY_CTX* pkey_ctx = NULL;
     EVP_PKEY_CTX* md_pkey_ctx = NULL;
 
     ctx->pkey = EVP_PKEY_new();
@@ -41,14 +42,14 @@ soter_status_t soter_sign_init_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
         goto free_pkey;
     }
 
-    ctx->pkey_ctx = EVP_PKEY_CTX_new(ctx->pkey, NULL);
-    if (!(ctx->pkey_ctx)) {
+    pkey_ctx = EVP_PKEY_CTX_new(ctx->pkey, NULL);
+    if (!pkey_ctx) {
         err = SOTER_NO_MEMORY;
         goto free_pkey;
     }
 
     if ((!private_key) && (!public_key)) {
-        err = soter_rsa_gen_key(ctx->pkey_ctx, &ctx->pkey);
+        err = soter_rsa_gen_key(pkey_ctx, &ctx->pkey);
         if (err != SOTER_SUCCESS) {
             goto free_pkey_ctx;
         }
@@ -90,8 +91,7 @@ free_md_ctx:
     EVP_MD_CTX_destroy(ctx->md_ctx);
     ctx->md_ctx = NULL;
 free_pkey_ctx:
-    EVP_PKEY_CTX_free(ctx->pkey_ctx);
-    ctx->pkey_ctx = NULL;
+    EVP_PKEY_CTX_free(pkey_ctx);
 free_pkey:
     EVP_PKEY_free(ctx->pkey);
     ctx->pkey = NULL;

--- a/src/soter/openssl/soter_sign_rsa.c
+++ b/src/soter/openssl/soter_sign_rsa.c
@@ -104,6 +104,9 @@ soter_status_t soter_sign_export_key_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
     if (!ctx) {
         return SOTER_INVALID_PARAMETER;
     }
+    if (EVP_PKEY_base_id(ctx->pkey) != EVP_PKEY_RSA) {
+        return SOTER_INVALID_PARAMETER;
+    }
     return soter_rsa_export_key(ctx, key, key_length, isprivate);
 }
 
@@ -111,10 +114,13 @@ soter_status_t soter_sign_update_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
                                                const void* data,
                                                const size_t data_length)
 {
-    if (!ctx) {
+    if (!ctx || !ctx->pkey) {
         return SOTER_INVALID_PARAMETER;
     }
     if (!data || data_length == 0) {
+        return SOTER_INVALID_PARAMETER;
+    }
+    if (EVP_PKEY_base_id(ctx->pkey) != EVP_PKEY_RSA) {
         return SOTER_INVALID_PARAMETER;
     }
 
@@ -132,6 +138,9 @@ soter_status_t soter_sign_final_rsa_pss_pkcs8(soter_sign_ctx_t* ctx, void* signa
         return SOTER_INVALID_PARAMETER;
     }
     if (!signature_length) {
+        return SOTER_INVALID_PARAMETER;
+    }
+    if (EVP_PKEY_base_id(ctx->pkey) != EVP_PKEY_RSA) {
         return SOTER_INVALID_PARAMETER;
     }
 

--- a/src/soter/openssl/soter_sign_rsa.c
+++ b/src/soter/openssl/soter_sign_rsa.c
@@ -32,6 +32,11 @@ soter_status_t soter_sign_init_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
     soter_status_t err = SOTER_FAIL;
     EVP_PKEY_CTX* md_pkey_ctx = NULL;
 
+    /* soter_sign_ctx_t should be initialized only once */
+    if (!ctx || ctx->pkey || ctx->md_ctx) {
+        return SOTER_INVALID_PARAMETER;
+    }
+
     if ((!private_key) && (!public_key)) {
         err = soter_rsa_gen_key(&ctx->pkey);
         if (err != SOTER_SUCCESS) {

--- a/src/soter/openssl/soter_sign_rsa.c
+++ b/src/soter/openssl/soter_sign_rsa.c
@@ -48,7 +48,7 @@ soter_status_t soter_sign_init_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
     }
 
     if ((!private_key) && (!public_key)) {
-        err = soter_rsa_gen_key(ctx->pkey_ctx);
+        err = soter_rsa_gen_key(ctx->pkey_ctx, &ctx->pkey);
         if (err != SOTER_SUCCESS) {
             goto free_pkey_ctx;
         }

--- a/src/soter/openssl/soter_sign_rsa.c
+++ b/src/soter/openssl/soter_sign_rsa.c
@@ -44,19 +44,19 @@ soter_status_t soter_sign_init_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
     if ((!private_key) && (!public_key)) {
         err = soter_rsa_gen_key(&ctx->pkey);
         if (err != SOTER_SUCCESS) {
-            goto free_pkey_ctx;
+            goto free_pkey;
         }
     } else {
         if (private_key != NULL) {
             err = soter_rsa_import_key(ctx->pkey, private_key, private_key_length);
             if (err != SOTER_SUCCESS) {
-                goto free_pkey_ctx;
+                goto free_pkey;
             }
         }
         if (public_key != NULL) {
             err = soter_rsa_import_key(ctx->pkey, public_key, public_key_length);
             if (err != SOTER_SUCCESS) {
-                goto free_pkey_ctx;
+                goto free_pkey;
             }
         }
     }
@@ -64,7 +64,7 @@ soter_status_t soter_sign_init_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
     ctx->md_ctx = EVP_MD_CTX_create();
     if (!(ctx->md_ctx)) {
         err = SOTER_NO_MEMORY;
-        goto free_pkey_ctx;
+        goto free_pkey;
     }
 
     /* md_pkey_ctx is owned by ctx->md_ctx */
@@ -83,7 +83,6 @@ soter_status_t soter_sign_init_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
 free_md_ctx:
     EVP_MD_CTX_destroy(ctx->md_ctx);
     ctx->md_ctx = NULL;
-free_pkey_ctx:
 free_pkey:
     EVP_PKEY_free(ctx->pkey);
     ctx->pkey = NULL;

--- a/src/soter/openssl/soter_sign_rsa.c
+++ b/src/soter/openssl/soter_sign_rsa.c
@@ -116,11 +116,10 @@ soter_status_t soter_sign_update_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
 
 soter_status_t soter_sign_final_rsa_pss_pkcs8(soter_sign_ctx_t* ctx, void* signature, size_t* signature_length)
 {
-    EVP_PKEY* pkey = ctx->pkey;
-    if (!pkey) {
+    if (!ctx->pkey) {
         return SOTER_INVALID_PARAMETER;
     }
-    int key_size = EVP_PKEY_size(pkey);
+    int key_size = EVP_PKEY_size(ctx->pkey);
     if (key_size < 0) {
         return SOTER_FAIL;
     }

--- a/src/soter/openssl/soter_sign_rsa.c
+++ b/src/soter/openssl/soter_sign_rsa.c
@@ -30,7 +30,6 @@ soter_status_t soter_sign_init_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
                                              const size_t public_key_length)
 {
     soter_status_t err = SOTER_FAIL;
-    EVP_PKEY_CTX* pkey_ctx = NULL;
     EVP_PKEY_CTX* md_pkey_ctx = NULL;
 
     ctx->pkey = EVP_PKEY_new();
@@ -42,14 +41,8 @@ soter_status_t soter_sign_init_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
         goto free_pkey;
     }
 
-    pkey_ctx = EVP_PKEY_CTX_new(ctx->pkey, NULL);
-    if (!pkey_ctx) {
-        err = SOTER_NO_MEMORY;
-        goto free_pkey;
-    }
-
     if ((!private_key) && (!public_key)) {
-        err = soter_rsa_gen_key(pkey_ctx, &ctx->pkey);
+        err = soter_rsa_gen_key(&ctx->pkey);
         if (err != SOTER_SUCCESS) {
             goto free_pkey_ctx;
         }
@@ -91,7 +84,6 @@ free_md_ctx:
     EVP_MD_CTX_destroy(ctx->md_ctx);
     ctx->md_ctx = NULL;
 free_pkey_ctx:
-    EVP_PKEY_CTX_free(pkey_ctx);
 free_pkey:
     EVP_PKEY_free(ctx->pkey);
     ctx->pkey = NULL;

--- a/src/soter/openssl/soter_sign_rsa.c
+++ b/src/soter/openssl/soter_sign_rsa.c
@@ -101,6 +101,9 @@ soter_status_t soter_sign_export_key_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
                                                    size_t* key_length,
                                                    bool isprivate)
 {
+    if (!ctx) {
+        return SOTER_INVALID_PARAMETER;
+    }
     return soter_rsa_export_key(ctx, key, key_length, isprivate);
 }
 
@@ -108,6 +111,9 @@ soter_status_t soter_sign_update_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
                                                const void* data,
                                                const size_t data_length)
 {
+    if (!ctx) {
+        return SOTER_INVALID_PARAMETER;
+    }
     if (!EVP_DigestSignUpdate(ctx->md_ctx, data, data_length)) {
         return SOTER_FAIL;
     }
@@ -118,7 +124,7 @@ soter_status_t soter_sign_final_rsa_pss_pkcs8(soter_sign_ctx_t* ctx, void* signa
 {
     int key_size = 0;
 
-    if (!ctx->pkey) {
+    if (!ctx || !ctx->pkey) {
         return SOTER_INVALID_PARAMETER;
     }
 

--- a/src/soter/openssl/soter_sign_rsa.c
+++ b/src/soter/openssl/soter_sign_rsa.c
@@ -32,21 +32,30 @@ soter_status_t soter_sign_init_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
     soter_status_t err = SOTER_FAIL;
     EVP_PKEY_CTX* md_pkey_ctx = NULL;
 
-    ctx->pkey = EVP_PKEY_new();
-    if (!ctx->pkey) {
-        return SOTER_NO_MEMORY;
-    }
-
-    if (!EVP_PKEY_set_type(ctx->pkey, EVP_PKEY_RSA)) {
-        goto free_pkey;
-    }
-
     if ((!private_key) && (!public_key)) {
+        ctx->pkey = EVP_PKEY_new();
+        if (!ctx->pkey) {
+            return SOTER_NO_MEMORY;
+        }
+
+        if (!EVP_PKEY_set_type(ctx->pkey, EVP_PKEY_RSA)) {
+            goto free_pkey;
+        }
+
         err = soter_rsa_gen_key(&ctx->pkey);
         if (err != SOTER_SUCCESS) {
             goto free_pkey;
         }
     } else {
+        ctx->pkey = EVP_PKEY_new();
+        if (!ctx->pkey) {
+            return SOTER_NO_MEMORY;
+        }
+
+        if (!EVP_PKEY_set_type(ctx->pkey, EVP_PKEY_RSA)) {
+            goto free_pkey;
+        }
+
         if (private_key != NULL) {
             err = soter_rsa_import_key(ctx->pkey, private_key, private_key_length);
             if (err != SOTER_SUCCESS) {

--- a/src/soter/openssl/soter_verify_ecdsa.c
+++ b/src/soter/openssl/soter_verify_ecdsa.c
@@ -45,8 +45,6 @@ soter_status_t soter_verify_init_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
         goto free_pkey;
     }
 
-    ctx->pkey_ctx = NULL;
-
     /* TODO: Review needed */
     if ((private_key) && (private_key_length)) {
         err = soter_ec_import_key(ctx->pkey, private_key, private_key_length);
@@ -136,10 +134,6 @@ soter_status_t soter_verify_cleanup_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx)
     if (ctx->md_ctx) {
         EVP_MD_CTX_destroy(ctx->md_ctx);
         ctx->md_ctx = NULL;
-    }
-    if (ctx->pkey_ctx) {
-        EVP_PKEY_CTX_free(ctx->pkey_ctx);
-        ctx->pkey_ctx = NULL;
     }
     return SOTER_SUCCESS;
 }

--- a/src/soter/openssl/soter_verify_rsa.c
+++ b/src/soter/openssl/soter_verify_rsa.c
@@ -93,6 +93,9 @@ soter_status_t soter_verify_update_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
                                                  const void* data,
                                                  const size_t data_length)
 {
+    if (!ctx) {
+        return SOTER_INVALID_PARAMETER;
+    }
     if (!EVP_DigestVerifyUpdate(ctx->md_ctx, data, data_length)) {
         return SOTER_FAIL;
     }

--- a/src/soter/openssl/soter_verify_rsa.c
+++ b/src/soter/openssl/soter_verify_rsa.c
@@ -108,7 +108,7 @@ soter_status_t soter_verify_final_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
     if (!ctx) {
         return SOTER_INVALID_PARAMETER;
     }
-    EVP_PKEY* pkey = EVP_PKEY_CTX_get0_pkey(ctx->pkey_ctx);
+    EVP_PKEY* pkey = ctx->pkey;
     if (!pkey) {
         return SOTER_INVALID_PARAMETER;
     }

--- a/src/soter/openssl/soter_verify_rsa.c
+++ b/src/soter/openssl/soter_verify_rsa.c
@@ -41,11 +41,7 @@ soter_status_t soter_verify_init_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
         goto free_pkey;
     }
 
-    ctx->pkey_ctx = EVP_PKEY_CTX_new(ctx->pkey, NULL);
-    if (!(ctx->pkey_ctx)) {
-        err = SOTER_NO_MEMORY;
-        goto free_pkey;
-    }
+    ctx->pkey_ctx = NULL;
 
     if (private_key && private_key_length != 0) {
         err = soter_rsa_import_key(ctx->pkey, private_key, private_key_length);
@@ -83,8 +79,6 @@ free_md_ctx:
     EVP_MD_CTX_destroy(ctx->md_ctx);
     ctx->md_ctx = NULL;
 free_pkey_ctx:
-    EVP_PKEY_CTX_free(ctx->pkey_ctx);
-    ctx->pkey_ctx = NULL;
 free_pkey:
     EVP_PKEY_free(ctx->pkey);
     ctx->pkey = NULL;

--- a/src/soter/openssl/soter_verify_rsa.c
+++ b/src/soter/openssl/soter_verify_rsa.c
@@ -96,6 +96,10 @@ soter_status_t soter_verify_update_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
     if (!ctx) {
         return SOTER_INVALID_PARAMETER;
     }
+    if (!data || data_length == 0) {
+        return SOTER_INVALID_PARAMETER;
+    }
+
     if (!EVP_DigestVerifyUpdate(ctx->md_ctx, data, data_length)) {
         return SOTER_FAIL;
     }
@@ -107,6 +111,9 @@ soter_status_t soter_verify_final_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
                                                 const size_t signature_length)
 {
     if (!ctx || !ctx->pkey) {
+        return SOTER_INVALID_PARAMETER;
+    }
+    if (!signature || signature_length == 0) {
         return SOTER_INVALID_PARAMETER;
     }
 

--- a/src/soter/openssl/soter_verify_rsa.c
+++ b/src/soter/openssl/soter_verify_rsa.c
@@ -68,13 +68,13 @@ soter_status_t soter_verify_init_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
     }
 
     /* md_pkey_ctx is owned by ctx->md_ctx */
-    if (!EVP_DigestVerifyInit(ctx->md_ctx, &md_pkey_ctx, EVP_sha256(), NULL, ctx->pkey)) {
+    if (EVP_DigestVerifyInit(ctx->md_ctx, &md_pkey_ctx, EVP_sha256(), NULL, ctx->pkey) != 1) {
         goto free_md_ctx;
     }
-    if (!EVP_PKEY_CTX_set_rsa_padding(md_pkey_ctx, RSA_PKCS1_PSS_PADDING)) {
+    if (EVP_PKEY_CTX_set_rsa_padding(md_pkey_ctx, RSA_PKCS1_PSS_PADDING) != 1) {
         goto free_md_ctx;
     }
-    if (!EVP_PKEY_CTX_set_rsa_pss_saltlen(md_pkey_ctx, -2)) {
+    if (EVP_PKEY_CTX_set_rsa_pss_saltlen(md_pkey_ctx, -2) != 1) {
         goto free_md_ctx;
     }
 
@@ -103,7 +103,7 @@ soter_status_t soter_verify_update_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
         return SOTER_INVALID_PARAMETER;
     }
 
-    if (!EVP_DigestVerifyUpdate(ctx->md_ctx, data, data_length)) {
+    if (EVP_DigestVerifyUpdate(ctx->md_ctx, data, data_length) != 1) {
         return SOTER_FAIL;
     }
     return SOTER_SUCCESS;

--- a/src/soter/openssl/soter_verify_rsa.c
+++ b/src/soter/openssl/soter_verify_rsa.c
@@ -32,6 +32,11 @@ soter_status_t soter_verify_init_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
     soter_status_t err = SOTER_FAIL;
     EVP_PKEY_CTX* md_pkey_ctx = NULL;
 
+    /* soter_sign_ctx_t should be initialized only once */
+    if (!ctx || ctx->pkey || ctx->md_ctx) {
+        return SOTER_INVALID_PARAMETER;
+    }
+
     ctx->pkey = EVP_PKEY_new();
     if (!ctx->pkey) {
         return SOTER_NO_MEMORY;

--- a/src/soter/openssl/soter_verify_rsa.c
+++ b/src/soter/openssl/soter_verify_rsa.c
@@ -46,20 +46,20 @@ soter_status_t soter_verify_init_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
     if (private_key && private_key_length != 0) {
         err = soter_rsa_import_key(ctx->pkey, private_key, private_key_length);
         if (err != SOTER_SUCCESS) {
-            goto free_pkey_ctx;
+            goto free_pkey;
         }
     }
     if (public_key && public_key_length != 0) {
         err = soter_rsa_import_key(ctx->pkey, public_key, public_key_length);
         if (err != SOTER_SUCCESS) {
-            goto free_pkey_ctx;
+            goto free_pkey;
         }
     }
 
     ctx->md_ctx = EVP_MD_CTX_create();
     if (!(ctx->md_ctx)) {
         err = SOTER_NO_MEMORY;
-        goto free_pkey_ctx;
+        goto free_pkey;
     }
 
     /* md_pkey_ctx is owned by ctx->md_ctx */
@@ -78,7 +78,6 @@ soter_status_t soter_verify_init_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
 free_md_ctx:
     EVP_MD_CTX_destroy(ctx->md_ctx);
     ctx->md_ctx = NULL;
-free_pkey_ctx:
 free_pkey:
     EVP_PKEY_free(ctx->pkey);
     ctx->pkey = NULL;

--- a/src/soter/openssl/soter_verify_rsa.c
+++ b/src/soter/openssl/soter_verify_rsa.c
@@ -46,8 +46,6 @@ soter_status_t soter_verify_init_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
         goto free_pkey;
     }
 
-    ctx->pkey_ctx = NULL;
-
     if (private_key && private_key_length != 0) {
         err = soter_rsa_import_key(ctx->pkey, private_key, private_key_length);
         if (err != SOTER_SUCCESS) {
@@ -141,10 +139,6 @@ soter_status_t soter_verify_cleanup_rsa_pss_pkcs8(soter_sign_ctx_t* ctx)
     if (ctx->pkey) {
         EVP_PKEY_free(ctx->pkey);
         ctx->pkey = NULL;
-    }
-    if (ctx->pkey_ctx) {
-        EVP_PKEY_CTX_free(ctx->pkey_ctx);
-        ctx->pkey_ctx = NULL;
     }
     if (ctx->md_ctx) {
         EVP_MD_CTX_destroy(ctx->md_ctx);

--- a/src/soter/openssl/soter_verify_rsa.c
+++ b/src/soter/openssl/soter_verify_rsa.c
@@ -126,9 +126,10 @@ soter_status_t soter_verify_final_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
     if (signature_length != (size_t)EVP_PKEY_size(ctx->pkey)) {
         return SOTER_FAIL;
     }
-    if (!EVP_DigestVerifyFinal(ctx->md_ctx, (unsigned char*)signature, signature_length)) {
+    if (EVP_DigestVerifyFinal(ctx->md_ctx, (unsigned char*)signature, signature_length) != 1) {
         return SOTER_FAIL;
     }
+
     return SOTER_SUCCESS;
 }
 

--- a/src/soter/openssl/soter_verify_rsa.c
+++ b/src/soter/openssl/soter_verify_rsa.c
@@ -106,14 +106,11 @@ soter_status_t soter_verify_final_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
                                                 const void* signature,
                                                 const size_t signature_length)
 {
-    if (!ctx) {
+    if (!ctx || !ctx->pkey) {
         return SOTER_INVALID_PARAMETER;
     }
-    EVP_PKEY* pkey = ctx->pkey;
-    if (!pkey) {
-        return SOTER_INVALID_PARAMETER;
-    }
-    if (signature_length != (size_t)EVP_PKEY_size(pkey)) {
+
+    if (signature_length != (size_t)EVP_PKEY_size(ctx->pkey)) {
         return SOTER_FAIL;
     }
     if (!EVP_DigestVerifyFinal(ctx->md_ctx, (unsigned char*)signature, signature_length)) {

--- a/src/soter/openssl/soter_verify_rsa.c
+++ b/src/soter/openssl/soter_verify_rsa.c
@@ -93,10 +93,13 @@ soter_status_t soter_verify_update_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
                                                  const void* data,
                                                  const size_t data_length)
 {
-    if (!ctx) {
+    if (!ctx || !ctx->pkey) {
         return SOTER_INVALID_PARAMETER;
     }
     if (!data || data_length == 0) {
+        return SOTER_INVALID_PARAMETER;
+    }
+    if (EVP_PKEY_base_id(ctx->pkey) != EVP_PKEY_RSA) {
         return SOTER_INVALID_PARAMETER;
     }
 
@@ -114,6 +117,9 @@ soter_status_t soter_verify_final_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
         return SOTER_INVALID_PARAMETER;
     }
     if (!signature || signature_length == 0) {
+        return SOTER_INVALID_PARAMETER;
+    }
+    if (EVP_PKEY_base_id(ctx->pkey) != EVP_PKEY_RSA) {
         return SOTER_INVALID_PARAMETER;
     }
 


### PR DESCRIPTION
Turns out, Soter generates EC keys incorrectly, by misusing OpenSSL API. It somehow works out for OpenSSL 1.1.1 (and earlier), but in OpenSSL 3.0 this fails. This ginormous PR improves the situation a bit by using proper key generation sequence which allows Secure Message sign/verify mode to work with OpenSSL 3.0. Collateral damage includes some extra checks and cleanups along the way.

This change was made in an autistic fit of spite against OpenSSL 3.0 for which I am sorry. I also apologize for such a long PR, I didn't have time to write a short one. I wish you happy code review. When you see 78 commits, 11 files, and 500+ lines changed – you know that's just the right size /s

Given the scope, I'd wait for at least ~~three~~ two sign-offs on this before merging.

### Background

We're not the first ones, and the issue probably ultimately stems from undoubtedly high quality of OpenSSL documentation, but nevertheless. See these issues:

- https://github.com/openssl/openssl/issues/11990
- https://github.com/openssl/openssl/issues/11549

Soter makes the same mistake. Thrice.

### Impact

The code changes *may* affect the following systems:

- key generation (both EC and RSA)
- Secure Message in sign/verify mode (ditto)
- Secure Message in encrypt mode (EC only)

But actually this should be a change with no functional impact.

OpenSSL 1.1.1 and OpenSSL 1.0.2 operation is unaffected. (CI does not check OpenSSL 1.0.2 but I can confirm that Soter & Themis Core test suites pass with it.)

With OpenSSL 3.0 the test failure rate improves a bit.

Soter test suite:

```diff
-==> 250 check(s) in 17 suite(s) finished after 1.00 second(s),
-    245 succeeded, 5 failed (2.00%)
+==> 269 check(s) in 17 suite(s) finished after 2.00 second(s),
+    267 succeeded, 2 failed (0.74%)
```

Themis Core test suite:

```diff
-==> 190 check(s) in 15 suite(s) finished after 4.00 second(s),
-    171 succeeded, 19 failed (10.00%)
+==> 242 check(s) in 15 suite(s) finished after 4.00 second(s),
+    232 succeeded, 10 failed (4.13%)
```

### Additional notes

Properly using OpenSSL API for EC key generation appears to trigger #657 on CI with legacy Node.js 8.x. I have applied the suggested workaround (switch to BoringSSL).

### Future work

This PR fixes one instance, on the code paths that affect sign/verify mode of Secure Message. The tests still fail with OpenSSL 3.0 as the key agreement code paths need to be corrected in the same manner, but I don't have enough spoons to do that now (and you probably don't want to get 40 more commits *here*).

Additionally, it would probably be nice to port all this to BoringSSL code as well, but it seems that it's currently more lenient, like OpenSSL 1.1.1 is.

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
