### PR TITLE
wasm: Upgrade ts-mocha 8 => 9

### DIFF
--- a/src/wrappers/themis/wasm/package-lock.json
+++ b/src/wrappers/themis/wasm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wasm-themis",
-  "version": "0.14.5",
+  "version": "0.14.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wasm-themis",
-      "version": "0.14.5",
+      "version": "0.14.6",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/emscripten": "^1.39.4",
@@ -14,7 +14,7 @@
         "@types/mocha": "^8.2.2",
         "@types/node": "^14.14.36",
         "mocha": "^9",
-        "ts-mocha": "^8.0.0",
+        "ts-mocha": "^9.0.2",
         "typescript": "^4.2.3"
       }
     },
@@ -1604,9 +1604,9 @@
       }
     },
     "node_modules/ts-mocha": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/ts-mocha/-/ts-mocha-8.0.0.tgz",
-      "integrity": "sha512-Kou1yxTlubLnD5C3unlCVO7nh0HERTezjoVhVw/M5S1SqoUec0WgllQvPk3vzPMc6by8m6xD1uR1yRf8lnVUbA==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/ts-mocha/-/ts-mocha-9.0.2.tgz",
+      "integrity": "sha512-WyQjvnzwrrubl0JT7EC1yWmNpcsU3fOuBFfdps30zbmFBgKniSaSOyZMZx+Wq7kytUs5CY+pEbSYEbGfIKnXTw==",
       "dev": true,
       "dependencies": {
         "ts-node": "7.0.1"
@@ -1619,6 +1619,9 @@
       },
       "optionalDependencies": {
         "tsconfig-paths": "^3.5.0"
+      },
+      "peerDependencies": {
+        "mocha": "^3.X.X || ^4.X.X || ^5.X.X || ^6.X.X || ^7.X.X || ^8.X.X || ^9.X.X"
       }
     },
     "node_modules/ts-node": {
@@ -3043,9 +3046,9 @@
       }
     },
     "ts-mocha": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/ts-mocha/-/ts-mocha-8.0.0.tgz",
-      "integrity": "sha512-Kou1yxTlubLnD5C3unlCVO7nh0HERTezjoVhVw/M5S1SqoUec0WgllQvPk3vzPMc6by8m6xD1uR1yRf8lnVUbA==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/ts-mocha/-/ts-mocha-9.0.2.tgz",
+      "integrity": "sha512-WyQjvnzwrrubl0JT7EC1yWmNpcsU3fOuBFfdps30zbmFBgKniSaSOyZMZx+Wq7kytUs5CY+pEbSYEbGfIKnXTw==",
       "dev": true,
       "requires": {
         "ts-node": "7.0.1",

--- a/src/wrappers/themis/wasm/package.json
+++ b/src/wrappers/themis/wasm/package.json
@@ -42,7 +42,7 @@
     "@types/mocha": "^8.2.2",
     "@types/node": "^14.14.36",
     "mocha": "^9",
-    "ts-mocha": "^8.0.0",
+    "ts-mocha": "^9.0.2",
     "typescript": "^4.2.3"
   }
 }


### PR DESCRIPTION
Apparently, 8.x has some issues with Node.js 16.x which I don't want to look into. Since this is a dev-dependency, whatever executes our tests is good enough.

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] ~~Changelog is updated~~ (nothing for users)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
