### PR TITLE
Add pythemis_uninstall target to Makefile. Fixes #948

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -611,6 +611,13 @@ endif
 	@echo -n "pythemis install "
 	@$(BUILD_CMD_)
 
+pythemis_uninstall: CMD = cd src/wrappers/themis/python/ && xargs rm -rf < files3.txt
+pythemis_uninstall:
+	@echo -n "pythemis uninstall "
+	@$(BUILD_CMD_)
+
+uninstall: pythemis_uninstall
+
 ########################################################################
 #
 # Packaging Themis Core: Linux distributions


### PR DESCRIPTION
Added a `pythemis_uninstall` target to `Makefile`.

## Checklist

- [x] The [coding guidelines] are followed

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
