### PR TITLE
rust: Deal with new Rust 1.66 warnings

### DIFF
--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        rust: [stable, '1.51']
+        rust: [stable, '1.56']
       fail-fast: false
     steps:
       - name: Install system dependencies
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        rust: [stable, '1.51']
+        rust: [stable, '1.56']
       fail-fast: false
     steps:
       - name: Install system dependencies

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -38,10 +38,11 @@ jobs:
           sudo sh -c 'echo "DEBIAN_FRONTEND=noninteractive" >> /etc/environment'
           sudo apt update
           sudo apt install --yes gcc make libssl-dev pkg-config clang
-      - name: Install stable Rust
+      - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
+          default: true
           profile: minimal
           components: rustfmt, clippy
       - name: Check out code
@@ -88,11 +89,12 @@ jobs:
           sudo sh -c 'echo "DEBIAN_FRONTEND=noninteractive" >> /etc/environment'
           sudo apt update
           sudo apt install --yes gcc make libssl-dev pkg-config clang
-      - name: Install stable Rust
+      - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
           profile: minimal
+          default: true
       - name: Check out code
         uses: actions/checkout@v2
       - name: Install Themis Core

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ _Code:_
 
     This is technically a breaking change, but most reasonble implementations should be `Send` already. Please raise an issue if your code fails to build.
 
+  - Minimum supported Rust version is now 1.56 ([#977](https://github.com/cossacklabs/themis/pull/977)).
+
 - **WebAssembly**
 
   - Node.js v8 is no longer supported ([#901](https://github.com/cossacklabs/themis/pull/901)).

--- a/benches/themis/benches/secure_message_encrypt_decrypt_ecdsa.rs
+++ b/benches/themis/benches/secure_message_encrypt_decrypt_ecdsa.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(clippy::needless_borrow)]
+
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 
 use libthemis_sys::{

--- a/benches/themis/benches/secure_message_encrypt_decrypt_rsa.rs
+++ b/benches/themis/benches/secure_message_encrypt_decrypt_rsa.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(clippy::needless_borrow)]
+
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 
 use libthemis_sys::{

--- a/benches/themis/benches/secure_message_sign_verify_ecdsa.rs
+++ b/benches/themis/benches/secure_message_sign_verify_ecdsa.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(clippy::needless_borrow)]
+
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 
 use libthemis_sys::{

--- a/benches/themis/benches/secure_message_sign_verify_rsa.rs
+++ b/benches/themis/benches/secure_message_sign_verify_rsa.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(clippy::needless_borrow)]
+
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 
 use libthemis_sys::{

--- a/docs/examples/rust/secure_session_echo_server.rs
+++ b/docs/examples/rust/secure_session_echo_server.rs
@@ -80,7 +80,7 @@ impl SecureSessionTransport for SocketTransport {
         }
         self.socket.read_exact(&mut data[0..length])?;
         debug!("{:?}: received {} bytes", self.socket.peer_addr(), length);
-        Ok(length as usize)
+        Ok(length)
     }
 
     fn state_changed(&mut self, state: SecureSessionState) {

--- a/src/wrappers/themis/rust/src/keygen.rs
+++ b/src/wrappers/themis/rust/src/keygen.rs
@@ -105,8 +105,8 @@ fn try_gen_rsa_key_pair() -> Result<RsaKeyPair> {
         }
         debug_assert!(private_key_len <= private_key.capacity());
         debug_assert!(public_key_len <= public_key.capacity());
-        private_key.set_len(private_key_len as usize);
-        public_key.set_len(public_key_len as usize);
+        private_key.set_len(private_key_len);
+        public_key.set_len(public_key_len);
     }
 
     let private_key = RsaPrivateKey::from_vec(private_key);
@@ -165,8 +165,8 @@ fn try_gen_ec_key_pair() -> Result<EcdsaKeyPair> {
         }
         debug_assert!(private_key_len <= private_key.capacity());
         debug_assert!(public_key_len <= public_key.capacity());
-        private_key.set_len(private_key_len as usize);
-        public_key.set_len(public_key_len as usize);
+        private_key.set_len(private_key_len);
+        public_key.set_len(public_key_len);
     }
 
     let private_key = EcdsaPrivateKey::from_vec(private_key);

--- a/src/wrappers/themis/rust/src/keys.rs
+++ b/src/wrappers/themis/rust/src/keys.rs
@@ -649,7 +649,7 @@ impl SymmetricKey {
                 return Err(error);
             }
             debug_assert!(key_len <= key.capacity());
-            key.set_len(key_len as usize);
+            key.set_len(key_len);
         }
 
         Ok(Self {

--- a/src/wrappers/themis/rust/src/secure_cell.rs
+++ b/src/wrappers/themis/rust/src/secure_cell.rs
@@ -935,7 +935,7 @@ fn encrypt_seal(master_key: &[u8], user_context: &[u8], message: &[u8]) -> Resul
         }
     }
 
-    encrypted_message.reserve(encrypted_message_len as usize);
+    encrypted_message.reserve(encrypted_message_len);
 
     unsafe {
         let status = themis_secure_cell_encrypt_seal(
@@ -953,7 +953,7 @@ fn encrypt_seal(master_key: &[u8], user_context: &[u8], message: &[u8]) -> Resul
             return Err(error);
         }
         debug_assert!(encrypted_message_len <= encrypted_message.capacity());
-        encrypted_message.set_len(encrypted_message_len as usize);
+        encrypted_message.set_len(encrypted_message_len);
     }
 
     Ok(encrypted_message)
@@ -985,7 +985,7 @@ fn decrypt_seal(master_key: &[u8], user_context: &[u8], message: &[u8]) -> Resul
         }
     }
 
-    decrypted_message.reserve(decrypted_message_len as usize);
+    decrypted_message.reserve(decrypted_message_len);
 
     unsafe {
         let status = themis_secure_cell_decrypt_seal(
@@ -1003,7 +1003,7 @@ fn decrypt_seal(master_key: &[u8], user_context: &[u8], message: &[u8]) -> Resul
             return Err(error);
         }
         debug_assert!(decrypted_message_len <= decrypted_message.capacity());
-        decrypted_message.set_len(decrypted_message_len as usize);
+        decrypted_message.set_len(decrypted_message_len);
     }
 
     Ok(decrypted_message)
@@ -1039,7 +1039,7 @@ fn encrypt_seal_with_passphrase(
         }
     }
 
-    encrypted_message.reserve(encrypted_message_len as usize);
+    encrypted_message.reserve(encrypted_message_len);
 
     unsafe {
         let status = themis_secure_cell_encrypt_seal_with_passphrase(
@@ -1057,7 +1057,7 @@ fn encrypt_seal_with_passphrase(
             return Err(error);
         }
         debug_assert!(encrypted_message_len <= encrypted_message.capacity());
-        encrypted_message.set_len(encrypted_message_len as usize);
+        encrypted_message.set_len(encrypted_message_len);
     }
 
     Ok(encrypted_message)
@@ -1093,7 +1093,7 @@ fn decrypt_seal_with_passphrase(
         }
     }
 
-    decrypted_message.reserve(decrypted_message_len as usize);
+    decrypted_message.reserve(decrypted_message_len);
 
     unsafe {
         let status = themis_secure_cell_decrypt_seal_with_passphrase(
@@ -1111,7 +1111,7 @@ fn decrypt_seal_with_passphrase(
             return Err(error);
         }
         debug_assert!(decrypted_message_len <= decrypted_message.capacity());
-        decrypted_message.set_len(decrypted_message_len as usize);
+        decrypted_message.set_len(decrypted_message_len);
     }
 
     Ok(decrypted_message)
@@ -1549,8 +1549,8 @@ fn encrypt_token_protect(
         }
     }
 
-    token.reserve(token_len as usize);
-    encrypted_message.reserve(encrypted_message_len as usize);
+    token.reserve(token_len);
+    encrypted_message.reserve(encrypted_message_len);
 
     unsafe {
         let status = themis_secure_cell_encrypt_token_protect(
@@ -1570,9 +1570,9 @@ fn encrypt_token_protect(
             return Err(error);
         }
         debug_assert!(token_len <= token.capacity());
-        token.set_len(token_len as usize);
+        token.set_len(token_len);
         debug_assert!(encrypted_message_len <= encrypted_message.capacity());
-        encrypted_message.set_len(encrypted_message_len as usize);
+        encrypted_message.set_len(encrypted_message_len);
     }
 
     Ok((encrypted_message, token))
@@ -1612,7 +1612,7 @@ fn decrypt_token_protect(
         }
     }
 
-    decrypted_message.reserve(decrypted_message_len as usize);
+    decrypted_message.reserve(decrypted_message_len);
 
     unsafe {
         let status = themis_secure_cell_decrypt_token_protect(
@@ -1632,7 +1632,7 @@ fn decrypt_token_protect(
             return Err(error);
         }
         debug_assert!(decrypted_message_len <= decrypted_message.capacity());
-        decrypted_message.set_len(decrypted_message_len as usize);
+        decrypted_message.set_len(decrypted_message_len);
     }
 
     Ok(decrypted_message)
@@ -1866,7 +1866,7 @@ fn encrypt_context_imprint(master_key: &[u8], message: &[u8], context: &[u8]) ->
         }
     }
 
-    encrypted_message.reserve(encrypted_message_len as usize);
+    encrypted_message.reserve(encrypted_message_len);
 
     unsafe {
         let status = themis_secure_cell_encrypt_context_imprint(
@@ -1884,7 +1884,7 @@ fn encrypt_context_imprint(master_key: &[u8], message: &[u8], context: &[u8]) ->
             return Err(error);
         }
         debug_assert!(encrypted_message_len <= encrypted_message.capacity());
-        encrypted_message.set_len(encrypted_message_len as usize);
+        encrypted_message.set_len(encrypted_message_len);
     }
 
     Ok(encrypted_message)
@@ -1916,7 +1916,7 @@ fn decrypt_context_imprint(master_key: &[u8], message: &[u8], context: &[u8]) ->
         }
     }
 
-    decrypted_message.reserve(decrypted_message_len as usize);
+    decrypted_message.reserve(decrypted_message_len);
 
     unsafe {
         let status = themis_secure_cell_decrypt_context_imprint(
@@ -1934,7 +1934,7 @@ fn decrypt_context_imprint(master_key: &[u8], message: &[u8], context: &[u8]) ->
             return Err(error);
         }
         debug_assert!(decrypted_message_len <= decrypted_message.capacity());
-        decrypted_message.set_len(decrypted_message_len as usize);
+        decrypted_message.set_len(decrypted_message_len);
     }
 
     Ok(decrypted_message)

--- a/src/wrappers/themis/rust/src/secure_message.rs
+++ b/src/wrappers/themis/rust/src/secure_message.rs
@@ -183,7 +183,7 @@ impl SecureMessage {
                 return Err(error);
             }
             debug_assert!(encrypted_len <= encrypted.capacity());
-            encrypted.set_len(encrypted_len as usize);
+            encrypted.set_len(encrypted_len);
         }
 
         Ok(encrypted)
@@ -233,7 +233,7 @@ impl SecureMessage {
                 return Err(error);
             }
             debug_assert!(decrypted_len <= decrypted.capacity());
-            decrypted.set_len(decrypted_len as usize);
+            decrypted.set_len(decrypted_len);
         }
 
         Ok(decrypted)
@@ -365,7 +365,7 @@ impl SecureSign {
                 return Err(error);
             }
             debug_assert!(signed_len <= signed.capacity());
-            signed.set_len(signed_len as usize);
+            signed.set_len(signed_len);
         }
 
         Ok(signed)
@@ -493,7 +493,7 @@ impl SecureVerify {
                 return Err(error);
             }
             debug_assert!(original_len <= original.capacity());
-            original.set_len(original_len as usize);
+            original.set_len(original_len);
         }
 
         Ok(original)


### PR DESCRIPTION
I noticed that both "stable" and "1.51" builds are failing with new warnings from Clippy 1.66. That's weird. Turns out the "1.51" build was actually testing the latest stable Rust. Way to go. And RustThemis actually does not work with 1.51, the minimum version that works is 1.56.

After that is dealt with, clean up some things that Clippy 1.66 complains about. Suppress some others (#971).

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] Example projects and code samples are up-to-date
- [X] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
