### PR TITLE
rust: Suppress "clippy::needless_borrow"

### DIFF
--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -28,6 +28,10 @@ jobs:
   unit-tests:
     name: Unit tests
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        rust: [stable, '1.51']
+      fail-fast: false
     steps:
       - name: Install system dependencies
         run: |
@@ -37,7 +41,7 @@ jobs:
       - name: Install stable Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.rust }}
           profile: minimal
           components: rustfmt, clippy
       - name: Check out code
@@ -74,6 +78,10 @@ jobs:
   examples:
     name: Code examples
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        rust: [stable, '1.51']
+      fail-fast: false
     steps:
       - name: Install system dependencies
         run: |
@@ -83,7 +91,7 @@ jobs:
       - name: Install stable Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.rust }}
           profile: minimal
       - name: Check out code
         uses: actions/checkout@v2

--- a/docs/examples/rust/secure_cell.rs
+++ b/docs/examples/rust/secure_cell.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(clippy::needless_borrow)]
+
 use themis::keys::SymmetricKey;
 use themis::secure_cell::SecureCell;
 

--- a/docs/examples/rust/secure_message_client_encrypt.rs
+++ b/docs/examples/rust/secure_message_client_encrypt.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(clippy::needless_borrow)]
+
 #[macro_use]
 extern crate log;
 

--- a/docs/examples/rust/secure_message_client_verify.rs
+++ b/docs/examples/rust/secure_message_client_verify.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(clippy::needless_borrow)]
+
 #[macro_use]
 extern crate log;
 

--- a/docs/examples/rust/secure_message_server.rs
+++ b/docs/examples/rust/secure_message_server.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(clippy::needless_borrow)]
+
 #[macro_use]
 extern crate log;
 

--- a/docs/examples/rust/secure_session_echo_client.rs
+++ b/docs/examples/rust/secure_session_echo_client.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(clippy::needless_borrow)]
+
 use std::io::{self, Read, Write};
 use std::net::TcpStream;
 

--- a/docs/examples/rust/secure_session_echo_server.rs
+++ b/docs/examples/rust/secure_session_echo_server.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(clippy::needless_borrow)]
+
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 

--- a/src/wrappers/themis/rust/libthemis-sys/bindgen.sh
+++ b/src/wrappers/themis/rust/libthemis-sys/bindgen.sh
@@ -38,9 +38,9 @@ bindgen bindgen.h \
     --disable-header-comment \
     --rustified-enum "themis_key_kind" \
     --size_t-is-usize \
-    --whitelist-function "$WHITELIST" \
-    --whitelist-type "$WHITELIST" \
-    --whitelist-var "$WHITELIST" \
+    --allowlist-function "$WHITELIST" \
+    --allowlist-type "$WHITELIST" \
+    --allowlist-var "$WHITELIST" \
     --output src/lib.rs \
     -- \
     -I ../../../../../include \

--- a/src/wrappers/themis/rust/src/lib.rs
+++ b/src/wrappers/themis/rust/src/lib.rs
@@ -41,6 +41,7 @@
 //! [Secure Cell]: secure_cell/index.html
 //! [Secure Comparator]: secure_comparator/index.html
 
+#![allow(clippy::needless_borrow)]
 #![warn(missing_docs)]
 #![doc(html_no_source)]
 #![doc(

--- a/tests/rust/keys.rs
+++ b/tests/rust/keys.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(clippy::needless_borrow)]
+
 use themis::keygen::{gen_ec_key_pair, gen_rsa_key_pair};
 use themis::keys::{
     EcdsaPrivateKey, EcdsaPublicKey, KeyKind, KeyPair, PrivateKey, PublicKey, RsaPrivateKey,

--- a/tests/rust/secure_cell.rs
+++ b/tests/rust/secure_cell.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(clippy::needless_borrow)]
+
 use themis::keys::SymmetricKey;
 use themis::secure_cell::SecureCell;
 

--- a/tests/rust/secure_message.rs
+++ b/tests/rust/secure_message.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(clippy::needless_borrow)]
+
 use themis::keygen::{gen_ec_key_pair, gen_rsa_key_pair};
 use themis::secure_message::{SecureMessage, SecureSign, SecureVerify};
 use themis::ErrorKind;

--- a/tests/rust/secure_session.rs
+++ b/tests/rust/secure_session.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(clippy::needless_borrow)]
+
 use std::sync::mpsc::{channel, Receiver, Sender};
 
 use themis::keygen::gen_ec_key_pair;

--- a/tools/rust/scell_context_string_echo.rs
+++ b/tools/rust/scell_context_string_echo.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(clippy::needless_borrow)]
+
 use std::process::exit;
 
 use clap::clap_app;

--- a/tools/rust/scell_seal_string_echo.rs
+++ b/tools/rust/scell_seal_string_echo.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(clippy::needless_borrow)]
+
 use std::process::exit;
 
 use clap::clap_app;

--- a/tools/rust/scell_seal_string_echo_pw.rs
+++ b/tools/rust/scell_seal_string_echo_pw.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(clippy::needless_borrow)]
+
 use std::process::exit;
 
 use clap::clap_app;

--- a/tools/rust/scell_token_string_echo.rs
+++ b/tools/rust/scell_token_string_echo.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(clippy::needless_borrow)]
+
 use std::process::exit;
 
 use clap::clap_app;

--- a/tools/rust/smessage_encryption.rs
+++ b/tools/rust/smessage_encryption.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(clippy::needless_borrow)]
+
 use std::fs::File;
 use std::io::{self, Read};
 use std::process::exit;


### PR DESCRIPTION
Latest Clippy got this new lint and it's, like, everywhere in the codebase. Initially I wanted to oblige the piece of metal, but after fixing up wave after wave of warnings I decided that it is enough and I won't be a slave to the machine, given that in some cases the changes make the code less aesthetically pleasing.

Also, teach CI to test with both Rust 1.51 (the oldest version we support) and stable. If only stable breaks, that's likely because of the new Clippy.

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Example projects and code samples are up-to-date
- [x] ~~Changelog is updated~~ (not needed)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
