### PR TITLE
pythemis: Populate `__all__` with all public modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ _Code:_
 
   - Node.js v8 is no longer supported ([#901](https://github.com/cossacklabs/themis/pull/901)).
 
+- **Python**
+
+  - `pythemis.scomparator` and `pythemis.skeygen` are now imported with `from pythemis import *` ([#914](https://github.com/cossacklabs/themis/pull/914)).
+
 - **Rust**
 
   - `SecureSessionTransport` implementations are now required to be `Send` ([#898](https://github.com/cossacklabs/themis/pull/898)).

--- a/src/wrappers/themis/python/pythemis/__init__.py
+++ b/src/wrappers/themis/python/pythemis/__init__.py
@@ -14,4 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__all__ = ["smessage", "scell", "ssession"]
+__all__ = [
+    "scell",
+    "scomparator",
+    "skeygen",
+    "smessage",
+    "ssession",
+]


### PR DESCRIPTION
This makes

```python
from pythemis import *
```

import all important modules into the scope, not some just of them.

`exception` is also sorta-kinda public, but users shouldn't really have a need for that by default, and it's a pretty generic name. You can still import it explicitly.

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
