### PR TITLE
CI: Test Themis with OpenSSL 3.0

### DIFF
--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -80,7 +80,10 @@ jobs:
           # Themis uses OpenSSL 1.1 by default if installed.
           # Explicitly request OpenSSL 3.0 by pointing the build into OpenSSL 3.0's paths.
           openssl3=$(brew --prefix openssl@3)
-          if ! make ENGINE=openssl BUILD_PATH=build-openssl-3.0 ENGINE_INCLUDE_PATH=$openssl3/include ENGINE_LIB_PATH=$openssl3/lib
+          export ENGINE=openssl
+          export ENGINE_INCLUDE_PATH="$openssl3/include"
+          export ENGINE_LIB_PATH="$openssl3/lib"
+          if ! make BUILD_PATH=build-openssl-3.0-without-magic-word
           then
             true
           else

--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -59,6 +59,18 @@ jobs:
       - name: Build Themis Core (OpenSSL)
         if: always()
         run: make prepare_tests_basic ENGINE=openssl BUILD_PATH=build-openssl
+      - name: Build Themis Core (OpenSSL 3.0)
+        # TODO: expand this to Linux systems when OpenSSL 3.0 system library is available there
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: |
+          openssl3="$(brew --prefix openssl@3)"
+          export ENGINE=openssl
+          export ENGINE_INCLUDE_PATH="$openssl3/include"
+          export ENGINE_LIB_PATH="$openssl3/lib"
+          # TODO: stop using deprecated API so that warnings can be errors again
+          export WITH_EXPERIMENTAL_OPENSSL_3_SUPPORT=yes
+          export WITH_FATAL_WARNINGS=no
+          make prepare_tests_basic BUILD_PATH=build-openssl-3.0
       - name: Build Themis Core (BoringSSL)
         if: always()
         run: make prepare_tests_basic ENGINE=boringssl BUILD_PATH=build-boringssl
@@ -68,6 +80,16 @@ jobs:
       - name: Run test suite (OpenSSL)
         if: always()
         run: make test ENGINE=openssl BUILD_PATH=build-openssl
+      - name: Run test suite (OpenSSL 3.0)
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: |
+          openssl3="$(brew --prefix openssl@3)"
+          export ENGINE=openssl
+          export ENGINE_INCLUDE_PATH="$openssl3/include"
+          export ENGINE_LIB_PATH="$openssl3/lib"
+          export WITH_EXPERIMENTAL_OPENSSL_3_SUPPORT=yes
+          export WITH_FATAL_WARNINGS=no
+          make test BUILD_PATH=build-openssl-3.0
       - name: Run test suite (BoringSSL)
         if: always()
         run: make test ENGINE=boringssl BUILD_PATH=build-boringssl


### PR DESCRIPTION
With #875 and #876, Soter and Themis test suites should now pass for OpenSSL 3.0.

Let's test OpenSSL 3.0 builds where we can, making sure that they work. Note that OpenSSL 3.0 support is still experimental and requires special setup. Also, we still use deprecated APIs. In order to make the builds green, stop treating warnings as errors, but *don't* suppress them. Sometime they need to be fixed, not stay like that forever.

While Themis can be built with OpenSSL 3.0 and apparently passes all the unit tests, it's still not fully supported. We don't know how compatible OpenSSL 1.1.1 is with OpenSSL 3.0 (or rather, how compatible is Themis use of them). Similarly, we have no provisions for building Themis packages linked against a specific version of OpenSSL.

Currently, only macOS provides a sort of a system installation of OpenSSL 3.0. While we could build OpenSSL 3.0 on Linux for testing, I don't think we should be testing non-system setups extensively. Verifying this on macOS alone is good enough for the time being.

## Checklist

- [x] Change is covered by automated tests (duh...)
- [x] The [coding guidelines] are followed
- [x] ~~Changelog is updated~~ (no need, ninja change)
- [x] [#875](https://github.com/cossacklabs/themis/pull/875) and [#876](https://github.com/cossacklabs/themis/pull/876) are merged and this PR is rebased

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
