### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Read about [Apple export regulations on cryptography for Themis](https://docs.co
 
 Each change in Themis core library is being reviewed and approved by our internal team of cryptographers and security engineers. For every release, we perform internal audits by cryptographers who don't work on Themis.
 
-We use a lot of automated security testing, i.e. static code analyzers, fuzzing tools, memory analyzers, unit tests (per each platform), integration tests (to find compatibility issues between different Themis-supported languages, OS and x86/x64 architectures). Read more about our security testing practices in [Themis security docs](https://docs.cossacklabs.com/themis/security/).
+We use a lot of automated security testing, i.e. static code analysers, fuzzing tools, memory analysers, unit tests (per each platform), integration tests (to find compatibility issues between different Themis-supported languages, OS and x86/x64 architectures). Read more about our security testing practices in [Themis security docs](https://docs.cossacklabs.com/themis/security/).
 
 If you believe that you've found a security-related issue, please drop us an email to [dev@cossacklabs.com](mailto:dev@cossacklabs.com). Bug bounty program may apply.
 

--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ Themis helps to build both simple and complex cryptographic features easily, qui
 
 * **Encrypt sensitive data fields** before storing in database (_"application-side field-level encryption"_).
 
-* Support **searchable encryption**, data tokenisation and data masking using Themis and [Acra](https://www.cossacklabs.com/acra/).
+* Support **searchable encryption**, data tokenization and data masking using Themis and [Acra](https://www.cossacklabs.com/acra/).
 
 * Exchange secrets securely: **share sensitive data** between parties, build simple chat app between patients and doctors.
 
-* Build **end-to-end encryption schemes** with centralised or decentralised architecture: encrypt data locally on one app, use it encrypted everywhere, decrypt only for authenticated user.
+* Build **end-to-end encryption schemes** with centralized or decentralized architecture: encrypt data locally on one app, use it encrypted everywhere, decrypt only for authenticated user.
 
 * Maintain **real-time secure sessions**: send encrypted messages to control connected devices from your app, receive real-time sensitive data from your apps to your backend.
 
@@ -121,7 +121,7 @@ Refer to the documentation to learn more about:
 
 # Cryptography
 
-Themis relies on proven cryptographic algorithms implemented by well-known cryptography libraries such as OpenSSL, LibreSSL, BoringSSL. Refer to [Cryptograhy in Themis](https://docs.cossacklabs.com/themis/crypto-theory/) docs to learn more.
+Themis relies on proven cryptographic algorithms implemented by well-known cryptography libraries such as OpenSSL, LibreSSL, BoringSSL. Refer to [Cryptography in Themis](https://docs.cossacklabs.com/themis/crypto-theory/) docs to learn more.
 
 
 This distribution includes cryptographic software. The country in which you currently reside may have restrictions on the import, possession, use, and/or re-export to another country, of encryption software. BEFORE using any encryption software, please check your country's laws, regulations, and policies concerning the import, possession, or use, and re-export of encryption software, to see if this is permitted. See http://www.wassenaar.org/ for more information.
@@ -138,7 +138,7 @@ Read about [Apple export regulations on cryptography for Themis](https://docs.co
 
 Each change in Themis core library is being reviewed and approved by our internal team of cryptographers and security engineers. For every release, we perform internal audits by cryptographers who don't work on Themis.
 
-We use a lot of automated security testing, i.e. static code analysers, fuzzing tools, memory analysers, unit tests (per each platform), integration tests (to find compatibility issues between different Themis-supported languages, OS and x86/x64 architectures). Read more about our security testing practices in [Themis security docs](https://docs.cossacklabs.com/themis/security/).
+We use a lot of automated security testing, i.e. static code analyzers, fuzzing tools, memory analyzers, unit tests (per each platform), integration tests (to find compatibility issues between different Themis-supported languages, OS and x86/x64 architectures). Read more about our security testing practices in [Themis security docs](https://docs.cossacklabs.com/themis/security/).
 
 If you believe that you've found a security-related issue, please drop us an email to [dev@cossacklabs.com](mailto:dev@cossacklabs.com). Bug bounty program may apply.
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Themis helps to build both simple and complex cryptographic features easily, qui
 
 * Exchange secrets securely: **share sensitive data** between parties, build simple chat app between patients and doctors.
 
-* Build **end-to-end encryption schemes** with centralized or decentralized architecture: encrypt data locally on one app, use it encrypted everywhere, decrypt only for authenticated user.
+* Build **end-to-end encryption schemes** with centralised or decentralised architecture: encrypt data locally on one app, use it encrypted everywhere, decrypt only for authenticated user.
 
 * Maintain **real-time secure sessions**: send encrypted messages to control connected devices from your app, receive real-time sensitive data from your apps to your backend.
 

--- a/docs/examples/react-native/react-native-example/App.js
+++ b/docs/examples/react-native/react-native-example/App.js
@@ -108,7 +108,7 @@ const App: () => Node = () => {
     console.log("==> Cat <==:", buf);
     // End of converting example
 
-    // Async Themis keyPair64 example. It resolves with asymmetric keypair anyway.
+    // Async Themis keyPair64 example. It resolves with asymmetric key pair anyway.
     // Always return base64 encoded strings
     keyPair64(KEYTYPE_EC)
       .then((pair: any) => {

--- a/gothemis/keys/keypair.go
+++ b/gothemis/keys/keypair.go
@@ -76,7 +76,7 @@ const (
 // Errors returned by key generation.
 var (
 	ErrGetKeySize       = errors.New("failed to get needed key sizes")
-	ErrGenerateKeypair  = errors.New("failed to generate keypair")
+	ErrGenerateKeypair  = errors.New("failed to generate key pair")
 	ErrInvalidType      = errors.NewWithCode(errors.InvalidParameter, "invalid key type specified")
 	ErrOutOfMemory      = errors.NewWithCode(errors.NoMemory, "key generator cannot allocate enough memory")
 	// Deprecated: Since 0.14. Use ErrOutOfMemory instead.

--- a/include/soter/soter_asym_cipher.h
+++ b/include/soter/soter_asym_cipher.h
@@ -47,12 +47,12 @@ typedef enum soter_asym_cipher_padding_type soter_asym_cipher_padding_t;
 typedef struct soter_asym_cipher_type soter_asym_cipher_t;
 
 /**
- * @brief create asymmetric encription/decription context
+ * @brief create asymmetric encryption/decryption context
  * @param [in] key cipher key. If key point to public key soter_asym_cipher_create return pointer to
- * encrypter object. Owervise will return pointer to decrypter object.
+ * encrypter object. Otherwise will return pointer to decrypter object.
  * @param [in] key_length length of key
  * @param [in] pad padding algorithm to be used. See @ref soter_asym_cipher_padding_type
- * @return pointer to created asymmetric encription/decription context on success or NULL on failure
+ * @return pointer to created asymmetric encryption/decryption context on success or NULL on failure
  */
 SOTER_API
 soter_asym_cipher_t* soter_asym_cipher_create(const void* key,
@@ -61,16 +61,16 @@ soter_asym_cipher_t* soter_asym_cipher_create(const void* key,
 
 /**
  * @brief encrypt data
- * @param [in] asym_cipher_ctx pointer to asymmetric encription/decription context previously
+ * @param [in] asym_cipher_ctx pointer to asymmetric encryption/decryption context previously
  * created by soter_asym_cipher_create
  * @param [in] plain_data data to encrypt
  * @param [in] plain_data_length length of plain_data
  * @param [out] cipher_data buffer for cipher data store. May be set to NULL for cipher data length
  * determination
  * @param [in, out] cipher_data_length length of cipher_data
- * @return result of operation, @ref SOTER_SUCESS on success or @ref SOTER_FAIL on failure
- * @note If cipher_data==NULL or cipher_data_length less then need to store cipher data, @ref
- * SOTER_BUFFER_TOO_SMALL will return and cipher_data_length will contain length of buffer thet need
+ * @return result of operation, @ref SOTER_SUCCESS on success or @ref SOTER_FAIL on failure
+ * @note If cipher_data==NULL or cipher_data_length less then needed to store cipher data, @ref
+ * SOTER_BUFFER_TOO_SMALL will return and cipher_data_length will contain length of buffer needed
  * to store cipher data.
  */
 SOTER_API
@@ -82,16 +82,16 @@ soter_status_t soter_asym_cipher_encrypt(soter_asym_cipher_t* asym_cipher_ctx,
 
 /**
  * @brief decrypt data
- * @param [in] asym_cipher_ctx pointer to asymmetric encription/decription context previously
+ * @param [in] asym_cipher_ctx pointer to asymmetric encryption/decryption context previously
  * created by soter_asym_cipher_create
  * @param [in] cipher_data data to decrypt
  * @param [in] cipher_data_length length of cipher_data
  * @param [out] plain_data buffer for plain data store. May be set to NULL for plain data length
  * determination
  * @param [in, out] plain_data_length length of plain_data
- * @return result of operation, @ref SOTER_SUCESS on success or @ref SOTER_FAIL on failure
+ * @return result of operation, @ref SOTER_SUCCESS on success or @ref SOTER_FAIL on failure
  * @note If plain_data==NULL or plain_data_length less then need to store plain data, @ref
- * SOTER_BUFFER_TOO_SMALL will return and plain_data_length will contain length of buffer thet need
+ * SOTER_BUFFER_TOO_SMALL will return and plain_data_length will contain length of buffer needed
  * to store plain data.
  */
 SOTER_API
@@ -102,21 +102,21 @@ soter_status_t soter_asym_cipher_decrypt(soter_asym_cipher_t* asym_cipher_ctx,
                                          size_t* plain_data_length);
 
 /**
- * @brief import key to asymmetric encription/decription context
- * @param [in] asym_cipher_ctx pointer to asymmetric encription/decription context previously
+ * @brief import key to asymmetric encryption/decryption context
+ * @param [in] asym_cipher_ctx pointer to asymmetric encryption/decryption context previously
  * created by soter_asym_cipher_create
  * @param [in] key buffer with stored key
  * @param [in] key_length length of key
- * @return result of operation, @ref SOTER_SUCESS on success or @ref SOTER_FAIL on failure
+ * @return result of operation, @ref SOTER_SUCCESS on success or @ref SOTER_FAIL on failure
  */
 // soter_status_t soter_asym_cipher_import_key(soter_asym_cipher_t* asym_cipher_ctx, const void*
 // key, size_t key_length);
 
 /**
- * @brief destroy asymmetric encription/decription context
- * @param [in] asym_cipher_ctx pointer to asymmetric encription/decription context previously
+ * @brief destroy asymmetric encryption/decryption context
+ * @param [in] asym_cipher_ctx pointer to asymmetric encryption/decryption context previously
  * created by soter_asym_cipher_create
- * @return result of operation, @ref SOTER_SUCESS on success or @ref SOTER_FAIL on failure
+ * @return result of operation, @ref SOTER_SUCCESS on success or @ref SOTER_FAIL on failure
  */
 SOTER_API
 soter_status_t soter_asym_cipher_destroy(soter_asym_cipher_t* asym_cipher_ctx);

--- a/include/soter/soter_asym_cipher.h
+++ b/include/soter/soter_asym_cipher.h
@@ -90,7 +90,7 @@ soter_status_t soter_asym_cipher_encrypt(soter_asym_cipher_t* asym_cipher_ctx,
  * determination
  * @param [in, out] plain_data_length length of plain_data
  * @return result of operation, @ref SOTER_SUCCESS on success or @ref SOTER_FAIL on failure
- * @note If plain_data==NULL or plain_data_length less then need to store plain data, @ref
+ * @note If plain_data==NULL or plain_data_length less than needed to store plain data, @ref
  * SOTER_BUFFER_TOO_SMALL will return and plain_data_length will contain length of buffer needed
  * to store plain data.
  */

--- a/include/soter/soter_asym_cipher.h
+++ b/include/soter/soter_asym_cipher.h
@@ -69,7 +69,7 @@ soter_asym_cipher_t* soter_asym_cipher_create(const void* key,
  * determination
  * @param [in, out] cipher_data_length length of cipher_data
  * @return result of operation, @ref SOTER_SUCCESS on success or @ref SOTER_FAIL on failure
- * @note If cipher_data==NULL or cipher_data_length less then needed to store cipher data, @ref
+ * @note If cipher_data==NULL or cipher_data_length less than needed to store cipher data, @ref
  * SOTER_BUFFER_TOO_SMALL will return and cipher_data_length will contain length of buffer needed
  * to store cipher data.
  */

--- a/include/soter/soter_asym_ka.h
+++ b/include/soter/soter_asym_ka.h
@@ -66,7 +66,7 @@ soter_status_t soter_asym_ka_gen_key(soter_asym_ka_t* asym_ka_ctx);
  * @param [in,out] key_length length of key. May be set to NULL for key length determination
  * @param [in] isprivate if set private key will be exported. If not set public key will be exported
  * @return result of operation, @ref  SOTER_SUCCESS on success or @ref SOTER_FAIL on failure
- * @note If key==NULL or key_length less then need to store key, @ref SOTER_BUFFER_TOO_SMALL will
+ * @note If key==NULL or key_length less than needed to store key, @ref SOTER_BUFFER_TOO_SMALL will
  * return and key_length will contain length of buffer needed to store key.
  */
 SOTER_API
@@ -96,7 +96,7 @@ soter_status_t soter_asym_ka_import_key(soter_asym_ka_t* asym_ka_ctx, const void
  * length determination
  * @param [in,out] shared_secret_length length of shared secret
  * @return result of operation, @ref SOTER_SUCCESS on success or @ref SOTER_FAIL on failure
- * @note If shared_secret==NULL or shared_secret_length less then need to store shared secret, @ref
+ * @note If shared_secret==NULL or shared_secret_length less than needed to store shared secret, @ref
  * SOTER_BUFFER_TOO_SMALL will return and shared_secret_length will contain length of buffer needed
  * to store shared secret.
  */

--- a/include/soter/soter_asym_ka.h
+++ b/include/soter/soter_asym_ka.h
@@ -36,7 +36,7 @@ enum soter_asym_ka_alg_type {
     SOTER_ASYM_KA_EC_P256 /**< elliptic curve 256 */
 };
 
-/** @brief key agreement algorims typedef */
+/** @brief key agreement algorithms typedef */
 typedef enum soter_asym_ka_alg_type soter_asym_ka_alg_t;
 
 /** @brief key agreement context typedef */
@@ -53,7 +53,7 @@ soter_asym_ka_t* soter_asym_ka_create(soter_asym_ka_alg_t alg);
  * @brief asymmetric keys pair generation for key agreement context
  * @param [in] asym_ka_ctx pointer to key agreement context previously created by
  * soter_asym_ka_create
- * @return result of operation, @ref SOTER_SUCESS on success or @ref SOTER_FAIL on failure
+ * @return result of operation, @ref SOTER_SUCCESS on success or @ref SOTER_FAIL on failure
  */
 SOTER_API
 soter_status_t soter_asym_ka_gen_key(soter_asym_ka_t* asym_ka_ctx);
@@ -65,9 +65,9 @@ soter_status_t soter_asym_ka_gen_key(soter_asym_ka_t* asym_ka_ctx);
  * @param [out] key buffer to store exported key
  * @param [in,out] key_length length of key. May be set to NULL for key length determination
  * @param [in] isprivate if set private key will be exported. If not set public key will be exported
- * @return result of operation, @ref  SOTER_SUCESS on success or @ref SOTER_FAIL on failure
+ * @return result of operation, @ref  SOTER_SUCCESS on success or @ref SOTER_FAIL on failure
  * @note If key==NULL or key_length less then need to store key, @ref SOTER_BUFFER_TOO_SMALL will
- * return and key_length will contain length of buffer thet need to store key.
+ * return and key_length will contain length of buffer needed to store key.
  */
 SOTER_API
 soter_status_t soter_asym_ka_export_key(soter_asym_ka_t* asym_ka_ctx,
@@ -81,7 +81,7 @@ soter_status_t soter_asym_ka_export_key(soter_asym_ka_t* asym_ka_ctx,
  * soter_asym_ka_create
  * @param [in] key buffer with stored key
  * @param [in] key_length length of key
- * @return result of operation, @ref SOTER_SUCESS on success or @ref SOTER_FAIL on failure
+ * @return result of operation, @ref SOTER_SUCCESS on success or @ref SOTER_FAIL on failure
  */
 SOTER_API
 soter_status_t soter_asym_ka_import_key(soter_asym_ka_t* asym_ka_ctx, const void* key, size_t key_length);
@@ -95,10 +95,10 @@ soter_status_t soter_asym_ka_import_key(soter_asym_ka_t* asym_ka_ctx, const void
  * @param [out] shared_secret buffer to store shared secret. May be set to NULL for shared secret
  * length determination
  * @param [in,out] shared_secret_length length of shared secret
- * @return result of operation, @ref SOTER_SUCESS on success or @ref SOTER_FAIL on failure
+ * @return result of operation, @ref SOTER_SUCCESS on success or @ref SOTER_FAIL on failure
  * @note If shared_secret==NULL or shared_secret_length less then need to store shared secret, @ref
- * SOTER_BUFFER_TOO_SMALL will return and shared_secret_length will contain length of buffer thet
- * need to store shared secret.
+ * SOTER_BUFFER_TOO_SMALL will return and shared_secret_length will contain length of buffer needed
+ * to store shared secret.
  */
 SOTER_API
 soter_status_t soter_asym_ka_derive(soter_asym_ka_t* asym_ka_ctx,
@@ -111,7 +111,7 @@ soter_status_t soter_asym_ka_derive(soter_asym_ka_t* asym_ka_ctx,
  * @brief destroy key agreement context
  * @param [in] asym_ka_ctx pointer to key agreement context previously created by
  * soter_asym_ka_create
- * @return result of operation, @ref SOTER_SUCESS on success or @ref SOTER_FAIL on failure
+ * @return result of operation, @ref SOTER_SUCCESS on success or @ref SOTER_FAIL on failure
  */
 SOTER_API
 soter_status_t soter_asym_ka_destroy(soter_asym_ka_t* asym_ka_ctx);

--- a/include/soter/soter_asym_sign.h
+++ b/include/soter/soter_asym_sign.h
@@ -82,7 +82,7 @@ soter_status_t soter_sign_update(soter_sign_ctx_t* ctx, const void* data, size_t
  * @param [in, out] signature_length length of signature
  * @return result of operation, @ref SOTER_SUCCESS on success or SOTER_FAIL on failure
  * @note If signature==NULL or signature_length less then need to store signature, @ref
- * SOTER_BUFFER_TOO_SMALL will return and signature_length will contain length of buffer thet need
+ * SOTER_BUFFER_TOO_SMALL will return and signature_length will contain length of buffer needed
  * to store signature.
  */
 SOTER_API
@@ -93,9 +93,9 @@ soter_status_t soter_sign_final(soter_sign_ctx_t* ctx, void* signature, size_t* 
  * @param [out] key buffer to store exported key
  * @param [in,out] key_length length of key. May be set to NULL for key length determination
  * @param [in] isprivate if set private key will be exported. If not set public key will be exported
- * @return result of operation, @ref SOTER_SUCESS on success or @ref SOTER_FAIL on failure
+ * @return result of operation, @ref SOTER_SUCCESS on success or @ref SOTER_FAIL on failure
  * @note If key==NULL or key_length less then need to store key, @ref SOTER_BUFFER_TOO_SMALL will
- * return and key_length will contain length of buffer thet need to store key.
+ * return and key_length will contain length of buffer needed to store key.
  */
 SOTER_API
 soter_status_t soter_sign_export_key(soter_sign_ctx_t* ctx, void* key, size_t* key_length, bool isprivate);

--- a/include/soter/soter_asym_sign.h
+++ b/include/soter/soter_asym_sign.h
@@ -81,7 +81,7 @@ soter_status_t soter_sign_update(soter_sign_ctx_t* ctx, const void* data, size_t
  * determination
  * @param [in, out] signature_length length of signature
  * @return result of operation, @ref SOTER_SUCCESS on success or SOTER_FAIL on failure
- * @note If signature==NULL or signature_length less then need to store signature, @ref
+ * @note If signature==NULL or signature_length less than needed to store signature, @ref
  * SOTER_BUFFER_TOO_SMALL will return and signature_length will contain length of buffer needed
  * to store signature.
  */
@@ -94,7 +94,7 @@ soter_status_t soter_sign_final(soter_sign_ctx_t* ctx, void* signature, size_t* 
  * @param [in,out] key_length length of key. May be set to NULL for key length determination
  * @param [in] isprivate if set private key will be exported. If not set public key will be exported
  * @return result of operation, @ref SOTER_SUCCESS on success or @ref SOTER_FAIL on failure
- * @note If key==NULL or key_length less then need to store key, @ref SOTER_BUFFER_TOO_SMALL will
+ * @note If key==NULL or key_length less than needed to store key, @ref SOTER_BUFFER_TOO_SMALL will
  * return and key_length will contain length of buffer needed to store key.
  */
 SOTER_API

--- a/include/soter/soter_hash.h
+++ b/include/soter/soter_hash.h
@@ -116,7 +116,7 @@ soter_status_t soter_hash_update(soter_hash_ctx_t* hash_ctx, const void* data, s
  * value length determination
  * @param [in, out] hash_length length of hash_value buffer
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure.
- * @note If hash_value==NULL or hash_length less then need to store hash value, @ref
+ * @note If hash_value==NULL or hash_length less than needed to store hash value, @ref
  * SOTER_BUFFER_TOO_SMALL will return and hash_length will contain length of buffer thet need to
  * store hash value.
  */

--- a/include/soter/soter_hash.h
+++ b/include/soter/soter_hash.h
@@ -83,14 +83,14 @@ typedef struct soter_hash_ctx_type soter_hash_ctx_t;
 /**
  * @brief creating of hash context
  * @param [in] algo hash algorithm to be used; see @ref soter_hash_algo_type
- * @return pointer to hash context on sussecc and  NULL on failure
+ * @return pointer to hash context on success and  NULL on failure
  */
 SOTER_API
 soter_hash_ctx_t* soter_hash_create(soter_hash_algo_t algo);
 
 /**
  * @brief destroy hash context
- * @param [in] hash_ctx pointer to hash context previosly created by @ref soter_hash_create
+ * @param [in] hash_ctx pointer to hash context previously created by @ref soter_hash_create
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure
  */
 SOTER_API
@@ -101,7 +101,7 @@ soter_status_t soter_hash_cleanup(soter_hash_ctx_t* hash_ctx);
 
 /**
  * @brief update hash context with data
- * @param [in] hash_ctx pointer to hash context previosly created by @ref soter_hash_create
+ * @param [in] hash_ctx pointer to hash context previously created by @ref soter_hash_create
  * @param [in] data pointer to buffer with data to hash update
  * @param [in] length of data buffer
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure
@@ -111,7 +111,7 @@ soter_status_t soter_hash_update(soter_hash_ctx_t* hash_ctx, const void* data, s
 
 /**
  * @brief final hash context and get hash value
- * @param [in] hash_ctx pointer to hash context previosly created by @ref soter_hash_create
+ * @param [in] hash_ctx pointer to hash context previously created by @ref soter_hash_create
  * @param [out] hash_value pointer to buffer for hash value retrieve, may be set to NULL for hash
  * value length determination
  * @param [in, out] hash_length length of hash_value buffer

--- a/include/soter/soter_hmac.h
+++ b/include/soter/soter_hmac.h
@@ -69,14 +69,14 @@ typedef struct soter_hmac_ctx_type soter_hmac_ctx_t;
 /**
  * @brief creating of HMAC context
  * @param [in] algo hash algorithm to be used; see @ref soter_hash_algo_type
- * @return pointer to HMAC context on sussecc and  NULL on failure
+ * @return pointer to HMAC context on success and  NULL on failure
  */
 SOTER_API
 soter_hmac_ctx_t* soter_hmac_create(soter_hash_algo_t algo, const uint8_t* key, size_t key_length);
 
 /**
  * @brief destroy HMAC context
- * @param [in] hmac_ctx pointer to HMAC context previosly created by @ref soter_hmac_create
+ * @param [in] hmac_ctx pointer to HMAC context previously created by @ref soter_hmac_create
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure
  */
 SOTER_API
@@ -84,7 +84,7 @@ soter_status_t soter_hmac_destroy(soter_hmac_ctx_t* hmac_ctx);
 
 /**
  * @brief update HMAC context with data
- * @param [in] hmac_ctx pointer to HMAC context previosly created by @ref soter_hmac_create
+ * @param [in] hmac_ctx pointer to HMAC context previously created by @ref soter_hmac_create
  * @param [in] data pointer to buffer with data to HMAC update
  * @param [in] length of data buffer
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure
@@ -94,7 +94,7 @@ soter_status_t soter_hmac_update(soter_hmac_ctx_t* hmac_ctx, const void* data, s
 
 /**
  * @brief final HMAC context and get hash value
- * @param [in] hmac_ctx pointer to hash context previosly created by @ref soter_hmac_create
+ * @param [in] hmac_ctx pointer to hash context previously created by @ref soter_hmac_create
  * @param [out] hmac_value pointer to buffer for HMAC value retrieve, may be set to NULL for HMAC
  * value length determination
  * @param [in, out] hmac_length length of hmac_value buffer

--- a/include/soter/soter_hmac.h
+++ b/include/soter/soter_hmac.h
@@ -99,7 +99,7 @@ soter_status_t soter_hmac_update(soter_hmac_ctx_t* hmac_ctx, const void* data, s
  * value length determination
  * @param [in, out] hmac_length length of hmac_value buffer
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure.
- * @note If hmac_value==NULL or hmac_length less then need to store HMAC value, @ref
+ * @note If hmac_value==NULL or hmac_length less than needed to store HMAC value, @ref
  * SOTER_BUFFER_TOO_SMALL will return and hmac_length will contain length of buffer thet need to
  * store HMAC value.
  */

--- a/include/soter/soter_kdf.h
+++ b/include/soter/soter_kdf.h
@@ -139,7 +139,7 @@ soter_status_t soter_kdf(const void* key,
  *
  * It is a good idea to periodically reevaluate your decision and increase
  * the iteration count as machines get faster. However, doing this results
- * in a different key being derived so you'd need to reencrypt data protected
+ * in a different key being derived so you'd need to re-encrypt data protected
  * by the previous key.
  *
  * @returns SOTER_SUCCESS on successful key derivation.

--- a/include/soter/soter_sym.h
+++ b/include/soter/soter_sym.h
@@ -149,7 +149,7 @@ soter_sym_ctx_t* soter_sym_encrypt_create(uint32_t alg,
  * data length determination
  * @param [in, out] cipher_data_length length of cipher_data
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure.
- * @note If cipher_data==NULL or cipher_data_length less then need to store cipher data, @ref
+ * @note If cipher_data==NULL or cipher_data_length less than needed to store cipher data, @ref
  * SOTER_BUFFER_TOO_SMALL will return and cipher_data_length will contain length of buffer needed
  * to store cipher data.
  */
@@ -168,7 +168,7 @@ soter_status_t soter_sym_encrypt_update(soter_sym_ctx_t* ctx,
  * data length determination
  * @param [in, out] cipher_data_length length of cipher_data
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure.
- * @note If cipher_data==NULL or cipher_data_length less then need to store cipher data, @ref
+ * @note If cipher_data==NULL or cipher_data_length less than needed to store cipher data, @ref
  * SOTER_BUFFER_TOO_SMALL will return and cipher_data_length will contain length of buffer needed
  * to store cipher data.
  */
@@ -221,7 +221,7 @@ soter_sym_ctx_t* soter_sym_decrypt_create(uint32_t alg,
  * length determination
  * @param [in, out] plain_data_length length of plaintext data
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure.
- * @note If plain_data==NULL or plain_data_length less then need to store plain data, @ref
+ * @note If plain_data==NULL or plain_data_length less than needed to store plain data, @ref
  * SOTER_BUFFER_TOO_SMALL will return and plain_data_length will contain length of buffer needed
  * to store plain data.
  */
@@ -240,7 +240,7 @@ soter_status_t soter_sym_decrypt_update(soter_sym_ctx_t* ctx,
  * length determination
  * @param [in, out] plain_data_length length of plaintext data
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure.
- * @note If plain_data==NULL or plain_data_length less then need to store plain data, @ref
+ * @note If plain_data==NULL or plain_data_length less than needed to store plain data, @ref
  * SOTER_BUFFER_TOO_SMALL will return and plain_data_length will contain length of buffer needed
  * to store plain data.
  */
@@ -311,7 +311,7 @@ soter_status_t soter_sym_aead_encrypt_aad(soter_sym_ctx_t* ctx, const void* plai
  * data length determination
  * @param [in, out] cipher_data_length  length of cipher data
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure.
- * @note If cipher_data==NULL or cipher_data_length less then need to store cipher data, @ref
+ * @note If cipher_data==NULL or cipher_data_length less than needed to store cipher data, @ref
  * SOTER_BUFFER_TOO_SMALL will return and cipher_data_length will contain length of buffer needed
  * to store cipher data.
  */
@@ -397,7 +397,7 @@ soter_status_t soter_sym_aead_decrypt_aad(soter_sym_ctx_t* ctx, const void* plai
  * length determination
  * @param [in, out] plain_data_length length of plain_data
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure.
- * @note If plain_data==NULL or plain_data_length less then need to store plain data, @ref
+ * @note If plain_data==NULL or plain_data_length less than needed to store plain data, @ref
  * SOTER_BUFFER_TOO_SMALL will return and plain_data_length will contain length of buffer needed
  * to store plain data.
  */

--- a/include/soter/soter_sym.h
+++ b/include/soter/soter_sym.h
@@ -16,7 +16,7 @@
 
 /**
  * @file soter_sym.h
- * @brief symmetric encryption/decription routines
+ * @brief symmetric encryption/decryption routines
  */
 
 #ifndef SOTER_SYM_H
@@ -28,11 +28,11 @@
 /**
  * @addtogroup SOTER
  * @{
- * @defgroup SOTER_SYM symmetric encryption/decription routines
- * @brief symmetric encryption/decription routines
+ * @defgroup SOTER_SYM symmetric encryption/decryption routines
+ * @brief symmetric encryption/decryption routines
  * @{
- * @defgroup SOTER_SYM_ALGORYTHMS symmetric encription/decryption  algorithms
- * @brief supported symmetric encryption/decription algorithms definitions
+ * @defgroup SOTER_SYM_ALGORITHMS symmetric encryption/decryption  algorithms
+ * @brief supported symmetric encryption/decryption algorithms definitions
  * @details Algorithm definition example:
  * @code
  * SOTER_SYM_AES_GCM|SOTER_SYM_NOKDF|SOTER_SYM_256_KEY_LENGTH  //AES in GCM mode with 256 bits key
@@ -41,8 +41,8 @@
  * @endcode
  * @{
  *
- * @defgroup SOTER_SYM_ALGORYTHMS_IDS symmetric encription/decryption  algorithms ids
- * @brief supported symmetric encryption/decription algorithms definitions
+ * @defgroup SOTER_SYM_ALGORITHMS_IDS symmetric encryption/decryption  algorithms ids
+ * @brief supported symmetric encryption/decryption algorithms definitions
  * @{
  */
 
@@ -64,7 +64,7 @@
  */
 /** do not use kdf */
 #define SOTER_SYM_NOKDF 0x00000000
-/** pbkdf2 algorythm */
+/** pbkdf2 algorithm */
 #define SOTER_SYM_PBKDF2 0x01000000
 /** @} */
 
@@ -83,8 +83,8 @@
 /** @} */
 
 /**
- * @defgroup SOTER_SYM_MASK masks definition for symmetryc algorithm id
- * @brief masks definition for symmetryc algorithm id
+ * @defgroup SOTER_SYM_MASK masks definition for symmetric algorithm id
+ * @brief masks definition for symmetric algorithm id
  * @{
  */
 /** key length mask */
@@ -109,19 +109,19 @@
 typedef struct soter_sym_ctx_type soter_sym_ctx_t;
 
 /**
- * @defgroup SOTER_SYM_ROUTINES_NOAUTH without authenticated encription
- * @brief symmetric encryption/decryption without authenticated encription
+ * @defgroup SOTER_SYM_ROUTINES_NOAUTH without authenticated encryption
+ * @brief symmetric encryption/decryption without authenticated encryption
  * @{
  */
 /**
  * @defgroup SOTER_SYM_ROUTINES_NOAUTH_ENCRYPT encryption
- * @brief symmetric encryption without authenticated encription
+ * @brief symmetric encryption without authenticated encryption
  * @{
  */
 
 /**
  * @brief create symmetric encryption context
- * @param [in] alg algorithm id for usage. See @ref SOTER_SYM_ALGORYTHMS
+ * @param [in] alg algorithm id for usage. See @ref SOTER_SYM_ALGORITHMS
  * @param [in] key pointer to key buffer
  * @param [in] key_length length of key
  * @param [in] salt pointer to salt buffer
@@ -141,7 +141,7 @@ soter_sym_ctx_t* soter_sym_encrypt_create(uint32_t alg,
 
 /**
  * @brief update symmetric encryption context
- * @param [in] ctx pointer to symmetric encryption context prerviosly created by
+ * @param [in] ctx pointer to symmetric encryption context previously created by
  * soter_sym_encrypt_create
  * @param [in] plain_data pointer to data buffer to encrypt
  * @param [in] data_length length of plain_data
@@ -150,7 +150,7 @@ soter_sym_ctx_t* soter_sym_encrypt_create(uint32_t alg,
  * @param [in, out] cipher_data_length length of cipher_data
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure.
  * @note If cipher_data==NULL or cipher_data_length less then need to store cipher data, @ref
- * SOTER_BUFFER_TOO_SMALL will return and cipher_data_length will contain length of buffer thet need
+ * SOTER_BUFFER_TOO_SMALL will return and cipher_data_length will contain length of buffer needed
  * to store cipher data.
  */
 SOTER_API
@@ -162,14 +162,14 @@ soter_status_t soter_sym_encrypt_update(soter_sym_ctx_t* ctx,
 
 /**
  * @brief final symmetric encryption context
- * @param [in] ctx pointer to symmetric encryption context prerviosly created by
+ * @param [in] ctx pointer to symmetric encryption context previously created by
  * soter_sym_encrypt_create
  * @param [out] cipher_data pointer to buffer to cipher data store, may be set to NULL for cipher
  * data length determination
  * @param [in, out] cipher_data_length length of cipher_data
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure.
  * @note If cipher_data==NULL or cipher_data_length less then need to store cipher data, @ref
- * SOTER_BUFFER_TOO_SMALL will return and cipher_data_length will contain length of buffer thet need
+ * SOTER_BUFFER_TOO_SMALL will return and cipher_data_length will contain length of buffer needed
  * to store cipher data.
  */
 SOTER_API
@@ -177,7 +177,7 @@ soter_status_t soter_sym_encrypt_final(soter_sym_ctx_t* ctx, void* cipher_data, 
 
 /**
  * @brief destroy symmetric encryption context
- * @param [in] ctx pointer to symmetric encryption context prerviosly created by
+ * @param [in] ctx pointer to symmetric encryption context previously created by
  * soter_sym_encrypt_create
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure.
  */
@@ -186,14 +186,14 @@ soter_status_t soter_sym_encrypt_destroy(soter_sym_ctx_t* ctx);
 /** @} */
 
 /**
- * @defgroup SOTER_SYM_ROUTINES_NOAUTH_DECRYPT decription
- * @brief symmetric decryption without authenticated encription
+ * @defgroup SOTER_SYM_ROUTINES_NOAUTH_DECRYPT decryption
+ * @brief symmetric decryption without authenticated encryption
  * @{
  */
 
 /**
  * @brief create symmetric decryption context
- * @param [in] alg algorithm id for usage. See @ref SOTER_SYM_ALGORYTHMS
+ * @param [in] alg algorithm id for usage. See @ref SOTER_SYM_ALGORITHMS
  * @param [in] key pointer to key buffer
  * @param [in] key_length length of key
  * @param [in] salt pointer to salt buffer
@@ -213,7 +213,7 @@ soter_sym_ctx_t* soter_sym_decrypt_create(uint32_t alg,
 
 /**
  * @brief update symmetric decryption context
- * @param [in] ctx pointer to symmetric decryption context prerviosly created by
+ * @param [in] ctx pointer to symmetric decryption context previously created by
  * soter_sym_decrypt_create
  * @param [in] cipher_data pointer to data buffer to decrypt
  * @param [in] data_length length of cipher_data
@@ -222,7 +222,7 @@ soter_sym_ctx_t* soter_sym_decrypt_create(uint32_t alg,
  * @param [in, out] plain_data_length length of plaintext data
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure.
  * @note If plain_data==NULL or plain_data_length less then need to store plain data, @ref
- * SOTER_BUFFER_TOO_SMALL will return and plain_data_length will contain length of buffer thet need
+ * SOTER_BUFFER_TOO_SMALL will return and plain_data_length will contain length of buffer needed
  * to store plain data.
  */
 SOTER_API
@@ -234,14 +234,14 @@ soter_status_t soter_sym_decrypt_update(soter_sym_ctx_t* ctx,
 
 /**
  * @brief final symmetric decryption context
- * @param [in] ctx pointer to symmetric decryption context prerviosly created by
+ * @param [in] ctx pointer to symmetric decryption context previously created by
  * soter_sym_decrypt_create
  * @param [out] plain_data pointer to buffer to plain data store, may be set to NULL for plain data
  * length determination
  * @param [in, out] plain_data_length length of plaintext data
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure.
  * @note If plain_data==NULL or plain_data_length less then need to store plain data, @ref
- * SOTER_BUFFER_TOO_SMALL will return and plain_data_length will contain length of buffer thet need
+ * SOTER_BUFFER_TOO_SMALL will return and plain_data_length will contain length of buffer needed
  * to store plain data.
  */
 SOTER_API
@@ -249,7 +249,7 @@ soter_status_t soter_sym_decrypt_final(soter_sym_ctx_t* ctx, void* plain_data, s
 
 /**
  * @brief destroy symmetric decryption context
- * @param [in] ctx pointer to symmetric decryption context prerviosly created by
+ * @param [in] ctx pointer to symmetric decryption context previously created by
  * soter_sym_decrypt_create
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure.
  */
@@ -259,20 +259,20 @@ soter_status_t soter_sym_decrypt_destroy(soter_sym_ctx_t* ctx);
 /** @} */
 
 /**
- * @defgroup SOTER_SYM_ROUTINES_AUTH with authenticated encription
- * @brief symmetric encryption/decryption with authenticated encription
+ * @defgroup SOTER_SYM_ROUTINES_AUTH with authenticated encryption
+ * @brief symmetric encryption/decryption with authenticated encryption
  * @{
  */
 
 /**
  * @defgroup SOTER_SYM_ROUTINES_AUTH_ENCRYPT encryption
- * @brief symmetric encryption with authenticated encription
+ * @brief symmetric encryption with authenticated encryption
  * @{
  */
 
 /**
  * @brief create symmetric encryption context
- * @param [in] alg algorithm id for usage. See @ref SOTER_SYM_ALGORYTHMS
+ * @param [in] alg algorithm id for usage. See @ref SOTER_SYM_ALGORITHMS
  * @param [in] key pointer to key buffer
  * @param [in] key_length length of key
  * @param [in] salt pointer to salt buffer
@@ -292,7 +292,7 @@ soter_sym_ctx_t* soter_sym_aead_encrypt_create(uint32_t alg,
 
 /**
  * @brief Add AAD data to symmetric encryption context
- * @param [in] ctx pointer to symmetric encryption context prerviosly created by
+ * @param [in] ctx pointer to symmetric encryption context previously created by
  * soter_sym_encrypt_create
  * @param [in] plain_data pointer to buffer with AAD data
  * @param [in] data_length length of AAD data
@@ -303,7 +303,7 @@ soter_status_t soter_sym_aead_encrypt_aad(soter_sym_ctx_t* ctx, const void* plai
 
 /**
  * @brief update symmetric encryption context
- * @param [in] ctx pointer to symmetric encryption context prerviosly created by
+ * @param [in] ctx pointer to symmetric encryption context previously created by
  * soter_sym_encrypt_create
  * @param [in] plain_data pointer to data buffer to encrypt
  * @param [in] data_length length of plain_data
@@ -312,7 +312,7 @@ soter_status_t soter_sym_aead_encrypt_aad(soter_sym_ctx_t* ctx, const void* plai
  * @param [in, out] cipher_data_length  length of cipher data
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure.
  * @note If cipher_data==NULL or cipher_data_length less then need to store cipher data, @ref
- * SOTER_BUFFER_TOO_SMALL will return and cipher_data_length will contain length of buffer thet need
+ * SOTER_BUFFER_TOO_SMALL will return and cipher_data_length will contain length of buffer needed
  * to store cipher data.
  */
 SOTER_API
@@ -342,7 +342,7 @@ soter_status_t soter_sym_aead_encrypt_final(soter_sym_ctx_t* ctx, void* auth_tag
 
 /**
  * @brief destroy symmetric encryption context
- * @param [in] ctx pointer to symmetric encryption context prerviosly created by
+ * @param [in] ctx pointer to symmetric encryption context previously created by
  * soter_sym_encrypt_create
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure.
  */
@@ -351,14 +351,14 @@ soter_status_t soter_sym_aead_encrypt_destroy(soter_sym_ctx_t* ctx);
 /** @} */
 
 /**
- * @defgroup SOTER_SYM_ROUTINES_AUTH_DECRYPT decription
- * @brief symmetric decryption with authenticated encription
+ * @defgroup SOTER_SYM_ROUTINES_AUTH_DECRYPT decryption
+ * @brief symmetric decryption with authenticated encryption
  * @{
  */
 
 /**
  * @brief create symmetric decryption context
- * @param [in] alg algorithm id for usage. See @ref SOTER_SYM_ALGORYTHMS
+ * @param [in] alg algorithm id for usage. See @ref SOTER_SYM_ALGORITHMS
  * @param [in] key pointer to key buffer
  * @param [in] key_length length of key
  * @param [in] salt pointer to salt buffer
@@ -378,7 +378,7 @@ soter_sym_ctx_t* soter_sym_aead_decrypt_create(uint32_t alg,
 
 /**
  * @brief Add AAD data to symmetric decryption context
- * @param [in] ctx pointer to symmetric decryption context prerviosly created by
+ * @param [in] ctx pointer to symmetric decryption context previously created by
  * soter_sym_decrypt_create
  * @param [in] plain_data pointer to buffer with AAD data
  * @param [in] data_length length of AAD data
@@ -389,7 +389,7 @@ soter_status_t soter_sym_aead_decrypt_aad(soter_sym_ctx_t* ctx, const void* plai
 
 /**
  * @brief update symmetric decryption context
- * @param [in] ctx pointer to symmetric decryption context prerviosly created by
+ * @param [in] ctx pointer to symmetric decryption context previously created by
  * soter_sym_decrypt_create
  * @param [in] cipher_data pointer to data buffer to decrypt
  * @param [in] data_length length of cipher_data
@@ -398,7 +398,7 @@ soter_status_t soter_sym_aead_decrypt_aad(soter_sym_ctx_t* ctx, const void* plai
  * @param [in, out] plain_data_length length of plain_data
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure.
  * @note If plain_data==NULL or plain_data_length less then need to store plain data, @ref
- * SOTER_BUFFER_TOO_SMALL will return and plain_data_length will contain length of buffer thet need
+ * SOTER_BUFFER_TOO_SMALL will return and plain_data_length will contain length of buffer needed
  * to store plain data.
  */
 SOTER_API
@@ -410,7 +410,7 @@ soter_status_t soter_sym_aead_decrypt_update(soter_sym_ctx_t* ctx,
 
 /**
  * @brief final symmetric decryption context
- * @param [in] ctx pointer to symmetric decryption context prerviosly created by
+ * @param [in] ctx pointer to symmetric decryption context previously created by
  * soter_sym_decrypt_create
  * @param [in] auth_tag pointer to buffer of auth tag
  * @param [in] auth_tag_length length of auth_tag
@@ -423,7 +423,7 @@ soter_status_t soter_sym_aead_decrypt_final(soter_sym_ctx_t* ctx,
 
 /**
  * @brief destroy symmetric decryption context
- * @param [in] ctx pointer to symmetric decryption context prerviosly created by
+ * @param [in] ctx pointer to symmetric decryption context previously created by
  * soter_sym_decrypt_create
  * @return result of operation, @ref SOTER_SUCCESS on success and @ref SOTER_FAIL on failure.
  */

--- a/include/themis/secure_cell.h
+++ b/include/themis/secure_cell.h
@@ -54,7 +54,7 @@ extern "C" {
  * encrypted message length determination
  * @param [in, out] encrypted_message_length length of encrypted_message
  * @return THEMIS_SUCCESS on success or THEMIS_FAIL on failure
- * @note If encrypted_message==NULL or encrypted_message_length is not enought for encrypted message
+ * @note If encrypted_message==NULL or encrypted_message_length is not enough for encrypted message
  * store then THEMIS_BUFFER_TOO_SMALL will return and encrypted_message_length will store length of
  * buffer needed for encrypted message store
  */
@@ -80,7 +80,7 @@ themis_status_t themis_secure_cell_encrypt_seal(const uint8_t* master_key,
  * length determination
  * @param [in, out] plain_message_length length of plain_message
  * @return THEMIS_SUCCESS on success or THEMIS_FAIL on failure
- * @note If plain_message==NULL or plain_message_length is not enought for plain message store then
+ * @note If plain_message==NULL or plain_message_length is not enough for plain message store then
  * THEMIS_BUFFER_TOO_SMALL will return and plain_message_length will store length of buffer needed
  * for plain1 message store
  */
@@ -237,10 +237,10 @@ themis_status_t themis_secure_cell_decrypt_seal_with_passphrase(const uint8_t* p
  * encrypted message length determination
  * @param [in, out] encrypted_message_length length of encrypted_message
  * @return THEMIS_SUCCESS on success or THEMIS_FAIL on failure
- * @note If encrypted_message==NULL or context==NULL or encrypted_message_length is not enought for
- * encrypted message or context_length is not enougth for additional authentication info store then
+ * @note If encrypted_message==NULL or context==NULL or encrypted_message_length is not enough for
+ * encrypted message or context_length is not enough for additional authentication info store then
  * THEMIS_BUFFER_TOO_SMALL will return and encrypted_message_length will store length of buffer
- * needed for encrypted message store and context_length will store length of buuffer needed for
+ * needed for encrypted message store and context_length will store length of buffer needed for
  * additional authentication info store
  */
 THEMIS_API
@@ -269,7 +269,7 @@ themis_status_t themis_secure_cell_encrypt_token_protect(const uint8_t* master_k
  * length determination
  * @param [in, out] plain_message_length length of plain_message
  * @return THEMIS_SUCCESS on success or THEMIS_FAIL on failure
- * @note If plain_message==NULL or plain_message_length is not enought for plain message store then
+ * @note If plain_message==NULL or plain_message_length is not enough for plain message store then
  * THEMIS_BUFFER_TOO_SMALL will return and plain_message_length will store length of buffer needed
  * for plain1 message store
  */
@@ -288,7 +288,7 @@ themis_status_t themis_secure_cell_decrypt_token_protect(const uint8_t* master_k
 /** @} */
 
 /**
- * @defgroup THEMIS_SECURE_CELL_CONEXT_IMPIRIT_MODE context imprint mode
+ * @defgroup THEMIS_SECURE_CELL_CONTEXT_IMPRINT_MODE context imprint mode
  * @brief This API is for environments where storage constraints do not allow the size of the data
  * to grow and there is no auxiliary storage available
  * @{
@@ -306,7 +306,7 @@ themis_status_t themis_secure_cell_decrypt_token_protect(const uint8_t* master_k
  * encrypted message length determination
  * @param [in, out] encrypted_message_length length of encrypted_message
  * @return THEMIS_SUCCESS on success or THEMIS_FAIL on failure
- * @note If encrypted_message==NULL or encrypted_message_length is not enought for encrypted message
+ * @note If encrypted_message==NULL or encrypted_message_length is not enough for encrypted message
  * store then THEMIS_BUFFER_TOO_SMALL will return and encrypted_message_length will store length of
  * buffer needed for encrypted message store
  */
@@ -332,7 +332,7 @@ themis_status_t themis_secure_cell_encrypt_context_imprint(const uint8_t* master
  * length determination
  * @param [in, out] plain_message_length length of plain_message
  * @return THEMIS_SUCCESS on success or THEMIS_FAIL on failure
- * @note If plain_message==NULL or plain_message_length is not enought for plain message store then
+ * @note If plain_message==NULL or plain_message_length is not enough for plain message store then
  * THEMIS_BUFFER_TOO_SMALL will return and plain_message_length will store length of buffer needed
  * for plain1 message store
  */

--- a/include/themis/secure_message.h
+++ b/include/themis/secure_message.h
@@ -150,7 +150,7 @@ themis_status_t themis_secure_message_verify(const uint8_t* public_key,
  * message length determination
  * @param [in, out] wrapped_message_length length of wrapped_message
  * @return THEMIS_SUCCESS on success or THEMIS_FAIL on failure
- * @note If wrapped_message==NULL or wrapped_message_length is not enought for wrapped message
+ * @note If wrapped_message==NULL or wrapped_message_length is not enough for wrapped message
  * storage then THEMIS_BUFFER_TOO_SMALL will return and wrapped_message_length will store length of
  * buffer needed for wrapped message store
  */
@@ -177,7 +177,7 @@ themis_status_t themis_secure_message_wrap(const uint8_t* private_key,
  * determination
  * @param [in, out] message_length length of message
  * @return THEMIS_SUCCESS on success or THEMIS_FAIL on failure
- * @note If message==NULL or message_length is not enought for plain message storage then
+ * @note If message==NULL or message_length is not enough for plain message storage then
  * THEMIS_BUFFER_TOO_SMALL will return and message_length will store length of buffer needed for
  * plain message store
  */

--- a/include/themis/secure_session.h
+++ b/include/themis/secure_session.h
@@ -63,13 +63,13 @@ extern "C" {
 /** @brief established state define */
 #define STATE_ESTABLISHED 2
 
-/** @brief send data callbeck tyoedef*/
+/** @brief send data callback typedef*/
 typedef ssize_t (*send_protocol_data_callback)(const uint8_t* data, size_t data_length, void* user_data);
-/** @brief receive data callbeck tyoedef*/
+/** @brief receive data callback typedef*/
 typedef ssize_t (*receive_protocol_data_callback)(uint8_t* data, size_t data_length, void* user_data);
-/** @brief state change callbeck tyoedef*/
+/** @brief state change callback typedef*/
 typedef void (*protocol_state_changed_callback)(int event, void* user_data);
-/** @brief get public key by id callbeck tyoedef*/
+/** @brief get public key by id callback typedef*/
 typedef int (*get_public_key_for_id_callback)(
     const void* id, size_t id_length, void* key_buffer, size_t key_buffer_length, void* user_data);
 

--- a/jni/themis_session.c
+++ b/jni/themis_session.c
@@ -466,8 +466,8 @@ err:
     return output;
 }
 
-JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureSession_jniGenerateConntect(JNIEnv* env,
-                                                                                           jobject thiz)
+JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureSession_jniGenerateConnect(JNIEnv* env,
+                                                                                          jobject thiz)
 {
     size_t request_length = 0;
     session_with_callbacks_t* ctx = get_native_session(env, thiz);
@@ -527,6 +527,9 @@ err:
 
     return output;
 }
+JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureSession_jniGenerateConntect(JNIEnv* env, 
+                                                                                           jobject thiz)
+__attribute__((alias("Java_com_cossacklabs_themis_SecureSession_jniGenerateConnect")));
 
 JNIEXPORT jlong JNICALL Java_com_cossacklabs_themis_SecureSession_create(JNIEnv* env,
                                                                          jobject thiz,

--- a/jni/themis_session.c
+++ b/jni/themis_session.c
@@ -529,7 +529,9 @@ err:
 }
 JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureSession_jniGenerateConntect(JNIEnv* env, 
                                                                                            jobject thiz)
-__attribute__((alias("Java_com_cossacklabs_themis_SecureSession_jniGenerateConnect")));
+{
+    return Java_com_cossacklabs_themis_SecureSession_jniGenerateConnect(env, thiz);
+}
 
 JNIEXPORT jlong JNICALL Java_com_cossacklabs_themis_SecureSession_create(JNIEnv* env,
                                                                          jobject thiz,

--- a/jni/themis_session.c
+++ b/jni/themis_session.c
@@ -527,7 +527,7 @@ err:
 
     return output;
 }
-JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureSession_jniGenerateConntect(JNIEnv* env, 
+JNIEXPORT jbyteArray JNICALL Java_com_cossacklabs_themis_SecureSession_jniGenerateConntect(JNIEnv* env,
                                                                                            jobject thiz)
 {
     return Java_com_cossacklabs_themis_SecureSession_jniGenerateConnect(env, thiz);

--- a/src/soter/boringssl/soter_asym_cipher.c
+++ b/src/soter/boringssl/soter_asym_cipher.c
@@ -47,7 +47,7 @@ soter_status_t soter_asym_cipher_import_key(soter_asym_cipher_t* asym_cipher_ctx
     }
 
     if (EVP_PKEY_RSA != EVP_PKEY_id(pkey)) {
-        /* We can only do assymetric encryption with RSA algorithm */
+        /* We can only do asymmetric encryption with RSA algorithm */
         return SOTER_INVALID_PARAMETER;
     }
 
@@ -153,7 +153,7 @@ soter_status_t soter_asym_cipher_encrypt(soter_asym_cipher_t* asym_cipher,
     }
 
     if (EVP_PKEY_RSA != EVP_PKEY_id(pkey)) {
-        /* We can only do assymetric encryption with RSA algorithm */
+        /* We can only do asymmetric encryption with RSA algorithm */
         return SOTER_INVALID_PARAMETER;
     }
     rsa = EVP_PKEY_get0_RSA(pkey);
@@ -227,7 +227,7 @@ soter_status_t soter_asym_cipher_decrypt(soter_asym_cipher_t* asym_cipher,
     }
 
     if (EVP_PKEY_RSA != EVP_PKEY_id(pkey)) {
-        /* We can only do assymetric encryption with RSA algorithm */
+        /* We can only do asymmetric encryption with RSA algorithm */
         return SOTER_INVALID_PARAMETER;
     }
 

--- a/src/soter/ed25519/fe_mul.c
+++ b/src/soter/ed25519/fe_mul.c
@@ -19,11 +19,11 @@ Notes on implementation strategy:
 Using schoolbook multiplication.
 Karatsuba would save a little in some cost models.
 
-Most multiplications by 2 and 19 are 32-bit precomputations;
-cheaper than 64-bit postcomputations.
+Most multiplications by 2 and 19 are 32-bit pre-computations;
+cheaper than 64-bit post-computations.
 
 There is one remaining multiplication by 19 in the carry chain;
-one *19 precomputation can be merged into this,
+one *19 pre-computation can be merged into this,
 but the resulting data flow is considerably less clean.
 
 There are 12 carries below.

--- a/src/soter/openssl/soter_asym_cipher.c
+++ b/src/soter/openssl/soter_asym_cipher.c
@@ -48,7 +48,7 @@ soter_status_t soter_asym_cipher_import_key(soter_asym_cipher_t* asym_cipher_ctx
     }
 
     if (EVP_PKEY_RSA != EVP_PKEY_id(pkey)) {
-        /* We can only do assymetric encryption with RSA algorithm */
+        /* We can only do asymmetric encryption with RSA algorithm */
         return SOTER_INVALID_PARAMETER;
     }
 
@@ -154,7 +154,7 @@ soter_status_t soter_asym_cipher_encrypt(soter_asym_cipher_t* asym_cipher,
     }
 
     if (EVP_PKEY_RSA != EVP_PKEY_id(pkey)) {
-        /* We can only do assymetric encryption with RSA algorithm */
+        /* We can only do asymmetric encryption with RSA algorithm */
         return SOTER_INVALID_PARAMETER;
     }
 
@@ -239,7 +239,7 @@ soter_status_t soter_asym_cipher_decrypt(soter_asym_cipher_t* asym_cipher,
     }
 
     if (EVP_PKEY_RSA != EVP_PKEY_id(pkey)) {
-        /* We can only do assymetric encryption with RSA algorithm */
+        /* We can only do asymmetric encryption with RSA algorithm */
         return SOTER_INVALID_PARAMETER;
     }
 

--- a/src/soter/openssl/soter_asym_ka.c
+++ b/src/soter/openssl/soter_asym_ka.c
@@ -168,7 +168,7 @@ soter_status_t soter_asym_ka_import_key(soter_asym_ka_t* asym_ka_ctx, const void
     /*
      * soter_ec_{priv,pub}_key_to_engine_specific() expect EVP_PKEY of EVP_PKEY_EC type
      * to be already allocated and non-NULL. We might be importing it anew, or we might be
-     * replacing previously generated keypair.
+     * replacing previously generated key pair.
      */
     if (asym_ka_ctx->pkey) {
         if (EVP_PKEY_base_id(asym_ka_ctx->pkey) != EVP_PKEY_EC) {

--- a/src/soter/soter_crc32.c
+++ b/src/soter/soter_crc32.c
@@ -84,7 +84,7 @@ uint32_t soter_crc32_final(soter_crc32_t* crc)
     /*  result  now holds the negated polynomial remainder;
      *  since the table and algorithm is "reflected" [williams95].
      *  That is,  result has the same value as if we mapped the message
-     *  to a polyomial, computed the host-bit-order polynomial
+     *  to a polynomial, computed the host-bit-order polynomial
      *  remainder, performed final negation, then did an end-for-end
      *  bit-reversal.
      *  Note that a 32-bit bit-reversal is identical to four inplace

--- a/src/soter/soter_ec_key.h
+++ b/src/soter/soter_ec_key.h
@@ -55,7 +55,7 @@
                                                   \
     typedef struct soter_ec_pub_key_##_KEY_SIZE_##_type soter_ec_pub_key_##_KEY_SIZE_##_t
 
-/* struct members are ordered this way to avoid struct member alingment on different platforms */
+/* struct members are ordered this way to avoid struct member alignment on different platforms */
 #define DECLARE_EC_PRIVATE_KEY(_KEY_SIZE_)         \
     struct soter_ec_priv_key_##_KEY_SIZE_##_type { \
         soter_container_hdr_t hdr;                 \

--- a/src/soter/soter_rsa_key.h
+++ b/src/soter/soter_rsa_key.h
@@ -56,7 +56,7 @@
 
 /* Our RSA private key containers include CRT params, since most crypto libraries support them. If
  * at some point CRT params are not available, respective fields a filled with zeroes. */
-/* struct members are ordered this way to avoid struct member alingment on different platforms */
+/* struct members are ordered this way to avoid struct member alignment on different platforms */
 #define DECLARE_RSA_PRIVATE_KEY(_KEY_SIZE_)          \
     struct soter_rsa_priv_key_##_KEY_SIZE_##_type {  \
         soter_container_hdr_t hdr;                   \

--- a/src/themis/secure_cell_seal_passphrase.h
+++ b/src/themis/secure_cell_seal_passphrase.h
@@ -134,7 +134,7 @@ static inline uint64_t themis_scell_auth_token_passphrase_size(
     const struct themis_scell_auth_token_passphrase* hdr)
 {
     uint64_t total_size = 0;
-    /* Add separately to avoid overflows in intermediade calculations */
+    /* Add separately to avoid overflows in intermediate calculations */
     total_size += sizeof(hdr->alg);
     total_size += sizeof(hdr->iv_length);
     total_size += hdr->iv_length;
@@ -183,7 +183,7 @@ static inline themis_status_t themis_read_scell_auth_token_passphrase(
     buffer = stream_read_uint32LE(buffer, &hdr->auth_tag_length);
     buffer = stream_read_uint32LE(buffer, &hdr->message_length);
     buffer = stream_read_uint32LE(buffer, &hdr->kdf_context_length);
-    /* Add separately to avoid overflows in intermediade calculations */
+    /* Add separately to avoid overflows in intermediate calculations */
     need_length += hdr->iv_length;
     need_length += hdr->auth_tag_length;
     need_length += hdr->kdf_context_length;
@@ -226,7 +226,7 @@ static const uint32_t themis_scell_pbkdf2_context_min_size = sizeof(uint32_t) + 
 static inline uint32_t themis_scell_pbkdf2_context_size(const struct themis_scell_pbkdf2_context* ctx)
 {
     uint32_t total_size = 0;
-    /* Add separately to avoid overflows in intermediade calculations */
+    /* Add separately to avoid overflows in intermediate calculations */
     total_size += sizeof(ctx->iteration_count);
     total_size += sizeof(ctx->salt_length);
     total_size += ctx->salt_length;
@@ -245,7 +245,7 @@ static inline themis_status_t themis_write_scell_pbkdf2_context(
     if (hdr->kdf_context_length != themis_scell_pbkdf2_context_size(ctx)) {
         return THEMIS_FAIL;
     }
-    /* Add separately to avoid overflows in intermediade calculations */
+    /* Add separately to avoid overflows in intermediate calculations */
     buffer += sizeof(hdr->alg);
     buffer += sizeof(hdr->iv_length);
     buffer += hdr->iv_length;

--- a/src/themis/secure_comparator.c
+++ b/src/themis/secure_comparator.c
@@ -945,7 +945,7 @@ static themis_status_t secure_comparator_bob_step4(secure_comparator_t* comp_ctx
 
     /* Finally Bob sends to Alice on 4 step:
      * Rb || Rb signature
-     * Bob proceeds 4 step, finishs and gets result, Alice proceeds 5 step, finishes and gets
+     * Bob proceeds 4 step, finishes and gets result, Alice proceeds 5 step, finishes and gets
      * result.
      */
     comp_ctx->state_handler = NULL;

--- a/src/themis/secure_message_wrapper.c
+++ b/src/themis/secure_message_wrapper.c
@@ -25,7 +25,7 @@
 #include "themis/secure_cell.h"
 
 #define THEMIS_RSA_SYM_ALG (SOTER_SYM_AES_CTR | SOTER_SYM_256_KEY_LENGTH | SOTER_SYM_PBKDF2)
-#define THEMIS_RSA_SYMM_PASSWD_LENGTH 70 //!!! need to aprove
+#define THEMIS_RSA_SYMM_PASSWD_LENGTH 70 //!!! need to approve
 //#define THEMIS_RSA_SYMM_ENCRYPTED_PASSWD_LENGTH 256 //encrypted password for rsa 256
 #define THEMIS_RSA_SYMM_SALT_LENGTH 16
 

--- a/src/themis/sym_enc_message.h
+++ b/src/themis/sym_enc_message.h
@@ -145,7 +145,7 @@ static inline themis_status_t themis_read_scell_auth_token_key(const uint8_t* bu
     buffer = stream_read_uint32LE(buffer, &hdr->iv_length);
     buffer = stream_read_uint32LE(buffer, &hdr->auth_tag_length);
     buffer = stream_read_uint32LE(buffer, &hdr->message_length);
-    /* Add separately to avoid overflows in intermediade calculations */
+    /* Add separately to avoid overflows in intermediate calculations */
     need_length += hdr->iv_length;
     need_length += hdr->auth_tag_length;
     if (buffer_length < need_length) {

--- a/src/wrappers/themis/Obj-C/objcthemis/serror.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/serror.h
@@ -19,7 +19,7 @@
 
 /**
  * @file objthemis/serror.h
- * @brief Status codes defenitions for Obj-C wrapper for themis
+ * @brief Status codes definitions for Obj-C wrapper for themis
  */
 
 /**

--- a/src/wrappers/themis/Obj-C/objcthemis/ssession_transport_interface.h
+++ b/src/wrappers/themis/Obj-C/objcthemis/ssession_transport_interface.h
@@ -16,7 +16,7 @@
 
 /**
 * @file objthemis/ssession_transport_interface.h
-* @brief secure session trancport callbacs interface
+* @brief secure session transport callbacks interface
 */
 #import <Foundation/Foundation.h>
 

--- a/src/wrappers/themis/java/com/cossacklabs/themis/Keypair.java
+++ b/src/wrappers/themis/java/com/cossacklabs/themis/Keypair.java
@@ -17,7 +17,7 @@
 package com.cossacklabs.themis;
 
 /**
- * Represents Themis asymmetric keypair
+ * Represents Themis asymmetric key pair
  */
 public class Keypair {
 	
@@ -25,9 +25,9 @@ public class Keypair {
 	PublicKey publicKey;
 	
 	/**
-	 * Creates a new keypair
-	 * @param privateKey of the keypair
-	 * @param publicKey of the keypair
+	 * Creates a new key pair
+	 * @param privateKey of the key pair
+	 * @param publicKey of the key pair
 	 */
 	public Keypair(PrivateKey privateKey, PublicKey publicKey) {
 		this.privateKey = privateKey;
@@ -35,16 +35,16 @@ public class Keypair {
 	}
 	
 	/**
-	 * Returns private key of this keypair
-	 * @return PrivateKey of the keypair
+	 * Returns private key of this key pair
+	 * @return PrivateKey of the key pair
 	 */
 	public PrivateKey getPrivateKey() {
 		return this.privateKey;
 	}
 	
 	/**
-	 * Returns public key of this keypair
-	 * @return PublicKey of the keypair
+	 * Returns public key of this key pair
+	 * @return PublicKey of the key pair
 	 */
 	public PublicKey getPublicKey() {
 		return this.publicKey;

--- a/src/wrappers/themis/java/com/cossacklabs/themis/KeypairGenerator.java
+++ b/src/wrappers/themis/java/com/cossacklabs/themis/KeypairGenerator.java
@@ -32,23 +32,23 @@ public abstract class KeypairGenerator {
 	static native byte[][] generateKeys(int keyType);
 	
 	/**
-	 * Generates new EC keypair
+	 * Generates new EC key pair
 	 * @return new EC Keypair
-	 * @throws KeyGenerationException when cannot generate a keypair
+	 * @throws KeyGenerationException when cannot generate a key pair
 	 */
 	public static Keypair generateKeypair() {
 		try {
 			return generateKeypair(AsymmetricKey.KEYTYPE_EC);
 		} catch (InvalidArgumentException e) {
-			throw new KeyGenerationException("failed to generate keypair", e);
+			throw new KeyGenerationException("failed to generate key pair", e);
 		}
 	}
 	
 	/**
-	 * Generates new keypair
-	 * @param keyType type of the keypair to generate (EC or RSA)
+	 * Generates new key pair
+	 * @param keyType type of the key pair to generate (EC or RSA)
 	 * @return new Keypair
-	 * @throws KeyGenerationException when cannot generate a keypair
+	 * @throws KeyGenerationException when cannot generate a key pair
 	 * @throws InvalidArgumentException when keyType is invalid
 	 */
 	public static Keypair generateKeypair(int keyType) {
@@ -60,7 +60,7 @@ public abstract class KeypairGenerator {
 		byte[][] keys = generateKeys(keyType);
 		
 		if (null == keys) {
-			throw new KeyGenerationException("failed to generate keypair");
+			throw new KeyGenerationException("failed to generate key pair");
 		}
 		
 		return new Keypair(new PrivateKey(keys[0]), new PublicKey(keys[1]));

--- a/src/wrappers/themis/java/com/cossacklabs/themis/SecureSession.java
+++ b/src/wrappers/themis/java/com/cossacklabs/themis/SecureSession.java
@@ -116,7 +116,7 @@ public class SecureSession {
 	native long create(byte[] id, byte[] signKey);
 	native void destroy();
 	
-	native byte[] jniGenerateConntect();
+	native byte[] jniGenerateConnect();
 	native byte[] jniWrap(byte[] data);
 	native byte[][] jniUnwrap(byte[] wrappedData);
 	native boolean jniIsEstablished();
@@ -178,7 +178,7 @@ public class SecureSession {
 			throw new IllegalStateException("Secure Session is closed");
 		}
 		
-		byte[] request = jniGenerateConntect();
+		byte[] request = jniGenerateConnect();
 		
 		if (null == request) {
 			throw new RuntimeException("Secure Session cannot generate connection request", new SecureSessionException());

--- a/src/wrappers/themis/php/php_themis.c
+++ b/src/wrappers/themis/php/php_themis.c
@@ -133,7 +133,7 @@ PHP_METHOD(themis_secure_session, wrap){
   }
   char* wrapped_message=emalloc((int)wrapped_message_length);
   if(wrapped_message==NULL){
-    zend_throw_exception(zend_exception_get_default(TSRMLS_C), "Error: themis_secure_session in wrap: not enough mamory.", 0 TSRMLS_CC);
+    zend_throw_exception(zend_exception_get_default(TSRMLS_C), "Error: themis_secure_session in wrap: not enough memory.", 0 TSRMLS_CC);
     RETURN_NULL();    
   }
   if(secure_session_wrap(obj->session, message, message_length, wrapped_message, &wrapped_message_length)!=THEMIS_SUCCESS){
@@ -150,7 +150,7 @@ PHP_METHOD(themis_secure_session, unwrap){
   char* message;
   int message_length;
   if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &message, &message_length) == FAILURE) {
-    zend_throw_exception(zend_exception_get_default(TSRMLS_C), "Error: themis_secure_session in uwrap: invalid parameters.", 0 TSRMLS_CC);
+    zend_throw_exception(zend_exception_get_default(TSRMLS_C), "Error: themis_secure_session in unwrap: invalid parameters.", 0 TSRMLS_CC);
     RETURN_NULL();
   }
   zval *object = getThis();
@@ -470,7 +470,7 @@ PHP_FUNCTION(phpthemis_scell_seal_decrypt){
     RETURN_NULL();
   }
   if(themis_secure_cell_decrypt_seal((uint8_t*)key, key_length, (uint8_t*)context, context_length, (uint8_t*)message, message_length, (uint8_t*)decrypted_message, &decrypted_message_length)!=THEMIS_SUCCESS){
-    zend_throw_exception(zend_exception_get_default(TSRMLS_C), "Error: phpthemis_scell_seal_decrypt: decription failed.", 0 TSRMLS_CC);
+    zend_throw_exception(zend_exception_get_default(TSRMLS_C), "Error: phpthemis_scell_seal_decrypt: decryption failed.", 0 TSRMLS_CC);
     RETURN_NULL();
   }
   ZVAL_STRINGL(return_value, decrypted_message, (int)decrypted_message_length, 0);
@@ -528,7 +528,7 @@ PHP_FUNCTION(phpthemis_scell_seal_decrypt_with_passphrase){
     RETURN_NULL();
   }
   if(themis_secure_cell_decrypt_seal_with_passphrase((uint8_t*)passphrase, passphrase_length, (uint8_t*)context, context_length, (uint8_t*)message, message_length, (uint8_t*)decrypted_message, &decrypted_message_length)!=THEMIS_SUCCESS){
-    zend_throw_exception(zend_exception_get_default(TSRMLS_C), "Error: phpthemis_scell_seal_decrypt_with_passphrase: decription failed.", 0 TSRMLS_CC);
+    zend_throw_exception(zend_exception_get_default(TSRMLS_C), "Error: phpthemis_scell_seal_decrypt_with_passphrase: decryption failed.", 0 TSRMLS_CC);
     RETURN_NULL();
   }
   ZVAL_STRINGL(return_value, decrypted_message, (int)decrypted_message_length, 0);
@@ -587,7 +587,7 @@ PHP_FUNCTION(phpthemis_scell_token_protect_decrypt){
   }
   size_t decrypted_message_length=0;
   if(themis_secure_cell_decrypt_token_protect((uint8_t*)key, key_length, (uint8_t*)context, context_length, (uint8_t*)message, message_length, (uint8_t*)additional_auth_data, additional_auth_data_length, NULL, &decrypted_message_length)!=THEMIS_BUFFER_TOO_SMALL){
-    zend_throw_exception(zend_exception_get_default(TSRMLS_C), "Error: phpthemis_scell_token_protect_decrypt: dectipt message length determination failed.", 0 TSRMLS_CC);
+    zend_throw_exception(zend_exception_get_default(TSRMLS_C), "Error: phpthemis_scell_token_protect_decrypt: decrypt message length determination failed.", 0 TSRMLS_CC);
     RETURN_NULL();
   }
   char* decrypted_message=emalloc((int)decrypted_message_length);

--- a/src/wrappers/themis/php7/php_cell.c
+++ b/src/wrappers/themis/php7/php_cell.c
@@ -76,7 +76,7 @@ ZEND_FUNCTION(phpthemis_scell_seal_decrypt){
         RETURN_NULL();
     }
     if(themis_secure_cell_decrypt_seal((uint8_t*)key, key_length, (uint8_t*)context, context_length, (uint8_t*)message, message_length, (uint8_t*)decrypted_message, &decrypted_message_length)!=THEMIS_SUCCESS){
-        zend_throw_exception(zend_exception_get_default(TSRMLS_C), "Error: phpthemis_scell_seal_decrypt: decription failed.", 0 TSRMLS_CC);
+        zend_throw_exception(zend_exception_get_default(TSRMLS_C), "Error: phpthemis_scell_seal_decrypt: decryption failed.", 0 TSRMLS_CC);
         RETURN_NULL();
     }
     ZVAL_STRINGL(return_value, decrypted_message, (int)decrypted_message_length);
@@ -134,7 +134,7 @@ ZEND_FUNCTION(phpthemis_scell_seal_decrypt_with_passphrase){
         RETURN_NULL();
     }
     if(themis_secure_cell_decrypt_seal_with_passphrase((uint8_t*)passphrase, passphrase_length, (uint8_t*)context, context_length, (uint8_t*)message, message_length, (uint8_t*)decrypted_message, &decrypted_message_length)!=THEMIS_SUCCESS){
-        zend_throw_exception(zend_exception_get_default(TSRMLS_C), "Error: phpthemis_scell_seal_decrypt_with_passphrase: decription failed.", 0 TSRMLS_CC);
+        zend_throw_exception(zend_exception_get_default(TSRMLS_C), "Error: phpthemis_scell_seal_decrypt_with_passphrase: decryption failed.", 0 TSRMLS_CC);
         RETURN_NULL();
     }
     ZVAL_STRINGL(return_value, decrypted_message, (int)decrypted_message_length);

--- a/src/wrappers/themis/php7/php_session.c
+++ b/src/wrappers/themis/php7/php_session.c
@@ -124,7 +124,7 @@ PHP_METHOD(themis_secure_session, wrap){
     }
     char* wrapped_message=emalloc((int)wrapped_message_length);
     if(wrapped_message==NULL){
-        zend_throw_exception(zend_exception_get_default(TSRMLS_C), "Error: themis_secure_session in wrap: not enough mamory.", 0 TSRMLS_CC);
+        zend_throw_exception(zend_exception_get_default(TSRMLS_C), "Error: themis_secure_session in wrap: not enough memory.", 0 TSRMLS_CC);
         RETURN_NULL();
     }
     if(secure_session_wrap(obj->session, message, message_length, wrapped_message, &wrapped_message_length)!=THEMIS_SUCCESS){
@@ -141,7 +141,7 @@ PHP_METHOD(themis_secure_session, unwrap){
     char* message;
     size_t message_length;
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &message, &message_length) == FAILURE) {
-        zend_throw_exception(zend_exception_get_default(TSRMLS_C), "Error: themis_secure_session in uwrap: invalid parameters.", 0 TSRMLS_CC);
+        zend_throw_exception(zend_exception_get_default(TSRMLS_C), "Error: themis_secure_session in unwrap: invalid parameters.", 0 TSRMLS_CC);
         RETURN_NULL();
     }
     themis_secure_session_object *obj = Z_SESSION_P(getThis());

--- a/src/wrappers/themis/python/pythemis/ssession.py
+++ b/src/wrappers/themis/python/pythemis/ssession.py
@@ -120,7 +120,7 @@ class SSession(object):
     def __init__(self, user_id, sign_key, transport):
         # user_id - user identification ("server" for example)
         # sign_key - private key of session owner
-        # transport - refference for transport_t object.
+        # transport - reference for transport_t object.
         self.session_ctx = ctypes.POINTER(ctypes.c_int)
         if transport is None:
             self.session_ctx = ssession_create(

--- a/src/wrappers/themis/rust/src/lib.rs
+++ b/src/wrappers/themis/rust/src/lib.rs
@@ -17,7 +17,7 @@
 //! **Themis** is a high-level cryptographic library.
 //!
 //! Themis allows you to protect data at rest (in your database, files, or wherever you store it
-//! in your application) and data in motion (i.e. traveling between client and server, server
+//! in your application) and data in motion (i.e. travelling between client and server, server
 //! and server, application and application, a smart coffee machine and a smart vacuum cleaner).
 //!
 //! Themis is a portable, cross-platform implementation of several cryptosystems:

--- a/src/wrappers/themis/rust/src/lib.rs
+++ b/src/wrappers/themis/rust/src/lib.rs
@@ -17,7 +17,7 @@
 //! **Themis** is a high-level cryptographic library.
 //!
 //! Themis allows you to protect data at rest (in your database, files, or wherever you store it
-//! in your application) and data in motion (i.e. travelling between client and server, server
+//! in your application) and data in motion (i.e. traveling between client and server, server
 //! and server, application and application, a smart coffee machine and a smart vacuum cleaner).
 //!
 //! Themis is a portable, cross-platform implementation of several cryptosystems:

--- a/src/wrappers/themis/themispp/input_buffer.hpp
+++ b/src/wrappers/themis/themispp/input_buffer.hpp
@@ -28,7 +28,7 @@ namespace themispp
  *
  * @param [in]  container   STL-compatible container of bytes
  *
- * `container` must be an STL-compatible contigous container of bytes. That is,
+ * `container` must be an STL-compatible contiguous container of bytes. That is,
  * there should be `std::begin()` and `std::end()` implementations for it which
  * return contiguous iterators over `uint8_t`.
  *
@@ -52,7 +52,7 @@ inline impl::input_buffer input_buffer(const Container& container) noexcept
  * @param [in]  begin   STL-compatible iterator over bytes
  * @param [in]  end     STL-compatible iterator over bytes
  *
- * `begin` and `end` must be STL-compatible contigous iterators over `uint8_t`.
+ * `begin` and `end` must be STL-compatible contiguous iterators over `uint8_t`.
  *
  * The following standard containers produce appropriate iterators:
  *

--- a/src/wrappers/themis/themispp/secure_cell_context_imprint.hpp
+++ b/src/wrappers/themis/themispp/secure_cell_context_imprint.hpp
@@ -107,7 +107,7 @@ public:
      * during decryption. Usually this is some plaintext data associated associated with the
      * encrypted data, such as database row number, protocol message ID, client name, etc.
      *
-     * @returns Newly allocated containter with encrypted data, same length as input.
+     * @returns Newly allocated container with encrypted data, same length as input.
      * Context Imprint mode does not include any additional data for integrity validation.
      *
      * @throws themispp::exception_t if `plaintext` or `context` is empty.
@@ -140,7 +140,7 @@ public:
      * mismatched context has been used, or if the message data has been
      * corrupted or tampered with.
      *
-     * @returns Newly allocated containter with decrypted data. You should
+     * @returns Newly allocated container with decrypted data. You should
      * validate its correctness and integrity.
      *
      * @throws themispp::exception_t if `encrypted` or `context` is empty.

--- a/src/wrappers/themis/themispp/secure_cell_seal.hpp
+++ b/src/wrappers/themis/themispp/secure_cell_seal.hpp
@@ -107,7 +107,7 @@ public:
      *
      * This method is equivalent to using an empty associated context.
      *
-     * @returns Newly allocated containter with encrypted data and authentication token.
+     * @returns Newly allocated container with encrypted data and authentication token.
      *
      * @throws themispp::exception_t if `plaintext` is empty.
      * @throws themispp::exception_t on encryption failure.
@@ -133,7 +133,7 @@ public:
      * during decryption. Usually this is some plaintext data associated associated with the
      * encrypted data, such as database row number, protocol message ID, etc.
      *
-     * @returns Newly allocated containter with encrypted data and authentication token.
+     * @returns Newly allocated container with encrypted data and authentication token.
      *
      * @throws themispp::exception_t if `plaintext` is empty.
      * @throws themispp::exception_t on encryption failure.
@@ -163,7 +163,7 @@ public:
      *
      * This method is equivalent to using an empty associated context.
      *
-     * @returns Newly allocated containter with decrypted data if everything goes well.
+     * @returns Newly allocated container with decrypted data if everything goes well.
      *
      * @throws themispp::exception_t if data cannot be decrypted. Usually this means that either
      * the data has been tampered with, or the master key or associated context are not the
@@ -192,7 +192,7 @@ public:
      * You need to provide the same context as it was used during encryption (or use
      * an empty context if there was no context).
      *
-     * @returns Newly allocated containter with decrypted data if everything goes well.
+     * @returns Newly allocated container with decrypted data if everything goes well.
      *
      * @throws themispp::exception_t if data cannot be decrypted. Usually this means that either
      * the data has been tampered with, or the master key or associated context are not the
@@ -365,7 +365,7 @@ public:
      *
      * This method is equivalent to using an empty associated context.
      *
-     * @returns Newly allocated containter with encrypted data and authentication token.
+     * @returns Newly allocated container with encrypted data and authentication token.
      *
      * @throws themispp::exception_t if `plaintext` is empty.
      * @throws themispp::exception_t on encryption failure.
@@ -391,7 +391,7 @@ public:
      * during decryption. Usually this is some plaintext data associated associated with the
      * encrypted data, such as database row number, protocol message ID, etc.
      *
-     * @returns Newly allocated containter with encrypted data and authentication token.
+     * @returns Newly allocated container with encrypted data and authentication token.
      *
      * @throws themispp::exception_t if `plaintext` is empty.
      * @throws themispp::exception_t on encryption failure.
@@ -421,7 +421,7 @@ public:
      *
      * This method is equivalent to using an empty associated context.
      *
-     * @returns Newly allocated containter with decrypted data if everything goes well.
+     * @returns Newly allocated container with decrypted data if everything goes well.
      *
      * @throws themispp::exception_t if data cannot be decrypted. Usually this means that either
      * the data has been tampered with, or the master key or associated context are not the
@@ -450,7 +450,7 @@ public:
      * You need to provide the same context as it was used during encryption (or use
      * an empty context if there was no context).
      *
-     * @returns Newly allocated containter with decrypted data if everything goes well.
+     * @returns Newly allocated container with decrypted data if everything goes well.
      *
      * @throws themispp::exception_t if data cannot be decrypted. Usually this means that either
      * the data has been tampered with, or the master key or associated context are not the

--- a/src/wrappers/themis/themispp/secure_cell_token_protect.hpp
+++ b/src/wrappers/themis/themispp/secure_cell_token_protect.hpp
@@ -108,7 +108,7 @@ public:
      * are supported as input. Plaintext must not be empty.
      *
      * Data is encrypted and authentication token is produced separately. Encrypted data has
-     * the same length as the original. You will need to provide the token durinng decryption
+     * the same length as the original. You will need to provide the token during decryption
      * so maintain the association between the data and the token.
      *
      * @see encrypt(const Plaintext& plaintext, const Context& context) const
@@ -136,7 +136,7 @@ public:
      * are supported as input. Plaintext must not be empty.
      *
      * Data is encrypted and authentication token is produced separately. Encrypted data has
-     * the same length as the original. You will need to provide the token durinng decryption
+     * the same length as the original. You will need to provide the token during decryption
      * so maintain the association between the data and the token.
      *
      * The context, if provided, is cryptographically mixed with the data, but is not included
@@ -175,7 +175,7 @@ public:
      *
      * This method is equivalent to using an empty associated context.
      *
-     * @returns Newly allocated containter with decrypted data if everything goes well.
+     * @returns Newly allocated container with decrypted data if everything goes well.
      *
      * @throws themispp::exception_t if data cannot be decrypted. Usually this means that either
      * the data or the token has been tampered with, or the master key or associated context
@@ -206,7 +206,7 @@ public:
      * or empty context if there was no context). The token also must be the one produced
      * during encryption.
      *
-     * @returns Newly allocated containter with decrypted data if everything goes well.
+     * @returns Newly allocated container with decrypted data if everything goes well.
      *
      * @throws themispp::exception_t if data cannot be decrypted. Usually this means that either
      * the data or the token has been tampered with, or the master key or associated context

--- a/src/wrappers/themis/wasm/src/index.ts
+++ b/src/wrappers/themis/wasm/src/index.ts
@@ -102,7 +102,7 @@ export const initialize = async (wasmPath?: string) => {
 // Users have been warned.
 
 // TypeScript does not allow to extend Promise nicely in ES5 [1], but since
-// JavaScript is actually duck-typed, we can just mimick the API.
+// JavaScript is actually duck-typed, we can just mimic the API.
 // [1]: https://github.com/microsoft/TypeScript/issues/15202
 class InitializedPromise {
   private initialized: boolean = false;

--- a/src/wrappers/themis/wasm/src/secure_comparator.ts
+++ b/src/wrappers/themis/wasm/src/secure_comparator.ts
@@ -48,7 +48,7 @@ export class SecureComparator {
     }
   }
 
-  // Unfortunately, JavsScript does not have a ubiquitious way to handle
+  // Unfortunately, JavsScript does not have a ubiquitous way to handle
   // scoped objects and does not specify any object finalization. Thus
   // it is VERY important to call destroy() on SecureComparators after
   // using them in order to avoid exhausting Emscripten heap memory.

--- a/src/wrappers/themis/wasm/src/secure_session.ts
+++ b/src/wrappers/themis/wasm/src/secure_session.ts
@@ -34,7 +34,7 @@ function isFunction(obj: any) {
   return !!(obj && obj.constructor && obj.call && obj.apply);
 }
 
-// Secure Session C API operatates with "secure_session_user_callbacks_t" context structure
+// Secure Session C API operates with "secure_session_user_callbacks_t" context structure
 // defined in <themis/secure_session.h>. It must be filled in with C function pointers and
 // an arbitrary C context pointer. Associated C functions are called by Secure Session
 // at appropriate moments. They receive the C context pointer as their last argument which
@@ -135,7 +135,7 @@ const getSecureSession = (callbacksPtr: number): SecureSession =>
 // write the key into provided buffer, and return zero on success. Non-zero return
 // values are considered errors.
 //
-// The function accepts five integer argumentes and returns an integer. Hence its
+// The function accepts five integer arguments and returns an integer. Hence its
 // LLVM signature is "iiiiii".
 //
 // We can throw JavaScript exceptions from inside the function, thanks to Emscripten.

--- a/src/wrappers/themis/wasm/test/test.js
+++ b/src/wrappers/themis/wasm/test/test.js
@@ -78,7 +78,7 @@ describe('wasm-themis', function() {
                 assert.throws(() => new themis.KeyPair(invalid, keyPair.publicKey), TypeError)
             })
         })
-        describe('invididual keys', function() {
+        describe('individual keys', function() {
             it('ensure matching kinds', function() {
                 let pair = new themis.KeyPair()
                 assert.throws(() => new themis.PrivateKey(pair.publicKey))
@@ -183,7 +183,7 @@ describe('wasm-themis', function() {
                 let encrypted = cell.encrypt(testInput)
                 assert(encrypted.length > testInput.length)
             })
-            it('forbits empty inputs', function() {
+            it('forbids empty inputs', function() {
                 assert.throws(() => themis.SecureCellSeal.withKey(emptyArray),
                     expectError(ThemisErrorCode.INVALID_PARAMETER)
                 )


### PR DESCRIPTION
<!-- Describe your changes here -->
Fixed typos in comments
Fixed typo in declaration in wrappers/themis/java...SecureSession.java:
  Renamed jniGenerateConntect to jniGenerateConnect

## Checklist
- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Public API has proper documentation
- [x] Example projects and code samples are up-to-date (in case of API changes)
- [x] ~~Changelog is updated~~ (not needed, despite JNI changes)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
