### PR TITLE
GoThemis: Module-aware tests

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -106,6 +106,8 @@ jobs:
         run: |
           mkdir -p $HOME/go/src/$GOTHEMIS_IMPORT
           rsync -auv gothemis/ $HOME/go/src/$GOTHEMIS_IMPORT
+      - name: Install GoThemis (test tools)
+        run: make gothemis_integration_tools
       # Cargo pulls in quite a few stuff from the Internet and Rust always
       # (slowly) recompiles dependencies, so make heavy use of caching
       - name: Cache Cargo registry

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -35,8 +35,6 @@ jobs:
   cross-language:
     name: Cross-language tests
     runs-on: ubuntu-latest
-    env:
-      GOTHEMIS_IMPORT: github.com/cossacklabs/themis/gothemis
     steps:
       - name: Install system dependencies
         run: |
@@ -102,10 +100,6 @@ jobs:
         run: sudo make pythemis_install
       - name: Install RubyThemis
         run: sudo make rbthemis_install
-      - name: Install GoThemis
-        run: |
-          mkdir -p $HOME/go/src/$GOTHEMIS_IMPORT
-          rsync -auv gothemis/ $HOME/go/src/$GOTHEMIS_IMPORT
       - name: Install GoThemis (test tools)
         run: make gothemis_integration_tools
       # Cargo pulls in quite a few stuff from the Internet and Rust always

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -25,7 +25,6 @@ on:
     - cron: '20 6 * * 1' # every Monday at 6:20 UTC
 
 env:
-  GOTHEMIS_IMPORT: github.com/cossacklabs/themis/gothemis
   WITH_FATAL_WARNINGS: yes
 
 jobs:
@@ -82,10 +81,6 @@ jobs:
         run: |
           make
           sudo make install
-      - name: Install GoThemis
-        run: |
-          mkdir -p $HOME/go/src/$GOTHEMIS_IMPORT
-          rsync -auv gothemis/ $HOME/go/src/$GOTHEMIS_IMPORT
       - name: Test examples (Secure Cell)
         run: |
           cd $GITHUB_WORKSPACE/docs/examples/go

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -41,6 +41,7 @@ jobs:
           - '1.14'
           - '1.15'
           - '1.16'
+          - '1.17'
       fail-fast: false
     steps:
       - name: Install system dependencies

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -72,6 +72,10 @@ jobs:
           sudo sh -c 'echo "DEBIAN_FRONTEND=noninteractive" >> /etc/environment'
           sudo apt update
           sudo apt install --yes gcc make libssl-dev
+      - name: Install Go 1.17
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.17
       - name: Check out code
         uses: actions/checkout@v2
       - name: Install Themis Core

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -61,7 +61,7 @@ jobs:
           make
           sudo make install
       - name: Run test suite (Go ${{ matrix.go }})
-        run: cd gothemis && go test -v ./...
+        run: make test_go
 
   examples:
     name: Code examples

--- a/docs/examples/Themis-server/go/go.mod
+++ b/docs/examples/Themis-server/go/go.mod
@@ -1,0 +1,5 @@
+module github.com/cossacklabs/themis/docs/examples/Themis-server/go
+
+require github.com/cossacklabs/themis/gothemis v0.13.1
+
+replace github.com/cossacklabs/themis/gothemis => ../../../../gothemis

--- a/docs/examples/go/go.mod
+++ b/docs/examples/go/go.mod
@@ -1,0 +1,5 @@
+module github.com/cossacklabs/themis/docs/examples/go
+
+require github.com/cossacklabs/themis/gothemis v0.13.1
+
+replace github.com/cossacklabs/themis/gothemis => ../../../gothemis

--- a/tests/_integration/tests_generator.py
+++ b/tests/_integration/tests_generator.py
@@ -15,7 +15,7 @@ languages = [
     LanguageSetting(name='python', command='python3', script_path='./tools/python', extension='py'),
     LanguageSetting(name='js', command='node', script_path='./tools/js/wasm-themis', extension='js'),
     LanguageSetting(name='node', command='node', script_path='./tools/js/jsthemis', extension='js'),
-    LanguageSetting(name='go', command='go run', script_path='./tools/go', extension='go'),
+    LanguageSetting(name='go', command='env', script_path='./tools/go', extension='go.compiled'),
     LanguageSetting(name='php', command='php -f', script_path='./tools/php', extension='php'),
     LanguageSetting(name='rust', command='env', script_path='./tools/rust', extension='rust'),
 ]

--- a/tests/test.mk
+++ b/tests/test.mk
@@ -41,6 +41,11 @@ rustthemis_integration_tools:
 	do cp target/debug/$$tool tools/rust/$$tool.rust; done
 	@$(PRINT_OK_)
 
+gothemis_integration_tools:
+	@echo "make integration tools for GoThemis..."
+	@cd tools/go && for tool in *.go; do go build -o "$$tool.compiled" "$$tool"; done
+	@$(PRINT_OK_)
+
 prepare_tests_basic: soter_test themis_test
 
 prepare_tests_all: prepare_tests_basic themispp_test

--- a/tests/test.mk
+++ b/tests/test.mk
@@ -17,8 +17,6 @@
 COMMON_TEST_SRC = $(wildcard tests/common/*.c)
 COMMON_TEST_OBJ = $(patsubst %,$(OBJ_PATH)/%.o, $(COMMON_TEST_SRC))
 
-GOTHEMIS_IMPORT = github.com/cossacklabs/themis/gothemis
-
 include tests/soter/soter.mk
 include tests/tools/tools.mk
 include tests/themis/themis.mk
@@ -30,6 +28,8 @@ themis_test:   $(THEMIS_TEST_BIN)
 themispp_test: $(TEST_BIN_PATH)/themispp_test
 
 $(OBJ_PATH)/tests/%: CFLAGS += -I$(TEST_SRC_PATH)
+
+GOTHEMIS_SRC = gothemis
 
 PYTHON2_TEST_SCRIPT=$(BIN_PATH)/tests/pythemis2_test.sh
 PYTHON3_TEST_SCRIPT=$(BIN_PATH)/tests/pythemis3_test.sh
@@ -153,7 +153,7 @@ ifdef GO_VERSION
 	@echo "Running gothemis tests."
 	@echo "In case of errors, see https://docs.cossacklabs.com/themis/languages/go/"
 	@echo "------------------------------------------------------------"
-	@GO111MODULE=off go test -v $(GOTHEMIS_IMPORT)/...
+	@cd $(GOTHEMIS_SRC) && go test -v ./...
 endif
 
 test_rust:

--- a/tests/tools/check_keygen.sh
+++ b/tests/tools/check_keygen.sh
@@ -30,7 +30,7 @@ test_lang 'node' && test_keygen node tools/js/jsthemis/keygen.js
 test_lang 'js' && test_keygen node tools/js/wasm-themis/keygen.js
 test_lang 'php' && test_keygen "php -f" tools/php/keygen.php
 test_lang 'ruby' && test_keygen ruby tools/ruby/keygen.rb
-test_lang 'go' && test_keygen "go run" tools/go/keygen.go
+test_lang 'go' && test_keygen env tools/go/keygen.go.compiled
 test_lang 'rust' && test_keygen env tools/rust/keygen_tool.rust
 
 exit ${status}

--- a/tools/go/go.mod
+++ b/tools/go/go.mod
@@ -1,0 +1,5 @@
+module github.com/cossacklabs/themis/tools/go
+
+require github.com/cossacklabs/themis/gothemis v0.13.1
+
+replace github.com/cossacklabs/themis/gothemis => ../../gothemis


### PR DESCRIPTION
Some time ago GoThemis unit tests were migrated to module-aware approach (#843) because Go 1.16 is module-aware by default. However, other tests – code examples and integration tests – have been left as is, requiring GoThemis to be installed in GOPATH and starting with Go 1.16 needing `GO111MODULE=off`.

Update these tests to be module-aware as well, adding `go.mod` files where necessary. Test modules use the `replace` feature to use the locally checked out GoThemis instead of fetching it from GitHub. Code examples are relatively easy to do, but integration tests are pretty heavily tied to the notion that they execute "scripts". With GOPATH it was possible to run test tools like scripts with `go run`, but now we can't do that from the repo root directory. Thus, GoThemis tools migrate to the approach used by RustThemis – precompiled binaries.

With this, instead of copying GoThemis into `~/go/src` you can run examples from `docs/examples/go` directory. In order to run integration tests you first need to compile the tools with
```
make gothemis_integration_tools
```

## Checklist

- [x] Change is covered by automated tests
- [x] Example projects and code samples are up-to-date
- [x] ~~Changelog is updated~~ (don't need it, I guess?)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
