### PR TITLE
OpenSSL 3 support

### DIFF
--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -58,7 +58,6 @@ jobs:
         with:
           submodules: true
       - name: Build Themis Core (OpenSSL)
-        if: ${{ matrix.os != 'ubuntu-22.04' }}
         run: make prepare_tests_basic ENGINE=openssl BUILD_PATH=build-openssl
       - name: Build Themis Core (OpenSSL 3.0)
         if: ${{ matrix.os != 'ubuntu-20.04' }}
@@ -70,21 +69,15 @@ jobs:
             export ENGINE_INCLUDE_PATH="$openssl3/include"
             export ENGINE_LIB_PATH="$openssl3/lib"
           fi
-          # TODO: stop using deprecated API so that warnings can be errors again
-          export WITH_EXPERIMENTAL_OPENSSL_3_SUPPORT=yes
-          export WITH_FATAL_WARNINGS=no
           make prepare_tests_basic BUILD_PATH=build-openssl-3.0
       - name: Build Themis Core (BoringSSL)
         if: always()
         run: make prepare_tests_basic ENGINE=boringssl BUILD_PATH=build-boringssl
       - name: Build Themis Core (WITH_SCELL_COMPAT)
-        if: ${{ matrix.os != 'ubuntu-22.04' }}
         run: make prepare_tests_basic WITH_SCELL_COMPAT=yes BUILD_PATH=build-compat
       - name: Run test suite (OpenSSL)
-        if: ${{ matrix.os != 'ubuntu-22.04' }}
         run: make test ENGINE=openssl BUILD_PATH=build-openssl
       - name: Run test suite (OpenSSL, uncompressed keys)
-        if: ${{ matrix.os != 'ubuntu-22.04' }}
         env:
           THEMIS_GEN_EC_KEY_PAIR_UNCOMPRESSED: "1"
         run: make test ENGINE=openssl BUILD_PATH=build-openssl
@@ -98,8 +91,6 @@ jobs:
             export ENGINE_INCLUDE_PATH="$openssl3/include"
             export ENGINE_LIB_PATH="$openssl3/lib"
           fi
-          export WITH_EXPERIMENTAL_OPENSSL_3_SUPPORT=yes
-          export WITH_FATAL_WARNINGS=no
           make test BUILD_PATH=build-openssl-3.0
       - name: Run test suite (OpenSSL 3.0, uncompressed keys)
         if: ${{ matrix.os != 'ubuntu-20.04' }}
@@ -113,8 +104,6 @@ jobs:
             export ENGINE_INCLUDE_PATH="$openssl3/include"
             export ENGINE_LIB_PATH="$openssl3/lib"
           fi
-          export WITH_EXPERIMENTAL_OPENSSL_3_SUPPORT=yes
-          export WITH_FATAL_WARNINGS=no
           make test BUILD_PATH=build-openssl-3.0
       - name: Run test suite (BoringSSL)
         if: always()
@@ -125,26 +114,7 @@ jobs:
           THEMIS_GEN_EC_KEY_PAIR_UNCOMPRESSED: "1"
         run: make test ENGINE=boringssl BUILD_PATH=build-boringssl
       - name: Run test suite (WITH_SCELL_COMPAT)
-        if: ${{ matrix.os != 'ubuntu-22.04' }}
         run: make test WITH_SCELL_COMPAT=yes BUILD_PATH=build-compat
-      - name: Ensure OpenSSL 3.0 fails
-        if: ${{ matrix.os != 'ubuntu-20.04' }}
-        run: |
-          export ENGINE=openssl
-          # Themis uses OpenSSL 1.1 by default if installed.
-          # Explicitly request OpenSSL 3.0 by pointing the build into OpenSSL 3.0's paths.
-          if [[ "$MATRIX_OS" = "macos-12" ]]; then
-            openssl3=$(brew --prefix openssl@3)
-            export ENGINE_INCLUDE_PATH="$openssl3/include"
-            export ENGINE_LIB_PATH="$openssl3/lib"
-          fi
-          if ! make BUILD_PATH=build-openssl-3.0-without-magic-word
-          then
-            true
-          else
-            echo "Build with OpenSSL 3.0 did not fail when it should have"
-            exit 1
-          fi
 
   examples:
     name: Code examples
@@ -432,7 +402,9 @@ jobs:
     runs-on: windows-2022
     env:
       SOTER_KDF_RUN_LONG_TESTS: yes
-      # TODO: stop using deprecated API so that warnings can be errors again
+      # TODO: remove these two options when MSYS2 build issues are solved,
+      #       because now PKGBUILD.MSYS2 just downloads latest release archive
+      #       from GitHub instead of using checked out files
       WITH_EXPERIMENTAL_OPENSSL_3_SUPPORT: yes
       WITH_FATAL_WARNINGS: "no" # YAML :trollface:
     defaults:

--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -454,7 +454,7 @@ jobs:
 
   macos-cross-compile:
     name: macOS cross toolchain
-    runs-on: macos-10.15
+    runs-on: macos-12
     steps:
       - name: Install system dependencies
         run: |
@@ -470,7 +470,7 @@ jobs:
       # and that changes the available SDKs. Check the combinations here:
       # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#xcode
       - name: Build Themis Core (BoringSSL, arm64)
-        run: make SDK=macosx11.1 ARCH=arm64 ENGINE=boringssl
+        run: make SDK=macosx13.1 ARCH=arm64 ENGINE=boringssl
       # Of course we can't run unit tests either because there is no emulator.
       # So I will be satisifed to see the build succeed and produce binaries
       # with expected architecture.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ _Code:_
   - **Soter** (low-level security core used by Themis)
 
     - `soter_sign_export_key()` is now deprecated, superseded by `soter_sign_export_private_key()` and `soter_sign_export_public_key()` ([#959](https://github.com/cossacklabs/themis/pull/959))
-    - better OpenSSL 3 support, with many EC-related deprecated functions being replaced with newer alternatives, and OpenSSL 1.X is still supported
+    - better OpenSSL 3 support, with many EC- and RSA-related deprecated functions being replaced with newer alternatives, and OpenSSL 1.X is still supported
+    - removed build option THEMIS_EXPERIMENTAL_OPENSSL_3_SUPPORT since building/linking with OpenSSL 3 now works out of the box
 
 - **Android**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ _Code:_
   - **Soter** (low-level security core used by Themis)
 
     - `soter_sign_export_key()` is now deprecated, superseded by `soter_sign_export_private_key()` and `soter_sign_export_public_key()` ([#959](https://github.com/cossacklabs/themis/pull/959))
+    - better OpenSSL 3 support, with many EC-related deprecated functions being replaced with newer alternatives, and OpenSSL 1.X is still supported
 
 - **Android**
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,6 @@ if (NO_NIST_STS)
 add_definitions(-DNO_NIST_STS=1)
 endif()
 
-if (WITH_EXPERIMENTAL_OPENSSL_3_SUPPORT)
-add_definitions(-DTHEMIS_EXPERIMENTAL_OPENSSL_3_SUPPORT=1)
-endif()
-
 file(GLOB SOTER_SOURCE_FILES src/soter/*.c src/soter/openssl/*.c src/soter/ed25519/*)
 add_library(soter ${SOTER_SOURCE_FILES})
 add_library(soter_shared SHARED ${SOTER_SOURCE_FILES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,13 @@ project(themis)
 cmake_minimum_required(VERSION 3.8)
 include_directories(src)
 
+if (NO_NIST_STS)
+add_definitions(-DNO_NIST_STS=1)
+endif()
+
+if (WITH_EXPERIMENTAL_OPENSSL_3_SUPPORT)
+add_definitions(-DTHEMIS_EXPERIMENTAL_OPENSSL_3_SUPPORT=1)
+endif()
 
 file(GLOB SOTER_SOURCE_FILES src/soter/*.c src/soter/openssl/*.c src/soter/ed25519/*)
 add_library(soter ${SOTER_SOURCE_FILES})

--- a/Makefile
+++ b/Makefile
@@ -186,10 +186,6 @@ ifeq ($(RSA_KEY_LENGTH),8192)
 	CFLAGS += -DTHEMIS_RSA_KEY_LENGTH=RSA_KEY_LENGTH_8192
 endif
 
-ifeq ($(WITH_EXPERIMENTAL_OPENSSL_3_SUPPORT),yes)
-	CFLAGS += -DTHEMIS_EXPERIMENTAL_OPENSSL_3_SUPPORT=1
-endif
-
 ########################################################################
 #
 # Compilation flags for C/C++ code

--- a/src/soter/openssl/soter_bignum_utils.h
+++ b/src/soter/openssl/soter_bignum_utils.h
@@ -19,6 +19,9 @@
 
 #include <openssl/bn.h>
 #include <openssl/opensslv.h>
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#include <openssl/params.h>
+#endif
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 /* Simple implementation for OpenSSL <1.1.0 where this function is missing */
@@ -68,6 +71,21 @@ static void memcpy_big_endian(void* dst, const void* src, size_t size)
     }
 }
 #endif
+
+static int get_bn_param(
+    const EVP_PKEY* pkey, const char* name, unsigned char* buf, size_t buf_size, BIGNUM** bn)
+{
+    OSSL_PARAM params[2];
+
+    params[0] = OSSL_PARAM_construct_BN(name, buf, buf_size);
+    params[1] = OSSL_PARAM_construct_end();
+
+    if (!EVP_PKEY_get_params(pkey, params)) {
+        return 0;
+    }
+
+    return OSSL_PARAM_get_BN(params, bn);
+}
 #endif
 
 #endif /* THEMIS_SOTER_BIGNUM_UTILS_H */

--- a/src/soter/openssl/soter_bignum_utils.h
+++ b/src/soter/openssl/soter_bignum_utils.h
@@ -1,0 +1,50 @@
+/*
+* Copyright (c) 2023 Cossack Labs Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef THEMIS_SOTER_BIGNUM_UTILS_H
+#define THEMIS_SOTER_BIGNUM_UTILS_H
+
+#include <openssl/bn.h>
+#include <openssl/opensslv.h>
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+/* Simple implementation for OpenSSL <1.1.0 where this function is missing */
+static int BN_bn2binpad(const BIGNUM* a, unsigned char* to, int tolen)
+{
+    int bn_size = BN_num_bytes(a);
+    int bytes_copied;
+
+    if (a == NULL || to == NULL) {
+        return -1;
+    }
+
+    if (tolen < bn_size) {
+        return -1;
+    }
+
+    bytes_copied = BN_bn2bin(a, to + (tolen - bn_size));
+
+    if (bytes_copied != bn_size) {
+        return -1;
+    }
+
+    memset(to, 0, (size_t)(tolen - bn_size));
+
+    return tolen;
+}
+#endif
+
+#endif /* THEMIS_SOTER_BIGNUM_UTILS_H */

--- a/src/soter/openssl/soter_bignum_utils.h
+++ b/src/soter/openssl/soter_bignum_utils.h
@@ -51,27 +51,6 @@ static int BN_bn2binpad(const BIGNUM* a, unsigned char* to, int tolen)
 #endif
 
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
-// Like memcpy() but if host endianness is not "big", bytes are copied in reverse order.
-// Needed because EVP_PKEY_get_params() fills bigint buffers in native byte order
-// (which is usually "little"), but we use "big" in our keys, so need to reverse it
-// before putting into serialized key.
-#if __BYTE_ORDER == __BIG_ENDIAN
-static void memcpy_big_endian(void* dst, const void* src, size_t size)
-{
-    // Just copy the bytes, EVP_PKET_get_params() filled buffer with native order
-    memcpy(dst, src, size);
-}
-#else
-static void memcpy_big_endian(void* dst, const void* src, size_t size)
-{
-    // Host system uses different byte order, need to reverse
-    size_t i;
-    for (i = 0; i < size; i++) {
-        ((char*)dst)[size - i - 1] = ((char*)src)[i];
-    }
-}
-#endif
-
 static int get_bn_param(
     const EVP_PKEY* pkey, const char* name, unsigned char* buf, size_t buf_size, BIGNUM** bn)
 {

--- a/src/soter/openssl/soter_bignum_utils.h
+++ b/src/soter/openssl/soter_bignum_utils.h
@@ -63,7 +63,7 @@ static int get_bn_param(
         return 0;
     }
 
-    return OSSL_PARAM_get_BN(params, bn);
+    return OSSL_PARAM_get_BN(&params[0], bn);
 }
 #endif
 

--- a/src/soter/openssl/soter_bignum_utils.h
+++ b/src/soter/openssl/soter_bignum_utils.h
@@ -47,4 +47,27 @@ static int BN_bn2binpad(const BIGNUM* a, unsigned char* to, int tolen)
 }
 #endif
 
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+// Like memcpy() but if host endianness is not "big", bytes are copied in reverse order.
+// Needed because EVP_PKEY_get_params() fills bigint buffers in native byte order
+// (which is usually "little"), but we use "big" in our keys, so need to reverse it
+// before putting into serialized key.
+#if __BYTE_ORDER == __BIG_ENDIAN
+static void memcpy_big_endian(void* dst, const void* src, size_t size)
+{
+    // Just copy the bytes, EVP_PKET_get_params() filled buffer with native order
+    memcpy(dst, src, size);
+}
+#else
+static void memcpy_big_endian(void* dst, const void* src, size_t size)
+{
+    // Host system uses different byte order, need to reverse
+    size_t i;
+    for (i = 0; i < size; i++) {
+        ((char*)dst)[size - i - 1] = ((char*)src)[i];
+    }
+}
+#endif
+#endif
+
 #endif /* THEMIS_SOTER_BIGNUM_UTILS_H */

--- a/src/soter/openssl/soter_ec_key.c
+++ b/src/soter/openssl/soter_ec_key.c
@@ -26,6 +26,7 @@
 #include <openssl/ec.h>
 #include <openssl/evp.h>
 
+#include "soter/openssl/soter_bignum_utils.h"
 #include "soter/openssl/soter_ec_key_utils.h"
 #include "soter/soter_portable_endian.h"
 
@@ -157,8 +158,8 @@ soter_status_t soter_engine_specific_to_ec_priv_key(const soter_engine_specific_
         goto err;
     }
 
-    if ((output_length - sizeof(soter_container_hdr_t))
-        != bn_encode(d, (unsigned char*)(key + 1), output_length - sizeof(soter_container_hdr_t))) {
+    if (BN_bn2binpad(d, (unsigned char*)(key + 1), (int)(output_length - sizeof(soter_container_hdr_t)))
+        == -1) {
         res = SOTER_FAIL;
         goto err;
     }

--- a/src/soter/openssl/soter_ec_key.c
+++ b/src/soter/openssl/soter_ec_key.c
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#include <openssl/opensslv.h>
+
+#if OPENSSL_VERSION_NUMBER < 0x30000000
+
 #include "soter/soter_ec_key.h"
 
 #include <string.h>
@@ -22,89 +26,8 @@
 #include <openssl/ec.h>
 #include <openssl/evp.h>
 
+#include "soter/openssl/soter_ec_key_utils.h"
 #include "soter/soter_portable_endian.h"
-
-static bool is_curve_supported(int curve)
-{
-    switch (curve) {
-    case NID_X9_62_prime256v1:
-    case NID_secp384r1:
-    case NID_secp521r1:
-        return true;
-    default:
-        return false;
-    }
-}
-
-/* Input size directly since public key type structures may be aligned to word boundary */
-static size_t ec_pub_key_size(int curve, bool compressed)
-{
-    switch (curve) {
-    case NID_X9_62_prime256v1: /* P-256 */
-        return sizeof(soter_container_hdr_t)
-               + (compressed ? EC_PUB_SIZE(256) : EC_PUB_UNCOMPRESSED_SIZE(256));
-    case NID_secp384r1: /* P-384 */
-        return sizeof(soter_container_hdr_t)
-               + (compressed ? EC_PUB_SIZE(384) : EC_PUB_UNCOMPRESSED_SIZE(384));
-    case NID_secp521r1: /* P-521 */
-        return sizeof(soter_container_hdr_t)
-               + (compressed ? EC_PUB_SIZE(521) : EC_PUB_UNCOMPRESSED_SIZE(521));
-    default:
-        return 0;
-    }
-}
-
-static size_t ec_priv_key_size(int curve)
-{
-    switch (curve) {
-    case NID_X9_62_prime256v1: /* P-256 */
-        return sizeof(soter_ec_priv_key_256_t);
-    case NID_secp384r1: /* P-384 */
-        return sizeof(soter_ec_priv_key_384_t);
-    case NID_secp521r1: /* P-521 */
-        return sizeof(soter_ec_priv_key_521_t);
-    default:
-        return 0;
-    }
-}
-
-static char* ec_pub_key_tag(int curve)
-{
-    switch (curve) {
-    case NID_X9_62_prime256v1: /* P-256 */
-        return EC_PUB_KEY_TAG(256);
-    case NID_secp384r1: /* P-384 */
-        return EC_PUB_KEY_TAG(384);
-    case NID_secp521r1: /* P-521 */
-        return EC_PUB_KEY_TAG(521);
-    default:
-        return NULL;
-    }
-}
-
-static char* ec_priv_key_tag(int curve)
-{
-    switch (curve) {
-    case NID_X9_62_prime256v1: /* P-256 */
-        return EC_PRIV_KEY_TAG(256);
-    case NID_secp384r1: /* P-384 */
-        return EC_PRIV_KEY_TAG(384);
-    case NID_secp521r1: /* P-521 */
-        return EC_PRIV_KEY_TAG(521);
-    default:
-        return NULL;
-    }
-}
-
-static size_t bn_encode(const BIGNUM* bn, uint8_t* buffer, size_t length)
-{
-    int bn_size = BN_num_bytes(bn);
-    if (length < (size_t)bn_size) {
-        return 0;
-    }
-    memset(buffer, 0, length - bn_size);
-    return (length - bn_size) + BN_bn2bin(bn, buffer + (length - bn_size));
-}
 
 soter_status_t soter_engine_specific_to_ec_pub_key(const soter_engine_specific_ec_key_t* engine_key,
                                                    bool compressed,
@@ -128,12 +51,14 @@ soter_status_t soter_engine_specific_to_ec_pub_key(const soter_engine_specific_e
         return SOTER_FAIL;
     }
 
+    // Curve identifier as EC_GROUP*
     group = EC_KEY_get0_group(ec);
     if (NULL == group) {
         res = SOTER_INVALID_PARAMETER;
         goto err;
     }
 
+    // Curve identifier as int (NID_X9_62_prime256v1, NID_secp384r1, NID_secp521r1 etc)
     curve = EC_GROUP_get_curve_name(group);
     if (!is_curve_supported(curve)) {
         res = SOTER_INVALID_PARAMETER;
@@ -440,3 +365,5 @@ err:
 
     return res;
 }
+
+#endif /* OPENSSL_VERSION_NUMBER < 0x30000000 */

--- a/src/soter/openssl/soter_ec_key_3.c
+++ b/src/soter/openssl/soter_ec_key_3.c
@@ -194,10 +194,7 @@ soter_status_t soter_engine_specific_to_ec_priv_key(const soter_engine_specific_
     res = SOTER_SUCCESS;
 
 err:
-    if (res != SOTER_SUCCESS) {
-        soter_wipe(bignum_buf, sizeof(bignum_buf));
-    }
-
+    soter_wipe(bignum_buf, sizeof(bignum_buf));
     BN_clear_free(bignum);
 
     return res;

--- a/src/soter/openssl/soter_ec_key_3.c
+++ b/src/soter/openssl/soter_ec_key_3.c
@@ -1,0 +1,391 @@
+/*
+* Copyright (c) 2023 Cossack Labs Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include <openssl/opensslv.h>
+
+#if OPENSSL_VERSION_NUMBER >= 0x30000000
+
+#include "soter/soter_ec_key.h"
+
+#include <string.h>
+
+#include <openssl/bn.h>
+#include <openssl/core_names.h>
+#include <openssl/evp.h>
+#include <openssl/obj_mac.h>
+#include <openssl/param_build.h>
+
+#include "soter/openssl/soter_ec_key_utils.h"
+#include "soter/openssl/soter_engine.h"
+#include "soter/soter_portable_endian.h"
+
+soter_status_t soter_engine_specific_to_ec_pub_key(const soter_engine_specific_ec_key_t* engine_key,
+                                                   bool compressed,
+                                                   soter_container_hdr_t* key,
+                                                   size_t* key_length)
+{
+    // FIXME: make `pkey` const if possible; even though we don't actually modify `pkey`,
+    //        we set one property so later it gives us public key in proper form
+    EVP_PKEY* pkey = (EVP_PKEY*)engine_key;
+    soter_status_t res;
+    size_t output_length;
+    char curve_str[MAX_CURVE_NAME_LEN];
+    int curve;
+    const char* param_name;
+    size_t serialized_len;
+
+    if ((!key_length) || (EVP_PKEY_EC != EVP_PKEY_id(pkey))) {
+        return SOTER_INVALID_PARAMETER;
+    }
+
+    // Curve identifier as string ("prime256v1", "secp384r1", "secp521r1" etc)
+    if (!EVP_PKEY_get_utf8_string_param(pkey, OSSL_PKEY_PARAM_GROUP_NAME, curve_str, sizeof(curve_str), NULL)) {
+        res = SOTER_INVALID_PARAMETER;
+        goto err;
+    }
+    curve = OBJ_sn2nid(curve_str);
+    if (curve == NID_undef) {
+        // Should never happen since Numeric IDentifier exists for all supported curves
+        res = SOTER_FAIL;
+        goto err;
+    }
+
+    if (!is_curve_supported(curve)) {
+        res = SOTER_INVALID_PARAMETER;
+        goto err;
+    }
+
+    output_length = ec_pub_key_size(curve, compressed);
+    if ((!key) || (output_length > *key_length)) {
+        *key_length = output_length;
+        res = SOTER_BUFFER_TOO_SMALL;
+        goto err;
+    }
+
+    *key_length = output_length;
+
+#if OPENSSL_VERSION_MINOR == 0 && OPENSSL_VERSION_PATCH < 8
+    // In OpenSSL <=3.0.7 param "pub" always contains compressed public key,
+    // while uncompressed one is available in "encoded-pub-key"
+
+    if (compressed) {
+        param_name = OSSL_PKEY_PARAM_PUB_KEY;
+    } else {
+        param_name = OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY;
+    }
+#else
+    // In OpenSSL >=3.0.8 param "pub" contains compressed or uncompressed public key
+    // based on value of "point-format" param. "encoded-pub-key" is still available,
+    // but we don't rely on it anymore
+
+    if (!EVP_PKEY_set_utf8_string_param(pkey,
+                                        OSSL_PKEY_PARAM_EC_POINT_CONVERSION_FORMAT,
+                                        compressed ? OSSL_PKEY_EC_POINT_CONVERSION_FORMAT_COMPRESSED
+                                                   : OSSL_PKEY_EC_POINT_CONVERSION_FORMAT_UNCOMPRESSED)) {
+        res = SOTER_FAIL;
+        goto err;
+    }
+
+    param_name = OSSL_PKEY_PARAM_PUB_KEY;
+#endif
+
+    if (!EVP_PKEY_get_octet_string_param(pkey,
+                                         param_name,
+                                         (unsigned char*)(key + 1),
+                                         output_length - sizeof(soter_container_hdr_t),
+                                         &serialized_len)) {
+        res = SOTER_INVALID_PARAMETER;
+        goto err;
+    }
+
+    if (serialized_len != output_length - sizeof(soter_container_hdr_t)) {
+        res = SOTER_INVALID_PARAMETER;
+        goto err;
+    }
+
+    memcpy(key->tag, ec_pub_key_tag(curve), SOTER_CONTAINER_TAG_LENGTH);
+    key->size = htobe32(output_length);
+    soter_update_container_checksum(key);
+    *key_length = output_length;
+    res = SOTER_SUCCESS;
+
+err:
+
+    return res;
+}
+
+soter_status_t soter_engine_specific_to_ec_priv_key(const soter_engine_specific_ec_key_t* engine_key,
+                                                    soter_container_hdr_t* key,
+                                                    size_t* key_length)
+{
+    const EVP_PKEY* pkey = (EVP_PKEY*)engine_key;
+    const bool compressed = true;
+    soter_status_t res;
+    size_t output_length;
+    char curve_str[MAX_CURVE_NAME_LEN];
+    int curve;
+    BIGNUM* d = NULL;
+
+    if ((!key_length) || (EVP_PKEY_EC != EVP_PKEY_id(pkey))) {
+        return SOTER_INVALID_PARAMETER;
+    }
+
+    // Curve identifier as string (SN_X9_62_prime256v1, SN_secp384r1, SN_secp521r1 etc)
+    if (!EVP_PKEY_get_utf8_string_param(pkey, OSSL_PKEY_PARAM_GROUP_NAME, curve_str, sizeof(curve_str), NULL)) {
+        res = SOTER_INVALID_PARAMETER;
+        goto err;
+    }
+    curve = OBJ_sn2nid(curve_str);
+    if (curve == NID_undef) {
+        // Should never happen since Numeric IDentifier exists for all supported curves
+        res = SOTER_FAIL;
+        goto err;
+    }
+
+    if (!is_curve_supported(curve)) {
+        res = SOTER_INVALID_PARAMETER;
+        goto err;
+    }
+
+    /*
+     * Note that we use a buffer suitable for a public key to store a private
+     * key. This was a historical mistake, now preserved for compatibility.
+     */
+    output_length = ec_pub_key_size(curve, compressed);
+    if ((!key) || (output_length > *key_length)) {
+        *key_length = output_length;
+        res = SOTER_BUFFER_TOO_SMALL;
+        goto err;
+    }
+
+    *key_length = output_length;
+
+    if (!EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_PRIV_KEY, &d)) {
+        res = SOTER_INVALID_PARAMETER;
+        goto err;
+    }
+
+    if ((output_length - sizeof(soter_container_hdr_t))
+        != bn_encode(d, (unsigned char*)(key + 1), output_length - sizeof(soter_container_hdr_t))) {
+        res = SOTER_FAIL;
+        goto err;
+    }
+
+    memcpy(key->tag, ec_priv_key_tag(curve), SOTER_CONTAINER_TAG_LENGTH);
+    key->size = htobe32(output_length);
+    soter_update_container_checksum(key);
+    *key_length = output_length;
+    res = SOTER_SUCCESS;
+
+err:
+
+    BN_clear_free(d);
+
+    return res;
+}
+
+soter_status_t soter_ec_pub_key_to_engine_specific(const soter_container_hdr_t* key,
+                                                   size_t key_length,
+                                                   soter_engine_specific_ec_key_t** engine_key)
+{
+    const char* curve_str;
+    OSSL_PARAM params[3];
+    EVP_PKEY_CTX* ctx = NULL;
+    soter_status_t res;
+
+    if ((!key) || (key_length < sizeof(soter_container_hdr_t))) {
+        return SOTER_INVALID_PARAMETER;
+    }
+
+    if (key_length != be32toh(key->size)) {
+        return SOTER_INVALID_PARAMETER;
+    }
+
+    /* Validate tag */
+    if (memcmp(key->tag, EC_PUB_KEY_PREF, strlen(EC_PUB_KEY_PREF)) != 0) {
+        return SOTER_INVALID_PARAMETER;
+    }
+
+    if (SOTER_SUCCESS != soter_verify_container_checksum(key)) {
+        return SOTER_DATA_CORRUPT;
+    }
+
+    switch (key->tag[3]) {
+    case EC_SIZE_TAG_256:
+        curve_str = SN_X9_62_prime256v1;
+        break;
+    case EC_SIZE_TAG_384:
+        curve_str = SN_secp384r1;
+        break;
+    case EC_SIZE_TAG_521:
+        curve_str = SN_secp521r1;
+        break;
+    default:
+        return SOTER_INVALID_PARAMETER;
+    }
+
+    params[0] = OSSL_PARAM_construct_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME,
+                                                 (char*)curve_str,
+                                                 strlen(curve_str));
+
+    params[1] = OSSL_PARAM_construct_octet_string(OSSL_PKEY_PARAM_PUB_KEY,
+                                                  (unsigned char*)(key + 1),
+                                                  (int)(key_length - sizeof(soter_container_hdr_t)));
+
+    params[2] = OSSL_PARAM_construct_end();
+
+    ctx = EVP_PKEY_CTX_new_from_name(NULL, "EC", NULL);
+    if (ctx == NULL) {
+        res = SOTER_FAIL;
+        goto err;
+    }
+
+    if (!EVP_PKEY_fromdata_init(ctx)) {
+        res = SOTER_FAIL;
+        goto err;
+    }
+
+    if (!EVP_PKEY_fromdata(ctx, (EVP_PKEY**)engine_key, EVP_PKEY_PUBLIC_KEY, params)) {
+        res = SOTER_FAIL;
+        goto err;
+    }
+
+    res = SOTER_SUCCESS;
+
+err:
+
+    EVP_PKEY_CTX_free(ctx);
+
+    return res;
+}
+
+soter_status_t soter_ec_priv_key_to_engine_specific(const soter_container_hdr_t* key,
+                                                    size_t key_length,
+                                                    soter_engine_specific_ec_key_t** engine_key)
+{
+    const char* curve_str;
+    int curve;
+    OSSL_PARAM* params = NULL;
+    OSSL_PARAM_BLD* bld = NULL;
+    EVP_PKEY_CTX* ctx = NULL;
+    BIGNUM* d = NULL;
+    soter_status_t res;
+
+    if (key_length != be32toh(key->size)) {
+        return SOTER_INVALID_PARAMETER;
+    }
+
+    /* Validate tag */
+    if (memcmp(key->tag, EC_PRIV_KEY_PREF, strlen(EC_PRIV_KEY_PREF)) != 0) {
+        return SOTER_INVALID_PARAMETER;
+    }
+
+    if (SOTER_SUCCESS != soter_verify_container_checksum(key)) {
+        return SOTER_DATA_CORRUPT;
+    }
+
+    switch (key->tag[3]) {
+    case EC_SIZE_TAG_256:
+        curve_str = SN_X9_62_prime256v1;
+        curve = NID_X9_62_prime256v1;
+        break;
+    case EC_SIZE_TAG_384:
+        curve_str = SN_secp384r1;
+        curve = NID_secp384r1;
+        break;
+    case EC_SIZE_TAG_521:
+        curve_str = SN_secp521r1;
+        curve = NID_secp521r1;
+        break;
+    default:
+        return SOTER_INVALID_PARAMETER;
+    }
+
+    if (key_length < ec_priv_key_size(curve)) {
+        return SOTER_INVALID_PARAMETER;
+    }
+
+    bld = OSSL_PARAM_BLD_new();
+    if (bld == NULL) {
+        res = SOTER_NO_MEMORY;
+        goto err;
+    }
+
+    if (!OSSL_PARAM_BLD_push_utf8_string(bld, OSSL_PKEY_PARAM_GROUP_NAME, curve_str, strlen(curve_str))) {
+        res = SOTER_FAIL;
+        goto err;
+    }
+
+    d = BN_bin2bn((const unsigned char*)(key + 1), (int)(key_length - sizeof(soter_container_hdr_t)), NULL);
+    if (d == NULL) {
+        res = SOTER_NO_MEMORY;
+        goto err;
+    }
+
+    // Unfortunately, using on stack `OSSL_PARAM params[3]`
+    // like in soter_ec_pub_key_to_engine_specific() and setting
+    // params[1] = OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_PRIV_KEY,
+    //                                     (unsigned char*)(key + 1) + 1,
+    //                                     (int)(key_length - sizeof(soter_container_hdr_t) - 1)))
+    // won't work properly. This is because private key number (32 bytes, not counting leading zero)
+    // is stored in one byte order and EVP_PKEY_fromdata() will read it in different byte order. As
+    // a result, `priv` property of generated `pkey` will have different value, with reversed bytes
+    // order. One working solution was to do like this, deserialize value into `BIGINT*`, then use
+    // param builder (OSSL_PARAM_BLD*) and OSSL_PARAM_BLD_push_BN(). Seems to have a slight overhead,
+    // but uses APIs that were designed for such actions.
+    // Another possible and working solution is to simply swap bytes into temporary buffer and use
+    // it instead of provided one, then we can avoid using EVP_PKEY_BLD* at all.
+
+    if (!OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_PRIV_KEY, d)) {
+        res = SOTER_FAIL;
+        goto err;
+    }
+
+    params = OSSL_PARAM_BLD_to_param(bld);
+    if (params == NULL) {
+        res = SOTER_NO_MEMORY;
+        goto err;
+    }
+
+    ctx = EVP_PKEY_CTX_new_from_name(NULL, "EC", NULL);
+    if (ctx == NULL) {
+        res = SOTER_NO_MEMORY;
+        goto err;
+    }
+
+    if (!EVP_PKEY_fromdata_init(ctx)) {
+        res = SOTER_FAIL;
+        goto err;
+    }
+
+    if (!EVP_PKEY_fromdata(ctx, (EVP_PKEY**)engine_key, EVP_PKEY_KEYPAIR, params)) {
+        res = SOTER_FAIL;
+        goto err;
+    }
+
+    res = SOTER_SUCCESS;
+
+err:
+
+    EVP_PKEY_CTX_free(ctx);
+    OSSL_PARAM_free(params);
+    OSSL_PARAM_BLD_free(bld);
+    BN_clear_free(d);
+
+    return res;
+}
+
+#endif /* OPENSSL_VERSION_NUMBER >= 0x30000000 */

--- a/src/soter/openssl/soter_ec_key_3.c
+++ b/src/soter/openssl/soter_ec_key_3.c
@@ -178,8 +178,8 @@ soter_status_t soter_engine_specific_to_ec_priv_key(const soter_engine_specific_
         goto err;
     }
 
-    if ((output_length - sizeof(soter_container_hdr_t))
-        != bn_encode(d, (unsigned char*)(key + 1), output_length - sizeof(soter_container_hdr_t))) {
+    if (BN_bn2binpad(d, (unsigned char*)(key + 1), (int)(output_length - sizeof(soter_container_hdr_t)))
+        == -1) {
         res = SOTER_FAIL;
         goto err;
     }

--- a/src/soter/openssl/soter_ec_key_utils.h
+++ b/src/soter/openssl/soter_ec_key_utils.h
@@ -19,7 +19,6 @@
 
 #include <string.h>
 
-#include <openssl/bn.h>
 #include <openssl/obj_mac.h>
 
 #include "soter/soter_ec_key.h"
@@ -94,16 +93,6 @@ static char* ec_priv_key_tag(int curve)
     default:
         return NULL;
     }
-}
-
-static size_t bn_encode(const BIGNUM* bn, uint8_t* buffer, size_t length)
-{
-    int bn_size = BN_num_bytes(bn);
-    if (length < (size_t)bn_size) {
-        return 0;
-    }
-    memset(buffer, 0, length - bn_size);
-    return (length - bn_size) + BN_bn2bin(bn, buffer + (length - bn_size));
 }
 
 #endif /* THEMIS_SOTER_EC_KEY_UTILS_H */

--- a/src/soter/openssl/soter_ec_key_utils.h
+++ b/src/soter/openssl/soter_ec_key_utils.h
@@ -1,0 +1,109 @@
+/*
+* Copyright (c) 2023 Cossack Labs Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef THEMIS_SOTER_EC_KEY_UTILS_H
+#define THEMIS_SOTER_EC_KEY_UTILS_H
+
+#include <string.h>
+
+#include <openssl/bn.h>
+#include <openssl/obj_mac.h>
+
+#include "soter/soter_ec_key.h"
+
+static bool is_curve_supported(int curve)
+{
+    switch (curve) {
+    case NID_X9_62_prime256v1:
+    case NID_secp384r1:
+    case NID_secp521r1:
+        return true;
+    default:
+        return false;
+    }
+}
+
+/* Input size directly since public key type structures may be aligned to word boundary */
+static size_t ec_pub_key_size(int curve, bool compressed)
+{
+    switch (curve) {
+    case NID_X9_62_prime256v1: /* P-256 */
+        return sizeof(soter_container_hdr_t)
+               + (compressed ? EC_PUB_SIZE(256) : EC_PUB_UNCOMPRESSED_SIZE(256));
+    case NID_secp384r1: /* P-384 */
+        return sizeof(soter_container_hdr_t)
+               + (compressed ? EC_PUB_SIZE(384) : EC_PUB_UNCOMPRESSED_SIZE(384));
+    case NID_secp521r1: /* P-521 */
+        return sizeof(soter_container_hdr_t)
+               + (compressed ? EC_PUB_SIZE(521) : EC_PUB_UNCOMPRESSED_SIZE(521));
+    default:
+        return 0;
+    }
+}
+
+static size_t ec_priv_key_size(int curve)
+{
+    switch (curve) {
+    case NID_X9_62_prime256v1: /* P-256 */
+        return sizeof(soter_ec_priv_key_256_t);
+    case NID_secp384r1: /* P-384 */
+        return sizeof(soter_ec_priv_key_384_t);
+    case NID_secp521r1: /* P-521 */
+        return sizeof(soter_ec_priv_key_521_t);
+    default:
+        return 0;
+    }
+}
+
+static char* ec_pub_key_tag(int curve)
+{
+    switch (curve) {
+    case NID_X9_62_prime256v1: /* P-256 */
+        return EC_PUB_KEY_TAG(256);
+    case NID_secp384r1: /* P-384 */
+        return EC_PUB_KEY_TAG(384);
+    case NID_secp521r1: /* P-521 */
+        return EC_PUB_KEY_TAG(521);
+    default:
+        return NULL;
+    }
+}
+
+static char* ec_priv_key_tag(int curve)
+{
+    switch (curve) {
+    case NID_X9_62_prime256v1: /* P-256 */
+        return EC_PRIV_KEY_TAG(256);
+    case NID_secp384r1: /* P-384 */
+        return EC_PRIV_KEY_TAG(384);
+    case NID_secp521r1: /* P-521 */
+        return EC_PRIV_KEY_TAG(521);
+    default:
+        return NULL;
+    }
+}
+
+static size_t bn_encode(const BIGNUM* bn, uint8_t* buffer, size_t length)
+{
+    int bn_size = BN_num_bytes(bn);
+    if (length < (size_t)bn_size) {
+        return 0;
+    }
+    memset(buffer, 0, length - bn_size);
+    return (length - bn_size) + BN_bn2bin(bn, buffer + (length - bn_size));
+}
+
+#endif /* THEMIS_SOTER_EC_KEY_UTILS_H */

--- a/src/soter/openssl/soter_engine.h
+++ b/src/soter/openssl/soter_engine.h
@@ -60,4 +60,6 @@ struct soter_sign_ctx_type {
     soter_sign_alg_t alg;
 };
 
+#define MAX_CURVE_NAME_LEN 11
+
 #endif /* SOTER_OPENSSL_ENGINE_H */

--- a/src/soter/openssl/soter_engine.h
+++ b/src/soter/openssl/soter_engine.h
@@ -51,6 +51,7 @@ struct soter_sign_ctx_type {
     soter_sign_alg_t alg;
 };
 
+/* Enough for "prime256v1\0" */
 #define MAX_CURVE_NAME_LEN 11
 
 #endif /* SOTER_OPENSSL_ENGINE_H */

--- a/src/soter/openssl/soter_engine.h
+++ b/src/soter/openssl/soter_engine.h
@@ -23,15 +23,6 @@
 
 #include "soter/soter_asym_sign.h"
 
-/*
- * For the time being Themis and Soter do not support OpenSSL 3.0.
- * The code seems to build fine but it fails the tests, so we're not sure
- * that it is safe to use Soter with OpenSSL 3.0.
- */
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L && !THEMIS_EXPERIMENTAL_OPENSSL_3_SUPPORT
-#error OpenSSL 3.0 is currently not supported
-#endif
-
 struct soter_hash_ctx_type {
     EVP_MD_CTX* evp_md_ctx;
 };

--- a/src/soter/openssl/soter_hash.c
+++ b/src/soter/openssl/soter_hash.c
@@ -17,6 +17,7 @@
 #include "soter/soter_hash.h"
 
 #include <openssl/evp.h>
+#include <openssl/opensslv.h>
 
 #include "soter/openssl/soter_engine.h"
 #include "soter/soter_api.h"
@@ -61,7 +62,11 @@ soter_status_t soter_hash_update(soter_hash_ctx_t* hash_ctx, const void* data, s
         return SOTER_INVALID_PARAMETER;
     }
 
+#if OPENSSL_VERSION_NUMBER >= 0x30000000
+    if (!EVP_MD_CTX_get0_md(hash_ctx->evp_md_ctx)) {
+#else
     if (!EVP_MD_CTX_md(hash_ctx->evp_md_ctx)) {
+#endif
         return SOTER_INVALID_PARAMETER;
     }
 
@@ -80,7 +85,11 @@ soter_status_t soter_hash_final(soter_hash_ctx_t* hash_ctx, uint8_t* hash_value,
         return SOTER_INVALID_PARAMETER;
     }
 
+#if OPENSSL_VERSION_NUMBER >= 0x30000000
+    if (!EVP_MD_CTX_get0_md(hash_ctx->evp_md_ctx)) {
+#else
     if (!EVP_MD_CTX_md(hash_ctx->evp_md_ctx)) {
+#endif
         return SOTER_INVALID_PARAMETER;
     }
 

--- a/src/soter/openssl/soter_rsa_key_3.c
+++ b/src/soter/openssl/soter_rsa_key_3.c
@@ -43,7 +43,7 @@ soter_status_t soter_engine_specific_to_rsa_pub_key(const soter_engine_specific_
     size_t output_length;
     uint32_t* pub_exp;
     // Maximum supported RSA key is 8192 bits (1024 bytes)
-    unsigned char bignum_buf[1024];
+    unsigned char bignum_buf[RSA_KEY_BYTES_MAX];
     BIGNUM* bignum = NULL;
 
     if (!key_length) {
@@ -126,7 +126,7 @@ soter_status_t soter_engine_specific_to_rsa_priv_key(const soter_engine_specific
     size_t output_length;
     uint32_t* pub_exp;
     // Maximum supported RSA key is 8192 bits (1024 bytes)
-    unsigned char bignum_buf[1024];
+    unsigned char bignum_buf[RSA_KEY_BYTES_MAX];
     BIGNUM* bignum = NULL;
     unsigned char* curr_bn;
 
@@ -281,11 +281,12 @@ clear_key:
     if (res != SOTER_SUCCESS) {
         /* Zero output memory to avoid leaking private key information */
         soter_wipe(key, output_length);
-        /* We did not use whole buffer, only `rsa_mod_size` bytes of it */
-        soter_wipe(bignum_buf, rsa_mod_size);
     }
 
 err:
+    /* We did not use whole buffer, only `rsa_mod_size` bytes of it */
+    soter_wipe(bignum_buf, rsa_mod_size);
+
     BN_clear_free(bignum);
 
     return res;

--- a/src/soter/openssl/soter_rsa_key_3.c
+++ b/src/soter/openssl/soter_rsa_key_3.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Cossack Labs Limited
+ * Copyright (c) 2023 Cossack Labs Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,131 +16,33 @@
 
 #include <openssl/opensslv.h>
 
-#if OPENSSL_VERSION_NUMBER < 0x30000000
+#if OPENSSL_VERSION_NUMBER >= 0x30000000
 
 #include "soter/soter_rsa_key.h"
 
 #include <string.h>
 
 #include <openssl/bn.h>
+#include <openssl/core_names.h>
 #include <openssl/evp.h>
+#include <openssl/param_build.h>
 #include <openssl/rsa.h>
 
-#include "soter/openssl/soter_bignum_utils.h"
 #include "soter/openssl/soter_rsa_key_utils.h"
 #include "soter/soter_portable_endian.h"
 #include "soter/soter_wipe.h"
-
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-static inline void RSA_get0_key(const RSA* rsa, const BIGNUM** n, const BIGNUM** e, const BIGNUM** d)
-{
-    if (n) {
-        *n = rsa->n;
-    }
-    if (e) {
-        *e = rsa->e;
-    }
-    if (d) {
-        *d = rsa->d;
-    }
-}
-
-static inline int RSA_set0_key(RSA* rsa, BIGNUM* n, BIGNUM* e, BIGNUM* d)
-{
-    if ((rsa->n == NULL && n == NULL) || (rsa->e == NULL && e == NULL)) {
-        return 0;
-    }
-    if (n != NULL) {
-        BN_free(rsa->n);
-        rsa->n = n;
-    }
-    if (e != NULL) {
-        BN_free(rsa->e);
-        rsa->e = e;
-    }
-    if (d != NULL) {
-        BN_free(rsa->d);
-        rsa->d = d;
-    }
-    return 1;
-}
-
-static inline void RSA_get0_factors(const RSA* rsa, const BIGNUM** p, const BIGNUM** q)
-{
-    if (p) {
-        *p = rsa->p;
-    }
-    if (q) {
-        *q = rsa->q;
-    }
-}
-
-static inline int RSA_set0_factors(RSA* rsa, BIGNUM* p, BIGNUM* q)
-{
-    if ((rsa->p == NULL && p == NULL) || (rsa->q == NULL && q == NULL)) {
-        return 0;
-    }
-    if (p != NULL) {
-        BN_free(rsa->p);
-        rsa->p = p;
-    }
-    if (q != NULL) {
-        BN_free(rsa->q);
-        rsa->q = q;
-    }
-    return 1;
-}
-
-static inline void RSA_get0_crt_params(const RSA* rsa,
-                                       const BIGNUM** dmp1,
-                                       const BIGNUM** dmq1,
-                                       const BIGNUM** iqmp)
-{
-    if (dmp1) {
-        *dmp1 = rsa->dmp1;
-    }
-    if (dmq1) {
-        *dmq1 = rsa->dmq1;
-    }
-    if (iqmp) {
-        *iqmp = rsa->iqmp;
-    }
-}
-
-static inline int RSA_set0_crt_params(RSA* rsa, BIGNUM* dmp1, BIGNUM* dmq1, BIGNUM* iqmp)
-{
-    if ((rsa->dmp1 == NULL && dmp1 == NULL) || (rsa->dmq1 == NULL && dmq1 == NULL)
-        || (rsa->iqmp == NULL && iqmp == NULL)) {
-        return 0;
-    }
-    if (dmp1 != NULL) {
-        BN_free(rsa->dmp1);
-        rsa->dmp1 = dmp1;
-    }
-    if (dmq1 != NULL) {
-        BN_free(rsa->dmq1);
-        rsa->dmq1 = dmq1;
-    }
-    if (iqmp != NULL) {
-        BN_free(rsa->iqmp);
-        rsa->iqmp = iqmp;
-    }
-    return 1;
-}
-#endif
 
 soter_status_t soter_engine_specific_to_rsa_pub_key(const soter_engine_specific_rsa_key_t* engine_key,
                                                     soter_container_hdr_t* key,
                                                     size_t* key_length)
 {
     EVP_PKEY* pkey = (EVP_PKEY*)engine_key;
-    RSA* rsa;
     soter_status_t res;
     int rsa_mod_size;
     size_t output_length;
     uint32_t* pub_exp;
-    const BIGNUM* rsa_e;
-    const BIGNUM* rsa_n;
+    // This bigint is reused multiple times: read into it, serialize it, read into it...
+    BIGNUM* tmp = NULL;
 
     if (!key_length) {
         return SOTER_INVALID_PARAMETER;
@@ -150,12 +52,19 @@ soter_status_t soter_engine_specific_to_rsa_pub_key(const soter_engine_specific_
         return SOTER_INVALID_PARAMETER;
     }
 
-    rsa = EVP_PKEY_get1_RSA((EVP_PKEY*)pkey);
-    if (NULL == rsa) {
-        return SOTER_FAIL;
-    }
+    // Relevant pkey params
+    // OSSL_PKEY_PARAM_BITS, "bits", int
+    // OSSL_PKEY_PARAM_RSA_N, "n", big uint
+    // OSSL_PKEY_PARAM_RSA_E, "e", big uint
 
-    rsa_mod_size = RSA_size(rsa);
+    // See https://docs.cossacklabs.com/themis/spec/asymmetric-keypairs/rsa/ for key layout
+
+    if (!EVP_PKEY_get_int_param(pkey, OSSL_PKEY_PARAM_BITS, &rsa_mod_size)) {
+        res = SOTER_FAIL;
+        goto err;
+    }
+    rsa_mod_size = (rsa_mod_size + 7) / 8;
+
     if (!is_mod_size_supported(rsa_mod_size)) {
         res = SOTER_INVALID_PARAMETER;
         goto err;
@@ -168,20 +77,28 @@ soter_status_t soter_engine_specific_to_rsa_pub_key(const soter_engine_specific_
         goto err;
     }
 
-    pub_exp = (uint32_t*)((unsigned char*)(key + 1) + rsa_mod_size);
-    RSA_get0_key(rsa, (const BIGNUM**)&rsa_n, &rsa_e, NULL);
-
-    if (BN_is_word(rsa_e, RSA_F4)) {
-        *pub_exp = htobe32(RSA_F4);
-    } else if (BN_is_word(rsa_e, RSA_3)) {
-        *pub_exp = htobe32(RSA_3);
-    } else {
-        res = SOTER_INVALID_PARAMETER;
+    if (!EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_RSA_N, &tmp)) {
+        res = SOTER_FAIL;
         goto err;
     }
 
-    res = BN_bn2binpad(rsa_n, (unsigned char*)(key + 1), rsa_mod_size);
-    if (res == -1) {
+    if (BN_bn2binpad(tmp, (unsigned char*)(key + 1), rsa_mod_size) == -1) {
+        res = SOTER_FAIL;
+        goto err;
+    }
+
+    if (!EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_RSA_E, &tmp)) {
+        res = SOTER_FAIL;
+        goto err;
+    }
+
+    pub_exp = (uint32_t*)((unsigned char*)(key + 1) + rsa_mod_size);
+    if (BN_is_word(tmp, RSA_F4)) {
+        *pub_exp = htobe32(RSA_F4);
+    } else if (BN_is_word(tmp, RSA_3)) {
+        *pub_exp = htobe32(RSA_3);
+    } else {
+        res = SOTER_INVALID_PARAMETER;
         goto err;
     }
 
@@ -192,8 +109,7 @@ soter_status_t soter_engine_specific_to_rsa_pub_key(const soter_engine_specific_
     res = SOTER_SUCCESS;
 
 err:
-    /* Free extra reference on RSA object provided by EVP_PKEY_get1_RSA */
-    RSA_free(rsa);
+    BN_free(tmp);
 
     return res;
 }
@@ -203,20 +119,13 @@ soter_status_t soter_engine_specific_to_rsa_priv_key(const soter_engine_specific
                                                      size_t* key_length)
 {
     EVP_PKEY* pkey = (EVP_PKEY*)engine_key;
-    RSA* rsa;
     soter_status_t res;
     int rsa_mod_size;
-    size_t output_length = 0;
+    size_t output_length;
     uint32_t* pub_exp;
-    const BIGNUM* rsa_e;
-    const BIGNUM* rsa_d;
-    const BIGNUM* rsa_n;
-    const BIGNUM* rsa_p;
-    const BIGNUM* rsa_q;
-    const BIGNUM* rsa_dmp1;
-    const BIGNUM* rsa_dmq1;
-    const BIGNUM* rsa_iqmp;
-    unsigned char* curr_bn = (unsigned char*)(key + 1);
+    // This bigint is reused multiple times: read into it, serialize it, read into it...
+    BIGNUM* tmp = NULL;
+    unsigned char* curr_bn;
 
     if (!key_length) {
         return SOTER_INVALID_PARAMETER;
@@ -226,12 +135,25 @@ soter_status_t soter_engine_specific_to_rsa_priv_key(const soter_engine_specific
         return SOTER_INVALID_PARAMETER;
     }
 
-    rsa = EVP_PKEY_get1_RSA((EVP_PKEY*)pkey);
-    if (NULL == rsa) {
-        return SOTER_FAIL;
-    }
+    // Relevant pkey params
+    // OSSL_PKEY_PARAM_BITS, "bits", int
+    // OSSL_PKEY_PARAM_RSA_D, "d", big uint
+    // OSSL_PKEY_PARAM_RSA_FACTOR1, "rsa-factor1", big uint
+    // OSSL_PKEY_PARAM_RSA_FACTOR2, "rsa-factor2", big uint
+    // OSSL_PKEY_PARAM_RSA_EXPONENT1, "rsa-exponent1", big uint
+    // OSSL_PKEY_PARAM_RSA_EXPONENT2, "rsa-exponent2", big uint
+    // OSSL_PKEY_PARAM_RSA_COEFFICIENT1, "rsa-coefficient1", big uint
+    // OSSL_PKEY_PARAM_RSA_N, "n", big uint
+    // OSSL_PKEY_PARAM_RSA_E, "e", big uint
 
-    rsa_mod_size = RSA_size(rsa);
+    // See https://docs.cossacklabs.com/themis/spec/asymmetric-keypairs/rsa/ for key layout
+
+    if (!EVP_PKEY_get_int_param(pkey, OSSL_PKEY_PARAM_BITS, &rsa_mod_size)) {
+        res = SOTER_FAIL;
+        goto err;
+    }
+    rsa_mod_size = (rsa_mod_size + 7) / 8;
+
     if (!is_mod_size_supported(rsa_mod_size)) {
         res = SOTER_INVALID_PARAMETER;
         goto err;
@@ -244,68 +166,106 @@ soter_status_t soter_engine_specific_to_rsa_priv_key(const soter_engine_specific
         goto err;
     }
 
-    pub_exp = (uint32_t*)(curr_bn + ((rsa_mod_size * 4) + (rsa_mod_size / 2)));
-    RSA_get0_key(rsa, &rsa_n, &rsa_e, &rsa_d);
+    curr_bn = (unsigned char*)(key + 1);
 
-    if (BN_is_word(rsa_e, RSA_F4)) {
-        *pub_exp = htobe32(RSA_F4);
-    } else if (BN_is_word(rsa_e, RSA_3)) {
-        *pub_exp = htobe32(RSA_3);
-    } else {
-        res = SOTER_INVALID_PARAMETER;
+    /* Private exponent */
+    if (!EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_RSA_D, &tmp)) {
+        res = SOTER_FAIL;
         goto err;
     }
 
-    /* Private exponent */
-    if (BN_bn2binpad(rsa_d, curr_bn, rsa_mod_size) == -1) {
+    if (BN_bn2binpad(tmp, curr_bn, rsa_mod_size) == -1) {
         res = SOTER_FAIL;
-        goto err;
+        goto clear_key;
     }
     curr_bn += rsa_mod_size;
 
-    RSA_get0_factors(rsa, &rsa_p, &rsa_q);
-
     /* p */
-    if (BN_bn2binpad(rsa_p, curr_bn, rsa_mod_size / 2) == -1) {
+    if (!EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_RSA_FACTOR1, &tmp)) {
         res = SOTER_FAIL;
-        goto err;
+        goto clear_key;
+    }
+
+    if (BN_bn2binpad(tmp, curr_bn, rsa_mod_size / 2) == -1) {
+        res = SOTER_FAIL;
+        goto clear_key;
     }
     curr_bn += rsa_mod_size / 2;
 
     /* q */
-    if (BN_bn2binpad(rsa_q, curr_bn, rsa_mod_size / 2) == -1) {
+    if (!EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_RSA_FACTOR2, &tmp)) {
         res = SOTER_FAIL;
-        goto err;
+        goto clear_key;
+    }
+
+    if (BN_bn2binpad(tmp, curr_bn, rsa_mod_size / 2) == -1) {
+        res = SOTER_FAIL;
+        goto clear_key;
     }
     curr_bn += rsa_mod_size / 2;
 
-    RSA_get0_crt_params(rsa, &rsa_dmp1, &rsa_dmq1, &rsa_iqmp);
-
     /* dp */
-    if (BN_bn2binpad(rsa_dmp1, curr_bn, rsa_mod_size / 2) == -1) {
+    if (!EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_RSA_EXPONENT1, &tmp)) {
         res = SOTER_FAIL;
-        goto err;
+        goto clear_key;
+    }
+
+    if (BN_bn2binpad(tmp, curr_bn, rsa_mod_size / 2) == -1) {
+        res = SOTER_FAIL;
+        goto clear_key;
     }
     curr_bn += rsa_mod_size / 2;
 
     /* dq */
-    if (BN_bn2binpad(rsa_dmq1, curr_bn, rsa_mod_size / 2) == -1) {
+    if (!EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_RSA_EXPONENT2, &tmp)) {
         res = SOTER_FAIL;
-        goto err;
+        goto clear_key;
+    }
+
+    if (BN_bn2binpad(tmp, curr_bn, rsa_mod_size / 2) == -1) {
+        res = SOTER_FAIL;
+        goto clear_key;
     }
     curr_bn += rsa_mod_size / 2;
 
     /* qp */
-    if (BN_bn2binpad(rsa_iqmp, curr_bn, rsa_mod_size / 2) == -1) {
+    if (!EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_RSA_COEFFICIENT1, &tmp)) {
         res = SOTER_FAIL;
-        goto err;
+        goto clear_key;
+    }
+
+    if (BN_bn2binpad(tmp, curr_bn, rsa_mod_size / 2) == -1) {
+        res = SOTER_FAIL;
+        goto clear_key;
     }
     curr_bn += rsa_mod_size / 2;
 
     /* modulus */
-    if (BN_bn2binpad(rsa_n, curr_bn, rsa_mod_size) == -1) {
+    if (!EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_RSA_N, &tmp)) {
         res = SOTER_FAIL;
-        goto err;
+        goto clear_key;
+    }
+
+    if (BN_bn2binpad(tmp, curr_bn, rsa_mod_size) == -1) {
+        res = SOTER_FAIL;
+        goto clear_key;
+    }
+    curr_bn += rsa_mod_size;
+
+    /* public exponent */
+    if (!EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_RSA_E, &tmp)) {
+        res = SOTER_FAIL;
+        goto clear_key;
+    }
+
+    pub_exp = (uint32_t*)curr_bn;
+    if (BN_is_word(tmp, RSA_F4)) {
+        *pub_exp = htobe32(RSA_F4);
+    } else if (BN_is_word(tmp, RSA_3)) {
+        *pub_exp = htobe32(RSA_3);
+    } else {
+        res = SOTER_INVALID_PARAMETER;
+        goto clear_key;
     }
 
     memcpy(key->tag, rsa_priv_key_tag(rsa_mod_size), SOTER_CONTAINER_TAG_LENGTH);
@@ -314,14 +274,14 @@ soter_status_t soter_engine_specific_to_rsa_priv_key(const soter_engine_specific
     *key_length = output_length;
     res = SOTER_SUCCESS;
 
-err:
-    /* Free extra reference on RSA object provided by EVP_PKEY_get1_RSA */
-    RSA_free(rsa);
-
-    if (res != SOTER_SUCCESS && output_length > 0) {
+clear_key:
+    if (res != SOTER_SUCCESS) {
         /* Zero output memory to avoid leaking private key information */
         soter_wipe(key, output_length);
     }
+
+err:
+    BN_clear_free(tmp);
 
     return res;
 }
@@ -334,13 +294,14 @@ soter_status_t soter_rsa_pub_key_to_engine_specific(const soter_container_hdr_t*
 {
     soter_status_t err = SOTER_FAIL;
     int rsa_mod_size;
-    RSA* rsa = NULL;
     BIGNUM* rsa_n = NULL;
     BIGNUM* rsa_e = NULL;
-    EVP_PKEY* pkey = (EVP_PKEY*)(*engine_key);
     const uint32_t* pub_exp;
+    OSSL_PARAM* params = NULL;
+    OSSL_PARAM_BLD* bld = NULL;
+    EVP_PKEY_CTX* ctx = NULL;
 
-    if (key_length < sizeof(soter_container_hdr_t) || key_length != be32toh(key->size)) {
+    if ((!key) || key_length < sizeof(soter_container_hdr_t) || key_length != be32toh(key->size)) {
         return SOTER_INVALID_PARAMETER;
     }
 
@@ -383,39 +344,68 @@ soter_status_t soter_rsa_pub_key_to_engine_specific(const soter_container_hdr_t*
         return SOTER_INVALID_PARAMETER;
     }
 
-    rsa = RSA_new();
     rsa_n = BN_new();
     rsa_e = BN_new();
-    if (!rsa || !rsa_n || !rsa_e) {
+    if (!rsa_n || !rsa_e) {
         err = SOTER_NO_MEMORY;
-        goto free_exponents;
+        goto out;
     }
 
     if (!BN_set_word(rsa_e, be32toh(*pub_exp))) {
-        goto free_exponents;
+        goto out;
     }
 
     if (!BN_bin2bn((const unsigned char*)(key + 1), rsa_mod_size, rsa_n)) {
-        goto free_exponents;
+        goto out;
     }
 
-    /* RSA_set0_key() transfers ownership over exponents to "rsa" */
-    if (!RSA_set0_key(rsa, rsa_n, rsa_e, NULL)) {
-        goto free_exponents;
+    bld = OSSL_PARAM_BLD_new();
+    if (bld == NULL) {
+        err = SOTER_NO_MEMORY;
+        goto out;
     }
 
-    /* EVP_PKEY_assign_RSA() transfers ownership over "rsa" to "pkey" */
-    if (!EVP_PKEY_assign_RSA(pkey, rsa)) {
-        goto free_rsa;
+    if (!OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_RSA_N, rsa_n)) {
+        err = SOTER_FAIL;
+        goto out;
     }
 
-    return SOTER_SUCCESS;
+    if (!OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_RSA_E, rsa_e)) {
+        err = SOTER_FAIL;
+        goto out;
+    }
 
-free_exponents:
+    params = OSSL_PARAM_BLD_to_param(bld);
+    if (params == NULL) {
+        err = SOTER_NO_MEMORY;
+        goto out;
+    }
+
+    ctx = EVP_PKEY_CTX_new_from_name(NULL, "RSA", NULL);
+    if (ctx == NULL) {
+        err = SOTER_NO_MEMORY;
+        goto out;
+    }
+
+    if (!EVP_PKEY_fromdata_init(ctx)) {
+        err = SOTER_FAIL;
+        goto out;
+    }
+
+    if (!EVP_PKEY_fromdata(ctx, (EVP_PKEY**)engine_key, EVP_PKEY_KEYPAIR, params)) {
+        err = SOTER_FAIL;
+        goto out;
+    }
+
+    err = SOTER_SUCCESS;
+
+out:
     BN_free(rsa_n);
     BN_free(rsa_e);
-free_rsa:
-    RSA_free(rsa);
+    EVP_PKEY_CTX_free(ctx);
+    OSSL_PARAM_free(params);
+    OSSL_PARAM_BLD_free(bld);
+
     return err;
 }
 
@@ -425,7 +415,6 @@ soter_status_t soter_rsa_priv_key_to_engine_specific(const soter_container_hdr_t
 {
     soter_status_t err = SOTER_FAIL;
     int rsa_mod_size;
-    RSA* rsa = NULL;
     BIGNUM* rsa_e = NULL;
     BIGNUM* rsa_d = NULL;
     BIGNUM* rsa_p = NULL;
@@ -434,11 +423,13 @@ soter_status_t soter_rsa_priv_key_to_engine_specific(const soter_container_hdr_t
     BIGNUM* rsa_dmq1 = NULL;
     BIGNUM* rsa_iqmp = NULL;
     BIGNUM* rsa_n = NULL;
-    EVP_PKEY* pkey = (EVP_PKEY*)(*engine_key);
     const uint32_t* pub_exp;
-    const unsigned char* curr_bn = (const unsigned char*)(key + 1);
+    const unsigned char* curr_bn;
+    OSSL_PARAM* params = NULL;
+    OSSL_PARAM_BLD* bld = NULL;
+    EVP_PKEY_CTX* ctx = NULL;
 
-    if (key_length < sizeof(soter_container_hdr_t) || key_length != be32toh(key->size)) {
+    if ((!key) || key_length < sizeof(soter_container_hdr_t) || key_length != be32toh(key->size)) {
         return SOTER_INVALID_PARAMETER;
     }
 
@@ -472,8 +463,9 @@ soter_status_t soter_rsa_priv_key_to_engine_specific(const soter_container_hdr_t
         return SOTER_INVALID_PARAMETER;
     }
 
+    curr_bn = (const unsigned char*)(key + 1);
+
     pub_exp = (const uint32_t*)(curr_bn + ((rsa_mod_size * 4) + (rsa_mod_size / 2)));
-    ;
     switch (be32toh(*pub_exp)) {
     case RSA_3:
     case RSA_F4:
@@ -482,7 +474,6 @@ soter_status_t soter_rsa_priv_key_to_engine_specific(const soter_container_hdr_t
         return SOTER_INVALID_PARAMETER;
     }
 
-    rsa = RSA_new();
     rsa_e = BN_new();
     rsa_d = BN_new();
     rsa_p = BN_new();
@@ -491,106 +482,158 @@ soter_status_t soter_rsa_priv_key_to_engine_specific(const soter_container_hdr_t
     rsa_dmq1 = BN_new();
     rsa_iqmp = BN_new();
     rsa_n = BN_new();
-    if (!rsa || !rsa_e || !rsa_d || !rsa_p || !rsa_q || !rsa_dmp1 || !rsa_dmq1 || !rsa_iqmp || !rsa_n) {
+    if (!rsa_e || !rsa_d || !rsa_p || !rsa_q || !rsa_dmp1 || !rsa_dmq1 || !rsa_iqmp || !rsa_n) {
         err = SOTER_NO_MEMORY;
-        goto free_exponents;
+        goto out;
     }
 
     if (!BN_set_word(rsa_e, be32toh(*pub_exp))) {
-        goto free_exponents;
+        goto out;
     }
 
     /* Private exponent */
     if (!BN_bin2bn(curr_bn, rsa_mod_size, rsa_d)) {
-        goto free_exponents;
+        goto out;
     }
     curr_bn += rsa_mod_size;
 
     if (!BN_bin2bn(curr_bn, rsa_mod_size / 2, rsa_p)) {
-        goto free_exponents;
+        goto out;
     }
     curr_bn += rsa_mod_size / 2;
 
     /* q */
     if (!BN_bin2bn(curr_bn, rsa_mod_size / 2, rsa_q)) {
-        goto free_exponents;
+        goto out;
     }
     curr_bn += rsa_mod_size / 2;
 
     /* dp */
     if (!BN_bin2bn(curr_bn, rsa_mod_size / 2, rsa_dmp1)) {
-        goto free_exponents;
+        goto out;
     }
     curr_bn += rsa_mod_size / 2;
 
     /* dq */
     if (!BN_bin2bn(curr_bn, rsa_mod_size / 2, rsa_dmq1)) {
-        goto free_exponents;
+        goto out;
     }
     curr_bn += rsa_mod_size / 2;
 
     /* qp */
     if (!BN_bin2bn(curr_bn, rsa_mod_size / 2, rsa_iqmp)) {
-        goto free_exponents;
+        goto out;
     }
     curr_bn += rsa_mod_size / 2;
 
     /* modulus */
     if (!BN_bin2bn(curr_bn, rsa_mod_size, rsa_n)) {
-        goto free_exponents;
+        goto out;
     }
 
     /* If at least one CRT parameter is zero, free them */
     if (BN_is_zero(rsa_p) || BN_is_zero(rsa_q) || BN_is_zero(rsa_dmp1) || BN_is_zero(rsa_dmq1)
         || BN_is_zero(rsa_iqmp)) {
-        BN_free(rsa_p);
+        BN_clear_free(rsa_p);
         rsa_p = NULL;
 
-        BN_free(rsa_q);
+        BN_clear_free(rsa_q);
         rsa_q = NULL;
 
-        BN_free(rsa_dmp1);
+        BN_clear_free(rsa_dmp1);
         rsa_dmp1 = NULL;
 
-        BN_free(rsa_dmq1);
+        BN_clear_free(rsa_dmq1);
         rsa_dmq1 = NULL;
 
-        BN_free(rsa_iqmp);
+        BN_clear_free(rsa_iqmp);
         rsa_iqmp = NULL;
     }
 
-    /* RSA_set0_*() functions transfer ownership over bignums to "rsa" */
-    if (!RSA_set0_key(rsa, rsa_n, rsa_e, rsa_d)) {
-        goto free_exponents;
-    }
-    if (!RSA_set0_factors(rsa, rsa_p, rsa_q)) {
-        goto free_factors;
-    }
-    if (!RSA_set0_crt_params(rsa, rsa_dmp1, rsa_dmq1, rsa_iqmp)) {
-        goto free_crt_params;
+    bld = OSSL_PARAM_BLD_new();
+    if (bld == NULL) {
+        err = SOTER_NO_MEMORY;
+        goto out;
     }
 
-    /* EVP_PKEY_assign_RSA() transfers ownership over "rsa" to "pkey" */
-    if (!EVP_PKEY_assign_RSA(pkey, rsa)) {
-        goto free_rsa;
+    if (!OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_RSA_D, rsa_d)) {
+        err = SOTER_FAIL;
+        goto out;
     }
 
-    return SOTER_SUCCESS;
+    if (!OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_RSA_FACTOR1, rsa_p)) {
+        err = SOTER_FAIL;
+        goto out;
+    }
 
-free_exponents:
+    if (!OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_RSA_FACTOR2, rsa_q)) {
+        err = SOTER_FAIL;
+        goto out;
+    }
+
+    if (!OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_RSA_EXPONENT1, rsa_dmp1)) {
+        err = SOTER_FAIL;
+        goto out;
+    }
+
+    if (!OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_RSA_EXPONENT2, rsa_dmq1)) {
+        err = SOTER_FAIL;
+        goto out;
+    }
+
+    if (!OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_RSA_COEFFICIENT1, rsa_iqmp)) {
+        err = SOTER_FAIL;
+        goto out;
+    }
+
+    if (!OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_RSA_N, rsa_n)) {
+        err = SOTER_FAIL;
+        goto out;
+    }
+
+    if (!OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_RSA_E, rsa_e)) {
+        err = SOTER_FAIL;
+        goto out;
+    }
+
+    params = OSSL_PARAM_BLD_to_param(bld);
+    if (params == NULL) {
+        err = SOTER_NO_MEMORY;
+        goto out;
+    }
+
+    ctx = EVP_PKEY_CTX_new_from_name(NULL, "RSA", NULL);
+    if (ctx == NULL) {
+        err = SOTER_NO_MEMORY;
+        goto out;
+    }
+
+    if (!EVP_PKEY_fromdata_init(ctx)) {
+        err = SOTER_FAIL;
+        goto out;
+    }
+
+    if (!EVP_PKEY_fromdata(ctx, (EVP_PKEY**)engine_key, EVP_PKEY_KEYPAIR, params)) {
+        err = SOTER_FAIL;
+        goto out;
+    }
+
+    err = SOTER_SUCCESS;
+
+out:
     BN_free(rsa_n);
     BN_free(rsa_e);
-    BN_free(rsa_d);
-free_factors:
-    BN_free(rsa_p);
-    BN_free(rsa_q);
-free_crt_params:
-    BN_free(rsa_dmp1);
-    BN_free(rsa_dmq1);
-    BN_free(rsa_iqmp);
-free_rsa:
-    RSA_free(rsa);
+    BN_clear_free(rsa_d);
+    BN_clear_free(rsa_p);
+    BN_clear_free(rsa_q);
+    BN_clear_free(rsa_dmp1);
+    BN_clear_free(rsa_dmq1);
+    BN_clear_free(rsa_iqmp);
+    EVP_PKEY_CTX_free(ctx);
+    OSSL_PARAM_free(params);
+    OSSL_PARAM_BLD_free(bld);
+
     return err;
 }
 
-#endif /* OPENSSL_VERSION_NUMBER < 0x30000000 */
+#endif /* OPENSSL_VERSION_NUMBER >= 0x30000000 */

--- a/src/soter/openssl/soter_rsa_key_3.c
+++ b/src/soter/openssl/soter_rsa_key_3.c
@@ -126,9 +126,8 @@ soter_status_t soter_engine_specific_to_rsa_priv_key(const soter_engine_specific
     size_t output_length;
     uint32_t* pub_exp;
     // Maximum supported RSA key is 8192 bits (1024 bytes)
-    unsigned char bigint_buf[1024];
-    OSSL_PARAM params[2];
-    BIGNUM* rsa_e = NULL;
+    unsigned char bignum_buf[1024];
+    BIGNUM* bignum = NULL;
     unsigned char* curr_bn;
 
     if (!key_length) {
@@ -170,89 +169,102 @@ soter_status_t soter_engine_specific_to_rsa_priv_key(const soter_engine_specific
         goto err;
     }
 
-    params[1] = OSSL_PARAM_construct_end();
     curr_bn = (unsigned char*)(key + 1);
 
     /* Private exponent */
-    params[0] = OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_RSA_D, bigint_buf, rsa_mod_size);
-    memset(bigint_buf, 0, rsa_mod_size);
-    if (!EVP_PKEY_get_params(pkey, params)) {
+    if (!get_bn_param(pkey, OSSL_PKEY_PARAM_RSA_D, bignum_buf, sizeof(bignum_buf), &bignum)) {
         res = SOTER_FAIL;
         goto err;
     }
-    memcpy_big_endian(curr_bn, bigint_buf, rsa_mod_size);
+
+    if (BN_bn2binpad(bignum, curr_bn, rsa_mod_size) == -1) {
+        res = SOTER_FAIL;
+        goto clear_key;
+    }
     curr_bn += rsa_mod_size;
 
     /* p */
-    params[0] = OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_RSA_FACTOR1, bigint_buf, rsa_mod_size / 2);
-    memset(bigint_buf, 0, rsa_mod_size / 2);
-    if (!EVP_PKEY_get_params(pkey, params)) {
+    if (!get_bn_param(pkey, OSSL_PKEY_PARAM_RSA_FACTOR1, bignum_buf, sizeof(bignum_buf), &bignum)) {
         res = SOTER_FAIL;
-        goto err;
+        goto clear_key;
     }
-    memcpy_big_endian(curr_bn, bigint_buf, rsa_mod_size / 2);
+
+    if (BN_bn2binpad(bignum, curr_bn, rsa_mod_size / 2) == -1) {
+        res = SOTER_FAIL;
+        goto clear_key;
+    }
     curr_bn += rsa_mod_size / 2;
 
     /* q */
-    params[0] = OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_RSA_FACTOR2, bigint_buf, rsa_mod_size / 2);
-    memset(bigint_buf, 0, rsa_mod_size / 2);
-    if (!EVP_PKEY_get_params(pkey, params)) {
+    if (!get_bn_param(pkey, OSSL_PKEY_PARAM_RSA_FACTOR2, bignum_buf, sizeof(bignum_buf), &bignum)) {
         res = SOTER_FAIL;
-        goto err;
+        goto clear_key;
     }
-    memcpy_big_endian(curr_bn, bigint_buf, rsa_mod_size / 2);
+
+    if (BN_bn2binpad(bignum, curr_bn, rsa_mod_size / 2) == -1) {
+        res = SOTER_FAIL;
+        goto clear_key;
+    }
     curr_bn += rsa_mod_size / 2;
 
     /* dp */
-    params[0] = OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_RSA_EXPONENT1, bigint_buf, rsa_mod_size / 2);
-    memset(bigint_buf, 0, rsa_mod_size / 2);
-    if (!EVP_PKEY_get_params(pkey, params)) {
+    if (!get_bn_param(pkey, OSSL_PKEY_PARAM_RSA_EXPONENT1, bignum_buf, sizeof(bignum_buf), &bignum)) {
         res = SOTER_FAIL;
-        goto err;
+        goto clear_key;
     }
-    memcpy_big_endian(curr_bn, bigint_buf, rsa_mod_size / 2);
+
+    if (BN_bn2binpad(bignum, curr_bn, rsa_mod_size / 2) == -1) {
+        res = SOTER_FAIL;
+        goto clear_key;
+    }
     curr_bn += rsa_mod_size / 2;
 
     /* dq */
-    params[0] = OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_RSA_EXPONENT2, bigint_buf, rsa_mod_size / 2);
-    memset(bigint_buf, 0, rsa_mod_size / 2);
-    if (!EVP_PKEY_get_params(pkey, params)) {
+    if (!get_bn_param(pkey, OSSL_PKEY_PARAM_RSA_EXPONENT2, bignum_buf, sizeof(bignum_buf), &bignum)) {
         res = SOTER_FAIL;
-        goto err;
+        goto clear_key;
     }
-    memcpy_big_endian(curr_bn, bigint_buf, rsa_mod_size / 2);
+
+    if (BN_bn2binpad(bignum, curr_bn, rsa_mod_size / 2) == -1) {
+        res = SOTER_FAIL;
+        goto clear_key;
+    }
     curr_bn += rsa_mod_size / 2;
 
     /* qp */
-    params[0] = OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_RSA_COEFFICIENT1, bigint_buf, rsa_mod_size / 2);
-    memset(bigint_buf, 0, rsa_mod_size / 2);
-    if (!EVP_PKEY_get_params(pkey, params)) {
+    if (!get_bn_param(pkey, OSSL_PKEY_PARAM_RSA_COEFFICIENT1, bignum_buf, sizeof(bignum_buf), &bignum)) {
         res = SOTER_FAIL;
-        goto err;
+        goto clear_key;
     }
-    memcpy_big_endian(curr_bn, bigint_buf, rsa_mod_size / 2);
+
+    if (BN_bn2binpad(bignum, curr_bn, rsa_mod_size / 2) == -1) {
+        res = SOTER_FAIL;
+        goto clear_key;
+    }
     curr_bn += rsa_mod_size / 2;
 
     /* modulus */
-    params[0] = OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_RSA_N, bigint_buf, rsa_mod_size);
-    memset(bigint_buf, 0, rsa_mod_size);
-    if (!EVP_PKEY_get_params(pkey, params)) {
+    if (!get_bn_param(pkey, OSSL_PKEY_PARAM_RSA_N, bignum_buf, sizeof(bignum_buf), &bignum)) {
         res = SOTER_FAIL;
-        goto err;
+        goto clear_key;
     }
-    memcpy_big_endian(curr_bn, bigint_buf, rsa_mod_size);
+
+    if (BN_bn2binpad(bignum, curr_bn, rsa_mod_size) == -1) {
+        res = SOTER_FAIL;
+        goto clear_key;
+    }
     curr_bn += rsa_mod_size;
 
     /* public exponent */
-    if (!EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_RSA_E, &rsa_e)) {
+    if (!get_bn_param(pkey, OSSL_PKEY_PARAM_RSA_E, bignum_buf, sizeof(bignum_buf), &bignum)) {
         res = SOTER_FAIL;
         goto clear_key;
     }
 
     pub_exp = (uint32_t*)curr_bn;
-    if (BN_is_word(rsa_e, RSA_F4)) {
+    if (BN_is_word(bignum, RSA_F4)) {
         *pub_exp = htobe32(RSA_F4);
-    } else if (BN_is_word(rsa_e, RSA_3)) {
+    } else if (BN_is_word(bignum, RSA_3)) {
         *pub_exp = htobe32(RSA_3);
     } else {
         res = SOTER_INVALID_PARAMETER;
@@ -270,11 +282,11 @@ clear_key:
         /* Zero output memory to avoid leaking private key information */
         soter_wipe(key, output_length);
         /* We did not use whole buffer, only `rsa_mod_size` bytes of it */
-        soter_wipe(bigint_buf, rsa_mod_size);
+        soter_wipe(bignum_buf, rsa_mod_size);
     }
 
 err:
-    BN_free(rsa_e);
+    BN_clear_free(bignum);
 
     return res;
 }

--- a/src/soter/openssl/soter_rsa_key_3.c
+++ b/src/soter/openssl/soter_rsa_key_3.c
@@ -175,6 +175,7 @@ soter_status_t soter_engine_specific_to_rsa_priv_key(const soter_engine_specific
 
     /* Private exponent */
     params[0] = OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_RSA_D, bigint_buf, rsa_mod_size);
+    memset(bigint_buf, 0, rsa_mod_size);
     if (!EVP_PKEY_get_params(pkey, params)) {
         res = SOTER_FAIL;
         goto err;
@@ -184,6 +185,7 @@ soter_status_t soter_engine_specific_to_rsa_priv_key(const soter_engine_specific
 
     /* p */
     params[0] = OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_RSA_FACTOR1, bigint_buf, rsa_mod_size / 2);
+    memset(bigint_buf, 0, rsa_mod_size / 2);
     if (!EVP_PKEY_get_params(pkey, params)) {
         res = SOTER_FAIL;
         goto err;
@@ -193,6 +195,7 @@ soter_status_t soter_engine_specific_to_rsa_priv_key(const soter_engine_specific
 
     /* q */
     params[0] = OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_RSA_FACTOR2, bigint_buf, rsa_mod_size / 2);
+    memset(bigint_buf, 0, rsa_mod_size / 2);
     if (!EVP_PKEY_get_params(pkey, params)) {
         res = SOTER_FAIL;
         goto err;
@@ -202,6 +205,7 @@ soter_status_t soter_engine_specific_to_rsa_priv_key(const soter_engine_specific
 
     /* dp */
     params[0] = OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_RSA_EXPONENT1, bigint_buf, rsa_mod_size / 2);
+    memset(bigint_buf, 0, rsa_mod_size / 2);
     if (!EVP_PKEY_get_params(pkey, params)) {
         res = SOTER_FAIL;
         goto err;
@@ -211,6 +215,7 @@ soter_status_t soter_engine_specific_to_rsa_priv_key(const soter_engine_specific
 
     /* dq */
     params[0] = OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_RSA_EXPONENT2, bigint_buf, rsa_mod_size / 2);
+    memset(bigint_buf, 0, rsa_mod_size / 2);
     if (!EVP_PKEY_get_params(pkey, params)) {
         res = SOTER_FAIL;
         goto err;
@@ -220,6 +225,7 @@ soter_status_t soter_engine_specific_to_rsa_priv_key(const soter_engine_specific
 
     /* qp */
     params[0] = OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_RSA_COEFFICIENT1, bigint_buf, rsa_mod_size / 2);
+    memset(bigint_buf, 0, rsa_mod_size / 2);
     if (!EVP_PKEY_get_params(pkey, params)) {
         res = SOTER_FAIL;
         goto err;
@@ -229,6 +235,7 @@ soter_status_t soter_engine_specific_to_rsa_priv_key(const soter_engine_specific
 
     /* modulus */
     params[0] = OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_RSA_N, bigint_buf, rsa_mod_size);
+    memset(bigint_buf, 0, rsa_mod_size);
     if (!EVP_PKEY_get_params(pkey, params)) {
         res = SOTER_FAIL;
         goto err;

--- a/src/soter/openssl/soter_rsa_key_utils.h
+++ b/src/soter/openssl/soter_rsa_key_utils.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2023 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef THEMIS_SOTER_RSA_KEY_UTILS_H
+#define THEMIS_SOTER_RSA_KEY_UTILS_H
+
+#include "soter/soter_rsa_key.h"
+
+#include <string.h>
+
+static size_t rsa_pub_key_size(int mod_size)
+{
+    switch (mod_size) {
+    case 128: /* 1024 */
+        return sizeof(soter_rsa_pub_key_1024_t);
+    case 256: /* 2048 */
+        return sizeof(soter_rsa_pub_key_2048_t);
+    case 512: /* 4096 */
+        return sizeof(soter_rsa_pub_key_4096_t);
+    case 1024: /* 8192 */
+        return sizeof(soter_rsa_pub_key_8192_t);
+    default:
+        return 0;
+    }
+}
+
+static size_t rsa_priv_key_size(int mod_size)
+{
+    switch (mod_size) {
+    case 128: /* 1024 */
+        return sizeof(soter_rsa_priv_key_1024_t);
+    case 256: /* 2048 */
+        return sizeof(soter_rsa_priv_key_2048_t);
+    case 512: /* 4096 */
+        return sizeof(soter_rsa_priv_key_4096_t);
+    case 1024: /* 8192 */
+        return sizeof(soter_rsa_priv_key_8192_t);
+    default:
+        return 0;
+    }
+}
+
+static char* rsa_pub_key_tag(int mod_size)
+{
+    switch (mod_size) {
+    case 128: /* 1024 */
+        return RSA_PUB_KEY_TAG(1024);
+    case 256: /* 2048 */
+        return RSA_PUB_KEY_TAG(2048);
+    case 512: /* 4096 */
+        return RSA_PUB_KEY_TAG(4096);
+    case 1024: /* 8192 */
+        return RSA_PUB_KEY_TAG(8192);
+    default:
+        return NULL;
+    }
+}
+
+static char* rsa_priv_key_tag(int mod_size)
+{
+    switch (mod_size) {
+    case 128: /* 1024 */
+        return RSA_PRIV_KEY_TAG(1024);
+    case 256: /* 2048 */
+        return RSA_PRIV_KEY_TAG(2048);
+    case 512: /* 4096 */
+        return RSA_PRIV_KEY_TAG(4096);
+    case 1024: /* 8192 */
+        return RSA_PRIV_KEY_TAG(8192);
+    default:
+        return NULL;
+    }
+}
+
+static bool is_mod_size_supported(int mod_size)
+{
+    switch (mod_size) {
+    case 128:
+    case 256:
+    case 512:
+    case 1024:
+        return true;
+    default:
+        return false;
+    }
+}
+
+#endif /* THEMIS_SOTER_RSA_KEY_UTILS_H */

--- a/src/soter/openssl/soter_sign_ecdsa.c
+++ b/src/soter/openssl/soter_sign_ecdsa.c
@@ -23,6 +23,9 @@
 #include "soter/openssl/soter_ecdsa_common.h"
 #include "soter/openssl/soter_engine.h"
 #include "soter/soter_ec_key.h"
+#if OPENSSL_VERSION_NUMBER >= 0x30000000
+#include <openssl/core_names.h>
+#endif
 
 soter_status_t soter_sign_init_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
                                                 const void* private_key,
@@ -145,7 +148,14 @@ soter_status_t soter_sign_final_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
         return SOTER_INVALID_PARAMETER;
     }
 
+#if OPENSSL_VERSION_NUMBER >= 0x30000000
+    // In OpenSSL 3, EVP_PKEY_size() returns 0 for some reason. Using different method instead.
+    if (!EVP_PKEY_get_int_param(ctx->pkey, OSSL_PKEY_PARAM_MAX_SIZE, &key_size)) {
+        return SOTER_FAIL;
+    }
+#else
     key_size = EVP_PKEY_size(ctx->pkey);
+#endif
     if (key_size <= 0) {
         return SOTER_FAIL;
     }

--- a/src/soter/openssl/soter_sign_rsa.c
+++ b/src/soter/openssl/soter_sign_rsa.c
@@ -17,7 +17,11 @@
 #include "soter/soter_sign_rsa.h"
 
 #include <openssl/evp.h>
+#include <openssl/opensslv.h>
 #include <openssl/rsa.h>
+#if OPENSSL_VERSION_NUMBER >= 0x30000000
+#include <openssl/core_names.h>
+#endif
 
 #include "soter/openssl/soter_engine.h"
 #include "soter/openssl/soter_rsa_common.h"
@@ -144,7 +148,16 @@ soter_status_t soter_sign_final_rsa_pss_pkcs8(soter_sign_ctx_t* ctx, void* signa
         return SOTER_INVALID_PARAMETER;
     }
 
+#if OPENSSL_VERSION_NUMBER >= 0x30000000
+    // Even though EVP_PKEY_size() is not deprecated in OpenSSL 3, it works incorrectly (returns
+    // zero or even crashes) when given a pkey generated with new EVP_PKEY_fromdata() function.
+    // Using different method instead.
+    if (!EVP_PKEY_get_int_param(ctx->pkey, OSSL_PKEY_PARAM_MAX_SIZE, &key_size)) {
+        return SOTER_FAIL;
+    }
+#else
     key_size = EVP_PKEY_size(ctx->pkey);
+#endif
     if (key_size <= 0) {
         return SOTER_FAIL;
     }

--- a/src/soter/openssl/soter_verify_rsa.c
+++ b/src/soter/openssl/soter_verify_rsa.c
@@ -16,6 +16,10 @@
 
 #include "soter/soter_sign_rsa.h"
 
+#include <openssl/opensslv.h>
+#if OPENSSL_VERSION_NUMBER >= 0x30000000
+#include <openssl/core_names.h>
+#endif
 #include <openssl/evp.h>
 #include <openssl/rsa.h>
 
@@ -111,6 +115,8 @@ soter_status_t soter_verify_final_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
                                                 const void* signature,
                                                 const size_t signature_length)
 {
+    int max_size = 0;
+
     if (!ctx || !ctx->pkey) {
         return SOTER_INVALID_PARAMETER;
     }
@@ -121,7 +127,16 @@ soter_status_t soter_verify_final_rsa_pss_pkcs8(soter_sign_ctx_t* ctx,
         return SOTER_INVALID_PARAMETER;
     }
 
-    if (signature_length != (size_t)EVP_PKEY_size(ctx->pkey)) {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000
+    // In OpenSSL 3, EVP_PKEY_size() crashes here for some reason. More precisely, when ctx->pkey
+    // was created using EVP_PKEY_fromdata() function. Using different method instead.
+    if (!EVP_PKEY_get_int_param(ctx->pkey, OSSL_PKEY_PARAM_MAX_SIZE, &max_size)) {
+        return SOTER_FAIL;
+    }
+#else
+    max_size = EVP_PKEY_size(ctx->pkey);
+#endif
+    if (signature_length != (size_t)max_size) {
         return SOTER_FAIL;
     }
     if (EVP_DigestVerifyFinal(ctx->md_ctx, (unsigned char*)signature, signature_length) != 1) {

--- a/src/soter/soter_rsa_key.h
+++ b/src/soter/soter_rsa_key.h
@@ -81,6 +81,9 @@ DECLARE_RSA_KEY(2048);
 DECLARE_RSA_KEY(4096);
 DECLARE_RSA_KEY(8192);
 
+/* Used internally when allocating large enough memory to store key components */
+#define RSA_KEY_BYTES_MAX RSA_BYTE_SIZE(8192)
+
 /* This is considered internal API */
 typedef void soter_engine_specific_rsa_key_t;
 

--- a/tests/soter/soter_asym_cipher_test.c
+++ b/tests/soter/soter_asym_cipher_test.c
@@ -356,6 +356,7 @@ void test_api_all(void)
     test_api(RSA_KEY_LENGTH_4096);
     //    test_api(RSA_KEY_LENGTH_8192);
 }
+
 void run_soter_asym_cipher_tests(void)
 {
     testsuite_enter_suite("soter asym cipher: basic flow");

--- a/tests/soter/soter_openssl_test.c
+++ b/tests/soter/soter_openssl_test.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023 Cossack Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <openssl/opensslv.h>
+
+#if OPENSSL_VERSION_NUMBER >= 0x30000000
+
+#include "soter/openssl/soter_engine.h"
+#include "soter/soter_test.h"
+
+#include <string.h>
+
+void test_openssl_constants(void)
+{
+    testsuite_fail_if(MAX_CURVE_NAME_LEN < strlen(SN_X9_62_prime256v1) + 1,
+                      "MAX_CURVE_NAME_LEN could fit SN_X9_62_prime256v1");
+    testsuite_fail_if(MAX_CURVE_NAME_LEN < strlen(SN_secp384r1) + 1,
+                      "MAX_CURVE_NAME_LEN could fit SN_secp384r1");
+    testsuite_fail_if(MAX_CURVE_NAME_LEN < strlen(SN_secp521r1) + 1,
+                      "MAX_CURVE_NAME_LEN could fit SN_secp521r1");
+}
+
+void run_openssl_tests(void)
+{
+    testsuite_enter_suite("soter openssl backend: constants");
+    testsuite_run_test(test_openssl_constants);
+}
+
+#else
+
+void run_openssl_tests(void)
+{
+}
+
+#endif

--- a/tests/soter/soter_test.c
+++ b/tests/soter/soter_test.c
@@ -32,6 +32,7 @@ int main(int argc, char* argv[])
     run_soter_sign_test();
     run_soter_rand_tests();
     run_soter_kdf_tests();
+    run_openssl_tests();
 
     testsuite_finish_testing();
 

--- a/tests/soter/soter_test.h
+++ b/tests/soter/soter_test.h
@@ -31,5 +31,6 @@ void run_soter_sign_test(void);
 void run_soter_rand_tests(void);
 void run_soter_hmac_tests(void);
 void run_soter_kdf_tests(void);
+void run_openssl_tests(void);
 
 #endif /* SOTER_TEST_H */


### PR DESCRIPTION
Essentially, a proposal to merge #989 and #993 into master.

### Brief description of changes

* New implementation of EC and RSA keys serialization and deserialization
  * Lives in separate files (with `_3` suffix in name)
  * Uses new APIs introduced in OpenSSL 3
  * Compile new or old file based on OpenSSL version from `OPENSSL_VERSION_NUMBER` macro
* Minor changes in few other places
  * Same `EVP_PKEY*` but created with newer APIs causes some older (but not deprecated) functions to behave incorrectly 
* Move few common util functions to separate `.h` files
* Remove `THEMIS_EXPERIMENTAL_OPENSSL_3_SUPPORT` build flag and corresponding macro definition
* Enable CI jobs that were previously disabled
* OpenSSL `1.1.1`, `1.1.0` and even `1.0.2` remain supported

### Differences in APIs

Some OpenSSL 1.X functions were deprecated in OpenSSL 3. Main purpose of this PR is to add a proper implementation that relies on newer API. TL;DR: Working with specific key types (such as `EC_KEY*`, `RSA*`) using corresponding functions is deprecated. Instead, one should set or extract key properties using new generalized API. Other operations like encryption and signing work as before, same functions, same `EVP_PKEY*`.

#### Key serialization procedure

There are `EVP_PKEY_todata()` and `EVP_PKEY_export()` functions for this. You give them array of params you want to get, they give you the values by filling buffers you provide. Or at least, that's how it was supposed to work. Didn't use these functions because of few issues. 
1) There are cases where extracting all params at once is not suitable. We first extract one param, compare its value to expected one, do some decisions or return error, and then proceed to extracting other things.
2) Because of byte order in bigint. I'm not sure about this one, but here's the thing:
   * `EVP_PKEY_fromdata()` (function used to create key from serialized components) expects bigints with native (or little endian) byte order if you prepare params on stack and point some bigint param to buffer with serialized bigint
   * `EVP_PKEY_fromdata()` will then incorrectly decode a bigint it you previously put it in big-endian byte order into that buffer
   * `EVP_PKEY_fromdata()` or the param pointing to bigint buffer have no flags to control which byte order should be used 
   * because of all this I supposed `EVP_PKEY_todata()` would put bigint params in little endian order as well when you ask to fill a buffer with serialized biging
  
But our keys use a different byte order. Big-endian everywhere, as far as I've seen. So to avoid reversing bytes, I instead used `EVP_PKEY_get_bn_param()` got get `BIGINT*` which was then serialized using `BN_bn2binpad()`. This time, with proper byte order. Overhead? Yes. But there is no flag to tell `EVP_PKEY_fromdata()` which byte order to use when reading bigints from buffers, same thing with `EVP_PKEY_todata()`.
 
So,
* bigint params are extracted with `EVP_PKEY_get_bn_param()`, single bigint struct could be reused over and over if we extract then serialize it then extract new value and so on
* string params (such as EC curve name) are extracted with `EVP_PKEY_get_utf8_string_param()`
* EC point (which represents EC public key) is extracted with `EVP_PKEY_get_octet_string_param()`

#### Key deserialization procedure

First, prepare params. These contain all the components of key (serialized EC points, bigints, etc)

Method 1: store on stack
* `OSSL_PARAM params[N]`
* `params[x] = OSSL_PARAM_construct_utf8_string("group", "prime256v1", strlen("prime256v1"))` to set EC curve
* `params[x] = OSSL_PARAM_construct_octet_string("pub", _buffer_, _buffer_len_))` to set EC public key
* `params[x] = OSSL_PARAM_construct_end()` to add terminator element

these `OSSL_PARAM_construct_xxx()` are all functions. But macros as alternative exist with similar names

Method 2: using so-called builder
* `EVP_PKEY_BLD *bld = OSSL_PARAM_BLD_new()`
* `OSSL_PARAM_BLD_push_BN(bld, "d", rsa_d)` to push bigint (RSA `d` in this case)
* `OSSL_PARAM* params = OSSL_PARAM_BLD_to_param(bld)`
* cleanup later: `OSSL_PARAM_BLD_free(bld)`
* cleanup later: `OSSL_PARAM_free(params)`

Of course, all possible param types are usable in both methods, this is just illustration from code. In some places I used params on stack to avoid overhead from builder. In other — had to use builder because of issue with bigints (mentioned in big comment in `soter_ec_key_3.c`).

Then, create the key itself
* `EVP_PKEY* pkey = NULL /* or some empty allocated pkey */`
* `EVP_PKEY_CTX* ctx = EVP_PKEY_CTX_new_from_name(NULL, "EC" /* or "RSA" */, NULL)`
* `EVP_PKEY_fromdata_init(ctx)`
* `EVP_PKEY_fromdata(ctx, &pkey, EVP_PKEY_KEYPAIR /* or EVP_PKEY_PUBLIC_KEY */, params)`

### Possibly important notes

* Private EC key in Themis only stores private part, a bigint. Not quite sure about behavior of older OpenSSL, but new API will not automagically compute public part of key when only private part was provided. That is, I'm not sure such deserialized pkey will be able to perform things like signature checking. Nevertheless, tests pass, and seems like private key is not used for things where public one is usually used

## Checklist

- [x] Change is covered by automated tests
- [x] Benchmark results are attached (if applicable)
- [x] The [coding guidelines] are followed
- [x] ~Public API has proper documentation~
- [x] ~Example projects and code samples are up-to-date (in case of API changes)~
- [x] Changelog is updated (in case of notable or breaking changes)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
