### PR TITLE
jsthemis: Bump nan version

### DIFF
--- a/src/wrappers/themis/jsthemis/package.json
+++ b/src/wrappers/themis/jsthemis/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://www.cossacklabs.com/themis/",
   "dependencies": {
-    "nan": "^2.14.0"
+    "nan": "^2.17.0"
   },
   "devDependencies": {
     "mocha": "^9"


### PR DESCRIPTION
This is a part of debugging themis to work on the ubuntu jammy with the openssl 3. There we use the node 18.0 which changed some of the API. This resulted in an error `'class v8::ArrayBuffer' has no member named 'GetContents'`. So, following the same fix as in https://github.com/Automattic/node-canvas/issues/1912, let's use the newest nan version as it fixes the issue.

## Checklist

- [x] Change is covered by automated tests
- [x] ~Benchmark results are attached (if applicable)~
- [x] ~The [coding guidelines] are followed~
- [x] ~Public API has proper documentation~
- [x] ~Example projects and code samples are up-to-date (in case of API changes)~
- [x] ~Changelog is updated (in case of notable or breaking changes)~

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
