### PR TITLE
rust: Add Send bound to SecureSessionTransport trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 Changes that are currently in development and have not been released yet.
 
+_Code:_
+
+- **Rust**
+
+  - `SecureSessionTransport` implementations are now required to be `Send` ([#898](https://github.com/cossacklabs/themis/pull/898)).
+
+    This is technically a breaking change, but most reasonble implementations should be `Send` already. Please raise an issue if your code fails to build.
+
 
 ## [0.14.0](https://github.com/cossacklabs/themis/releases/tag/0.14.0), December 24th 2021
 

--- a/src/wrappers/themis/rust/src/secure_session.rs
+++ b/src/wrappers/themis/rust/src/secure_session.rs
@@ -147,6 +147,11 @@ struct SecureSessionContext {
 // state. However, it needs external synchronization for safe concurrent usage (hence no Sync).
 unsafe impl Send for SecureSession {}
 
+// secure_session_user_callbacks_t in SecureSessionContext holds a pointer to itself and thus
+// it is !Send by default. However, we keep SecureSessionContext in a box, pinned in memory,
+// and that pointer is the only extra reference.
+unsafe impl Send for SecureSessionContext {}
+
 /// Transport delegate for Secure Session.
 ///
 /// This is an interface you need to provide for Secure Session operation.

--- a/src/wrappers/themis/rust/src/secure_session.rs
+++ b/src/wrappers/themis/rust/src/secure_session.rs
@@ -157,7 +157,7 @@ unsafe impl Send for SecureSession {}
 ///
 /// [`get_public_key_for_id`]: trait.SecureSessionTransport.html#tymethod.get_public_key_for_id
 #[allow(unused_variables)]
-pub trait SecureSessionTransport {
+pub trait SecureSessionTransport: Send {
     /// Get a public key corresponding to a remote peer ID.
     ///
     /// Return `None` if you are unable to locate a public key corresponding to the provided ID.


### PR DESCRIPTION
New Clippy 1.58 has found an unsoundness in RustThemis: `unsafe impl` for `SecureSession` make it `Send` – safe to pass over to a different thread – but in fact it's not safe to do that unless `SecureSessionTransport` implementation used by `SecureSession` is also `Send`, which was expected but never required. Well, now it is required.

This would break application code that uses `SecureSessionTransport` implementations that are `!Send` (e.g., using `Rc` inside, or raw pointers). This is not safe if `SecureSession` is moved to another thread, but it should be okay if it stays on the same thread as its transport.

I believe that most applications will not be affected by this change. If someone is really out there using `!Send` transports, they'd come complaining, then I'd decide what to do: either tell them “you're doing it wrong”, or make a patch release that make it possible to `SecureSession` to be `!Send` as well.

For now, my goal is to fix a warning from Clippy on CI.

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
