### PR TITLE
Run and pin bindgen

### DIFF
--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -215,7 +215,7 @@ jobs:
             ${{ runner.os }}-cargo-build-target-unit-tests-
             ${{ runner.os }}-cargo-build-target-
       - name: Install Bindgen
-        run: cargo install bindgen-cli
+        run: cargo install bindgen-cli --version 0.66.1 --force
       - name: Check out code
         uses: actions/checkout@v2
       - name: Check bindgen.sh output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ _Code:_
     This is technically a breaking change, but most reasonble implementations should be `Send` already. Please raise an issue if your code fails to build.
 
   - Minimum supported Rust version is now 1.58 ([#977](https://github.com/cossacklabs/themis/pull/977), [#984](https://github.com/cossacklabs/themis/pull/984)).
+  - Bindgen is pinned to 0.66.1 on CI ([#1008](https://github.com/cossacklabs/themis/pull/1008)).
 
 - **WebAssembly**
 

--- a/src/wrappers/themis/rust/libthemis-sys/bindgen.sh
+++ b/src/wrappers/themis/rust/libthemis-sys/bindgen.sh
@@ -10,7 +10,7 @@
 # You need to have Bindgen, LLVM, rustfmt installed to run this script.
 # Bindgen can be installed with
 #
-#     cargo install bindgen
+#     cargo install bindgen-cli --version 0.66.1 --force
 #
 # rustfmt can be installed with
 #

--- a/src/wrappers/themis/rust/libthemis-sys/src/lib.rs
+++ b/src/wrappers/themis/rust/libthemis-sys/src/lib.rs
@@ -44,6 +44,9 @@ pub const THEMIS_SCOMPARE_SEND_OUTPUT_TO_PEER: u32 = 1;
 pub const THEMIS_SCOMPARE_MATCH: u32 = 21;
 pub const THEMIS_SCOMPARE_NO_MATCH: u32 = 22;
 pub const THEMIS_SCOMPARE_NOT_READY: u32 = 0;
+pub const STATE_IDLE: u32 = 0;
+pub const STATE_NEGOTIATING: u32 = 1;
+pub const STATE_ESTABLISHED: u32 = 2;
 pub type themis_status_t = i32;
 extern "C" {
     pub fn themis_secure_cell_encrypt_seal(
@@ -286,9 +289,6 @@ extern "C" {
         message_length: *mut usize,
     ) -> themis_status_t;
 }
-pub const STATE_IDLE: u32 = 0;
-pub const STATE_NEGOTIATING: u32 = 1;
-pub const STATE_ESTABLISHED: u32 = 2;
 pub type send_protocol_data_callback = ::std::option::Option<
     unsafe extern "C" fn(
         data: *const u8,


### PR DESCRIPTION
You wouldn't believe but the failing bindgen tests in #1007 are caused by the bindgen which again updated and changed the format.

So, I propose pinning the exact version on CI just to save our time. Though you would have to make sure to use the correct bindgen version while developing locally.

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Changelog is updated (in case of notable or breaking changes)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
