### PR TITLE
Fix benchmarks build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,3 @@ members = [
 default-members = [
     "src/wrappers/themis/rust",
 ]
-
-# Freeze `rayon` version (used by `criterion` used by benchmarks)
-# so that benchmarks still build/run with Rust 1.58.
-# FIXME: remove this after we bump minimum required Rust version
-[patch.crates-io]
-rayon = { git = "https://github.com/rayon-rs/rayon.git", tag = "v1.6.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,9 @@ members = [
 default-members = [
     "src/wrappers/themis/rust",
 ]
+
+# Freeze `rayon` version (used by `criterion` used by benchmarks)
+# so that benchmarks still build/run with Rust 1.58.
+# FIXME: remove this after we bump minimum required Rust version
+[patch.crates-io]
+rayon = { git = "https://github.com/rayon-rs/rayon.git", tag = "v1.6.1" }

--- a/benches/rust/Cargo.toml
+++ b/benches/rust/Cargo.toml
@@ -2,7 +2,6 @@
 name = "rust-themis-bench"
 version = "0.0.0"
 edition = "2018"
-rust-version = "1.59.0"
 publish = false
 
 [dependencies]

--- a/benches/rust/Cargo.toml
+++ b/benches/rust/Cargo.toml
@@ -11,6 +11,11 @@ themis = { version = "0.14", path = "../../src/wrappers/themis/rust" }
 criterion = { version = "0.3.4", features = ["cargo_bench_support", "html_reports"] }
 # Unpin when MSRV > 1.60
 csv = "~1.1"
+# Freeze `rayon` and `rayon-core` versions (first is used by `criterion`)
+# so that benchmarks still build/run with Rust 1.58.
+# FIXME: remove thiese two after we bump minimum required Rust version
+rayon = "=1.6.1"
+rayon-core = "=1.10.1"
 
 [[bench]]
 name = "secure_cell_seal_master_key"

--- a/benches/rust/Cargo.toml
+++ b/benches/rust/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rust-themis-bench"
 version = "0.0.0"
 edition = "2018"
+rust-version = "1.59.0"
 publish = false
 
 [dependencies]

--- a/benches/themis/Cargo.toml
+++ b/benches/themis/Cargo.toml
@@ -2,7 +2,6 @@
 name = "themis-core-bench"
 version = "0.0.0"
 edition = "2018"
-rust-version = "1.59.0"
 publish = false
 
 [dependencies]
@@ -10,6 +9,7 @@ themis = { version = "0.14", path = "../../src/wrappers/themis/rust" }
 libthemis-sys = { version = "0.14", path = "../../src/wrappers/themis/rust/libthemis-sys" }
 
 [dev-dependencies]
+criterion = { version = "0.3.4", features = ["cargo_bench_support", "html_reports"] }
 # Unpin when MSRV > 1.60
 csv = "~1.1"
 

--- a/benches/themis/Cargo.toml
+++ b/benches/themis/Cargo.toml
@@ -10,7 +10,6 @@ themis = { version = "0.14", path = "../../src/wrappers/themis/rust" }
 libthemis-sys = { version = "0.14", path = "../../src/wrappers/themis/rust/libthemis-sys" }
 
 [dev-dependencies]
-criterion = { version = "0.3.4", features = ["cargo_bench_support", "html_reports"] }
 # Unpin when MSRV > 1.60
 csv = "~1.1"
 

--- a/benches/themis/Cargo.toml
+++ b/benches/themis/Cargo.toml
@@ -12,6 +12,11 @@ libthemis-sys = { version = "0.14", path = "../../src/wrappers/themis/rust/libth
 criterion = { version = "0.3.4", features = ["cargo_bench_support", "html_reports"] }
 # Unpin when MSRV > 1.60
 csv = "~1.1"
+# Freeze `rayon` and `rayon-core` versions (first is used by `criterion`)
+# so that benchmarks still build/run with Rust 1.58.
+# FIXME: remove thiese two after we bump minimum required Rust version
+rayon = "=1.6.1"
+rayon-core = "=1.10.1"
 
 [[bench]]
 name = "secure_cell_seal_master_key"

--- a/benches/themis/Cargo.toml
+++ b/benches/themis/Cargo.toml
@@ -2,6 +2,7 @@
 name = "themis-core-bench"
 version = "0.0.0"
 edition = "2018"
+rust-version = "1.59.0"
 publish = false
 
 [dependencies]


### PR DESCRIPTION
One of dev dependencies pulls rayon 1.7.0, and its dependency rayon-core 1.11.0 now requires rust 1.59+

Freeze `rayon` so it will pull a bit older `rayon-core`

See [failed job](https://github.com/cossacklabs/themis/actions/runs/4344242147/jobs/7587317472) for the cause of this PR

<!-- Describe your changes here -->

## Checklist

- [x] Change is covered by automated tests
- [x] ~Benchmark results are attached (if applicable)~
- [x] The [coding guidelines] are followed
- [x] ~Public API has proper documentation~
- [x] ~Example projects and code samples are up-to-date (in case of API changes)~
- [x] ~Changelog is updated (in case of notable or breaking changes)~

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
