### PR TITLE
jsthemis: Add missing returns after errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ _Code:_
 - **Node.js**
 
   - Node.js v8 is no longer supported ([#901](https://github.com/cossacklabs/themis/pull/901)).
+  - Fixed bug that leads to segfauls if key pair generation fails ([#999](https://github.com/cossacklabs/themis/pull/999))
 
 - **Python**
 

--- a/src/wrappers/themis/jsthemis/secure_keygen.cpp
+++ b/src/wrappers/themis/jsthemis/secure_keygen.cpp
@@ -92,6 +92,7 @@ void KeyPair::New(const Nan::FunctionCallbackInfo<v8::Value>& args)
             if (status != THEMIS_BUFFER_TOO_SMALL) {
                 ThrowError("Key Pair generation failed", status);
                 args.GetReturnValue().SetUndefined();
+                return;
             }
             std::vector<uint8_t> prk(private_key_length);
             std::vector<uint8_t> puk(public_key_length);
@@ -99,6 +100,7 @@ void KeyPair::New(const Nan::FunctionCallbackInfo<v8::Value>& args)
             if (status != THEMIS_SUCCESS) {
                 ThrowError("Key Pair generation failed", status);
                 args.GetReturnValue().SetUndefined();
+                return;
             }
             KeyPair* obj = new KeyPair(prk, puk);
             obj->Wrap(args.This());


### PR DESCRIPTION
There were two places in the code with missing return statements after errors. As a result, if something in key generation goes wrong, the wrapper will segfault while trying to allocate huge vectors for the keys.

It's interesting how these bugs remained unnoticed for such a long time (~4 years). This is because it's hard to make key pair generation fail and it works surprisingly well most of the time :)

This change will prevent some of the segfaults in the #996, but will not resolve the issue.

<!-- Describe your changes here -->

## Checklist

- [x] Change is covered by automated tests
- [x] ~Benchmark results are attached (if applicable)~
- [x] The [coding guidelines] are followed
- [x] ~Public API has proper documentation~
- [x] ~Example projects and code samples are up-to-date (in case of API changes)~
- [x] Changelog is updated (in case of notable or breaking changes)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
