### PR TITLE
Fix macOS npm install procedure of JsThemis 

### DIFF
--- a/src/wrappers/themis/jsthemis/binding.gyp
+++ b/src/wrappers/themis/jsthemis/binding.gyp
@@ -14,11 +14,13 @@
         "secure_comparator.cpp",
       ],
       "include_dirs": [
+         "/opt/homebrew/include",
          "<!(node -e \"require('nan')\")",
       ],
       "conditions": [
         [ "OS=='linux' or OS=='mac'", {
           "libraries": [
+            "-L/opt/homebrew/lib",
             "-L/usr/local/lib",
             "-L/usr/lib",
             "-lsoter",


### PR DESCRIPTION
I found that /opt/homebrew/lib and /opt/homebrew/include contains all required files. So, we do not need to find the libthemis files in deep of /opt/homebrew/Cellar directories. We just need to add additional paths to the settings of bindings. 

I added two strings:
- homebrew include dir to the include_dires property 
- homebrew libraries dir to the libraries property on macOS or Linux targets 

## Checklist
- [x] Change is covered by automated tests
