### PR TITLE
CI: Remove Carthage distractions

### DIFF
--- a/.github/workflows/test-objc.yaml
+++ b/.github/workflows/test-objc.yaml
@@ -291,7 +291,11 @@ jobs:
         if: always()
         run: |
           cd $GITHUB_WORKSPACE/docs/examples/objc/iOS-Carthage
-          carthage bootstrap --platform iOS --use-xcframeworks
+          carthage bootstrap --platform iOS --use-xcframeworks --no-build
+          find Carthage/Checkouts/themis -type d -name '*.xcodeproj' \
+            | grep -v 'Carthage/Checkouts/themis/Themis.xcodeproj' \
+            | xargs rm -rf
+          carthage build --platform iOS --use-xcframeworks
           rm -rf DerivedData
           xcodebuild \
             -derivedDataPath DerivedData \
@@ -304,7 +308,11 @@ jobs:
         if: always()
         run: |
           cd $GITHUB_WORKSPACE/docs/examples/objc/macOS-Carthage
-          carthage bootstrap --platform macOS --use-xcframeworks
+          carthage bootstrap --platform macOS --use-xcframeworks --no-build
+          find Carthage/Checkouts/themis -type d -name '*.xcodeproj' \
+            | grep -v 'Carthage/Checkouts/themis/Themis.xcodeproj' \
+            | xargs rm -rf
+          carthage build --platform macOS --use-xcframeworks
           rm -rf DerivedData
           xcodebuild \
             -derivedDataPath DerivedData \
@@ -331,7 +339,11 @@ jobs:
         if: always()
         run: |
           cd $GITHUB_WORKSPACE/docs/examples/swift/iOS-Carthage
-          carthage bootstrap --platform iOS --use-xcframeworks
+          carthage bootstrap --platform iOS --use-xcframeworks --no-build
+          find Carthage/Checkouts/themis -type d -name '*.xcodeproj' \
+            | grep -v 'Carthage/Checkouts/themis/Themis.xcodeproj' \
+            | xargs rm -rf
+          carthage build --platform iOS --use-xcframeworks
           rm -rf DerivedData
           xcodebuild \
             -derivedDataPath DerivedData \
@@ -344,7 +356,11 @@ jobs:
         if: always()
         run: |
           cd $GITHUB_WORKSPACE/docs/examples/swift/macOS-Carthage
-          carthage bootstrap --platform macOS --use-xcframeworks
+          carthage bootstrap --platform macOS --use-xcframeworks --no-build
+          find Carthage/Checkouts/themis -type d -name '*.xcodeproj' \
+            | grep -v 'Carthage/Checkouts/themis/Themis.xcodeproj' \
+            | xargs rm -rf
+          carthage build --platform macOS --use-xcframeworks
           rm -rf DerivedData
           xcodebuild \
             -derivedDataPath DerivedData \


### PR DESCRIPTION
Carthage has this retarded tendency to build every Xcode project it sees when building dependencies. So when we do `carthage bootstrap` during example builds, it downloads dependencies (Themis repo), then proceeds to build the dependencies—but instead of building only Themis.xcodeproj in the root, Carthage decides that after that it gotta build every other Xcode project there as well, why not. Eventually it times out and dies.

This very frustrating, but Carthage people think it is okay, multilanguage monorepos do not exist, and you should not put example Xcode projects along with the source code. One repo = One library = One Xcode project. Anything else is heresy.

Anyway. This PR seems to help avoid timeouts and prevent Carthage from going on adventure. Sadly, builds still take fucking forever while Carthage fetches the repo, then fetches OpenSSL binaries, then does it again, then builds Themis, then builds example, then repeat that 5 more times for other examples. But at least they should not hang for 10 minutes and then die 🤞

Similar hack is applied in Bitrise builds, IIRC.

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Example projects and code samples are up-to-date
- [x] Changelog is updated
- [x] Carthage is a pile of 💩

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md