### PR TITLE
Bump embedded BoringSSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ _Code:_
   - Uncompressed EC public keys are now supported ([#959](https://github.com/cossacklabs/themis/pull/959), [#954](https://github.com/cossacklabs/themis/pull/954))
   - Themis will generate uncompressed EC public keys when `THEMIS_GEN_EC_KEY_PAIR_UNCOMPRESSED=1` environment variable is set ([#959](https://github.com/cossacklabs/themis/pull/959))
   - Increased PBKDF2 iteration count to maintain security of Secure Cell passphrase mode ([#976](https://github.com/cossacklabs/themis/pull/976)).
+  - Bumped embedded BoringSSL to the latest version ([#1004](https://github.com/cossacklabs/themis/pull/1004)).
 
   - **Soter** (low-level security core used by Themis)
 

--- a/src/soter/boringssl/soter.mk
+++ b/src/soter/boringssl/soter.mk
@@ -87,14 +87,12 @@ ifeq ($(RENAME_BORINGSSL_SYMBOLS),yes)
 	 $(GO) run util/read_symbols.go -out $(abspath $(BIN_PATH)/boringssl/symbols.txt) \
 	     $(abspath $(BIN_PATH)/boringssl/stage-1/crypto/libcrypto.a) \
 	     $(abspath $(BIN_PATH)/boringssl/stage-1/decrepit/libdecrepit.a)
-	@# Path to symbols must be a relative one (relative to the build directory)
-	@# because absolute paths confuse BoringSSL's make.
 	@echo "building embedded BoringSSL again with renamed symbols..."
 	@mkdir -p $(BIN_PATH)/boringssl/stage-2
 	@cd $(BIN_PATH)/boringssl/stage-2 && \
 	 $(CMAKE) $(SOTER_ENGINE_CMAKE_FLAGS) \
 	     -DBORINGSSL_PREFIX=$(SOTER_BORINGSSL_PREFIX) \
-	     -DBORINGSSL_PREFIX_SYMBOLS=../symbols.txt \
+	     -DBORINGSSL_PREFIX_SYMBOLS=$(abspath $(BIN_PATH)/boringssl/symbols.txt) \
 	     $(abspath third_party/boringssl/src)
 ifeq ($(NINJA),)
 	@$(MAKE) -C $(BIN_PATH)/boringssl/stage-2 crypto decrepit

--- a/src/soter/boringssl/soter_rsa_key.c
+++ b/src/soter/boringssl/soter_rsa_key.c
@@ -101,7 +101,7 @@ static bool is_mod_size_supported(unsigned mod_size)
     }
 }
 
-static soter_status_t bignum_to_bytes(BIGNUM* bn, uint8_t* to, size_t to_length)
+static soter_status_t bignum_to_bytes(const BIGNUM* bn, uint8_t* to, size_t to_length)
 {
     size_t bn_size = (size_t)BN_num_bytes(bn);
     size_t bytes_copied;

--- a/src/soter/boringssl/soter_rsa_key.c
+++ b/src/soter/boringssl/soter_rsa_key.c
@@ -159,16 +159,16 @@ soter_status_t soter_engine_specific_to_rsa_pub_key(const soter_engine_specific_
     }
 
     pub_exp = (uint32_t*)((unsigned char*)(key + 1) + rsa_mod_size);
-    if (BN_is_word(rsa->e, RSA_F4)) {
+    if (BN_is_word(RSA_get0_e(rsa), RSA_F4)) {
         *pub_exp = htobe32(RSA_F4);
-    } else if (BN_is_word(rsa->e, RSA_3)) {
+    } else if (BN_is_word(RSA_get0_e(rsa), RSA_3)) {
         *pub_exp = htobe32(RSA_3);
     } else {
         res = SOTER_INVALID_PARAMETER;
         goto err;
     }
 
-    res = bignum_to_bytes(rsa->n, (unsigned char*)(key + 1), rsa_mod_size);
+    res = bignum_to_bytes(RSA_get0_n(rsa), (unsigned char*)(key + 1), rsa_mod_size);
     if (SOTER_SUCCESS != res) {
         goto err;
     }
@@ -225,9 +225,9 @@ soter_status_t soter_engine_specific_to_rsa_priv_key(const soter_engine_specific
     }
 
     pub_exp = (uint32_t*)(curr_bn + ((rsa_mod_size * 4) + (rsa_mod_size / 2)));
-    if (BN_is_word(rsa->e, RSA_F4)) {
+    if (BN_is_word(RSA_get0_e(rsa), RSA_F4)) {
         *pub_exp = htobe32(RSA_F4);
-    } else if (BN_is_word(rsa->e, RSA_3)) {
+    } else if (BN_is_word(RSA_get0_e(rsa), RSA_3)) {
         *pub_exp = htobe32(RSA_3);
     } else {
         res = SOTER_INVALID_PARAMETER;
@@ -235,49 +235,49 @@ soter_status_t soter_engine_specific_to_rsa_priv_key(const soter_engine_specific
     }
 
     /* Private exponent */
-    res = bignum_to_bytes(rsa->d, curr_bn, rsa_mod_size);
+    res = bignum_to_bytes(RSA_get0_d(rsa), curr_bn, rsa_mod_size);
     if (SOTER_SUCCESS != res) {
         goto err;
     }
     curr_bn += rsa_mod_size;
 
     /* p */
-    res = bignum_to_bytes(rsa->p, curr_bn, rsa_mod_size / 2);
+    res = bignum_to_bytes(RSA_get0_p(rsa), curr_bn, rsa_mod_size / 2);
     if (SOTER_SUCCESS != res) {
         goto err;
     }
     curr_bn += rsa_mod_size / 2;
 
     /* q */
-    res = bignum_to_bytes(rsa->q, curr_bn, rsa_mod_size / 2);
+    res = bignum_to_bytes(RSA_get0_q(rsa), curr_bn, rsa_mod_size / 2);
     if (SOTER_SUCCESS != res) {
         goto err;
     }
     curr_bn += rsa_mod_size / 2;
 
     /* dp */
-    res = bignum_to_bytes(rsa->dmp1, curr_bn, rsa_mod_size / 2);
+    res = bignum_to_bytes(RSA_get0_dmp1(rsa), curr_bn, rsa_mod_size / 2);
     if (SOTER_SUCCESS != res) {
         goto err;
     }
     curr_bn += rsa_mod_size / 2;
 
     /* dq */
-    res = bignum_to_bytes(rsa->dmq1, curr_bn, rsa_mod_size / 2);
+    res = bignum_to_bytes(RSA_get0_dmq1(rsa), curr_bn, rsa_mod_size / 2);
     if (SOTER_SUCCESS != res) {
         goto err;
     }
     curr_bn += rsa_mod_size / 2;
 
     /* qp */
-    res = bignum_to_bytes(rsa->iqmp, curr_bn, rsa_mod_size / 2);
+    res = bignum_to_bytes(RSA_get0_iqmp(rsa), curr_bn, rsa_mod_size / 2);
     if (SOTER_SUCCESS != res) {
         goto err;
     }
     curr_bn += rsa_mod_size / 2;
 
     /* modulus */
-    res = bignum_to_bytes(rsa->n, curr_bn, rsa_mod_size);
+    res = bignum_to_bytes(RSA_get0_n(rsa), curr_bn, rsa_mod_size);
     if (SOTER_SUCCESS != res) {
         goto err;
     }

--- a/src/soter/boringssl/soter_sign_ecdsa.c
+++ b/src/soter/boringssl/soter_sign_ecdsa.c
@@ -135,7 +135,7 @@ soter_status_t soter_sign_final_ecdsa_none_pkcs8(soter_sign_ctx_t* ctx,
     if (!pkey) {
         return SOTER_INVALID_PARAMETER;
     }
-    if (EVP_PKEY_type(pkey->type) != EVP_PKEY_EC) {
+    if (EVP_PKEY_type(EVP_PKEY_id(pkey)) != EVP_PKEY_EC) {
         return SOTER_INVALID_PARAMETER;
     }
     /* TODO: need review */


### PR DESCRIPTION
Unfortunately, this was not so smooth as expected, but fixes are pretty easy so not a problem. Though it took me some time to figure it out. Main changes:

- Some annoying bug with relative/absolute paths in make scripts was fixed
- Some types became opaque (RSA, pkey), so they needed accessors

Locally core tests pass, so let's see what our CI will say.

## Checklist

- [x] Change is covered by automated tests
- [x] ~Benchmark results are attached (if applicable)~
- [x] The [coding guidelines] are followed
- [x] ~Public API has proper documentation~
- [x] ~Example projects and code samples are up-to-date (in case of API changes)~
- [x] Changelog is updated (in case of notable or breaking changes)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
