### PR TITLE
rbthemis: Extra effort to locate Themis Core library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ _Code:_
 
   - `pythemis.scomparator` and `pythemis.skeygen` are now imported with `from pythemis import *` ([#914](https://github.com/cossacklabs/themis/pull/914)).
 
+- **Ruby**
+
+  - Improved compatibility with non-standard installations on Apple M1 ([#917](https://github.com/cossacklabs/themis/pull/917)).
+
 - **Rust**
 
   - `SecureSessionTransport` implementations are now required to be `Send` ([#898](https://github.com/cossacklabs/themis/pull/898)).


### PR DESCRIPTION
Just like with PyThemis, migrate RbThemis to the same pattern of loading Themis Core library dynamically with more attention to versioning.

Detect the platform and load properly versioned libraries first, reducing the chance for an ABI mismatch. However, keep the `'themis'` as a fallback (and a default action for Windows).

Ruby's `ffi_lib` is in some ways more smart than Python's `find_library` (it supports Apple M1 by accident, for example) but in some ways it's also dumber. Don't depend on ffi's maintainers and hardcode a list of absolute paths to try first in attempt to make things "just work".

## Checklist

- [X] Change is covered by automated tests (kinda?)
- [X] The [coding guidelines] are followed
- [X] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md