### PR TITLE
hotfix wasm themis: rebuild wasm-themis with -O3 flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 Changes that are currently in development and have not been released yet.
 
+
+## [0.14.8](https://github.com/cossacklabs/themis/releases/tag/0.14.8), Aug 22th 2022
+
+Rebuild wasm-themis with optimization flag to make package smaller again.
+
+
 ## [0.14.7](https://github.com/cossacklabs/themis/releases/tag/0.14.7), Aug 12th 2022
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ Changes that are currently in development and have not been released yet.
 
 ## [0.14.8](https://github.com/cossacklabs/themis/releases/tag/0.14.8), Aug 22th 2022
 
-Rebuild wasm-themis with optimization flag to make package smaller again.
-
+**Rebuild wasm-themis with optimization flag to make package smaller again.
+([938](https://github.com/cossacklabs/themis/pull/938/)).**
 
 ## [0.14.7](https://github.com/cossacklabs/themis/releases/tag/0.14.7), Aug 12th 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,20 +15,22 @@ Changes that are currently in development and have not been released yet.
 
 ## [0.14.7](https://github.com/cossacklabs/themis/releases/tag/0.14.7), Aug 12th 2022
 
+### React Native Themis
 
 **Upgrade packages versions for security reasons in React Native Themis package.json
 ([934](https://github.com/cossacklabs/themis/pull/934/)).**
-
-
-**Fix the bug with encryption of large files
-([933](https://github.com/cossacklabs/themis/pull/933/)).**
-
-- Added option to build WASM file.
 
 **Resolve the issue in React Native Themis to support Javascript exceptions
 ([930](https://github.com/cossacklabs/themis/pull/930/))**
 
 - Define additional checks to generate Javascript exceptions in case of empty required parameters.
+
+### WASM Themis
+
+**Fix the bug with encryption of large files
+([933](https://github.com/cossacklabs/themis/pull/933/)).**
+
+- Added option to build WASM file.
 
 
 ## [0.14.6](https://github.com/cossacklabs/themis/releases/tag/0.14.6), May 24th 2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ Changes that are currently in development and have not been released yet.
 
 ## [0.14.8](https://github.com/cossacklabs/themis/releases/tag/0.14.8), Aug 22th 2022
 
-**Rebuild wasm-themis with optimization flag to make package smaller again.
-([938](https://github.com/cossacklabs/themis/pull/938/)).**
+### WASM Themis
+
+- Rebuild wasm-themis with optimization flag to make package smaller again.
+([938](https://github.com/cossacklabs/themis/pull/938/)).
+
 
 ## [0.14.7](https://github.com/cossacklabs/themis/releases/tag/0.14.7), Aug 12th 2022
 

--- a/src/wrappers/themis/wasm/package-lock.json
+++ b/src/wrappers/themis/wasm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wasm-themis",
-  "version": "0.14.5",
+  "version": "0.14.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wasm-themis",
-      "version": "0.14.5",
+      "version": "0.14.7",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/emscripten": "^1.39.4",

--- a/src/wrappers/themis/wasm/package.json
+++ b/src/wrappers/themis/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wasm-themis",
-  "version": "0.14.7",
+  "version": "0.14.8",
   "description": "Themis is a convenient cryptographic library for data protection.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/wrappers/themis/wasm/wasmthemis.mk
+++ b/src/wrappers/themis/wasm/wasmthemis.mk
@@ -39,9 +39,7 @@ $(BIN_PATH)/libthemis.js: LDFLAGS += -s LINKABLE=1
 # does not use are missing the from the binary. Suppress the warnings.
 $(BIN_PATH)/libthemis.js: LDFLAGS += -s ERROR_ON_UNDEFINED_SYMBOLS=0
 $(BIN_PATH)/libthemis.js: LDFLAGS += --pre-js $(WASM_PRE_JS)
-
 $(BIN_PATH)/libthemis.js: CMD = $(CC) -o $@ $(filter %.o %a, $^) -O3 $(LDFLAGS)
-
 $(BIN_PATH)/libthemis.js: $(THEMIS_STATIC) $(WASM_RUNTIME) $(WASM_PRE_JS)
 	@mkdir -p $(@D)
 	@echo -n "link "


### PR DESCRIPTION
Previously I removed -O3 flag to make the code readable and ready to debug. I remember to return the flag but forgot to rebuild the package. Mea culpa. I return the flag and rebuild the package. 