### PR TITLE
jsthemis: Downgrade mocha to ^7 for Centos7

### DIFF
--- a/src/wrappers/themis/jsthemis/install_centos7_specific_deps.sh
+++ b/src/wrappers/themis/jsthemis/install_centos7_specific_deps.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# centos:7 has pretty old Node (v8) which is not supported by many packages,
+# including mocha - test framework that we use. Therefore, we need to downgrade
+# it for testing. The addon itself works fine, we just cannot test it without
+# this patch.
+
+
+set -e -o pipefail
+
+OS=$(cat /etc/*-release | grep '^NAME' | tr -d 'NAME="' || true)
+VERSION=$(cat /etc/*-release | grep '^VERSION_ID' | tr -d 'VERSION_ID="' || true)
+
+if [[ "$OS" == "CentOS Linux" && "$VERSION" == "7" ]]; then
+	npm install mocha@7 --save-dev
+fi

--- a/src/wrappers/themis/jsthemis/package.json
+++ b/src/wrappers/themis/jsthemis/package.json
@@ -5,7 +5,8 @@
   "main": "build/Release/jsthemis.node",
   "scripts": {
     "test": "mocha",
-    "preuninstall": "rm -rf build/*"
+    "preuninstall": "rm -rf build/*",
+    "install_centos7_specific_deps": "./install_centos7_specific_deps.sh"
   },
   "repository": {
     "type": "git",

--- a/src/wrappers/themis/jsthemis/package.json
+++ b/src/wrappers/themis/jsthemis/package.json
@@ -31,7 +31,7 @@
     "nan": "^2.17.0"
   },
   "devDependencies": {
-    "mocha": "^9"
+    "mocha": "^7"
   },
   "gypfile": true
 }

--- a/src/wrappers/themis/jsthemis/package.json
+++ b/src/wrappers/themis/jsthemis/package.json
@@ -32,7 +32,7 @@
     "nan": "^2.17.0"
   },
   "devDependencies": {
-    "mocha": "^7"
+    "mocha": "^9"
   },
   "gypfile": true
 }

--- a/tests/test.mk
+++ b/tests/test.mk
@@ -148,7 +148,7 @@ ifdef NPM_VERSION
 	@echo "Running jsthemis tests."
 	@echo "In case of errors, see https://docs.cossacklabs.com/themis/languages/nodejs/"
 	@echo "------------------------------------------------------------"
-	cd $(JSTHEMIS_SRC) && npm install && npm test
+	cd $(JSTHEMIS_SRC) && npm run install_centos7_specific_deps && npm install && npm test
 	@echo "------------------------------------------------------------"
 endif
 


### PR DESCRIPTION
This version and all its transitive dependencies support node v8 which is the only version we can run on centos 7. It seems like other OS work fine with it, at least on buildbot.

Another option is to fix our scripts on buildbot just for centos 7, so they patch the versions before testing. This may save us from future problems or dependency issues. However, downgrading dev dependency is not that scary, so maybe this approach is okay.

<!-- Describe your changes here -->

## Checklist

- [x] Change is covered by automated tests
- [x] ~Benchmark results are attached (if applicable)~
- [x] ~The [coding guidelines] are followed~
- [x] ~Public API has proper documentation~
- [x] ~Example projects and code samples are up-to-date (in case of API changes)~
- [x] ~Changelog is updated (in case of notable or breaking changes)~

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
