### PR TITLE
rust: Use f-string formatting syntax

### DIFF
--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        rust: [stable, '1.56']
+        rust: [stable, '1.58']
       fail-fast: false
     steps:
       - name: Install system dependencies
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        rust: [stable, '1.56']
+        rust: [stable, '1.58']
       fail-fast: false
     steps:
       - name: Install system dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _Code:_
 
     This is technically a breaking change, but most reasonble implementations should be `Send` already. Please raise an issue if your code fails to build.
 
-  - Minimum supported Rust version is now 1.56 ([#977](https://github.com/cossacklabs/themis/pull/977)).
+  - Minimum supported Rust version is now 1.58 ([#977](https://github.com/cossacklabs/themis/pull/977), [#984](https://github.com/cossacklabs/themis/pull/984)).
 
 - **WebAssembly**
 

--- a/benches/rust/Cargo.toml
+++ b/benches/rust/Cargo.toml
@@ -9,6 +9,8 @@ themis = { version = "0.14", path = "../../src/wrappers/themis/rust" }
 
 [dev-dependencies]
 criterion = { version = "0.3.4", features = ["cargo_bench_support", "html_reports"] }
+# Unpin when MSRV > 1.60
+csv = "~1.1"
 
 [[bench]]
 name = "secure_cell_seal_master_key"

--- a/benches/rust/benches/secure_cell_context_imprint_master_key.rs
+++ b/benches/rust/benches/secure_cell_context_imprint_master_key.rs
@@ -90,7 +90,7 @@ fn pretty(size: usize) -> String {
     } else if size >= KB {
         format!("{} KB", size / KB)
     } else {
-        format!("{}", size)
+        format!("{size}")
     }
 }
 

--- a/benches/rust/benches/secure_cell_seal_master_key.rs
+++ b/benches/rust/benches/secure_cell_seal_master_key.rs
@@ -88,7 +88,7 @@ fn pretty(size: usize) -> String {
     } else if size >= KB {
         format!("{} KB", size / KB)
     } else {
-        format!("{}", size)
+        format!("{size}")
     }
 }
 

--- a/benches/rust/benches/secure_cell_seal_passphrase.rs
+++ b/benches/rust/benches/secure_cell_seal_passphrase.rs
@@ -83,7 +83,7 @@ fn pretty(size: usize) -> String {
     } else if size >= KB {
         format!("{} KB", size / KB)
     } else {
-        format!("{}", size)
+        format!("{size}")
     }
 }
 

--- a/benches/rust/benches/secure_cell_token_protect_master_key.rs
+++ b/benches/rust/benches/secure_cell_token_protect_master_key.rs
@@ -90,7 +90,7 @@ fn pretty(size: usize) -> String {
     } else if size >= KB {
         format!("{} KB", size / KB)
     } else {
-        format!("{}", size)
+        format!("{size}")
     }
 }
 

--- a/benches/themis/Cargo.toml
+++ b/benches/themis/Cargo.toml
@@ -10,6 +10,8 @@ libthemis-sys = { version = "0.14", path = "../../src/wrappers/themis/rust/libth
 
 [dev-dependencies]
 criterion = { version = "0.3.4", features = ["cargo_bench_support", "html_reports"] }
+# Unpin when MSRV > 1.60
+csv = "~1.1"
 
 [[bench]]
 name = "secure_cell_seal_master_key"

--- a/benches/themis/benches/secure_cell_context_imprint_master_key.rs
+++ b/benches/themis/benches/secure_cell_context_imprint_master_key.rs
@@ -151,7 +151,7 @@ fn pretty(size: usize) -> String {
     } else if size >= KB {
         format!("{} KB", size / KB)
     } else {
-        format!("{}", size)
+        format!("{size}")
     }
 }
 

--- a/benches/themis/benches/secure_cell_seal_master_key.rs
+++ b/benches/themis/benches/secure_cell_seal_master_key.rs
@@ -150,7 +150,7 @@ fn pretty(size: usize) -> String {
     } else if size >= KB {
         format!("{} KB", size / KB)
     } else {
-        format!("{}", size)
+        format!("{size}")
     }
 }
 

--- a/benches/themis/benches/secure_cell_seal_passphrase.rs
+++ b/benches/themis/benches/secure_cell_seal_passphrase.rs
@@ -153,7 +153,7 @@ fn pretty(size: usize) -> String {
     } else if size >= KB {
         format!("{} KB", size / KB)
     } else {
-        format!("{}", size)
+        format!("{size}")
     }
 }
 

--- a/benches/themis/benches/secure_cell_token_protect_master_key.rs
+++ b/benches/themis/benches/secure_cell_token_protect_master_key.rs
@@ -163,7 +163,7 @@ fn pretty(size: usize) -> String {
     } else if size >= KB {
         format!("{} KB", size / KB)
     } else {
-        format!("{}", size)
+        format!("{size}")
     }
 }
 

--- a/benches/themis/benches/secure_message_encrypt_decrypt_ecdsa.rs
+++ b/benches/themis/benches/secure_message_encrypt_decrypt_ecdsa.rs
@@ -153,7 +153,7 @@ fn pretty(size: usize) -> String {
     } else if size >= KB {
         format!("{} KB", size / KB)
     } else {
-        format!("{}", size)
+        format!("{size}")
     }
 }
 

--- a/benches/themis/benches/secure_message_encrypt_decrypt_rsa.rs
+++ b/benches/themis/benches/secure_message_encrypt_decrypt_rsa.rs
@@ -153,7 +153,7 @@ fn pretty(size: usize) -> String {
     } else if size >= KB {
         format!("{} KB", size / KB)
     } else {
-        format!("{}", size)
+        format!("{size}")
     }
 }
 

--- a/benches/themis/benches/secure_message_sign_verify_ecdsa.rs
+++ b/benches/themis/benches/secure_message_sign_verify_ecdsa.rs
@@ -145,7 +145,7 @@ fn pretty(size: usize) -> String {
     } else if size >= KB {
         format!("{} KB", size / KB)
     } else {
-        format!("{}", size)
+        format!("{size}")
     }
 }
 

--- a/benches/themis/benches/secure_message_sign_verify_rsa.rs
+++ b/benches/themis/benches/secure_message_sign_verify_rsa.rs
@@ -145,7 +145,7 @@ fn pretty(size: usize) -> String {
     } else if size >= KB {
         format!("{} KB", size / KB)
     } else {
-        format!("{}", size)
+        format!("{size}")
     }
 }
 

--- a/docs/examples/rust/keygen.rs
+++ b/docs/examples/rust/keygen.rs
@@ -32,12 +32,12 @@ fn main() {
     let (private_key, public_key) = gen_ec_key_pair().split();
 
     match write_file(&private_key, private_path) {
-        Ok(_) => eprintln!("wrote private key to {}", private_path),
-        Err(e) => eprintln!("failed to write private key to {}: {}", private_path, e),
+        Ok(_) => eprintln!("wrote private key to {private_path}"),
+        Err(e) => eprintln!("failed to write private key to {private_path}: {e}"),
     }
     match write_file(&public_key, public_path) {
-        Ok(_) => eprintln!("wrote public key to {}", public_path),
-        Err(e) => eprintln!("failed to write public key to {}: {}", public_path, e),
+        Ok(_) => eprintln!("wrote public key to {public_path}"),
+        Err(e) => eprintln!("failed to write public key to {public_path}: {e}"),
     }
 }
 

--- a/src/wrappers/themis/rust/Cargo.toml
+++ b/src/wrappers/themis/rust/Cargo.toml
@@ -2,6 +2,7 @@
 name = "themis"
 version = "0.14.0"
 edition = "2018"
+rust-version = "1.58.0"
 authors = ["rust-themis developers"]
 description = "High-level cryptographic services for storage and messaging"
 homepage = "https://www.cossacklabs.com/themis/"

--- a/src/wrappers/themis/rust/libthemis-sys/Cargo.toml
+++ b/src/wrappers/themis/rust/libthemis-sys/Cargo.toml
@@ -2,6 +2,7 @@
 name = "libthemis-sys"
 version = "0.14.0"
 edition = "2018"
+rust-version = "1.58.0"
 authors = ["rust-themis developers"]
 description = "FFI binding to libthemis"
 homepage = "https://www.cossacklabs.com/themis/"

--- a/src/wrappers/themis/rust/libthemis-sys/build.rs
+++ b/src/wrappers/themis/rust/libthemis-sys/build.rs
@@ -46,7 +46,7 @@ to locate your library by setting the PKG_CONFIG_PATH environment
 variable to the path where `libthemis.pc` file is located.
 "
             );
-            eprintln!("{}", error);
+            eprintln!("{error}");
 
             if try_system_themis() {
                 eprintln!(

--- a/src/wrappers/themis/rust/src/error.rs
+++ b/src/wrappers/themis/rust/src/error.rs
@@ -121,7 +121,7 @@ impl error::Error for Error {}
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.kind {
-            ErrorKind::UnknownError(status) => write!(f, "unknown error: {}", status),
+            ErrorKind::UnknownError(status) => write!(f, "unknown error: {status}"),
             ErrorKind::Success => write!(f, "success"),
 
             ErrorKind::Fail => write!(f, "failure"),
@@ -135,7 +135,7 @@ impl fmt::Display for Error {
             ErrorKind::SessionSendOutputToPeer => write!(f, "send key agreement data to peer"),
             ErrorKind::SessionKeyAgreementNotFinished => write!(f, "key agreement not finished"),
             ErrorKind::SessionTransportError(ref details) => {
-                write!(f, "transport layer error: {}", details)
+                write!(f, "transport layer error: {details}")
             }
             ErrorKind::SessionGetPublicKeyForIdError => {
                 write!(f, "failed to get public key for ID")

--- a/src/wrappers/themis/rust/src/secure_session.rs
+++ b/src/wrappers/themis/rust/src/secure_session.rs
@@ -294,8 +294,8 @@ impl fmt::Display for TransportError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self.inner {
             TransportErrorInner::Unspecified => write!(f, "Secure Session transport failed"),
-            TransportErrorInner::Simple(s) => write!(f, "Secure Session transport failed: {}", s),
-            TransportErrorInner::Custom(e) => write!(f, "Secure Session transport failed: {}", e),
+            TransportErrorInner::Simple(s) => write!(f, "Secure Session transport failed: {s}"),
+            TransportErrorInner::Custom(e) => write!(f, "Secure Session transport failed: {e}"),
         }
     }
 }
@@ -304,8 +304,8 @@ impl fmt::Debug for TransportError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self.inner {
             TransportErrorInner::Unspecified => write!(f, "TransportError::Unspecified"),
-            TransportErrorInner::Simple(s) => write!(f, "TransportError::Simple({:?})", s),
-            TransportErrorInner::Custom(e) => write!(f, "TransportError::Custom({:?})", e),
+            TransportErrorInner::Simple(s) => write!(f, "TransportError::Simple({s:?})"),
+            TransportErrorInner::Custom(e) => write!(f, "TransportError::Custom({e:?})"),
         }
     }
 }

--- a/tools/rust/keygen_tool.rs
+++ b/tools/rust/keygen_tool.rs
@@ -36,11 +36,11 @@ fn main() {
 
     match write_file(&private_key, private_path, 0o400) {
         Ok(_) => {}
-        Err(e) => eprintln!("failed to write private key to {}: {}", private_path, e),
+        Err(e) => eprintln!("failed to write private key to {private_path}: {e}"),
     }
     match write_file(&public_key, public_path, 0o666) {
         Ok(_) => {}
-        Err(e) => eprintln!("failed to write public key to {}: {}", public_path, e),
+        Err(e) => eprintln!("failed to write public key to {public_path}: {e}"),
     }
 }
 

--- a/tools/rust/scell_context_string_echo.rs
+++ b/tools/rust/scell_context_string_echo.rs
@@ -47,26 +47,26 @@ fn main() {
             let encrypted = cell
                 .encrypt_with_context(&message, &context)
                 .unwrap_or_else(|error| {
-                    eprintln!("failed to encrypt message: {}", error);
+                    eprintln!("failed to encrypt message: {error}");
                     exit(1);
                 });
             println!("{}", base64::encode(&encrypted));
         }
         "dec" => {
             let decoded_message = base64::decode(&message).unwrap_or_else(|error| {
-                eprintln!("failed to decode message: {}", error);
+                eprintln!("failed to decode message: {error}");
                 exit(1);
             });
             let decrypted = cell
                 .decrypt_with_context(&decoded_message, &context)
                 .unwrap_or_else(|error| {
-                    eprintln!("failed to decrypt message: {}", error);
+                    eprintln!("failed to decrypt message: {error}");
                     exit(1);
                 });
             println!("{}", std::str::from_utf8(&decrypted).expect("UTF-8 string"));
         }
         other => {
-            eprintln!("invalid mode {}, use \"enc\" or \"dec\"", other);
+            eprintln!("invalid mode {other}, use \"enc\" or \"dec\"");
             exit(1);
         }
     }

--- a/tools/rust/scell_seal_string_echo.rs
+++ b/tools/rust/scell_seal_string_echo.rs
@@ -47,26 +47,26 @@ fn main() {
             let encrypted = cell
                 .encrypt_with_context(&message, &context)
                 .unwrap_or_else(|error| {
-                    eprintln!("failed to encrypt message: {}", error);
+                    eprintln!("failed to encrypt message: {error}");
                     exit(1);
                 });
             println!("{}", base64::encode(&encrypted));
         }
         "dec" => {
             let decoded_message = base64::decode(&message).unwrap_or_else(|error| {
-                eprintln!("failed to decode message: {}", error);
+                eprintln!("failed to decode message: {error}");
                 exit(1);
             });
             let decrypted = cell
                 .decrypt_with_context(&decoded_message, &context)
                 .unwrap_or_else(|error| {
-                    eprintln!("failed to decrypt message: {}", error);
+                    eprintln!("failed to decrypt message: {error}");
                     exit(1);
                 });
             println!("{}", std::str::from_utf8(&decrypted).expect("UTF-8 string"));
         }
         other => {
-            eprintln!("invalid mode {}, use \"enc\" or \"dec\"", other);
+            eprintln!("invalid mode {other}, use \"enc\" or \"dec\"");
             exit(1);
         }
     }

--- a/tools/rust/scell_seal_string_echo_pw.rs
+++ b/tools/rust/scell_seal_string_echo_pw.rs
@@ -47,26 +47,26 @@ fn main() {
             let encrypted = cell
                 .encrypt_with_context(&message, &context)
                 .unwrap_or_else(|error| {
-                    eprintln!("failed to encrypt message: {}", error);
+                    eprintln!("failed to encrypt message: {error}");
                     exit(1);
                 });
             println!("{}", base64::encode(&encrypted));
         }
         "dec" => {
             let decoded_message = base64::decode(&message).unwrap_or_else(|error| {
-                eprintln!("failed to decode message: {}", error);
+                eprintln!("failed to decode message: {error}");
                 exit(1);
             });
             let decrypted = cell
                 .decrypt_with_context(&decoded_message, &context)
                 .unwrap_or_else(|error| {
-                    eprintln!("failed to decrypt message: {}", error);
+                    eprintln!("failed to decrypt message: {error}");
                     exit(1);
                 });
             println!("{}", std::str::from_utf8(&decrypted).expect("UTF-8 string"));
         }
         other => {
-            eprintln!("invalid command \"{}\", use \"enc\" or \"dec\"", other);
+            eprintln!("invalid command \"{other}\", use \"enc\" or \"dec\"");
             exit(1);
         }
     }

--- a/tools/rust/scell_token_string_echo.rs
+++ b/tools/rust/scell_token_string_echo.rs
@@ -51,30 +51,30 @@ fn main() {
             let (encrypted, token) = cell
                 .encrypt_with_context(&message, &context)
                 .unwrap_or_else(|error| {
-                    eprintln!("failed to encrypt message: {}", error);
+                    eprintln!("failed to encrypt message: {error}");
                     exit(1);
                 });
             println!("{},{}", base64::encode(&encrypted), base64::encode(&token));
         }
         "dec" => {
             let decoded_message = base64::decode(&message).unwrap_or_else(|error| {
-                eprintln!("failed to decode message: {}", error);
+                eprintln!("failed to decode message: {error}");
                 exit(1);
             });
             let decoded_token = base64::decode(&token).unwrap_or_else(|error| {
-                eprintln!("failed to decode token: {}", error);
+                eprintln!("failed to decode token: {error}");
                 exit(1);
             });
             let decrypted = cell
                 .decrypt_with_context(&decoded_message, &decoded_token, &context)
                 .unwrap_or_else(|error| {
-                    eprintln!("failed to decrypt message: {}", error);
+                    eprintln!("failed to decrypt message: {error}");
                     exit(1);
                 });
             println!("{}", std::str::from_utf8(&decrypted).expect("UTF-8 string"));
         }
         other => {
-            eprintln!("invalid mode {}, use \"enc\" or \"dec\"", other);
+            eprintln!("invalid mode {other}, use \"enc\" or \"dec\"");
             exit(1);
         }
     }

--- a/tools/rust/smessage_encryption.rs
+++ b/tools/rust/smessage_encryption.rs
@@ -49,7 +49,7 @@ fn main() {
             let encrypter = SecureMessage::new(key_pair);
 
             let encrypted = encrypter.encrypt(&message).unwrap_or_else(|error| {
-                eprintln!("failed to encrypt message: {}", error);
+                eprintln!("failed to encrypt message: {error}");
                 exit(1);
             });
 
@@ -60,11 +60,11 @@ fn main() {
             let encrypter = SecureMessage::new(key_pair);
 
             let decoded_message = base64::decode(&message).unwrap_or_else(|error| {
-                eprintln!("failed to decode message: {}", error);
+                eprintln!("failed to decode message: {error}");
                 exit(1);
             });
             let decrypted = encrypter.decrypt(&decoded_message).unwrap_or_else(|error| {
-                eprintln!("failed to decrypt message: {}", error);
+                eprintln!("failed to decrypt message: {error}");
                 exit(1);
             });
 
@@ -74,7 +74,7 @@ fn main() {
             let signer = SecureSign::new(private_key);
 
             let signed = signer.sign(&message).unwrap_or_else(|error| {
-                eprintln!("failed to sign message: {}", error);
+                eprintln!("failed to sign message: {error}");
                 exit(1);
             });
 
@@ -84,21 +84,18 @@ fn main() {
             let signer = SecureVerify::new(public_key);
 
             let decoded_message = base64::decode(&message).unwrap_or_else(|error| {
-                eprintln!("failed to decode message: {}", error);
+                eprintln!("failed to decode message: {error}");
                 exit(1);
             });
             let verified = signer.verify(&decoded_message).unwrap_or_else(|error| {
-                eprintln!("failed to verify message: {}", error);
+                eprintln!("failed to verify message: {error}");
                 exit(1);
             });
 
             println!("{}", std::str::from_utf8(&verified).expect("UTF-8 string"));
         }
         other => {
-            eprintln!(
-                "invalid command {}, use \"enc\", \"dec\", \"sign\", \"verify\"",
-                other
-            );
+            eprintln!("invalid command {other}, use \"enc\", \"dec\", \"sign\", \"verify\"",);
             exit(1);
         }
     }


### PR DESCRIPTION
Or "variable capture" as it's called around here. Since of Rust 1.67, our God-Emperor Clippy started demanding this form of formatting.

    error: variables can be used directly in the `format!` string
        --> src/wrappers/themis/rust/libthemis-sys/build.rs:49:13
        |
     49 |             eprintln!("{}", error);
        |             ^^^^^^^^^^^^^^^^^^^^^^
        |
        = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
        = note: `-D clippy::uninlined-format-args` implied by `-D warnings`
    help: change this to
        |
     49 -             eprintln!("{}", error);
     49 +             eprintln!("{error}");
        |

Given that we're running WITH_FATAL_WARNINGS, we must either cave in, or suppress the lint. Suppressing it on Rust 1.56 requires suppressing another lint about unknown lint being suppressed.

So, given that we're unlikely to have users which require Rust 1.56 specifically, I think it's okay to cave in, update MSRV to 1.58, and update all affect format strings so that Clippy stays happy.

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Example projects and code samples are up-to-date (in case of API changes)
- [x] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md