### PR TITLE
Rix Rust CI builds

### DIFF
--- a/benches/rust/Cargo.toml
+++ b/benches/rust/Cargo.toml
@@ -13,7 +13,7 @@ criterion = { version = "0.3.4", features = ["cargo_bench_support", "html_report
 csv = "~1.1"
 # Freeze `rayon` and `rayon-core` versions (first is used by `criterion`)
 # so that benchmarks still build/run with Rust 1.58.
-# FIXME: remove thiese two after we bump minimum required Rust version
+# FIXME: remove these two after we bump minimum required Rust version
 rayon = "=1.6.1"
 rayon-core = "=1.10.1"
 

--- a/benches/themis/Cargo.toml
+++ b/benches/themis/Cargo.toml
@@ -14,7 +14,7 @@ criterion = { version = "0.3.4", features = ["cargo_bench_support", "html_report
 csv = "~1.1"
 # Freeze `rayon` and `rayon-core` versions (first is used by `criterion`)
 # so that benchmarks still build/run with Rust 1.58.
-# FIXME: remove thiese two after we bump minimum required Rust version
+# FIXME: remove these two after we bump minimum required Rust version
 rayon = "=1.6.1"
 rayon-core = "=1.10.1"
 

--- a/src/wrappers/themis/rust/Cargo.toml
+++ b/src/wrappers/themis/rust/Cargo.toml
@@ -33,5 +33,7 @@ base64 = "0.10.0"
 byteorder = "1.2.7"
 clap = "2.32"
 lazy_static = "1.2.0"
-log = "0.4.6"
+# Freeze `log` so that tests still build/run with Rust 1.58.
+# FIXME: remove/update strict version requirement after we bump minimum required Rust version
+log = "=0.4.17"
 env_logger = "0.6.0"

--- a/src/wrappers/themis/rust/Cargo.toml
+++ b/src/wrappers/themis/rust/Cargo.toml
@@ -30,10 +30,10 @@ zeroize = "1"
 
 [dev-dependencies]
 base64 = "0.10.0"
-byteorder = "1.2.7"
+# Freeze `log` and `byteorder` so that tests still build/run with Rust 1.58.
+# FIXME: remove/update strict version requirement after we bump minimum required Rust version
+byteorder = "=1.4.3"
 clap = "2.32"
 lazy_static = "1.2.0"
-# Freeze `log` so that tests still build/run with Rust 1.58.
-# FIXME: remove/update strict version requirement after we bump minimum required Rust version
 log = "=0.4.17"
 env_logger = "0.6.0"


### PR DESCRIPTION
Freeze versions of two dependencies used in tests: `byteorder` and `log`.
Solves issue like [this one](https://github.com/cossacklabs/themis/actions/runs/6588316022/job/17900303227?pr=1031).
Alternative solution may be increasing MSRV, but why do that if Themis itself does not need these dependencies?

## Checklist

- [x] Change is covered by automated tests
- [x] ~Benchmark results are attached (if applicable)~
- [x] The [coding guidelines] are followed
- [x] ~Public API has proper documentation~
- [x] ~Example projects and code samples are up-to-date (in case of API changes)~
- [x] ~Changelog is updated (in case of notable or breaking changes)~

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
