### PR TITLE
rust: Respect WITH_FATAL_WARNINGS setting

### DIFF
--- a/tests/rust/run_tests.sh
+++ b/tests/rust/run_tests.sh
@@ -2,8 +2,10 @@
 
 set -e
 
-# Treat warnings as errors
-export RUSTFLAGS="-D warnings"
+if [ "${WITH_FATAL_WARNINGS:-}" = "yes" ]; then
+    # Treat warnings as errors
+    export RUSTFLAGS="-D warnings"
+fi
 
 echo
 echo "Checking code style..."


### PR DESCRIPTION
Uh... I am not sure why it's like that, but warnings should be treated as errors only when WITH_FATAL_WARNINGS is set. At least, that's what the rest of the build system expects.

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] ~~Changelog is updated~~ (CI only)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
