### PR TITLE
Small corrections. 

### DIFF
--- a/src/wrappers/themis/react-native-themis/package.json
+++ b/src/wrappers/themis/react-native-themis/package.json
@@ -74,7 +74,7 @@
     "prettier": "^2.0.5",
     "react": "18.2.0",
     "react-native": "0.72.5",
-    "react-native-builder-bob": "^0.18.0",
+    "react-native-builder-bob": "^0.23.0",
     "release-it": "^16.2.1",
     "typescript": "^5.2.2"
   },

--- a/src/wrappers/themis/react-native-themis/tsconfig.json
+++ b/src/wrappers/themis/react-native-themis/tsconfig.json
@@ -7,7 +7,7 @@
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
     "esModuleInterop": true,
-    "importsNotUsedAsValues": "error",
+    "verbatimModuleSyntax": true,
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",
     "lib": ["esnext"],


### PR DESCRIPTION
I found the error during the pre-publish final test process.

Replace the deprecated typescript configuration rule. And increase the version of the builder tool. 

## Checklist

- [x] Change is covered by automated tests

