### PR TITLE
CI: Pin "ubuntu-20.04" et al to branch release/0.14 

### DIFF
--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -32,7 +32,7 @@ env:
 jobs:
   check-formatting:
     name: Check formatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     # GitHub's host contains way too much crap in /etc/apt/sources.list
     # which causes package conflicts in clang-format-8 and clang-tidy-8
     # installation. Run this job in a pristine Ubuntu 20.04 container.

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -34,7 +34,7 @@ env:
 jobs:
   cross-language:
     name: Cross-language tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |

--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -37,9 +37,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       SOTER_KDF_RUN_LONG_TESTS: yes
+      MATRIX_OS: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-20.04, ubuntu-22.04, macos-12]
       fail-fast: false
     steps:
       - name: Install system dependencies
@@ -57,16 +58,18 @@ jobs:
         with:
           submodules: true
       - name: Build Themis Core (OpenSSL)
-        if: always()
+        if: ${{ matrix.os != 'ubuntu-22.04' }}
         run: make prepare_tests_basic ENGINE=openssl BUILD_PATH=build-openssl
       - name: Build Themis Core (OpenSSL 3.0)
-        # TODO: expand this to Linux systems when OpenSSL 3.0 system library is available there
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os != 'ubuntu-20.04' }}
         run: |
-          openssl3="$(brew --prefix openssl@3)"
           export ENGINE=openssl
-          export ENGINE_INCLUDE_PATH="$openssl3/include"
-          export ENGINE_LIB_PATH="$openssl3/lib"
+          # macOS has both OpenSSL 1.1.1 and 3.0 installed, be specific.
+          if [[ "$MATRIX_OS" = "macos-12" ]]; then
+            openssl3="$(brew --prefix openssl@3)"
+            export ENGINE_INCLUDE_PATH="$openssl3/include"
+            export ENGINE_LIB_PATH="$openssl3/lib"
+          fi
           # TODO: stop using deprecated API so that warnings can be errors again
           export WITH_EXPERIMENTAL_OPENSSL_3_SUPPORT=yes
           export WITH_FATAL_WARNINGS=no
@@ -75,18 +78,21 @@ jobs:
         if: always()
         run: make prepare_tests_basic ENGINE=boringssl BUILD_PATH=build-boringssl
       - name: Build Themis Core (WITH_SCELL_COMPAT)
-        if: always()
+        if: ${{ matrix.os != 'ubuntu-22.04' }}
         run: make prepare_tests_basic WITH_SCELL_COMPAT=yes BUILD_PATH=build-compat
       - name: Run test suite (OpenSSL)
-        if: always()
+        if: ${{ matrix.os != 'ubuntu-22.04' }}
         run: make test ENGINE=openssl BUILD_PATH=build-openssl
       - name: Run test suite (OpenSSL 3.0)
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os != 'ubuntu-20.04' }}
         run: |
-          openssl3="$(brew --prefix openssl@3)"
           export ENGINE=openssl
-          export ENGINE_INCLUDE_PATH="$openssl3/include"
-          export ENGINE_LIB_PATH="$openssl3/lib"
+          # macOS has both OpenSSL 1.1.1 and 3.0 installed, be specific.
+          if [[ "$MATRIX_OS" = "macos-12" ]]; then
+            openssl3="$(brew --prefix openssl@3)"
+            export ENGINE_INCLUDE_PATH="$openssl3/include"
+            export ENGINE_LIB_PATH="$openssl3/lib"
+          fi
           export WITH_EXPERIMENTAL_OPENSSL_3_SUPPORT=yes
           export WITH_FATAL_WARNINGS=no
           make test BUILD_PATH=build-openssl-3.0
@@ -94,17 +100,19 @@ jobs:
         if: always()
         run: make test ENGINE=boringssl BUILD_PATH=build-boringssl
       - name: Run test suite (WITH_SCELL_COMPAT)
-        if: always()
+        if: ${{ matrix.os != 'ubuntu-22.04' }}
         run: make test WITH_SCELL_COMPAT=yes BUILD_PATH=build-compat
-      - name: Ensure OpenSSL 3.0 fails (macOS only)
-        if: ${{ matrix.os == 'macos-latest' }}
+      - name: Ensure OpenSSL 3.0 fails
+        if: ${{ matrix.os != 'ubuntu-20.04' }}
         run: |
+          export ENGINE=openssl
           # Themis uses OpenSSL 1.1 by default if installed.
           # Explicitly request OpenSSL 3.0 by pointing the build into OpenSSL 3.0's paths.
-          openssl3=$(brew --prefix openssl@3)
-          export ENGINE=openssl
-          export ENGINE_INCLUDE_PATH="$openssl3/include"
-          export ENGINE_LIB_PATH="$openssl3/lib"
+          if [[ "$MATRIX_OS" = "macos-12" ]]; then
+            openssl3=$(brew --prefix openssl@3)
+            export ENGINE_INCLUDE_PATH="$openssl3/include"
+            export ENGINE_LIB_PATH="$openssl3/lib"
+          fi
           if ! make BUILD_PATH=build-openssl-3.0-without-magic-word
           then
             true
@@ -115,7 +123,7 @@ jobs:
 
   examples:
     name: Code examples
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |
@@ -142,7 +150,7 @@ jobs:
 
   sanitizers:
     name: Unit tests (with sanitizers)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       WITH_FATAL_SANITIZERS: yes
     steps:
@@ -176,7 +184,7 @@ jobs:
 
   benchmarks:
     name: Benchmarks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |
@@ -329,7 +337,7 @@ jobs:
 
   leak-check:
     name: Memory leaks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |
@@ -367,7 +375,7 @@ jobs:
 
   coverage:
     name: Unit test coverage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |
@@ -396,7 +404,7 @@ jobs:
 
   msys2:
     name: MSYS2 environment
-    runs-on: windows-latest
+    runs-on: windows-2022
     env:
       SOTER_KDF_RUN_LONG_TESTS: yes
     defaults:

--- a/.github/workflows/test-cpp.yaml
+++ b/.github/workflows/test-cpp.yaml
@@ -28,7 +28,7 @@ env:
 jobs:
   unit-tests:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |
@@ -73,7 +73,7 @@ jobs:
 
   examples:
     name: Code examples
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -29,7 +29,7 @@ env:
 jobs:
   unit-tests:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         go:
@@ -63,7 +63,7 @@ jobs:
 
   examples:
     name: Code examples
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |
@@ -121,7 +121,7 @@ jobs:
 
   reference-implementation:
     name: Reference implementation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |

--- a/.github/workflows/test-java.yaml
+++ b/.github/workflows/test-java.yaml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-20.04, macos-12]
       fail-fast: false
     steps:
       - name: Install system dependencies
@@ -95,7 +95,7 @@ jobs:
 
   android-example:
     name: Example – AndroidThemis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -108,7 +108,7 @@ jobs:
 
   java-example:
     name: Example project – JavaThemis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |

--- a/.github/workflows/test-nodejs.yaml
+++ b/.github/workflows/test-nodejs.yaml
@@ -26,7 +26,7 @@ env:
 jobs:
   unit-tests:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         node-version:
@@ -69,7 +69,7 @@ jobs:
 
   examples:
     name: Code examples
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         node-version:

--- a/.github/workflows/test-objc.yaml
+++ b/.github/workflows/test-objc.yaml
@@ -56,15 +56,13 @@ env:
   HACK_REPOSITORY: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
   HACK_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
-  # let's use Xcode 12 to test Xcode12-specifics
-  # the list is here
-  # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md
-  DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
+  # https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#xcode
+  DEVELOPER_DIR: /Applications/Xcode_14.0.1.app/Contents/Developer
 
 jobs:
   unit-tests-cocoapods:
     name: Unit tests (CocoaPods)
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -98,7 +96,7 @@ jobs:
 
   unit-tests-carthage:
     name: Unit tests (Carthage)
-    runs-on: macos-latest
+    runs-on: macos-12
     env:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -164,7 +162,7 @@ jobs:
 
   project-carthage:
     name: Carthage project
-    runs-on: macos-latest
+    runs-on: macos-12
     env:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -190,7 +188,7 @@ jobs:
 
   project-cocoapods:
     name: CocoaPods project
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -233,7 +231,7 @@ jobs:
 
   examples:
     name: Code examples
-    runs-on: macos-latest
+    runs-on: macos-12
     env:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/test-php.yaml
+++ b/.github/workflows/test-php.yaml
@@ -26,7 +26,7 @@ env:
 jobs:
   unit-tests:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |
@@ -115,7 +115,7 @@ jobs:
 
   examples:
     name: Code examples
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -26,7 +26,7 @@ env:
 jobs:
   unit-tests:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |
@@ -49,7 +49,7 @@ jobs:
 
   examples:
     name: Code examples
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
     services:

--- a/.github/workflows/test-ruby.yaml
+++ b/.github/workflows/test-ruby.yaml
@@ -26,7 +26,7 @@ env:
 jobs:
   unit-tests:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |
@@ -62,7 +62,7 @@ jobs:
 
   examples:
     name: Code examples
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -27,7 +27,7 @@ env:
 jobs:
   unit-tests:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |
@@ -73,7 +73,7 @@ jobs:
 
   examples:
     name: Code examples
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |
@@ -169,7 +169,7 @@ jobs:
 
   bindgen:
     name: libthemis-sys bindings
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |

--- a/.github/workflows/test-wasm.yaml
+++ b/.github/workflows/test-wasm.yaml
@@ -33,7 +33,7 @@ env:
 jobs:
   build-wasmthemis:
     name: Build WasmThemis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install system dependencies
         run: |
@@ -73,7 +73,7 @@ jobs:
 
   unit-tests:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: build-wasmthemis
     strategy:
       matrix:
@@ -106,7 +106,7 @@ jobs:
 
   examples:
     name: Code examples
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: build-wasmthemis
     strategy:
       matrix:


### PR DESCRIPTION
* CI: Pin ubuntu-20.04

Themis currently does not support OpenSSL 3.0 officially. Ubuntu 22.04 has made the switch and we can't support it in default configuration. This is something to be worked on in Themis 0.15, I guess, but for that we need a working CI first. Roll back "ubuntu-latest" to "ubuntu-20.04".

* CI: Pin macos-12 and windows-2022

While we're at it, pin macOS environment as well, along with Windows.

This a tradeoff. Now we have a more stable environment, but when it breaks -- due to GitHub dropping support -- we won't have an easy way to roll it back.

* CI: Use brew only in macOS builds

Pass "matrix.os" value as environment variable to the scripts and use it to decide whether to probe Homebrew for OpenSSL 3 paths. This is necessary for OpenSSL 3.0 testing on Linux.

* CI: Test Themis Core on Ubuntu 22.04

So here's the story. Themis does not (yet) support OpenSSL 3.0. There is an experimental flag to enable support, but we haven't tested it all too well. It probably works, but we aren't ready to sign off on that. Thus the build fails with OpenSSL 3.0 by default.

Here's the situation with CI:

  - Ubuntu 20.04 has only OpenSSL 1.1.1 (which is the default)

  - Ubuntu 22.04 has only OpenSSL 3.0 (which is the default)

  - macOS can have both, using OpenSSL 1.1.1 if available, or failing the build otherwise.

Make sure to test all these expectations. Note that most of the jobs are still running on Ubuntu 20.04 now. Ubuntu 22.04 is tested with OpenSSL 3.0 only for the core library.

* CI: Update Xcode DEVELOPER_DIR

Update the Xcode to the current default for macOS 12. This is likely to be outdated by the next year lol, but the previous versions have served us well for years.

<!-- Describe your changes here -->

## Checklist

- [x] Change is covered by automated tests
