### PR TITLE
CI: Pin "ubuntu-20.04" et al.

### DIFF
--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -32,7 +32,7 @@ env:
 jobs:
   check-formatting:
     name: Check formatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     # GitHub's host contains way too much crap in /etc/apt/sources.list
     # which causes package conflicts in clang-format-8 and clang-tidy-8
     # installation. Run this job in a pristine Ubuntu 20.04 container.

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -34,7 +34,7 @@ env:
 jobs:
   cross-language:
     name: Cross-language tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |

--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -39,7 +39,7 @@ jobs:
       SOTER_KDF_RUN_LONG_TESTS: yes
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-20.04, macos-latest]
       fail-fast: false
     steps:
       - name: Install system dependencies
@@ -115,7 +115,7 @@ jobs:
 
   examples:
     name: Code examples
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |
@@ -142,7 +142,7 @@ jobs:
 
   sanitizers:
     name: Unit tests (with sanitizers)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       WITH_FATAL_SANITIZERS: yes
     steps:
@@ -176,7 +176,7 @@ jobs:
 
   benchmarks:
     name: Benchmarks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |
@@ -329,7 +329,7 @@ jobs:
 
   leak-check:
     name: Memory leaks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |
@@ -367,7 +367,7 @@ jobs:
 
   coverage:
     name: Unit test coverage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |

--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -40,7 +40,7 @@ jobs:
       MATRIX_OS: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12]
+        os: [ubuntu-20.04, ubuntu-22.04, macos-12]
       fail-fast: false
     steps:
       - name: Install system dependencies
@@ -58,11 +58,10 @@ jobs:
         with:
           submodules: true
       - name: Build Themis Core (OpenSSL)
-        if: always()
+        if: ${{ matrix.os != 'ubuntu-22.04' }}
         run: make prepare_tests_basic ENGINE=openssl BUILD_PATH=build-openssl
       - name: Build Themis Core (OpenSSL 3.0)
-        # TODO: expand this to Linux systems when OpenSSL 3.0 system library is available there
-        if: ${{ matrix.os == 'macos-12' }}
+        if: ${{ matrix.os != 'ubuntu-20.04' }}
         run: |
           export ENGINE=openssl
           # macOS has both OpenSSL 1.1.1 and 3.0 installed, be specific.
@@ -79,13 +78,13 @@ jobs:
         if: always()
         run: make prepare_tests_basic ENGINE=boringssl BUILD_PATH=build-boringssl
       - name: Build Themis Core (WITH_SCELL_COMPAT)
-        if: always()
+        if: ${{ matrix.os != 'ubuntu-22.04' }}
         run: make prepare_tests_basic WITH_SCELL_COMPAT=yes BUILD_PATH=build-compat
       - name: Run test suite (OpenSSL)
-        if: always()
+        if: ${{ matrix.os != 'ubuntu-22.04' }}
         run: make test ENGINE=openssl BUILD_PATH=build-openssl
       - name: Run test suite (OpenSSL 3.0)
-        if: ${{ matrix.os == 'macos-12' }}
+        if: ${{ matrix.os != 'ubuntu-20.04' }}
         run: |
           export ENGINE=openssl
           # macOS has both OpenSSL 1.1.1 and 3.0 installed, be specific.
@@ -101,10 +100,10 @@ jobs:
         if: always()
         run: make test ENGINE=boringssl BUILD_PATH=build-boringssl
       - name: Run test suite (WITH_SCELL_COMPAT)
-        if: always()
+        if: ${{ matrix.os != 'ubuntu-22.04' }}
         run: make test WITH_SCELL_COMPAT=yes BUILD_PATH=build-compat
-      - name: Ensure OpenSSL 3.0 fails (macOS only)
-        if: ${{ matrix.os == 'macos-12' }}
+      - name: Ensure OpenSSL 3.0 fails
+        if: ${{ matrix.os != 'ubuntu-20.04' }}
         run: |
           export ENGINE=openssl
           # Themis uses OpenSSL 1.1 by default if installed.

--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -37,6 +37,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       SOTER_KDF_RUN_LONG_TESTS: yes
+      MATRIX_OS: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-12]
@@ -63,10 +64,13 @@ jobs:
         # TODO: expand this to Linux systems when OpenSSL 3.0 system library is available there
         if: ${{ matrix.os == 'macos-12' }}
         run: |
-          openssl3="$(brew --prefix openssl@3)"
           export ENGINE=openssl
-          export ENGINE_INCLUDE_PATH="$openssl3/include"
-          export ENGINE_LIB_PATH="$openssl3/lib"
+          # macOS has both OpenSSL 1.1.1 and 3.0 installed, be specific.
+          if [[ "$MATRIX_OS" = "macos-12" ]]; then
+            openssl3="$(brew --prefix openssl@3)"
+            export ENGINE_INCLUDE_PATH="$openssl3/include"
+            export ENGINE_LIB_PATH="$openssl3/lib"
+          fi
           # TODO: stop using deprecated API so that warnings can be errors again
           export WITH_EXPERIMENTAL_OPENSSL_3_SUPPORT=yes
           export WITH_FATAL_WARNINGS=no
@@ -83,10 +87,13 @@ jobs:
       - name: Run test suite (OpenSSL 3.0)
         if: ${{ matrix.os == 'macos-12' }}
         run: |
-          openssl3="$(brew --prefix openssl@3)"
           export ENGINE=openssl
-          export ENGINE_INCLUDE_PATH="$openssl3/include"
-          export ENGINE_LIB_PATH="$openssl3/lib"
+          # macOS has both OpenSSL 1.1.1 and 3.0 installed, be specific.
+          if [[ "$MATRIX_OS" = "macos-12" ]]; then
+            openssl3="$(brew --prefix openssl@3)"
+            export ENGINE_INCLUDE_PATH="$openssl3/include"
+            export ENGINE_LIB_PATH="$openssl3/lib"
+          fi
           export WITH_EXPERIMENTAL_OPENSSL_3_SUPPORT=yes
           export WITH_FATAL_WARNINGS=no
           make test BUILD_PATH=build-openssl-3.0
@@ -99,12 +106,14 @@ jobs:
       - name: Ensure OpenSSL 3.0 fails (macOS only)
         if: ${{ matrix.os == 'macos-12' }}
         run: |
+          export ENGINE=openssl
           # Themis uses OpenSSL 1.1 by default if installed.
           # Explicitly request OpenSSL 3.0 by pointing the build into OpenSSL 3.0's paths.
-          openssl3=$(brew --prefix openssl@3)
-          export ENGINE=openssl
-          export ENGINE_INCLUDE_PATH="$openssl3/include"
-          export ENGINE_LIB_PATH="$openssl3/lib"
+          if [[ "$MATRIX_OS" = "macos-12" ]]; then
+            openssl3=$(brew --prefix openssl@3)
+            export ENGINE_INCLUDE_PATH="$openssl3/include"
+            export ENGINE_LIB_PATH="$openssl3/lib"
+          fi
           if ! make BUILD_PATH=build-openssl-3.0-without-magic-word
           then
             true

--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -39,7 +39,7 @@ jobs:
       SOTER_KDF_RUN_LONG_TESTS: yes
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest]
+        os: [ubuntu-20.04, macos-12]
       fail-fast: false
     steps:
       - name: Install system dependencies
@@ -61,7 +61,7 @@ jobs:
         run: make prepare_tests_basic ENGINE=openssl BUILD_PATH=build-openssl
       - name: Build Themis Core (OpenSSL 3.0)
         # TODO: expand this to Linux systems when OpenSSL 3.0 system library is available there
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == 'macos-12' }}
         run: |
           openssl3="$(brew --prefix openssl@3)"
           export ENGINE=openssl
@@ -81,7 +81,7 @@ jobs:
         if: always()
         run: make test ENGINE=openssl BUILD_PATH=build-openssl
       - name: Run test suite (OpenSSL 3.0)
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == 'macos-12' }}
         run: |
           openssl3="$(brew --prefix openssl@3)"
           export ENGINE=openssl
@@ -97,7 +97,7 @@ jobs:
         if: always()
         run: make test WITH_SCELL_COMPAT=yes BUILD_PATH=build-compat
       - name: Ensure OpenSSL 3.0 fails (macOS only)
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == 'macos-12' }}
         run: |
           # Themis uses OpenSSL 1.1 by default if installed.
           # Explicitly request OpenSSL 3.0 by pointing the build into OpenSSL 3.0's paths.
@@ -396,7 +396,7 @@ jobs:
 
   msys2:
     name: MSYS2 environment
-    runs-on: windows-latest
+    runs-on: windows-2022
     env:
       SOTER_KDF_RUN_LONG_TESTS: yes
     defaults:

--- a/.github/workflows/test-cpp.yaml
+++ b/.github/workflows/test-cpp.yaml
@@ -28,7 +28,7 @@ env:
 jobs:
   unit-tests:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |
@@ -73,7 +73,7 @@ jobs:
 
   examples:
     name: Code examples
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -29,7 +29,7 @@ env:
 jobs:
   unit-tests:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         go:
@@ -63,7 +63,7 @@ jobs:
 
   examples:
     name: Code examples
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |
@@ -121,7 +121,7 @@ jobs:
 
   reference-implementation:
     name: Reference implementation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |

--- a/.github/workflows/test-java.yaml
+++ b/.github/workflows/test-java.yaml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest]
+        os: [ubuntu-20.04, macos-12]
       fail-fast: false
     steps:
       - name: Install system dependencies

--- a/.github/workflows/test-java.yaml
+++ b/.github/workflows/test-java.yaml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-20.04, macos-latest]
       fail-fast: false
     steps:
       - name: Install system dependencies
@@ -99,7 +99,7 @@ jobs:
 
   android-example:
     name: Example – AndroidThemis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -112,7 +112,7 @@ jobs:
 
   java-example:
     name: Example project – JavaThemis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |

--- a/.github/workflows/test-nodejs.yaml
+++ b/.github/workflows/test-nodejs.yaml
@@ -26,7 +26,7 @@ env:
 jobs:
   unit-tests:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         node-version:
@@ -63,7 +63,7 @@ jobs:
 
   examples:
     name: Code examples
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         node-version:

--- a/.github/workflows/test-objc.yaml
+++ b/.github/workflows/test-objc.yaml
@@ -56,10 +56,8 @@ env:
   HACK_REPOSITORY: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
   HACK_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
-  # let's use Xcode 12 to test Xcode12-specifics
-  # the list is here
-  # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md
-  DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
+  # https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#xcode
+  DEVELOPER_DIR: /Applications/Xcode_14.0.1.app/Contents/Developer
 
 jobs:
   unit-tests-cocoapods:

--- a/.github/workflows/test-objc.yaml
+++ b/.github/workflows/test-objc.yaml
@@ -64,7 +64,7 @@ env:
 jobs:
   unit-tests-cocoapods:
     name: Unit tests (CocoaPods)
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -98,7 +98,7 @@ jobs:
 
   unit-tests-carthage:
     name: Unit tests (Carthage)
-    runs-on: macos-latest
+    runs-on: macos-12
     env:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -164,7 +164,7 @@ jobs:
 
   project-carthage:
     name: Carthage project
-    runs-on: macos-latest
+    runs-on: macos-12
     env:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -190,7 +190,7 @@ jobs:
 
   project-cocoapods:
     name: CocoaPods project
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -233,7 +233,7 @@ jobs:
 
   examples:
     name: Code examples
-    runs-on: macos-latest
+    runs-on: macos-12
     env:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/test-php.yaml
+++ b/.github/workflows/test-php.yaml
@@ -26,7 +26,7 @@ env:
 jobs:
   unit-tests:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |
@@ -115,7 +115,7 @@ jobs:
 
   examples:
     name: Code examples
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -26,7 +26,7 @@ env:
 jobs:
   unit-tests:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |
@@ -49,7 +49,7 @@ jobs:
 
   examples:
     name: Code examples
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
     services:

--- a/.github/workflows/test-ruby.yaml
+++ b/.github/workflows/test-ruby.yaml
@@ -26,7 +26,7 @@ env:
 jobs:
   unit-tests:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |
@@ -62,7 +62,7 @@ jobs:
 
   examples:
     name: Code examples
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -27,7 +27,7 @@ env:
 jobs:
   unit-tests:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |
@@ -73,7 +73,7 @@ jobs:
 
   examples:
     name: Code examples
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |
@@ -169,7 +169,7 @@ jobs:
 
   bindgen:
     name: libthemis-sys bindings
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |

--- a/.github/workflows/test-wasm.yaml
+++ b/.github/workflows/test-wasm.yaml
@@ -33,7 +33,7 @@ env:
 jobs:
   build-wasmthemis:
     name: Build WasmThemis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |
@@ -73,7 +73,7 @@ jobs:
 
   unit-tests:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: build-wasmthemis
     strategy:
       matrix:
@@ -105,7 +105,7 @@ jobs:
 
   examples:
     name: Code examples
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: build-wasmthemis
     strategy:
       matrix:


### PR DESCRIPTION
So recently the microsoft gods have decided that `ubuntu-latest` will mean `ubuntu-22.04` for this repo. Sadly, we don't (officially) support Ubuntu 22.04 just yet because of OpenSSL 3.0 business. See:

- #953
- #873

Roll back CI to using `ubuntu-20.04` explicitly. Pin other OSes while we're at it. Now if a build breaks because of the runner environment, this is likely because we have missed all the warnings and pleadings from GitHub, the runner is permanently unavailable and we _must_ migrate. A different tradeoff compared to the current status quo when builds simply break one day because of an unexpected upgrade.

Anyways. Additionally, do test `ubuntu-22.04` but only for one job, verifying Themis Core library with OpenSSL 3.0, setting all the necessary secret flags.

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Public API has proper documentation
- [x] ~~Changelog is updated~~ (don't need anything, right?)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
