### PR TITLE
hotfix: told zip to store symlinks as required by Apple guide

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,11 +15,11 @@ let package = Package(
     targets: [
         .binaryTarget(name: "themis",
                       // update version in URL path
-                      url: "https://github.com/cossacklabs/themis/releases/download/0.13.12/themis.xcframework.zip",
+                      url: "https://github.com/cossacklabs/themis/releases/download/0.14.10/themis.xcframework.zip",
                       // The scripts/create_xcframework.sh calculates the checksum when generating the XCF.
                       // Alternatively, run from package directory:
                       // swift package compute-checksum build/xcf_output/themis.xcframework.zip
-                      checksum: "c74f65d4918884220efe99c3195001fa8aabc8030ad85f8ef30d2bfed11065a3"),
+                      checksum: "9f0f3407c6713962074e264cc1a6184c55304d87626df50117448eea55444b89"),
 
     ]
 )

--- a/scripts/create_xcframeworks.sh
+++ b/scripts/create_xcframeworks.sh
@@ -61,7 +61,8 @@ rm -rf $output_dir/macosx
 # zip the xcodeframework
 # SPM accepts binary targets only in zip format
 cd $output_dir
-zip -r themis.xcframework.zip themis.xcframework
+# -y flag stores symlink instead of followed file 
+zip -r -y themis.xcframework.zip themis.xcframework
 
 rm -rf themis.xcframework
 


### PR DESCRIPTION
I have investigated the issues and found that themis.framework.zip which is located in "releases/0.13.12/download" section is incorrect for macOS. Part of the structure for macOS platforms contains regular files, not symlinks. The zip command needs the additional option "-y" to store symlinks.  
I made a new themis.framework.zip and am ready to upload to GitHub immediately after release/hotfix 0.14.10 
