### PR TITLE
Improve OpenSSL 3.0 compatibility

### DIFF
--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -67,13 +67,13 @@ jobs:
         run: make prepare_tests_basic WITH_SCELL_COMPAT=yes BUILD_PATH=build-compat
       - name: Run test suite (OpenSSL)
         if: always()
-        run: make test BUILD_PATH=build-openssl
+        run: make test ENGINE=openssl BUILD_PATH=build-openssl
       - name: Run test suite (BoringSSL)
         if: always()
-        run: make test BUILD_PATH=build-boringssl
+        run: make test ENGINE=boringssl BUILD_PATH=build-boringssl
       - name: Run test suite (WITH_SCELL_COMPAT)
         if: always()
-        run: make test BUILD_PATH=build-compat
+        run: make test WITH_SCELL_COMPAT=yes BUILD_PATH=build-compat
       - name: Ensure OpenSSL 3.0 fails (macOS only)
         if: ${{ matrix.os == 'macos-latest' }}
         run: |

--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -59,6 +59,18 @@ jobs:
       - name: Build Themis Core (OpenSSL)
         if: always()
         run: make prepare_tests_basic ENGINE=openssl BUILD_PATH=build-openssl
+      - name: Build Themis Core (OpenSSL 3.0)
+        # TODO: expand this to Linux systems when OpenSSL 3.0 system library is available there
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: |
+          openssl3="$(brew --prefix openssl@3)"
+          export ENGINE=openssl
+          export ENGINE_INCLUDE_PATH="$openssl3/include"
+          export ENGINE_LIB_PATH="$openssl3/lib"
+          # TODO: stop using deprecated API so that warnings can be errors again
+          export WITH_EXPERIMENTAL_OPENSSL_3_SUPPORT=yes
+          export WITH_FATAL_WARNINGS=no
+          make prepare_tests_basic BUILD_PATH=build-openssl-3.0
       - name: Build Themis Core (BoringSSL)
         if: always()
         run: make prepare_tests_basic ENGINE=boringssl BUILD_PATH=build-boringssl
@@ -68,6 +80,16 @@ jobs:
       - name: Run test suite (OpenSSL)
         if: always()
         run: make test ENGINE=openssl BUILD_PATH=build-openssl
+      - name: Run test suite (OpenSSL 3.0)
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: |
+          openssl3="$(brew --prefix openssl@3)"
+          export ENGINE=openssl
+          export ENGINE_INCLUDE_PATH="$openssl3/include"
+          export ENGINE_LIB_PATH="$openssl3/lib"
+          export WITH_EXPERIMENTAL_OPENSSL_3_SUPPORT=yes
+          export WITH_FATAL_WARNINGS=no
+          make test BUILD_PATH=build-openssl-3.0
       - name: Run test suite (BoringSSL)
         if: always()
         run: make test ENGINE=boringssl BUILD_PATH=build-boringssl
@@ -80,7 +102,10 @@ jobs:
           # Themis uses OpenSSL 1.1 by default if installed.
           # Explicitly request OpenSSL 3.0 by pointing the build into OpenSSL 3.0's paths.
           openssl3=$(brew --prefix openssl@3)
-          if ! make ENGINE=openssl BUILD_PATH=build-openssl-3.0 ENGINE_INCLUDE_PATH=$openssl3/include ENGINE_LIB_PATH=$openssl3/lib
+          export ENGINE=openssl
+          export ENGINE_INCLUDE_PATH="$openssl3/include"
+          export ENGINE_LIB_PATH="$openssl3/lib"
+          if ! make BUILD_PATH=build-openssl-3.0-without-magic-word
           then
             true
           else

--- a/.github/workflows/test-nodejs.yaml
+++ b/.github/workflows/test-nodejs.yaml
@@ -48,10 +48,19 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Check out code
         uses: actions/checkout@v2
+        with:
+          submodules: true
       - name: Install Themis Core
+        env:
+          NODE_VERSION: ${{ matrix.node-version }}
         run: |
+          # Workaround for Node.js 8.x using OpenSSL 1.0.2 when Themis is built against OpenSSL 1.1
+          # https://github.com/cossacklabs/themis/issues/657
+          if [[ "$NODE_VERSION" = "8.x" ]]; then
+            export ENGINE=boringssl
+          fi
           make
-          sudo make install
+          sudo -E make install
       - name: Run test suite
         run: |
           echo Node.js: $(node --version)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ _Code:_
   - Fixed cross-compilation on macOS by setting `ARCH` and `SDK` variables ([#849](https://github.com/cossacklabs/themis/pull/849)).
   - Updated embedded BoringSSL to the latest version ([#812](https://github.com/cossacklabs/themis/pull/812)).
   - Builds with OpenSSL 3.0 will result in a compilation error for the time being ([#872](https://github.com/cossacklabs/themis/pull/872)).
-  - Hardened EC/RSA key generation and Secure Message sign/verify code paths ([#875](https://github.com/cossacklabs/themis/pull/875)).
+  - Hardened EC/RSA key generation and handling in Secure Message and Secure Session ([#875](https://github.com/cossacklabs/themis/pull/875), [#876](https://github.com/cossacklabs/themis/pull/876))
 
 - **Android**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ _Code:_
   - Fixed cross-compilation on macOS by setting `ARCH` and `SDK` variables ([#849](https://github.com/cossacklabs/themis/pull/849)).
   - Updated embedded BoringSSL to the latest version ([#812](https://github.com/cossacklabs/themis/pull/812)).
   - Builds with OpenSSL 3.0 will result in a compilation error for the time being ([#872](https://github.com/cossacklabs/themis/pull/872)).
+  - Hardened EC/RSA key generation and Secure Message sign/verify code paths ([#875](https://github.com/cossacklabs/themis/pull/875)).
 
 - **Android**
 

--- a/src/soter/openssl/soter_ecdsa_common.h
+++ b/src/soter/openssl/soter_ecdsa_common.h
@@ -21,8 +21,8 @@
 #include "soter/soter_ec_key.h"
 #include "soter/soter_error.h"
 
-soter_status_t soter_ec_gen_key(EVP_PKEY_CTX* pkey_ctx);
+soter_status_t soter_ec_gen_key(EVP_PKEY** ppkey);
 soter_status_t soter_ec_import_key(EVP_PKEY* pkey, const void* key, size_t key_length);
-soter_status_t soter_ec_export_key(soter_sign_ctx_t* ctx, void* key, size_t* key_length, bool isprivate);
+soter_status_t soter_ec_export_key(EVP_PKEY* pkey, void* key, size_t* key_length, bool isprivate);
 
 #endif /* SOTER_OPENSSL_ECDSA_COMMON_H */

--- a/src/soter/openssl/soter_engine.h
+++ b/src/soter/openssl/soter_engine.h
@@ -54,7 +54,7 @@ struct soter_asym_ka_type {
 };
 
 struct soter_sign_ctx_type {
-    EVP_PKEY_CTX* pkey_ctx;
+    EVP_PKEY* pkey;
     EVP_MD_CTX* md_ctx;
     soter_sign_alg_t alg;
 };

--- a/src/soter/openssl/soter_engine.h
+++ b/src/soter/openssl/soter_engine.h
@@ -50,7 +50,8 @@ struct soter_rsa_key_pair_gen_type {
 };
 
 struct soter_asym_ka_type {
-    EVP_PKEY_CTX* pkey_ctx;
+    EVP_PKEY* param;
+    EVP_PKEY* pkey;
 };
 
 struct soter_sign_ctx_type {

--- a/src/soter/openssl/soter_rsa_common.h
+++ b/src/soter/openssl/soter_rsa_common.h
@@ -21,8 +21,8 @@
 #include "soter/soter_error.h"
 #include "soter/soter_rsa_key.h"
 
-soter_status_t soter_rsa_gen_key(EVP_PKEY_CTX* pkey_ctx);
+soter_status_t soter_rsa_gen_key(EVP_PKEY** ppkey);
 soter_status_t soter_rsa_import_key(EVP_PKEY* pkey, const void* key, size_t key_length);
-soter_status_t soter_rsa_export_key(soter_sign_ctx_t* ctx, void* key, size_t* key_length, bool isprivate);
+soter_status_t soter_rsa_export_key(EVP_PKEY* pkey, void* key, size_t* key_length, bool isprivate);
 
 #endif /* SOTER_OPENSSL_RSA_COMMON_H */

--- a/src/soter/openssl/soter_sign_ecdsa.c
+++ b/src/soter/openssl/soter_sign_ecdsa.c
@@ -31,49 +31,39 @@ soter_status_t soter_sign_init_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
                                                 const size_t public_key_length)
 {
     soter_status_t err = SOTER_FAIL;
-    EVP_PKEY* pkey = NULL;
 
-    pkey = EVP_PKEY_new();
-    if (!pkey) {
-        return SOTER_NO_MEMORY;
-    }
-
-    if (!EVP_PKEY_set_type(pkey, EVP_PKEY_EC)) {
-        goto free_pkey;
-    }
-
-    ctx->pkey_ctx = EVP_PKEY_CTX_new(pkey, NULL);
-    if (!(ctx->pkey_ctx)) {
-        err = SOTER_NO_MEMORY;
-        goto free_pkey;
-    }
-
-    if (!EVP_PKEY_paramgen_init(ctx->pkey_ctx)) {
-        goto free_pkey_ctx;
-    }
-    if (!EVP_PKEY_CTX_set_ec_paramgen_curve_nid(ctx->pkey_ctx, NID_X9_62_prime256v1)) {
-        goto free_pkey_ctx;
-    }
-    if (!EVP_PKEY_paramgen(ctx->pkey_ctx, &pkey)) {
-        goto free_pkey_ctx;
+    /* soter_sign_ctx_t should be initialized only once */
+    if (!ctx || ctx->pkey || ctx->md_ctx) {
+        return SOTER_INVALID_PARAMETER;
     }
 
     if ((!private_key) && (!public_key)) {
-        err = soter_ec_gen_key(ctx->pkey_ctx);
+        err = soter_ec_gen_key(&ctx->pkey);
         if (err != SOTER_SUCCESS) {
-            goto free_pkey_ctx;
+            goto free_pkey;
         }
     } else {
+        ctx->pkey = EVP_PKEY_new();
+        if (!ctx->pkey) {
+            err = SOTER_NO_MEMORY;
+            goto free_pkey;
+        }
+
+        if (!EVP_PKEY_set_type(ctx->pkey, EVP_PKEY_EC)) {
+            err = SOTER_FAIL;
+            goto free_pkey;
+        }
+
         if (private_key != NULL) {
-            err = soter_ec_import_key(pkey, private_key, private_key_length);
+            err = soter_ec_import_key(ctx->pkey, private_key, private_key_length);
             if (err != SOTER_SUCCESS) {
-                goto free_pkey_ctx;
+                goto free_pkey;
             }
         }
         if (public_key != NULL) {
-            err = soter_ec_import_key(pkey, public_key, public_key_length);
+            err = soter_ec_import_key(ctx->pkey, public_key, public_key_length);
             if (err != SOTER_SUCCESS) {
-                goto free_pkey_ctx;
+                goto free_pkey;
             }
         }
     }
@@ -81,24 +71,21 @@ soter_status_t soter_sign_init_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
     ctx->md_ctx = EVP_MD_CTX_create();
     if (!(ctx->md_ctx)) {
         err = SOTER_NO_MEMORY;
-        goto free_pkey_ctx;
+        goto free_pkey;
     }
 
-    if (EVP_DigestSignInit(ctx->md_ctx, NULL, EVP_sha256(), NULL, pkey) != 1) {
+    if (EVP_DigestSignInit(ctx->md_ctx, NULL, EVP_sha256(), NULL, ctx->pkey) != 1) {
         goto free_md_ctx;
     }
 
-    EVP_PKEY_free(pkey);
     return SOTER_SUCCESS;
 
 free_md_ctx:
     EVP_MD_CTX_destroy(ctx->md_ctx);
     ctx->md_ctx = NULL;
-free_pkey_ctx:
-    EVP_PKEY_CTX_free(ctx->pkey_ctx);
-    ctx->pkey_ctx = NULL;
 free_pkey:
-    EVP_PKEY_free(pkey);
+    EVP_PKEY_free(ctx->pkey);
+    ctx->pkey = NULL;
     return err;
 }
 
@@ -107,13 +94,28 @@ soter_status_t soter_sign_export_key_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
                                                       size_t* key_length,
                                                       bool isprivate)
 {
-    return soter_ec_export_key(ctx, key, key_length, isprivate);
+    if (!ctx || !ctx->pkey) {
+        return SOTER_INVALID_PARAMETER;
+    }
+    if (EVP_PKEY_base_id(ctx->pkey) != EVP_PKEY_EC) {
+        return SOTER_INVALID_PARAMETER;
+    }
+    return soter_ec_export_key(ctx->pkey, key, key_length, isprivate);
 }
 
 soter_status_t soter_sign_update_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
                                                   const void* data,
                                                   const size_t data_length)
 {
+    if (!ctx || !ctx->pkey) {
+        return SOTER_INVALID_PARAMETER;
+    }
+    if (!data || data_length == 0) {
+        return SOTER_INVALID_PARAMETER;
+    }
+    if (EVP_PKEY_base_id(ctx->pkey) != EVP_PKEY_EC) {
+        return SOTER_INVALID_PARAMETER;
+    }
     if (EVP_DigestSignUpdate(ctx->md_ctx, data, data_length) != 1) {
         return SOTER_FAIL;
     }
@@ -124,23 +126,31 @@ soter_status_t soter_sign_final_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
                                                  void* signature,
                                                  size_t* signature_length)
 {
-    EVP_PKEY* pkey = EVP_PKEY_CTX_get0_pkey(ctx->pkey_ctx);
-    if (!pkey) {
+    int key_size = 0;
+
+    if (!ctx || !ctx->pkey) {
         return SOTER_INVALID_PARAMETER;
     }
-    if (EVP_PKEY_base_id(pkey) != EVP_PKEY_EC) {
+    if (!signature_length) {
         return SOTER_INVALID_PARAMETER;
-    } /* TODO: need review */
-    soter_status_t res = SOTER_SUCCESS;
-    if (!signature || (*signature_length) < (size_t)EVP_PKEY_size(pkey)) {
-        (*signature_length) = (size_t)EVP_PKEY_size(pkey);
-        res = SOTER_BUFFER_TOO_SMALL;
-    } else {
-        if (EVP_DigestSignFinal(ctx->md_ctx, signature, signature_length) != 1) {
-            res = SOTER_INVALID_SIGNATURE;
-        }
     }
-    return res;
+    if (EVP_PKEY_base_id(ctx->pkey) != EVP_PKEY_EC) {
+        return SOTER_INVALID_PARAMETER;
+    }
+
+    key_size = EVP_PKEY_size(ctx->pkey);
+    if (key_size <= 0) {
+        return SOTER_FAIL;
+    }
+    if (!signature || (*signature_length) < (size_t)key_size) {
+        (*signature_length) = (size_t)key_size;
+        return SOTER_BUFFER_TOO_SMALL;
+    }
+
+    if (EVP_DigestSignFinal(ctx->md_ctx, signature, signature_length) != 1) {
+        return SOTER_INVALID_SIGNATURE;
+    }
+    return SOTER_SUCCESS;
 }
 
 soter_status_t soter_sign_cleanup_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx)
@@ -148,13 +158,13 @@ soter_status_t soter_sign_cleanup_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx)
     if (!ctx) {
         return SOTER_INVALID_PARAMETER;
     }
+    if (ctx->pkey) {
+        EVP_PKEY_free(ctx->pkey);
+        ctx->pkey = NULL;
+    }
     if (ctx->md_ctx) {
         EVP_MD_CTX_destroy(ctx->md_ctx);
         ctx->md_ctx = NULL;
-    }
-    if (ctx->pkey_ctx) {
-        EVP_PKEY_CTX_free(ctx->pkey_ctx);
-        ctx->pkey_ctx = NULL;
     }
     return SOTER_SUCCESS;
 }

--- a/src/soter/openssl/soter_verify_ecdsa.c
+++ b/src/soter/openssl/soter_verify_ecdsa.c
@@ -30,58 +30,53 @@ soter_status_t soter_verify_init_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
                                                   const size_t public_key_length)
 {
     soter_status_t err = SOTER_FAIL;
-    EVP_PKEY* pkey = NULL;
 
-    pkey = EVP_PKEY_new();
-    if (!pkey) {
+    /* soter_sign_ctx_t should be initialized only once */
+    if (!ctx || ctx->pkey || ctx->md_ctx) {
+        return SOTER_INVALID_PARAMETER;
+    }
+
+    ctx->pkey = EVP_PKEY_new();
+    if (!ctx->pkey) {
         return SOTER_NO_MEMORY;
     }
 
-    if (!EVP_PKEY_set_type(pkey, EVP_PKEY_EC)) {
-        goto free_pkey;
-    }
-
-    ctx->pkey_ctx = EVP_PKEY_CTX_new(pkey, NULL);
-    if (!(ctx->pkey_ctx)) {
-        err = SOTER_NO_MEMORY;
+    if (EVP_PKEY_set_type(ctx->pkey, EVP_PKEY_EC) != 1) {
         goto free_pkey;
     }
 
     /* TODO: Review needed */
     if ((private_key) && (private_key_length)) {
-        err = soter_ec_import_key(pkey, private_key, private_key_length);
+        err = soter_ec_import_key(ctx->pkey, private_key, private_key_length);
         if (err != SOTER_SUCCESS) {
-            goto free_pkey_ctx;
+            goto free_pkey;
         }
     }
     if ((public_key) && (public_key_length)) {
-        err = soter_ec_import_key(pkey, public_key, public_key_length);
+        err = soter_ec_import_key(ctx->pkey, public_key, public_key_length);
         if (err != SOTER_SUCCESS) {
-            goto free_pkey_ctx;
+            goto free_pkey;
         }
     }
 
     ctx->md_ctx = EVP_MD_CTX_create();
     if (!(ctx->md_ctx)) {
         err = SOTER_NO_MEMORY;
-        goto free_pkey_ctx;
+        goto free_pkey;
     }
 
-    if (!EVP_DigestVerifyInit(ctx->md_ctx, NULL, EVP_sha256(), NULL, pkey)) {
+    if (EVP_DigestVerifyInit(ctx->md_ctx, NULL, EVP_sha256(), NULL, ctx->pkey) != 1) {
         goto free_md_ctx;
     }
 
-    EVP_PKEY_free(pkey);
     return SOTER_SUCCESS;
 
 free_md_ctx:
     EVP_MD_CTX_destroy(ctx->md_ctx);
     ctx->md_ctx = NULL;
-free_pkey_ctx:
-    EVP_PKEY_CTX_free(ctx->pkey_ctx);
-    ctx->pkey_ctx = NULL;
 free_pkey:
-    EVP_PKEY_free(pkey);
+    EVP_PKEY_free(ctx->pkey);
+    ctx->pkey = NULL;
     return err;
 }
 
@@ -89,7 +84,17 @@ soter_status_t soter_verify_update_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
                                                     const void* data,
                                                     const size_t data_length)
 {
-    if (!EVP_DigestVerifyUpdate(ctx->md_ctx, data, data_length)) {
+    if (!ctx || !ctx->pkey) {
+        return SOTER_INVALID_PARAMETER;
+    }
+    if (!data || data_length == 0) {
+        return SOTER_INVALID_PARAMETER;
+    }
+    if (EVP_PKEY_base_id(ctx->pkey) != EVP_PKEY_EC) {
+        return SOTER_INVALID_PARAMETER;
+    }
+
+    if (EVP_DigestVerifyUpdate(ctx->md_ctx, data, data_length) != 1) {
         return SOTER_FAIL;
     }
     return SOTER_SUCCESS;
@@ -100,23 +105,21 @@ soter_status_t soter_verify_final_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
                                                    const void* signature,
                                                    const size_t signature_length)
 {
-    if (!ctx) {
+    if (!ctx || !ctx->pkey) {
         return SOTER_INVALID_PARAMETER;
     }
-    EVP_PKEY* pkey = EVP_PKEY_CTX_get0_pkey(ctx->pkey_ctx);
-    if (!pkey) {
+    if (!signature || signature_length == 0) {
+        return SOTER_INVALID_PARAMETER;
+    }
+    if (EVP_PKEY_base_id(ctx->pkey) != EVP_PKEY_EC) {
         return SOTER_INVALID_PARAMETER;
     }
 
-    int res = EVP_DigestVerifyFinal(ctx->md_ctx, (unsigned char*)signature, signature_length);
-    switch (res) {
-    case 0:
-        return SOTER_INVALID_SIGNATURE;
-    case 1:
-        return SOTER_SUCCESS;
-    default:
+    if (EVP_DigestVerifyFinal(ctx->md_ctx, (unsigned char*)signature, signature_length) != 1) {
         return SOTER_INVALID_SIGNATURE;
     }
+
+    return SOTER_SUCCESS;
 }
 
 soter_status_t soter_verify_cleanup_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx)
@@ -124,13 +127,13 @@ soter_status_t soter_verify_cleanup_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx)
     if (!ctx) {
         return SOTER_INVALID_PARAMETER;
     }
+    if (ctx->pkey) {
+        EVP_PKEY_free(ctx->pkey);
+        ctx->pkey = NULL;
+    }
     if (ctx->md_ctx) {
         EVP_MD_CTX_destroy(ctx->md_ctx);
         ctx->md_ctx = NULL;
-    }
-    if (ctx->pkey_ctx) {
-        EVP_PKEY_CTX_free(ctx->pkey_ctx);
-        ctx->pkey_ctx = NULL;
     }
     return SOTER_SUCCESS;
 }

--- a/src/soter/openssl/soter_verify_rsa.c
+++ b/src/soter/openssl/soter_verify_rsa.c
@@ -30,65 +30,60 @@ soter_status_t soter_verify_init_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
                                                const size_t public_key_length)
 {
     soter_status_t err = SOTER_FAIL;
-    EVP_PKEY* pkey = NULL;
     EVP_PKEY_CTX* md_pkey_ctx = NULL;
 
-    pkey = EVP_PKEY_new();
-    if (!pkey) {
+    /* soter_sign_ctx_t should be initialized only once */
+    if (!ctx || ctx->pkey || ctx->md_ctx) {
+        return SOTER_INVALID_PARAMETER;
+    }
+
+    ctx->pkey = EVP_PKEY_new();
+    if (!ctx->pkey) {
         return SOTER_NO_MEMORY;
     }
 
-    if (!EVP_PKEY_set_type(pkey, EVP_PKEY_RSA)) {
-        goto free_pkey;
-    }
-
-    ctx->pkey_ctx = EVP_PKEY_CTX_new(pkey, NULL);
-    if (!(ctx->pkey_ctx)) {
-        err = SOTER_NO_MEMORY;
+    if (!EVP_PKEY_set_type(ctx->pkey, EVP_PKEY_RSA)) {
         goto free_pkey;
     }
 
     if (private_key && private_key_length != 0) {
-        err = soter_rsa_import_key(pkey, private_key, private_key_length);
+        err = soter_rsa_import_key(ctx->pkey, private_key, private_key_length);
         if (err != SOTER_SUCCESS) {
-            goto free_pkey_ctx;
+            goto free_pkey;
         }
     }
     if (public_key && public_key_length != 0) {
-        err = soter_rsa_import_key(pkey, public_key, public_key_length);
+        err = soter_rsa_import_key(ctx->pkey, public_key, public_key_length);
         if (err != SOTER_SUCCESS) {
-            goto free_pkey_ctx;
+            goto free_pkey;
         }
     }
 
     ctx->md_ctx = EVP_MD_CTX_create();
     if (!(ctx->md_ctx)) {
         err = SOTER_NO_MEMORY;
-        goto free_pkey_ctx;
+        goto free_pkey;
     }
 
     /* md_pkey_ctx is owned by ctx->md_ctx */
-    if (!EVP_DigestVerifyInit(ctx->md_ctx, &md_pkey_ctx, EVP_sha256(), NULL, pkey)) {
+    if (EVP_DigestVerifyInit(ctx->md_ctx, &md_pkey_ctx, EVP_sha256(), NULL, ctx->pkey) != 1) {
         goto free_md_ctx;
     }
-    if (!EVP_PKEY_CTX_set_rsa_padding(md_pkey_ctx, RSA_PKCS1_PSS_PADDING)) {
+    if (EVP_PKEY_CTX_set_rsa_padding(md_pkey_ctx, RSA_PKCS1_PSS_PADDING) != 1) {
         goto free_md_ctx;
     }
-    if (!EVP_PKEY_CTX_set_rsa_pss_saltlen(md_pkey_ctx, -2)) {
+    if (EVP_PKEY_CTX_set_rsa_pss_saltlen(md_pkey_ctx, -2) != 1) {
         goto free_md_ctx;
     }
 
-    EVP_PKEY_free(pkey);
     return SOTER_SUCCESS;
 
 free_md_ctx:
     EVP_MD_CTX_destroy(ctx->md_ctx);
     ctx->md_ctx = NULL;
-free_pkey_ctx:
-    EVP_PKEY_CTX_free(ctx->pkey_ctx);
-    ctx->pkey_ctx = NULL;
 free_pkey:
-    EVP_PKEY_free(pkey);
+    EVP_PKEY_free(ctx->pkey);
+    ctx->pkey = NULL;
     return err;
 }
 
@@ -96,7 +91,17 @@ soter_status_t soter_verify_update_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
                                                  const void* data,
                                                  const size_t data_length)
 {
-    if (!EVP_DigestVerifyUpdate(ctx->md_ctx, data, data_length)) {
+    if (!ctx || !ctx->pkey) {
+        return SOTER_INVALID_PARAMETER;
+    }
+    if (!data || data_length == 0) {
+        return SOTER_INVALID_PARAMETER;
+    }
+    if (EVP_PKEY_base_id(ctx->pkey) != EVP_PKEY_RSA) {
+        return SOTER_INVALID_PARAMETER;
+    }
+
+    if (EVP_DigestVerifyUpdate(ctx->md_ctx, data, data_length) != 1) {
         return SOTER_FAIL;
     }
     return SOTER_SUCCESS;
@@ -106,19 +111,23 @@ soter_status_t soter_verify_final_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
                                                 const void* signature,
                                                 const size_t signature_length)
 {
-    if (!ctx) {
+    if (!ctx || !ctx->pkey) {
         return SOTER_INVALID_PARAMETER;
     }
-    EVP_PKEY* pkey = EVP_PKEY_CTX_get0_pkey(ctx->pkey_ctx);
-    if (!pkey) {
+    if (!signature || signature_length == 0) {
         return SOTER_INVALID_PARAMETER;
     }
-    if (signature_length != (size_t)EVP_PKEY_size(pkey)) {
+    if (EVP_PKEY_base_id(ctx->pkey) != EVP_PKEY_RSA) {
+        return SOTER_INVALID_PARAMETER;
+    }
+
+    if (signature_length != (size_t)EVP_PKEY_size(ctx->pkey)) {
         return SOTER_FAIL;
     }
-    if (!EVP_DigestVerifyFinal(ctx->md_ctx, (unsigned char*)signature, signature_length)) {
+    if (EVP_DigestVerifyFinal(ctx->md_ctx, (unsigned char*)signature, signature_length) != 1) {
         return SOTER_FAIL;
     }
+
     return SOTER_SUCCESS;
 }
 
@@ -127,9 +136,9 @@ soter_status_t soter_verify_cleanup_rsa_pss_pkcs8(soter_sign_ctx_t* ctx)
     if (!ctx) {
         return SOTER_INVALID_PARAMETER;
     }
-    if (ctx->pkey_ctx) {
-        EVP_PKEY_CTX_free(ctx->pkey_ctx);
-        ctx->pkey_ctx = NULL;
+    if (ctx->pkey) {
+        EVP_PKEY_free(ctx->pkey);
+        ctx->pkey = NULL;
     }
     if (ctx->md_ctx) {
         EVP_MD_CTX_destroy(ctx->md_ctx);


### PR DESCRIPTION
Pull in the updates, YOLO.

If that does not work, [`man git-revert` on “How to revert a faulty merge”](https://github.com/git/git/blob/master/Documentation/howto/revert-a-faulty-merge.txt).

Make sure to merge this with a **merge commit**, _not squash_. Also, apparently we'd need to disable the linear history thing in branch protection to actually allow merge commits.

## Checklist

- [X] Change is covered by automated tests
- [X] ~~Benchmark results are attached~~ (people say OpenSSL 3.0 is slower, but here we don't care)
- [X] The [coding guidelines] are followed
- [X] ~~Example projects and code samples are up-to-date~~ (still using whatever they were using)
- [X] ~~Changelog is updated~~ (ninja change)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
