### PR TITLE
soter: Fix misuse of OpenSSL API for EC key agreement

### DIFF
--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -67,13 +67,13 @@ jobs:
         run: make prepare_tests_basic WITH_SCELL_COMPAT=yes BUILD_PATH=build-compat
       - name: Run test suite (OpenSSL)
         if: always()
-        run: make test BUILD_PATH=build-openssl
+        run: make test ENGINE=openssl BUILD_PATH=build-openssl
       - name: Run test suite (BoringSSL)
         if: always()
-        run: make test BUILD_PATH=build-boringssl
+        run: make test ENGINE=boringssl BUILD_PATH=build-boringssl
       - name: Run test suite (WITH_SCELL_COMPAT)
         if: always()
-        run: make test BUILD_PATH=build-compat
+        run: make test WITH_SCELL_COMPAT=yes BUILD_PATH=build-compat
       - name: Ensure OpenSSL 3.0 fails (macOS only)
         if: ${{ matrix.os == 'macos-latest' }}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ _Code:_
   - Fixed cross-compilation on macOS by setting `ARCH` and `SDK` variables ([#849](https://github.com/cossacklabs/themis/pull/849)).
   - Updated embedded BoringSSL to the latest version ([#812](https://github.com/cossacklabs/themis/pull/812)).
   - Builds with OpenSSL 3.0 will result in a compilation error for the time being ([#872](https://github.com/cossacklabs/themis/pull/872)).
-  - Hardened EC/RSA key generation and Secure Message sign/verify code paths ([#875](https://github.com/cossacklabs/themis/pull/875)).
+  - Hardened EC/RSA key generation and handling in Secure Message and Secure Session ([#875](https://github.com/cossacklabs/themis/pull/875), [#876](https://github.com/cossacklabs/themis/pull/876))
 
 - **Android**
 

--- a/src/soter/openssl/soter_asym_ka.c
+++ b/src/soter/openssl/soter_asym_ka.c
@@ -285,7 +285,7 @@ soter_status_t soter_asym_ka_derive(soter_asym_ka_t* asym_ka_ctx,
         goto err;
     }
 
-    if (out_length > *shared_secret_length) {
+    if (!shared_secret || out_length > *shared_secret_length) {
         *shared_secret_length = out_length;
         res = SOTER_BUFFER_TOO_SMALL;
         goto err;

--- a/src/soter/openssl/soter_asym_ka.c
+++ b/src/soter/openssl/soter_asym_ka.c
@@ -248,14 +248,16 @@ soter_status_t soter_asym_ka_derive(soter_asym_ka_t* asym_ka_ctx,
     EVP_PKEY* peer_pkey = NULL;
     size_t out_length = 0;
 
+    if (!asym_ka_ctx || !asym_ka_ctx->pkey) {
+        return SOTER_INVALID_PARAMETER;
+    }
+    if (!peer_key || peer_key_length == 0 || !shared_secret_length) {
+        return SOTER_INVALID_PARAMETER;
+    }
+
     peer_pkey = EVP_PKEY_new();
     if (NULL == peer_pkey) {
         return SOTER_NO_MEMORY;
-    }
-
-    if ((!asym_ka_ctx) || (!shared_secret_length)) {
-        EVP_PKEY_free(peer_pkey);
-        return SOTER_INVALID_PARAMETER;
     }
 
     res = soter_ec_pub_key_to_engine_specific((const soter_container_hdr_t*)peer_key,

--- a/src/soter/openssl/soter_asym_ka.c
+++ b/src/soter/openssl/soter_asym_ka.c
@@ -36,33 +36,34 @@ SOTER_PRIVATE_API
 soter_status_t soter_asym_ka_init(soter_asym_ka_t* asym_ka_ctx, soter_asym_ka_alg_t alg)
 {
     soter_status_t err = SOTER_FAIL;
+    EVP_PKEY_CTX* param_ctx = NULL;
     int nid = soter_alg_to_curve_nid(alg);
 
     if ((!asym_ka_ctx) || (0 == nid)) {
         return SOTER_INVALID_PARAMETER;
     }
 
-    asym_ka_ctx->pkey_ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, NULL);
-    if (!(asym_ka_ctx->pkey_ctx)) {
+    param_ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, NULL);
+    if (!param_ctx) {
         err = SOTER_NO_MEMORY;
         goto free_pkey;
     }
 
-    if (1 != EVP_PKEY_paramgen_init(asym_ka_ctx->pkey_ctx)) {
+    if (1 != EVP_PKEY_paramgen_init(param_ctx)) {
         goto free_pkey_ctx;
     }
-    if (1 != EVP_PKEY_CTX_set_ec_paramgen_curve_nid(asym_ka_ctx->pkey_ctx, nid)) {
+    if (1 != EVP_PKEY_CTX_set_ec_paramgen_curve_nid(param_ctx, nid)) {
         goto free_pkey_ctx;
     }
-    if (1 != EVP_PKEY_paramgen(asym_ka_ctx->pkey_ctx, &asym_ka_ctx->param)) {
+    if (1 != EVP_PKEY_paramgen(param_ctx, &asym_ka_ctx->param)) {
         goto free_pkey_ctx;
     }
 
+    EVP_PKEY_CTX_free(param_ctx);
     return SOTER_SUCCESS;
 
 free_pkey_ctx:
-    EVP_PKEY_CTX_free(asym_ka_ctx->pkey_ctx);
-    asym_ka_ctx->pkey_ctx = NULL;
+    EVP_PKEY_CTX_free(param_ctx);
 free_pkey:
     return err;
 }

--- a/src/soter/openssl/soter_asym_ka.c
+++ b/src/soter/openssl/soter_asym_ka.c
@@ -222,7 +222,7 @@ soter_status_t soter_asym_ka_export_key(soter_asym_ka_t* asym_ka_ctx,
     if (!asym_ka_ctx || !asym_ka_ctx->pkey) {
         return SOTER_INVALID_PARAMETER;
     }
-    if (EVP_PKEY_id(asym_ka_ctx->pkey) != EVP_PKEY_EC) {
+    if (EVP_PKEY_base_id(asym_ka_ctx->pkey) != EVP_PKEY_EC) {
         return SOTER_INVALID_PARAMETER;
     }
 
@@ -252,6 +252,9 @@ soter_status_t soter_asym_ka_derive(soter_asym_ka_t* asym_ka_ctx,
         return SOTER_INVALID_PARAMETER;
     }
     if (!peer_key || peer_key_length == 0 || !shared_secret_length) {
+        return SOTER_INVALID_PARAMETER;
+    }
+    if (EVP_PKEY_base_id(asym_ka_ctx->pkey) != EVP_PKEY_EC) {
         return SOTER_INVALID_PARAMETER;
     }
 

--- a/src/soter/openssl/soter_asym_ka.c
+++ b/src/soter/openssl/soter_asym_ka.c
@@ -219,29 +219,21 @@ soter_status_t soter_asym_ka_export_key(soter_asym_ka_t* asym_ka_ctx,
                                         size_t* key_length,
                                         bool isprivate)
 {
-    EVP_PKEY* pkey;
-
-    if (!asym_ka_ctx) {
+    if (!asym_ka_ctx || !asym_ka_ctx->pkey) {
         return SOTER_INVALID_PARAMETER;
     }
-
-    pkey = EVP_PKEY_CTX_get0_pkey(asym_ka_ctx->pkey_ctx);
-
-    if (!pkey) {
-        return SOTER_INVALID_PARAMETER;
-    }
-
-    if (EVP_PKEY_EC != EVP_PKEY_id(pkey)) {
+    if (EVP_PKEY_id(asym_ka_ctx->pkey) != EVP_PKEY_EC) {
         return SOTER_INVALID_PARAMETER;
     }
 
     if (isprivate) {
-        return soter_engine_specific_to_ec_priv_key((const soter_engine_specific_ec_key_t*)pkey,
+        return soter_engine_specific_to_ec_priv_key((const soter_engine_specific_ec_key_t*)
+                                                        asym_ka_ctx->pkey,
                                                     (soter_container_hdr_t*)key,
                                                     key_length);
     }
 
-    return soter_engine_specific_to_ec_pub_key((const soter_engine_specific_ec_key_t*)pkey,
+    return soter_engine_specific_to_ec_pub_key((const soter_engine_specific_ec_key_t*)asym_ka_ctx->pkey,
                                                (soter_container_hdr_t*)key,
                                                key_length);
 }

--- a/src/soter/openssl/soter_asym_ka.c
+++ b/src/soter/openssl/soter_asym_ka.c
@@ -267,36 +267,39 @@ soter_status_t soter_asym_ka_derive(soter_asym_ka_t* asym_ka_ctx,
                                               peer_key_length,
                                               ((soter_engine_specific_ec_key_t**)&peer_pkey));
     if (SOTER_SUCCESS != res) {
-        EVP_PKEY_free(peer_pkey);
-        return res;
+        goto err;
     }
 
     if (1 != EVP_PKEY_derive_init(asym_ka_ctx->pkey_ctx)) {
-        EVP_PKEY_free(peer_pkey);
-        return SOTER_FAIL;
+        res = SOTER_FAIL;
+        goto err;
     }
 
     if (1 != EVP_PKEY_derive_set_peer(asym_ka_ctx->pkey_ctx, peer_pkey)) {
-        EVP_PKEY_free(peer_pkey);
-        return SOTER_FAIL;
+        res = SOTER_FAIL;
+        goto err;
     }
 
     if (1 != EVP_PKEY_derive(asym_ka_ctx->pkey_ctx, NULL, &out_length)) {
-        EVP_PKEY_free(peer_pkey);
-        return SOTER_FAIL;
+        res = SOTER_FAIL;
+        goto err;
     }
 
     if (out_length > *shared_secret_length) {
-        EVP_PKEY_free(peer_pkey);
         *shared_secret_length = out_length;
-        return SOTER_BUFFER_TOO_SMALL;
+        res = SOTER_BUFFER_TOO_SMALL;
+        goto err;
     }
 
     if (1 != EVP_PKEY_derive(asym_ka_ctx->pkey_ctx, (unsigned char*)shared_secret, shared_secret_length)) {
-        EVP_PKEY_free(peer_pkey);
-        return SOTER_FAIL;
+        res = SOTER_FAIL;
+        goto err;
     }
 
+    res = SOTER_SUCCESS;
+
+err:
     EVP_PKEY_free(peer_pkey);
-    return SOTER_SUCCESS;
+
+    return res;
 }

--- a/src/soter/openssl/soter_asym_ka.c
+++ b/src/soter/openssl/soter_asym_ka.c
@@ -43,9 +43,6 @@ soter_status_t soter_asym_ka_init(soter_asym_ka_t* asym_ka_ctx, soter_asym_ka_al
         return SOTER_INVALID_PARAMETER;
     }
 
-    asym_ka_ctx->param = NULL;
-    asym_ka_ctx->pkey = NULL;
-
     pkey = EVP_PKEY_new();
     if (!pkey) {
         return SOTER_NO_MEMORY;
@@ -106,7 +103,7 @@ soter_status_t soter_asym_ka_cleanup(soter_asym_ka_t* asym_ka_ctx)
 soter_asym_ka_t* soter_asym_ka_create(soter_asym_ka_alg_t alg)
 {
     soter_status_t status;
-    soter_asym_ka_t* ctx = malloc(sizeof(soter_asym_ka_t));
+    soter_asym_ka_t* ctx = calloc(1, sizeof(*ctx));
     if (!ctx) {
         return NULL;
     }

--- a/src/soter/openssl/soter_asym_ka.c
+++ b/src/soter/openssl/soter_asym_ka.c
@@ -35,7 +35,7 @@ static int soter_alg_to_curve_nid(soter_asym_ka_alg_t alg)
 SOTER_PRIVATE_API
 soter_status_t soter_asym_ka_init(soter_asym_ka_t* asym_ka_ctx, soter_asym_ka_alg_t alg)
 {
-    soter_status_t err = SOTER_FAIL;
+    soter_status_t res = SOTER_FAIL;
     EVP_PKEY_CTX* param_ctx = NULL;
     int nid = soter_alg_to_curve_nid(alg);
 
@@ -45,27 +45,29 @@ soter_status_t soter_asym_ka_init(soter_asym_ka_t* asym_ka_ctx, soter_asym_ka_al
 
     param_ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, NULL);
     if (!param_ctx) {
-        err = SOTER_NO_MEMORY;
-        goto free_pkey;
+        res = SOTER_NO_MEMORY;
+        goto err;
     }
 
     if (1 != EVP_PKEY_paramgen_init(param_ctx)) {
-        goto free_pkey_ctx;
+        res = SOTER_FAIL;
+        goto err;
     }
     if (1 != EVP_PKEY_CTX_set_ec_paramgen_curve_nid(param_ctx, nid)) {
-        goto free_pkey_ctx;
+        res = SOTER_FAIL;
+        goto err;
     }
     if (1 != EVP_PKEY_paramgen(param_ctx, &asym_ka_ctx->param)) {
-        goto free_pkey_ctx;
+        res = SOTER_FAIL;
+        goto err;
     }
 
-    EVP_PKEY_CTX_free(param_ctx);
-    return SOTER_SUCCESS;
+    res = SOTER_SUCCESS;
 
-free_pkey_ctx:
+err:
     EVP_PKEY_CTX_free(param_ctx);
-free_pkey:
-    return err;
+
+    return res;
 }
 
 SOTER_PRIVATE_API

--- a/src/soter/openssl/soter_asym_ka.c
+++ b/src/soter/openssl/soter_asym_ka.c
@@ -43,6 +43,9 @@ soter_status_t soter_asym_ka_init(soter_asym_ka_t* asym_ka_ctx, soter_asym_ka_al
         return SOTER_INVALID_PARAMETER;
     }
 
+    asym_ka_ctx->param = NULL;
+    asym_ka_ctx->pkey = NULL;
+
     pkey = EVP_PKEY_new();
     if (!pkey) {
         return SOTER_NO_MEMORY;
@@ -84,6 +87,14 @@ soter_status_t soter_asym_ka_cleanup(soter_asym_ka_t* asym_ka_ctx)
 {
     if (!asym_ka_ctx) {
         return SOTER_INVALID_PARAMETER;
+    }
+    if (asym_ka_ctx->param) {
+        EVP_PKEY_free(asym_ka_ctx->param);
+        asym_ka_ctx->param = NULL;
+    }
+    if (asym_ka_ctx->pkey) {
+        EVP_PKEY_free(asym_ka_ctx->pkey);
+        asym_ka_ctx->pkey = NULL;
     }
     if (asym_ka_ctx->pkey_ctx) {
         EVP_PKEY_CTX_free(asym_ka_ctx->pkey_ctx);

--- a/src/soter/openssl/soter_asym_ka.c
+++ b/src/soter/openssl/soter_asym_ka.c
@@ -36,23 +36,13 @@ SOTER_PRIVATE_API
 soter_status_t soter_asym_ka_init(soter_asym_ka_t* asym_ka_ctx, soter_asym_ka_alg_t alg)
 {
     soter_status_t err = SOTER_FAIL;
-    EVP_PKEY* pkey = NULL;
     int nid = soter_alg_to_curve_nid(alg);
 
     if ((!asym_ka_ctx) || (0 == nid)) {
         return SOTER_INVALID_PARAMETER;
     }
 
-    pkey = EVP_PKEY_new();
-    if (!pkey) {
-        return SOTER_NO_MEMORY;
-    }
-
-    if (!EVP_PKEY_set_type(pkey, EVP_PKEY_EC)) {
-        goto free_pkey;
-    }
-
-    asym_ka_ctx->pkey_ctx = EVP_PKEY_CTX_new(pkey, NULL);
+    asym_ka_ctx->pkey_ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, NULL);
     if (!(asym_ka_ctx->pkey_ctx)) {
         err = SOTER_NO_MEMORY;
         goto free_pkey;
@@ -68,14 +58,12 @@ soter_status_t soter_asym_ka_init(soter_asym_ka_t* asym_ka_ctx, soter_asym_ka_al
         goto free_pkey_ctx;
     }
 
-    EVP_PKEY_free(pkey);
     return SOTER_SUCCESS;
 
 free_pkey_ctx:
     EVP_PKEY_CTX_free(asym_ka_ctx->pkey_ctx);
     asym_ka_ctx->pkey_ctx = NULL;
 free_pkey:
-    EVP_PKEY_free(pkey);
     return err;
 }
 

--- a/src/soter/openssl/soter_asym_ka.c
+++ b/src/soter/openssl/soter_asym_ka.c
@@ -244,10 +244,11 @@ soter_status_t soter_asym_ka_derive(soter_asym_ka_t* asym_ka_ctx,
                                     void* shared_secret,
                                     size_t* shared_secret_length)
 {
-    EVP_PKEY* peer_pkey = EVP_PKEY_new();
-    soter_status_t res;
-    size_t out_length;
+    soter_status_t res = SOTER_FAIL;
+    EVP_PKEY* peer_pkey = NULL;
+    size_t out_length = 0;
 
+    peer_pkey = EVP_PKEY_new();
     if (NULL == peer_pkey) {
         return SOTER_NO_MEMORY;
     }

--- a/src/soter/openssl/soter_asym_ka.c
+++ b/src/soter/openssl/soter_asym_ka.c
@@ -84,10 +84,6 @@ soter_status_t soter_asym_ka_cleanup(soter_asym_ka_t* asym_ka_ctx)
         EVP_PKEY_free(asym_ka_ctx->pkey);
         asym_ka_ctx->pkey = NULL;
     }
-    if (asym_ka_ctx->pkey_ctx) {
-        EVP_PKEY_CTX_free(asym_ka_ctx->pkey_ctx);
-        asym_ka_ctx->pkey_ctx = NULL;
-    }
     return SOTER_SUCCESS;
 }
 

--- a/src/soter/openssl/soter_asym_ka.c
+++ b/src/soter/openssl/soter_asym_ka.c
@@ -64,7 +64,7 @@ soter_status_t soter_asym_ka_init(soter_asym_ka_t* asym_ka_ctx, soter_asym_ka_al
     if (1 != EVP_PKEY_CTX_set_ec_paramgen_curve_nid(asym_ka_ctx->pkey_ctx, nid)) {
         goto free_pkey_ctx;
     }
-    if (1 != EVP_PKEY_paramgen(asym_ka_ctx->pkey_ctx, &pkey)) {
+    if (1 != EVP_PKEY_paramgen(asym_ka_ctx->pkey_ctx, &asym_ka_ctx->param)) {
         goto free_pkey_ctx;
     }
 

--- a/src/soter/openssl/soter_engine.h
+++ b/src/soter/openssl/soter_engine.h
@@ -52,7 +52,6 @@ struct soter_rsa_key_pair_gen_type {
 struct soter_asym_ka_type {
     EVP_PKEY* param;
     EVP_PKEY* pkey;
-    EVP_PKEY_CTX* pkey_ctx;
 };
 
 struct soter_sign_ctx_type {

--- a/src/soter/openssl/soter_engine.h
+++ b/src/soter/openssl/soter_engine.h
@@ -50,6 +50,8 @@ struct soter_rsa_key_pair_gen_type {
 };
 
 struct soter_asym_ka_type {
+    EVP_PKEY* param;
+    EVP_PKEY* pkey;
     EVP_PKEY_CTX* pkey_ctx;
 };
 


### PR DESCRIPTION
And again, Soter makes the same mistake of using EVP_PKEY_CTX as a container for EVP_PKEY with unspecified role and retaining this context. In fact, `soter_asym_ka_t` deals with three separate operations each of which requires different contexts:

  1. EC parameter generation (input: curve, output: parameters).
  2. EC keypair generation (input: parameters, output: keypair).
  3. Shared secret derivation (input: keypair, peer public key, output: shared secret).

And all of these need separate contexts, not just one being reused. Previous incorrect code worked with OpenSSL 1.1.1 and before by accident, but with OpenSSL 3.0 this fails. We need to do things correctly now.

This change is stacked on top of #875. Same as before, I'd like at least two approvals.

### Background

See #875, this is basically the same change but to *key agreement* code path, the one used by Secure Message in encrypt/decrypt mode to derive a shared secret for encryption with EC keys, as well as Secure Session deriving session secret during negotiation phase.

### Impact

Like in #875, Secure Message and Secure Session might be affected, but no functional changes are expected.

The builds are fine with OpenSSL 1.0.2, 1.1.1, 3.0.

Unit test suite now passes with flying colors against OpenSSL 3.0.

### Additional notes

Changing the layout of private struct `soter_asym_ka_t` uncovered an issue with CI setup that likely used OpenSSL code paths while testing BoringSSL builds. This has been corrected. It's purely a CI issue, the BoringSSL packaging builds Themis with BoringSSL correctly.

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Changelog is updated
- [x] [#875](https://github.com/cossacklabs/themis/pull/875) is merged and this PR is rebased

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
