### PR TITLE
Fix rust issues (pin log, run bindgen)

### DIFF
--- a/src/wrappers/themis/rust/Cargo.toml
+++ b/src/wrappers/themis/rust/Cargo.toml
@@ -33,5 +33,6 @@ base64 = "0.10.0"
 byteorder = "1.2.7"
 clap = "2.32"
 lazy_static = "1.2.0"
-log = "0.4.6"
+# it can be unpinned when we update the minimum supported version of rustc
+log = "=0.4.18"
 env_logger = "0.6.0"

--- a/src/wrappers/themis/rust/libthemis-sys/src/lib.rs
+++ b/src/wrappers/themis/rust/libthemis-sys/src/lib.rs
@@ -44,9 +44,6 @@ pub const THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER: u32 = 1;
 pub const THEMIS_SCOMPARE_MATCH: u32 = 21;
 pub const THEMIS_SCOMPARE_NO_MATCH: u32 = 22;
 pub const THEMIS_SCOMPARE_NOT_READY: u32 = 0;
-pub const STATE_IDLE: u32 = 0;
-pub const STATE_NEGOTIATING: u32 = 1;
-pub const STATE_ESTABLISHED: u32 = 2;
 pub type themis_status_t = i32;
 extern "C" {
     pub fn themis_secure_cell_encrypt_seal(
@@ -289,6 +286,9 @@ extern "C" {
         message_length: *mut usize,
     ) -> themis_status_t;
 }
+pub const STATE_IDLE: u32 = 0;
+pub const STATE_NEGOTIATING: u32 = 1;
+pub const STATE_ESTABLISHED: u32 = 2;
 pub type send_protocol_data_callback = ::std::option::Option<
     unsafe extern "C" fn(
         data: *const u8,


### PR DESCRIPTION
The failed CI is in #1004 is a result of two changes of rust side:

- `log` dependency updated and started started to support only rustc 1.60 and higher. Since we have no `Cargo.lock`, this change was immediately obtained. It would be cool to have `Cargo.lock` only for dev dependencies, but seems like there is no such thing.
- bindgen was updated again which resulted in some changes of the generated file. I'm thinking, maybe it's time to pin the exact version of it?

## Checklist

- [x] Change is covered by automated tests
- [x] ~Benchmark results are attached (if applicable)~
- [x] The [coding guidelines] are followed
- [x] ~Public API has proper documentation~
- [x] ~Example projects and code samples are up-to-date (in case of API changes)~
- [ ] Changelog is updated (in case of notable or breaking changes)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
