### PR TITLE
Add ALLOW_MEMORY_GROWTH=1

### DIFF
--- a/src/wrappers/themis/wasm/wasmthemis.mk
+++ b/src/wrappers/themis/wasm/wasmthemis.mk
@@ -27,6 +27,7 @@ WASM_PACKAGE = $(BIN_PATH)/wasm-themis.tgz
 $(BIN_PATH)/libthemis.js: LDFLAGS += -s EXPORTED_RUNTIME_METHODS=@$(WASM_RUNTIME)
 $(BIN_PATH)/libthemis.js: LDFLAGS += -s ALLOW_TABLE_GROWTH
 $(BIN_PATH)/libthemis.js: LDFLAGS += -s MODULARIZE=1
+$(BIN_PATH)/libthemis.js: LDFLAGS += -s ALLOW_MEMORY_GROWTH=1
 # FIXME(ilammy, 2020-11-29): rely in EMSCRIPTEN_KEEPALIVE instead of LINKABLE
 # For some reason existing EMSCRIPTEN_KEEPALIVE macros do not work and without
 # LINKABLE flag wasm-ld ends up stripping *all* Themis functions from "*.wasm"


### PR DESCRIPTION
To Reproduce
Steps to reproduce the behavior:
Encrypt a large file like a video 20 MB using wasm-themis library. Runs out of memory buffer.

1) Convert File to Uint8 
2) Encrypt File using Secure Cell

```
const bytes = new Uint8Array(file.arrayBuffer());

let symmetricKey = new themis.SymmetricKey()

let sealCell = themis.SecureCellSeal.withKey(symmetricKey)

let contextImprintCell= themis.SecureCellContextImprint.withKey(symmetricKey);

let encryptedWithSeal = sealCell.encrypt(bytes); // this line causes issue
let context = Uint8Array(...)
let encryptedWithContextImprintCelll = contextImprintCell.encrypt(bytes,context); // the same issue
```
See the following error:
![image](https://user-images.githubusercontent.com/5740725/180587308-ca741dcc-3255-4759-adcc-1331888d7b7c.png)

Expected behavior
Encryption to work for files

OS: Windows
Hardware: not relevant browser computer
Themis version: 0.14.6
Installation way: npm 


suggested fix:
Add ALLOW_MEMORY_GROWTH=1 to fix the issue #928
