### PR TITLE
Add ALLOW_MEMORY_GROWTH=1

### DIFF
--- a/src/wrappers/themis/wasm/wasmthemis.mk
+++ b/src/wrappers/themis/wasm/wasmthemis.mk
@@ -27,6 +27,7 @@ WASM_PACKAGE = $(BIN_PATH)/wasm-themis.tgz
 $(BIN_PATH)/libthemis.js: LDFLAGS += -s EXPORTED_RUNTIME_METHODS=@$(WASM_RUNTIME)
 $(BIN_PATH)/libthemis.js: LDFLAGS += -s ALLOW_TABLE_GROWTH
 $(BIN_PATH)/libthemis.js: LDFLAGS += -s MODULARIZE=1
+$(BIN_PATH)/libthemis.js: LDFLAGS += -s ALLOW_MEMORY_GROWTH=1
 # FIXME(ilammy, 2020-11-29): rely in EMSCRIPTEN_KEEPALIVE instead of LINKABLE
 # For some reason existing EMSCRIPTEN_KEEPALIVE macros do not work and without
 # LINKABLE flag wasm-ld ends up stripping *all* Themis functions from "*.wasm"


### PR DESCRIPTION
As described in https://github.com/cossacklabs/themis/pull/929 this hotfix allowed to encrypt of large files such as 20Mb.  
I have tested it on macOS and M1Pro CPU. 
