### PR TITLE
Rust-themis: Allocate with try_reserve

### DIFF
--- a/src/wrappers/themis/rust/src/error.rs
+++ b/src/wrappers/themis/rust/src/error.rs
@@ -149,6 +149,14 @@ impl fmt::Display for Error {
     }
 }
 
+impl From<std::collections::TryReserveError> for Error {
+    fn from(_: std::collections::TryReserveError) -> Self {
+        Self {
+            kind: ErrorKind::NoMemory,
+        }
+    }
+}
+
 /// A list of Themis error categories.
 ///
 /// This enumeration is used by [`Error`] type, returned by most Themis functions. Some error kinds

--- a/src/wrappers/themis/rust/src/keygen.rs
+++ b/src/wrappers/themis/rust/src/keygen.rs
@@ -89,8 +89,8 @@ fn try_gen_rsa_key_pair() -> Result<RsaKeyPair> {
         }
     }
 
-    private_key.reserve(private_key_len);
-    public_key.reserve(public_key_len);
+    private_key.try_reserve(private_key_len)?;
+    public_key.try_reserve(public_key_len)?;
 
     unsafe {
         let status = themis_gen_rsa_key_pair(
@@ -149,8 +149,8 @@ fn try_gen_ec_key_pair() -> Result<EcdsaKeyPair> {
         }
     }
 
-    private_key.reserve(private_key_len);
-    public_key.reserve(public_key_len);
+    private_key.try_reserve(private_key_len)?;
+    public_key.try_reserve(public_key_len)?;
 
     unsafe {
         let status = themis_gen_ec_key_pair(

--- a/src/wrappers/themis/rust/src/keys.rs
+++ b/src/wrappers/themis/rust/src/keys.rs
@@ -640,7 +640,7 @@ impl SymmetricKey {
             }
         }
 
-        key.reserve(key_len);
+        key.try_reserve(key_len)?;
 
         unsafe {
             let status = themis_gen_sym_key(key.as_mut_ptr(), &mut key_len);

--- a/src/wrappers/themis/rust/src/secure_cell.rs
+++ b/src/wrappers/themis/rust/src/secure_cell.rs
@@ -935,7 +935,7 @@ fn encrypt_seal(master_key: &[u8], user_context: &[u8], message: &[u8]) -> Resul
         }
     }
 
-    encrypted_message.reserve(encrypted_message_len);
+    encrypted_message.try_reserve(encrypted_message_len)?;
 
     unsafe {
         let status = themis_secure_cell_encrypt_seal(
@@ -985,7 +985,7 @@ fn decrypt_seal(master_key: &[u8], user_context: &[u8], message: &[u8]) -> Resul
         }
     }
 
-    decrypted_message.reserve(decrypted_message_len);
+    decrypted_message.try_reserve(decrypted_message_len)?;
 
     unsafe {
         let status = themis_secure_cell_decrypt_seal(
@@ -1039,7 +1039,7 @@ fn encrypt_seal_with_passphrase(
         }
     }
 
-    encrypted_message.reserve(encrypted_message_len);
+    encrypted_message.try_reserve(encrypted_message_len)?;
 
     unsafe {
         let status = themis_secure_cell_encrypt_seal_with_passphrase(
@@ -1093,7 +1093,7 @@ fn decrypt_seal_with_passphrase(
         }
     }
 
-    decrypted_message.reserve(decrypted_message_len);
+    decrypted_message.try_reserve(decrypted_message_len)?;
 
     unsafe {
         let status = themis_secure_cell_decrypt_seal_with_passphrase(
@@ -1549,8 +1549,8 @@ fn encrypt_token_protect(
         }
     }
 
-    token.reserve(token_len);
-    encrypted_message.reserve(encrypted_message_len);
+    token.try_reserve(token_len)?;
+    encrypted_message.try_reserve(encrypted_message_len)?;
 
     unsafe {
         let status = themis_secure_cell_encrypt_token_protect(
@@ -1612,7 +1612,7 @@ fn decrypt_token_protect(
         }
     }
 
-    decrypted_message.reserve(decrypted_message_len);
+    decrypted_message.try_reserve(decrypted_message_len)?;
 
     unsafe {
         let status = themis_secure_cell_decrypt_token_protect(
@@ -1866,7 +1866,7 @@ fn encrypt_context_imprint(master_key: &[u8], message: &[u8], context: &[u8]) ->
         }
     }
 
-    encrypted_message.reserve(encrypted_message_len);
+    encrypted_message.try_reserve(encrypted_message_len)?;
 
     unsafe {
         let status = themis_secure_cell_encrypt_context_imprint(
@@ -1916,7 +1916,7 @@ fn decrypt_context_imprint(master_key: &[u8], message: &[u8], context: &[u8]) ->
         }
     }
 
-    decrypted_message.reserve(decrypted_message_len);
+    decrypted_message.try_reserve(decrypted_message_len)?;
 
     unsafe {
         let status = themis_secure_cell_decrypt_context_imprint(

--- a/src/wrappers/themis/rust/src/secure_comparator.rs
+++ b/src/wrappers/themis/rust/src/secure_comparator.rs
@@ -269,7 +269,7 @@ impl SecureComparator {
             }
         }
 
-        compare_data.reserve(compare_data_len);
+        compare_data.try_reserve(compare_data_len)?;
 
         unsafe {
             let status = secure_comparator_begin_compare(
@@ -327,7 +327,7 @@ impl SecureComparator {
             }
         }
 
-        compare_data.reserve(compare_data_len);
+        compare_data.try_reserve(compare_data_len)?;
 
         unsafe {
             let status = secure_comparator_proceed_compare(

--- a/src/wrappers/themis/rust/src/secure_message.rs
+++ b/src/wrappers/themis/rust/src/secure_message.rs
@@ -165,7 +165,7 @@ impl SecureMessage {
             }
         }
 
-        encrypted.reserve(encrypted_len);
+        encrypted.try_reserve(encrypted_len)?;
 
         unsafe {
             let status = themis_secure_message_encrypt(
@@ -215,7 +215,7 @@ impl SecureMessage {
             }
         }
 
-        decrypted.reserve(decrypted_len);
+        decrypted.try_reserve(decrypted_len)?;
 
         unsafe {
             let status = themis_secure_message_decrypt(
@@ -349,7 +349,7 @@ impl SecureSign {
             }
         }
 
-        signed.reserve(signed_len);
+        signed.try_reserve(signed_len)?;
 
         unsafe {
             let status = themis_secure_message_sign(
@@ -477,7 +477,7 @@ impl SecureVerify {
             }
         }
 
-        original.reserve(original_len);
+        original.try_reserve(original_len)?;
 
         unsafe {
             let status = themis_secure_message_verify(

--- a/src/wrappers/themis/rust/src/secure_session.rs
+++ b/src/wrappers/themis/rust/src/secure_session.rs
@@ -434,7 +434,7 @@ impl SecureSession {
             }
         }
 
-        id.reserve(id_len);
+        id.try_reserve(id_len)?;
 
         unsafe {
             let status = secure_session_get_remote_id(self.session, id.as_mut_ptr(), &mut id_len);
@@ -628,7 +628,7 @@ impl SecureSession {
             }
         }
 
-        output.reserve(output_len);
+        output.try_reserve(output_len)?;
 
         unsafe {
             let status = secure_session_generate_connect_request(
@@ -681,7 +681,7 @@ impl SecureSession {
             }
         }
 
-        message.reserve(message_len);
+        message.try_reserve(message_len)?;
 
         unsafe {
             let status = secure_session_unwrap(
@@ -736,7 +736,7 @@ impl SecureSession {
             }
         }
 
-        wrapped.reserve(wrapped_len);
+        wrapped.try_reserve(wrapped_len)?;
 
         unsafe {
             let status = secure_session_wrap(
@@ -787,7 +787,7 @@ impl SecureSession {
             }
         }
 
-        message.reserve(message_len);
+        message.try_reserve(message_len)?;
 
         unsafe {
             let status = secure_session_unwrap(

--- a/src/wrappers/themis/rust/src/secure_session.rs
+++ b/src/wrappers/themis/rust/src/secure_session.rs
@@ -570,7 +570,8 @@ impl SecureSession {
     /// [`negotiate`]: struct.SecureSession.html#method.negotiate
     /// [`receive_data`]: trait.SecureSessionTransport.html#method.receive_data
     pub fn receive(&mut self, max_len: usize) -> Result<Vec<u8>> {
-        let mut message = Vec::with_capacity(max_len);
+        let mut message = Vec::new();
+        message.try_reserve(max_len)?;
 
         unsafe {
             let length = secure_session_receive(

--- a/tests/rust/secure_cell.rs
+++ b/tests/rust/secure_cell.rs
@@ -760,11 +760,6 @@ mod token_protect {
     }
 
     #[test]
-    // FIXME(ilammy, 2020-05-25): avoid capacity allocation panics (T1649)
-    // This tests panics on 32-bit architectures due to size overflow.
-    // The implementation needs to use Vec::try_reserve instead of Vec::reserve
-    // when it becomes available in stable Rust.
-    #[cfg_attr(target_pointer_width = "32", ignore)]
     fn detects_corrupted_token() {
         let cell = SecureCell::with_key(SymmetricKey::new())
             .unwrap()
@@ -817,11 +812,6 @@ mod token_protect {
     }
 
     #[test]
-    // FIXME(ilammy, 2020-05-25): avoid capacity allocation panics (T1649)
-    // This tests panics on 32-bit architectures due to size overflow.
-    // The implementation needs to use Vec::try_reserve instead of Vec::reserve
-    // when it becomes available in stable Rust.
-    #[cfg_attr(target_pointer_width = "32", ignore)]
     fn detects_data_token_swap() {
         let cell = SecureCell::with_key(SymmetricKey::new())
             .unwrap()


### PR DESCRIPTION
While looking at our backlog, I found T1649. In a nutshell, some tests were failing on 32-bit machines, because they corrupt the secure cell tag. This was done in a way that triggers allocation of 2GB from the rust code, which failed. But at that time, it wasn't possible to handle this failure gracefully, so rust wrapper just panicked. It means that on 32-bit platforms it was possible to execute DoS attack with maliciously crafted input.

Since we traversed to the rust 1.58, we now have the `try_*` methods, including the [`.try_reserve`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.try_reserve) which allows us to handle failures gracefully.

So, let's use it! I've tested it manually on Pi 4 and the tests pass without issues.

## Checklist

- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Public API has proper documentation
- [ ] Changelog is updated (in case of notable or breaking changes)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
