### PR TITLE
jsthemis: Fix search paths on Apple M1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@
 Changes that are currently in development and have not been released yet.
 
 
+## [0.14.1](https://github.com/cossacklabs/themis/releases/tag/0.14.1), March 18th 2022
+
+**Hotfix for JsThemis on Apple M1**
+
+_Code:_
+
+- **Node.js**
+
+  - JsThemis now works with `libthemis` installed from Homebrew on Apple M1 ([#907](https://github.com/cossacklabs/themis/pull/907)).
+
+
 ## [0.14.0](https://github.com/cossacklabs/themis/releases/tag/0.14.0), December 24th 2021
 
 **TL;DR:**

--- a/src/wrappers/themis/jsthemis/binding.gyp
+++ b/src/wrappers/themis/jsthemis/binding.gyp
@@ -18,6 +18,11 @@
       ],
       "conditions": [
         [ "OS=='linux' or OS=='mac'", {
+          "include_dirs": [
+            "/opt/homebrew/include",
+            "/usr/local/include",
+            "/usr/include"
+          ],
           "libraries": [
             "-L/opt/homebrew/lib",
             "-L/usr/local/lib",

--- a/src/wrappers/themis/jsthemis/binding.gyp
+++ b/src/wrappers/themis/jsthemis/binding.gyp
@@ -19,6 +19,7 @@
       "conditions": [
         [ "OS=='linux' or OS=='mac'", {
           "libraries": [
+            "-L/opt/homebrew/lib",
             "-L/usr/local/lib",
             "-L/usr/lib",
             "-lsoter",

--- a/src/wrappers/themis/jsthemis/package-lock.json
+++ b/src/wrappers/themis/jsthemis/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "jsthemis",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.14.0",
+      "name": "jsthemis",
+      "version": "0.14.1",
       "license": "Apache-2.0",
       "dependencies": {
         "nan": "^2.14.0"

--- a/src/wrappers/themis/jsthemis/package.json
+++ b/src/wrappers/themis/jsthemis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsthemis",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Themis is a convenient cryptographic library for data protection.",
   "main": "build/Release/jsthemis.node",
   "scripts": {


### PR DESCRIPTION
Homebrew on Apple M1 installs its stuff in `/opt/homebrew` because they wanted clean breakage. And breakage they got. Reportedly, JsThemis fails to install on M1 as it does not look for `libthemis` where it should be.

Add M1 paths to search paths that GYP passes to compiler. Hopefully, that's all we need for now. After `jsthemis@0.14.1` is released, normal installation should work again:

```bash
brew tap cossacklabs/tap
brew install libthemis
npm install jsthemis
```

## Checklist

- [X] ~~Change is covered by automated tests~~ (not really, but you tried...)
- [X] The [coding guidelines] are followed
- [X] Changelog is updated (in case of notable or breaking changes)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
