### PR TITLE
pythemis: Extra effort to locate Themis Core library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ _Code:_
 - **Python**
 
   - `pythemis.scomparator` and `pythemis.skeygen` are now imported with `from pythemis import *` ([#914](https://github.com/cossacklabs/themis/pull/914)).
+  - Improved compatibility with non-Homebrew Python installations on Apple M1 ([#915](https://github.com/cossacklabs/themis/pull/915)).
 
 - **Rust**
 

--- a/src/wrappers/themis/python/pythemis/__init__.py
+++ b/src/wrappers/themis/python/pythemis/__init__.py
@@ -51,7 +51,7 @@ def _load_themis():
     for path in _canonical_themis_paths():
         try:
             return cdll.LoadLibrary(path)
-        except: # TODO
+        except OSError:
             continue
 
     warnings.warn("""failed to load the canonical Themis Core library

--- a/src/wrappers/themis/python/pythemis/__init__.py
+++ b/src/wrappers/themis/python/pythemis/__init__.py
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from ctypes import cdll
+from ctypes.util import find_library
+
 __all__ = [
     "scell",
     "scomparator",
@@ -21,3 +25,5 @@ __all__ = [
     "smessage",
     "ssession",
 ]
+
+themis = cdll.LoadLibrary(find_library('themis'))

--- a/src/wrappers/themis/python/pythemis/__init__.py
+++ b/src/wrappers/themis/python/pythemis/__init__.py
@@ -61,7 +61,12 @@ This might cause ABI mismatch and crash the process.
 """,
                   category=RuntimeWarning)
 
-    return cdll.LoadLibrary(find_library('themis'))
+    themis_path = find_library('themis')
+    # find_library() returns None on failure and LoadLibrary() would
+    # happily 'load' that. We kinda need the library, make it an error.
+    if not themis_path:
+        raise RuntimeError('failed to locate Themis Core library')
+    return cdll.LoadLibrary(themis_path)
 
 
 __all__ = [

--- a/src/wrappers/themis/python/pythemis/scell.py
+++ b/src/wrappers/themis/python/pythemis/scell.py
@@ -18,13 +18,11 @@
 import six
 import warnings
 
-from ctypes import cdll, c_int, byref, create_string_buffer, string_at
-from ctypes.util import find_library
+from ctypes import c_int, byref, create_string_buffer, string_at
 
+from . import themis
 from .exception import ThemisError
 from .exception import THEMIS_CODES
-
-themis = cdll.LoadLibrary(find_library('themis'))
 
 
 class SecureCellError(ThemisError):

--- a/src/wrappers/themis/python/pythemis/scomparator.py
+++ b/src/wrappers/themis/python/pythemis/scomparator.py
@@ -18,13 +18,10 @@
 
 import warnings
 import ctypes
-from ctypes.util import find_library
 from enum import IntEnum
 
-from . import exception
+from . import exception, themis
 from .exception import THEMIS_CODES
-
-themis = ctypes.cdll.LoadLibrary(find_library("themis"))
 
 themis.secure_comparator_get_result.restype = ctypes.c_int32
 

--- a/src/wrappers/themis/python/pythemis/scomparator.py
+++ b/src/wrappers/themis/python/pythemis/scomparator.py
@@ -21,7 +21,7 @@ import ctypes
 from ctypes.util import find_library
 from enum import IntEnum
 
-from . import exception as exception
+from . import exception
 from .exception import THEMIS_CODES
 
 themis = ctypes.cdll.LoadLibrary(find_library("themis"))

--- a/src/wrappers/themis/python/pythemis/skeygen.py
+++ b/src/wrappers/themis/python/pythemis/skeygen.py
@@ -14,12 +14,10 @@
 # limitations under the License.
 #
 import warnings
-from ctypes import cdll, c_int, create_string_buffer, byref, string_at
-from ctypes.util import find_library
+from ctypes import c_int, create_string_buffer, byref, string_at
 
+from . import themis
 from .exception import ThemisError, THEMIS_CODES
-
-themis = cdll.LoadLibrary(find_library('themis'))
 
 
 class KEY_PAIR_TYPE(object):

--- a/src/wrappers/themis/python/pythemis/smessage.py
+++ b/src/wrappers/themis/python/pythemis/smessage.py
@@ -14,13 +14,11 @@
 # limitations under the License.
 #
 import warnings
-from ctypes import cdll, create_string_buffer, c_int, string_at, byref
-from ctypes.util import find_library
+from ctypes import create_string_buffer, c_int, string_at, byref
 from enum import IntEnum
 
+from . import themis
 from .exception import ThemisError, THEMIS_CODES
-
-themis = cdll.LoadLibrary(find_library('themis'))
 
 
 class SMessage(object):

--- a/src/wrappers/themis/python/pythemis/ssession.py
+++ b/src/wrappers/themis/python/pythemis/ssession.py
@@ -21,7 +21,7 @@ from ctypes.util import find_library
 from collections import deque
 from abc import abstractmethod
 
-from . import exception as exception
+from . import exception
 from .exception import THEMIS_CODES, ThemisError
 
 themis = ctypes.cdll.LoadLibrary(find_library('themis'))

--- a/src/wrappers/themis/python/pythemis/ssession.py
+++ b/src/wrappers/themis/python/pythemis/ssession.py
@@ -17,14 +17,11 @@
 #
 import warnings
 import ctypes
-from ctypes.util import find_library
 from collections import deque
 from abc import abstractmethod
 
-from . import exception
+from . import exception, themis
 from .exception import THEMIS_CODES, ThemisError
-
-themis = ctypes.cdll.LoadLibrary(find_library('themis'))
 
 ON_GET_PUBLIC_KEY = ctypes.CFUNCTYPE(
     ctypes.c_int, ctypes.POINTER(ctypes.c_byte),


### PR DESCRIPTION
Put in some extra effort to locate the right native library.

- Look for `libthemis.so.0` or `libthemis.0.dylib` first.

  Instead of looking for *some* Themis Core, look for the one with the proper ABI version in it. First of all, this finally allows users to install only `libthemis` package, without `libthemis-dev`. Second, this prevents PyThemis from accidentally loading Themis 1.x or 2.x libraries, should they ever be co-installed in the system.

  `find_library('themis')` code path remains as a fallback on Linux and macOS, and it's also used on Windows by default. No idea whether PyThemis works there, but this PR should at least not make it worse.

- Look in some "standard" search paths as well.

  PyThemis expects Themis Core to be installed in one of the paths dynamic linker would be looking in. Normally, it all works out, but ~~on some 🌈 ｓｐｅｃｉａｌ 🦄 systems~~ Homebrew on Apple M1 installs libraries into `/opt/homebrew`, which – surprise! – is not in standard search paths when non-Homebrew Python is used.

  While arguably it's the user environment issue, Python developers are not very fond of debugging native library loading and that's PyThemis fault for requiring a native library in the first place, so let's at least attempt to make things "just work" before giving up.

  So on both Linux and macOS we'd be looking in `/usr/local/lib` where `make install` puts Themis Core, and on macOS we'd be looking in `/opt/homebrew/lib` just in case (on Intel CPUs Homebrew installs to `/usr/local/lib`).

Related issues:

- https://github.com/cossacklabs/themis/issues/913

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] Public API has proper documentation
- [X] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
