### PR TITLE
CI: Run MSYS2 build with OpenSSL 3.0

### DIFF
--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -432,6 +432,9 @@ jobs:
     runs-on: windows-2022
     env:
       SOTER_KDF_RUN_LONG_TESTS: yes
+      # TODO: stop using deprecated API so that warnings can be errors again
+      WITH_EXPERIMENTAL_OPENSSL_3_SUPPORT: yes
+      WITH_FATAL_WARNINGS: "no" # YAML :trollface:
     defaults:
       run:
         shell: msys2 {0}
@@ -441,8 +444,8 @@ jobs:
         with:
           install: >-
             base-devel tar git gcc make
-            libopenssl>=1.1.1
-            openssl-devel>=1.1.1
+            libopenssl>=3.0.0
+            openssl-devel>=3.0.0
             mingw-w64-x86_64-nsis
       # Git, I know you're only trying to help, but MSYS can work with
       # UNIX line endings just fine. In fact, "makepkg" *requires* them.

--- a/PKGBUILD.MSYS2
+++ b/PKGBUILD.MSYS2
@@ -4,7 +4,7 @@
 
 pkgname=('themis' 'themis-devel')
 pkgbase=themis
-pkgver=0.13.0
+pkgver=0.14.0
 pkgrel=1
 
 pkgdesc="Data security library for network communication and data storage"
@@ -17,9 +17,9 @@ depends=('libopenssl>=1.1.1')
 makedepends=('tar' 'gcc' 'make' 'openssl-devel>=1.1.1')
 
 source=("https://github.com/cossacklabs/themis/archive/$pkgver.tar.gz")
-sha256sums=('4dbe8faff569b8992ee091a207367604db468648503e5e6679a4c89e0918d525')
-sha1sums=('21372309e4e3d714bd637bce1e931e9be39a765f')
-md5sums=('623383678c6e73651a31b38cadcab441')
+sha256sums=('2efb793e0ef604fb97258b07671a83135ad9229d83b92d7758b43510dcc6cb07')
+sha1sums=('6d89a69014c24f39aedea684a78fc10f6019e505')
+md5sums=('46a69d51d9e8a5d96ae919f3bf547ce9')
 # TODO: verify package signature
 
 # Unfortunately, bsdtar cannot handle symlinks on MSYS2 [1] so we have to use


### PR DESCRIPTION
`master` is failing again. Looks like MSYS2 started defaulting to packaging OpenSSL 3.0 (like macOS does). So, uh, test the build with OpenSSL 3.0 now. It's an experimental build anyway. Make it green at least.

This is also embarrassing, but update MSYS2 package to package Themis 0.14.0 and not 0.13.0 lol

## Checklist

- [X] Change is covered by automated tests
- [X] The [coding guidelines] are followed
- [X] Changelog is updated (nothing needed, right?)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
