### PR TITLE
Fix clippy and fmt issues

### DIFF
--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        rust: [stable, '1.58']
+        rust: [stable, '1.60']
       fail-fast: false
     steps:
       - name: Install system dependencies
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        rust: [stable, '1.58']
+        rust: [stable, '1.60']
       fail-fast: false
     steps:
       - name: Install system dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ _Code:_
 
     This is technically a breaking change, but most reasonble implementations should be `Send` already. Please raise an issue if your code fails to build.
 
-  - Minimum supported Rust version is now 1.58 ([#977](https://github.com/cossacklabs/themis/pull/977), [#984](https://github.com/cossacklabs/themis/pull/984)).
+  - Minimum supported Rust version is now 1.60 ([#977](https://github.com/cossacklabs/themis/pull/977), [#984](https://github.com/cossacklabs/themis/pull/984), [#1039](https://github.com/cossacklabs/themis/pull/1039)).
 
 - **WasmThemis**
 

--- a/benches/themis/benches/secure_message_encrypt_decrypt_ecdsa.rs
+++ b/benches/themis/benches/secure_message_encrypt_decrypt_ecdsa.rs
@@ -106,7 +106,7 @@ pub fn decryption(c: &mut Criterion) {
             |b, &size| {
                 let message = vec![0; size];
                 let encrypted = SecureMessage::new(key_pair.clone())
-                    .encrypt(&message)
+                    .encrypt(message)
                     .expect("failed encryption");
 
                 let mut decrypted = vec![0; size];

--- a/benches/themis/benches/secure_message_encrypt_decrypt_rsa.rs
+++ b/benches/themis/benches/secure_message_encrypt_decrypt_rsa.rs
@@ -106,7 +106,7 @@ pub fn decryption(c: &mut Criterion) {
             |b, &size| {
                 let message = vec![0; size];
                 let encrypted = SecureMessage::new(key_pair.clone())
-                    .encrypt(&message)
+                    .encrypt(message)
                     .expect("failed encryption");
 
                 let mut decrypted = vec![0; size];

--- a/benches/themis/benches/secure_message_sign_verify_ecdsa.rs
+++ b/benches/themis/benches/secure_message_sign_verify_ecdsa.rs
@@ -102,7 +102,7 @@ pub fn verification(c: &mut Criterion) {
             |b, &size| {
                 let message = vec![0; size];
                 let signature = SecureSign::new(private.clone())
-                    .sign(&message)
+                    .sign(message)
                     .expect("failed signing");
 
                 let mut received_message = vec![0; size];

--- a/benches/themis/benches/secure_message_sign_verify_rsa.rs
+++ b/benches/themis/benches/secure_message_sign_verify_rsa.rs
@@ -102,7 +102,7 @@ pub fn verification(c: &mut Criterion) {
             |b, &size| {
                 let message = vec![0; size];
                 let signature = SecureSign::new(private.clone())
-                    .sign(&message)
+                    .sign(message)
                     .expect("failed signing");
 
                 let mut received_message = vec![0; size];

--- a/docs/examples/rust/secure_cell.rs
+++ b/docs/examples/rust/secure_cell.rs
@@ -33,7 +33,7 @@ fn main() -> themis::Result<()> {
 
         println!("Encoded:   {}", base64::encode(&message));
 
-        let encrypted_message = scell_mk.encrypt(&message)?;
+        let encrypted_message = scell_mk.encrypt(message)?;
         println!("Encrypted: {}", base64::encode(&encrypted_message));
 
         let decrypted_message = scell_mk.decrypt(&encrypted_message)?;
@@ -44,11 +44,11 @@ fn main() -> themis::Result<()> {
 
     println!("## Passphrase API");
     {
-        let scell_pw = SecureCell::with_passphrase(&passphrase)?.seal();
+        let scell_pw = SecureCell::with_passphrase(passphrase)?.seal();
 
         println!("Encoded:   {}", base64::encode(&message));
 
-        let encrypted_message = scell_pw.encrypt(&message)?;
+        let encrypted_message = scell_pw.encrypt(message)?;
         println!("Encrypted: {}", base64::encode(&encrypted_message));
 
         let decrypted_message = scell_pw.decrypt(&encrypted_message)?;
@@ -64,7 +64,7 @@ fn main() -> themis::Result<()> {
 
         println!("Encoded:    {}", base64::encode(&message));
 
-        let (encrypted_message, auth_token) = scell_tp.encrypt(&message)?;
+        let (encrypted_message, auth_token) = scell_tp.encrypt(message)?;
         println!("Encrypted:  {}", base64::encode(&encrypted_message));
         println!("Auth token: {}", base64::encode(&auth_token));
 
@@ -81,10 +81,10 @@ fn main() -> themis::Result<()> {
 
         println!("Encoded:   {}", base64::encode(&message));
 
-        let encrypted_message = scell_ci.encrypt_with_context(&message, &context)?;
+        let encrypted_message = scell_ci.encrypt_with_context(message, context)?;
         println!("Encrypted: {}", base64::encode(&encrypted_message));
 
-        let decrypted_message = scell_ci.decrypt_with_context(&encrypted_message, &context)?;
+        let decrypted_message = scell_ci.decrypt_with_context(&encrypted_message, context)?;
         println!("Decrypted: {}", as_str(&decrypted_message));
         assert_eq!(decrypted_message, message);
     }

--- a/docs/examples/rust/secure_message_client_encrypt.rs
+++ b/docs/examples/rust/secure_message_client_encrypt.rs
@@ -51,7 +51,7 @@ fn main() {
     let key_pair = KeyPair::try_join(private_key, public_key).expect("matching keys");
 
     let socket = UdpSocket::bind("localhost:0").expect("client socket");
-    socket.connect(&remote_addr).expect("client connection");
+    socket.connect(remote_addr).expect("client connection");
 
     let receive_socket = socket;
     let relay_socket = receive_socket.try_clone().unwrap();

--- a/docs/examples/rust/secure_message_client_verify.rs
+++ b/docs/examples/rust/secure_message_client_verify.rs
@@ -49,7 +49,7 @@ fn main() {
     let public_key = PublicKey::try_from_slice(public_key).expect("parse public key");
 
     let socket = UdpSocket::bind("localhost:0").expect("client socket");
-    socket.connect(&remote_addr).expect("client connection");
+    socket.connect(remote_addr).expect("client connection");
 
     let receive_socket = socket;
     let relay_socket = receive_socket.try_clone().unwrap();

--- a/docs/examples/rust/secure_message_server.rs
+++ b/docs/examples/rust/secure_message_server.rs
@@ -36,7 +36,7 @@ fn main() {
     let port = matches.value_of("port").unwrap_or("7573").parse().unwrap();
     let listen_addr = SocketAddr::new([0; 16].into(), port);
 
-    let socket = UdpSocket::bind(&listen_addr).expect("server listen");
+    let socket = UdpSocket::bind(listen_addr).expect("server listen");
     let mut peers = HashSet::new();
     let mut process_message = || -> io::Result<()> {
         let (message, sender) = recv_from(&socket)?;

--- a/docs/examples/rust/secure_session_echo_client.rs
+++ b/docs/examples/rust/secure_session_echo_client.rs
@@ -64,9 +64,9 @@ fn main() {
 
     info!("connecting to {:?}", remote_addr);
 
-    let mut socket = TcpStream::connect(&remote_addr).expect("client connection");
+    let mut socket = TcpStream::connect(remote_addr).expect("client connection");
 
-    let mut session = SecureSession::new(&CLIENT_ID, &CLIENT_PRIVATE, ExpectServer)
+    let mut session = SecureSession::new(CLIENT_ID, &CLIENT_PRIVATE, ExpectServer)
         .expect("Secure Session client");
     let mut buffer = [0; MAX_MESSAGE_SIZE];
 
@@ -75,7 +75,7 @@ fn main() {
 
     loop {
         let reply = read_framed(&mut socket, &mut buffer).expect("receive reply");
-        let response = session.negotiate_reply(&reply).expect("negotiate");
+        let response = session.negotiate_reply(reply).expect("negotiate");
         if session.is_established() {
             break;
         }
@@ -95,7 +95,7 @@ fn main() {
         write_framed(&mut socket, &message).expect("write to socket");
 
         let reply = read_framed(&mut socket, &mut buffer).expect("read from socket");
-        let reply = session.unwrap(&reply).expect("unwrap incoming");
+        let reply = session.unwrap(reply).expect("unwrap incoming");
 
         io::stdout().write_all(&reply).expect("write to stdout");
     }

--- a/docs/examples/rust/secure_session_echo_server.rs
+++ b/docs/examples/rust/secure_session_echo_server.rs
@@ -105,7 +105,7 @@ fn main() {
         .expect("valid port");
 
     let listen_addr = SocketAddr::new([0; 16].into(), port);
-    let listen_socket = TcpListener::bind(&listen_addr).expect("server listen");
+    let listen_socket = TcpListener::bind(listen_addr).expect("server listen");
 
     info!("listening on port {}", port);
 
@@ -123,7 +123,7 @@ fn main() {
             info!("{:?}: connected", client_address);
 
             let transport = SocketTransport::new(client);
-            let mut session = SecureSession::new(&SERVER_ID, &SERVER_PRIVATE, transport)
+            let mut session = SecureSession::new(SERVER_ID, &SERVER_PRIVATE, transport)
                 .expect("Secure Session server");
 
             while !session.is_established() {

--- a/src/wrappers/themis/rust/Cargo.toml
+++ b/src/wrappers/themis/rust/Cargo.toml
@@ -29,15 +29,18 @@ bindings = { package = "libthemis-sys", path = "libthemis-sys", version = "0.14.
 zeroize = "1"
 
 [dev-dependencies]
-base64 = "0.10.0"
-# Freeze byteorder, log, memchr, regex so that tests still build/run with Rust 1.60.
-# `regex` is dependency of `env_logger`, 1.9.6 switched to Rust 1.65.
-# `memchr` is dependency of `regex`, at the time of writing this latest version required Rust 1.65.
+# Freeze byteorder, log so that tests still build/run with Rust 1.60.
+# Other crates are frozen in hope to avoid more problems in future, where something updates
+# and requires newer toolchain version compared to what we require for RustThemis.
 # FIXME: remove/update strict version requirement after we bump minimum required Rust version
+base64 = "=0.10.1"
 byteorder = "=1.4.3"
-clap = "2.32"
-lazy_static = "1.2.0"
+clap = "=2.34.0"
+lazy_static = "=1.4.0"
 log = "=0.4.17"
-env_logger = "0.6.0"
+env_logger = "=0.6.2"
+
+# These are not used in themis tests, but are rather dependencies of dev-dependencies listed above.
+# Specifying exact versions so that tests could build/run on Rust 1.60.
 regex = "=1.9.5"
 memchr = "=2.6.1"

--- a/src/wrappers/themis/rust/Cargo.toml
+++ b/src/wrappers/themis/rust/Cargo.toml
@@ -2,7 +2,7 @@
 name = "themis"
 version = "0.14.0"
 edition = "2018"
-rust-version = "1.58.0"
+rust-version = "1.60.0"
 authors = ["rust-themis developers"]
 description = "High-level cryptographic services for storage and messaging"
 homepage = "https://www.cossacklabs.com/themis/"
@@ -30,10 +30,14 @@ zeroize = "1"
 
 [dev-dependencies]
 base64 = "0.10.0"
-# Freeze `log` and `byteorder` so that tests still build/run with Rust 1.58.
+# Freeze byteorder, log, memchr, regex so that tests still build/run with Rust 1.60.
+# `regex` is dependency of `env_logger`, 1.9.6 switched to Rust 1.65.
+# `memchr` is dependency of `regex`, at the time of writing this latest version required Rust 1.65.
 # FIXME: remove/update strict version requirement after we bump minimum required Rust version
 byteorder = "=1.4.3"
 clap = "2.32"
 lazy_static = "1.2.0"
 log = "=0.4.17"
 env_logger = "0.6.0"
+regex = "=1.9.5"
+memchr = "=2.6.1"

--- a/src/wrappers/themis/rust/libthemis-sys/Cargo.toml
+++ b/src/wrappers/themis/rust/libthemis-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libthemis-sys"
 version = "0.14.0"
 edition = "2018"
-rust-version = "1.58.0"
+rust-version = "1.60.0"
 authors = ["rust-themis developers"]
 description = "FFI binding to libthemis"
 homepage = "https://www.cossacklabs.com/themis/"

--- a/src/wrappers/themis/rust/src/secure_cell.rs
+++ b/src/wrappers/themis/rust/src/secure_cell.rs
@@ -358,7 +358,7 @@ impl SecureCellSeal {
     /// # }
     /// ```
     pub fn encrypt(&self, message: impl AsRef<[u8]>) -> Result<Vec<u8>> {
-        self.encrypt_with_context(message, &[])
+        self.encrypt_with_context(message, [])
     }
 
     /// Encrypts the provided message with associated context.
@@ -501,7 +501,7 @@ impl SecureCellSeal {
     /// # }
     /// ```
     pub fn decrypt(&self, message: impl AsRef<[u8]>) -> Result<Vec<u8>> {
-        self.decrypt_with_context(message, &[])
+        self.decrypt_with_context(message, [])
     }
 
     /// Decrypts the provided message with associated context.
@@ -689,7 +689,7 @@ impl SecureCellSealWithPassphrase {
     /// # }
     /// ```
     pub fn encrypt(&self, message: impl AsRef<[u8]>) -> Result<Vec<u8>> {
-        self.encrypt_with_context(message, &[])
+        self.encrypt_with_context(message, [])
     }
 
     /// Encrypts the provided message with associated context.
@@ -822,7 +822,7 @@ impl SecureCellSealWithPassphrase {
     /// # }
     /// ```
     pub fn decrypt(&self, message: impl AsRef<[u8]>) -> Result<Vec<u8>> {
-        self.decrypt_with_context(message, &[])
+        self.decrypt_with_context(message, [])
     }
 
     /// Decrypts the provided message with associated context.
@@ -1225,7 +1225,7 @@ impl SecureCellTokenProtect {
     /// # }
     /// ```
     pub fn encrypt(&self, message: impl AsRef<[u8]>) -> Result<(Vec<u8>, Vec<u8>)> {
-        self.encrypt_with_context(message, &[])
+        self.encrypt_with_context(message, [])
     }
 
     /// Encrypts the provided message with associated context.
@@ -1393,7 +1393,7 @@ impl SecureCellTokenProtect {
     /// # }
     /// ```
     pub fn decrypt(&self, message: impl AsRef<[u8]>, token: impl AsRef<[u8]>) -> Result<Vec<u8>> {
-        self.decrypt_with_context(message, token, &[])
+        self.decrypt_with_context(message, token, [])
     }
 
     /// Decrypts the provided message with associated context.

--- a/tests/rust/keys.rs
+++ b/tests/rust/keys.rs
@@ -64,10 +64,10 @@ fn parse_generated_keys_back() {
 
 #[test]
 fn parse_invalid_buffers() {
-    let error = EcdsaPublicKey::try_from_slice(&[1, 2, 3]).expect_err("parse failure");
+    let error = EcdsaPublicKey::try_from_slice([1, 2, 3]).expect_err("parse failure");
     assert_eq!(error.kind(), ErrorKind::InvalidParameter);
 
-    let error = RsaPrivateKey::try_from_slice(&[]).expect_err("parse failure");
+    let error = RsaPrivateKey::try_from_slice([]).expect_err("parse failure");
     assert_eq!(error.kind(), ErrorKind::InvalidParameter);
 }
 
@@ -105,6 +105,6 @@ fn parse_generated_symmetric_keys_back() {
 
 #[test]
 fn parse_custom_symmetric_keys() {
-    assert!(SymmetricKey::try_from_slice(&[0]).is_ok());
-    assert!(SymmetricKey::try_from_slice(&[]).is_err());
+    assert!(SymmetricKey::try_from_slice([0]).is_ok());
+    assert!(SymmetricKey::try_from_slice([]).is_err());
 }

--- a/tests/rust/secure_cell.rs
+++ b/tests/rust/secure_cell.rs
@@ -23,7 +23,7 @@ mod context_imprint {
     #[test]
     fn initialization() {
         assert!(SecureCell::with_key(SymmetricKey::new()).is_ok());
-        assert!(SecureCell::with_key(&[]).is_err());
+        assert!(SecureCell::with_key([]).is_err());
     }
 
     #[test]
@@ -34,8 +34,8 @@ mod context_imprint {
         let message = b"Colorless green ideas sleep furiously".as_ref();
         let context = b"...and a toilet seat cover!".as_ref();
 
-        let encrypted = cell.encrypt_with_context(&message, &context).unwrap();
-        let decrypted = cell.decrypt_with_context(&encrypted, &context).unwrap();
+        let encrypted = cell.encrypt_with_context(message, context).unwrap();
+        let decrypted = cell.decrypt_with_context(encrypted, context).unwrap();
 
         assert_eq!(decrypted, message);
     }
@@ -48,7 +48,7 @@ mod context_imprint {
         let message = b"Colorless green ideas sleep furiously".as_ref();
         let context = b"...and a toilet seat cover!".as_ref();
 
-        let encrypted = cell.encrypt_with_context(&message, &context).unwrap();
+        let encrypted = cell.encrypt_with_context(message, context).unwrap();
 
         assert_eq!(encrypted.len(), message.len());
     }
@@ -63,8 +63,8 @@ mod context_imprint {
         let context_long =
             b"Buffalo buffalo Buffalo buffalo buffalo buffalo Buffalo buffalo".as_ref();
 
-        let encrypted_short = cell.encrypt_with_context(&message, &context_short).unwrap();
-        let encrypted_long = cell.encrypt_with_context(&message, &context_long).unwrap();
+        let encrypted_short = cell.encrypt_with_context(message, context_short).unwrap();
+        let encrypted_long = cell.encrypt_with_context(message, context_long).unwrap();
 
         // Context is not (directly) included into encrypted message.
         assert_eq!(encrypted_short.len(), encrypted_long.len());
@@ -81,16 +81,16 @@ mod context_imprint {
         let message = b"Colorless green ideas sleep furiously".as_ref();
         let context = b"...and a toilet seat cover!".as_ref();
 
-        let encrypted = cell_a.encrypt_with_context(&message, &context).unwrap();
+        let encrypted = cell_a.encrypt_with_context(message, context).unwrap();
 
         // Context Imprint mode does not validate message data so using an incorrect key
         // will successfully return garbage output.
-        let decrypted_incorrect = cell_b.decrypt_with_context(&encrypted, &context).unwrap();
+        let decrypted_incorrect = cell_b.decrypt_with_context(&encrypted, context).unwrap();
         assert_ne!(decrypted_incorrect, message);
         assert_ne!(decrypted_incorrect, encrypted);
 
         // Only the correct key will work.
-        let decrypted_correct = cell_a.decrypt_with_context(&encrypted, &context).unwrap();
+        let decrypted_correct = cell_a.decrypt_with_context(&encrypted, context).unwrap();
         assert_eq!(decrypted_correct, message);
     }
 
@@ -103,16 +103,16 @@ mod context_imprint {
         let context_a = b"The jaws that bite, the claws that catch!".as_ref();
         let context_b = b"One, two! One, two! And through and through".as_ref();
 
-        let encrypted = cell.encrypt_with_context(&message, &context_a).unwrap();
+        let encrypted = cell.encrypt_with_context(message, context_a).unwrap();
 
         // Context Imprint mode does not validate message data so using an incorrect context
         // will successfully return garbage output.
-        let decrypted_incorrect = cell.decrypt_with_context(&encrypted, &context_b).unwrap();
+        let decrypted_incorrect = cell.decrypt_with_context(&encrypted, context_b).unwrap();
         assert_ne!(decrypted_incorrect, message);
         assert_ne!(decrypted_incorrect, encrypted);
 
         // Only the correct context will work.
-        let decrypted_correct = cell.decrypt_with_context(&encrypted, &context_a).unwrap();
+        let decrypted_correct = cell.decrypt_with_context(&encrypted, context_a).unwrap();
         assert_eq!(decrypted_correct, message);
     }
 
@@ -124,7 +124,7 @@ mod context_imprint {
         let message = b"Colorless green ideas sleep furiously".as_ref();
         let context = b"...and a toilet seat cover!".as_ref();
 
-        let encrypted = cell.encrypt_with_context(&message, &context).unwrap();
+        let encrypted = cell.encrypt_with_context(message, context).unwrap();
 
         // Invert every odd byte, this will surely break the message.
         let mut corrupted = encrypted;
@@ -135,7 +135,7 @@ mod context_imprint {
         }
 
         // Decrypts successfully but the content is garbage.
-        let decrypted = cell.decrypt_with_context(&corrupted, &context).unwrap();
+        let decrypted = cell.decrypt_with_context(&corrupted, context).unwrap();
         assert_ne!(decrypted, message);
     }
 
@@ -147,12 +147,12 @@ mod context_imprint {
         let message = b"Colorless green ideas sleep furiously".as_ref();
         let context = b"...and a toilet seat cover!".as_ref();
 
-        let encrypted = cell.encrypt_with_context(&message, &context).unwrap();
+        let encrypted = cell.encrypt_with_context(message, context).unwrap();
 
         let truncated = &encrypted[..encrypted.len() - 1];
 
         // Decrypts successfully but the content is garbage.
-        let decrypted = cell.decrypt_with_context(&truncated, &context).unwrap();
+        let decrypted = cell.decrypt_with_context(truncated, context).unwrap();
         assert_ne!(decrypted, message);
     }
 
@@ -164,13 +164,13 @@ mod context_imprint {
         let message = b"Colorless green ideas sleep furiously".as_ref();
         let context = b"...and a toilet seat cover!".as_ref();
 
-        let encrypted = cell.encrypt_with_context(&message, &context).unwrap();
+        let encrypted = cell.encrypt_with_context(message, context).unwrap();
 
         let mut extended = encrypted;
         extended.push(0);
 
         // Decrypts successfully but the content is garbage.
-        let decrypted = cell.decrypt_with_context(&extended, &context).unwrap();
+        let decrypted = cell.decrypt_with_context(&extended, context).unwrap();
         assert_ne!(decrypted, message);
     }
 
@@ -183,11 +183,11 @@ mod context_imprint {
         let context = b"...and a toilet seat cover!".as_ref();
 
         // With Context Imprint the context cannot be empty.
-        assert!(cell.encrypt_with_context(&message, &[]).is_err());
-        assert!(cell.encrypt_with_context(&[], &context).is_err());
+        assert!(cell.encrypt_with_context(message, []).is_err());
+        assert!(cell.encrypt_with_context([], context).is_err());
 
-        assert!(cell.decrypt_with_context(&message, &[]).is_err());
-        assert!(cell.decrypt_with_context(&[], &context).is_err());
+        assert!(cell.decrypt_with_context(message, []).is_err());
+        assert!(cell.decrypt_with_context([], context).is_err());
     }
 }
 
@@ -197,7 +197,7 @@ mod seal {
     #[test]
     fn initialization() {
         assert!(SecureCell::with_key(SymmetricKey::new()).is_ok());
-        assert!(SecureCell::with_key(&[]).is_err());
+        assert!(SecureCell::with_key([]).is_err());
     }
 
     #[test]
@@ -206,8 +206,8 @@ mod seal {
         let message = b"Colorless green ideas sleep furiously".as_ref();
         let context = b"...and a toilet seat cover!".as_ref();
 
-        let encrypted = cell.encrypt_with_context(&message, &context).unwrap();
-        let decrypted = cell.decrypt_with_context(&encrypted, &context).unwrap();
+        let encrypted = cell.encrypt_with_context(message, context).unwrap();
+        let decrypted = cell.decrypt_with_context(encrypted, context).unwrap();
 
         assert_eq!(decrypted, message);
     }
@@ -217,7 +217,7 @@ mod seal {
         let cell = SecureCell::with_key(SymmetricKey::new()).unwrap().seal();
         let message = b"Colorless green ideas sleep furiously".as_ref();
 
-        let encrypted = cell.encrypt(&message).unwrap();
+        let encrypted = cell.encrypt(message).unwrap();
 
         assert!(encrypted.len() > message.len());
     }
@@ -230,8 +230,8 @@ mod seal {
         let context_long =
             b"Buffalo buffalo Buffalo buffalo buffalo buffalo Buffalo buffalo".as_ref();
 
-        let encrypted_short = cell.encrypt_with_context(&message, &context_short).unwrap();
-        let encrypted_long = cell.encrypt_with_context(&message, &context_long).unwrap();
+        let encrypted_short = cell.encrypt_with_context(message, context_short).unwrap();
+        let encrypted_long = cell.encrypt_with_context(message, context_long).unwrap();
 
         // Context is not (directly) included into encrypted message.
         assert_eq!(encrypted_short.len(), encrypted_long.len());
@@ -243,18 +243,18 @@ mod seal {
         let message = b"Colorless green ideas sleep furiously".as_ref();
 
         // encrypt(...) is encrypt_with_context(..., &[])
-        let encrypted_1 = cell.encrypt(&message).unwrap();
-        let encrypted_2 = cell.encrypt_with_context(&message, &[]).unwrap();
+        let encrypted_1 = cell.encrypt(message).unwrap();
+        let encrypted_2 = cell.encrypt_with_context(message, []).unwrap();
 
         assert_eq!(cell.decrypt(&encrypted_1), Ok(message.to_vec()));
         assert_eq!(cell.decrypt(&encrypted_2), Ok(message.to_vec()));
 
         assert_eq!(
-            cell.decrypt_with_context(&encrypted_1, &[]),
+            cell.decrypt_with_context(&encrypted_1, []),
             Ok(message.to_vec())
         );
         assert_eq!(
-            cell.decrypt_with_context(&encrypted_2, &[]),
+            cell.decrypt_with_context(&encrypted_2, []),
             Ok(message.to_vec())
         );
     }
@@ -265,7 +265,7 @@ mod seal {
         let cell_b = SecureCell::with_key(SymmetricKey::new()).unwrap().seal();
         let message = b"Colorless green ideas sleep furiously".as_ref();
 
-        let encrypted = cell_a.encrypt(&message).unwrap();
+        let encrypted = cell_a.encrypt(message).unwrap();
 
         // You cannot use a different key to decrypt data.
         assert!(cell_b.decrypt(&encrypted).is_err());
@@ -282,13 +282,13 @@ mod seal {
         let context_a = b"The jaws that bite, the claws that catch!".as_ref();
         let context_b = b"One, two! One, two! And through and through".as_ref();
 
-        let encrypted = cell.encrypt_with_context(&message, &context_a).unwrap();
+        let encrypted = cell.encrypt_with_context(message, context_a).unwrap();
 
         // You cannot use a different context to decrypt data.
-        assert!(cell.decrypt_with_context(&encrypted, &context_b).is_err());
+        assert!(cell.decrypt_with_context(&encrypted, context_b).is_err());
 
         // Only the correct context will work.
-        let decrypted = cell.decrypt_with_context(&encrypted, &context_a).unwrap();
+        let decrypted = cell.decrypt_with_context(&encrypted, context_a).unwrap();
         assert_eq!(decrypted, message);
     }
 
@@ -297,7 +297,7 @@ mod seal {
         let cell = SecureCell::with_key(SymmetricKey::new()).unwrap().seal();
         let message = b"Colorless green ideas sleep furiously".as_ref();
 
-        let encrypted = cell.encrypt(&message).unwrap();
+        let encrypted = cell.encrypt(message).unwrap();
 
         // Invert every odd byte, this will surely break the message.
         let mut corrupted = encrypted;
@@ -315,7 +315,7 @@ mod seal {
         let cell = SecureCell::with_key(SymmetricKey::new()).unwrap().seal();
         let message = b"Colorless green ideas sleep furiously".as_ref();
 
-        let encrypted = cell.encrypt(&message).unwrap();
+        let encrypted = cell.encrypt(message).unwrap();
 
         let truncated = &encrypted[..encrypted.len() - 1];
 
@@ -327,7 +327,7 @@ mod seal {
         let cell = SecureCell::with_key(SymmetricKey::new()).unwrap().seal();
         let message = b"Colorless green ideas sleep furiously".as_ref();
 
-        let encrypted = cell.encrypt(&message).unwrap();
+        let encrypted = cell.encrypt(message).unwrap();
 
         let mut extended = encrypted;
         extended.push(0);
@@ -339,8 +339,8 @@ mod seal {
     fn empty_messages_not_allowed() {
         let cell = SecureCell::with_key(SymmetricKey::new()).unwrap().seal();
 
-        assert!(cell.encrypt(&[]).is_err());
-        assert!(cell.decrypt(&[]).is_err());
+        assert!(cell.encrypt([]).is_err());
+        assert!(cell.decrypt([]).is_err());
     }
 }
 
@@ -361,8 +361,8 @@ mod seal_with_passphrase {
         let message = b"Colorless green ideas sleep furiously".as_ref();
         let context = b"...and a toilet seat cover!".as_ref();
 
-        let encrypted = cell.encrypt_with_context(&message, &context).unwrap();
-        let decrypted = cell.decrypt_with_context(&encrypted, &context).unwrap();
+        let encrypted = cell.encrypt_with_context(message, context).unwrap();
+        let decrypted = cell.decrypt_with_context(encrypted, context).unwrap();
 
         assert_eq!(decrypted, message);
     }
@@ -374,7 +374,7 @@ mod seal_with_passphrase {
             .seal();
         let message = b"Colorless green ideas sleep furiously".as_ref();
 
-        let encrypted = cell.encrypt(&message).unwrap();
+        let encrypted = cell.encrypt(message).unwrap();
 
         assert!(encrypted.len() > message.len());
     }
@@ -389,8 +389,8 @@ mod seal_with_passphrase {
         let context_long =
             b"Buffalo buffalo Buffalo buffalo buffalo buffalo Buffalo buffalo".as_ref();
 
-        let encrypted_short = cell.encrypt_with_context(&message, &context_short).unwrap();
-        let encrypted_long = cell.encrypt_with_context(&message, &context_long).unwrap();
+        let encrypted_short = cell.encrypt_with_context(message, context_short).unwrap();
+        let encrypted_long = cell.encrypt_with_context(message, context_long).unwrap();
 
         // Context is not (directly) included into encrypted message.
         assert_eq!(encrypted_short.len(), encrypted_long.len());
@@ -404,18 +404,18 @@ mod seal_with_passphrase {
         let message = b"Colorless green ideas sleep furiously".as_ref();
 
         // encrypt is encrypt_with_context(..., )
-        let encrypted_1 = cell.encrypt(&message).unwrap();
-        let encrypted_2 = cell.encrypt_with_context(&message, &[]).unwrap();
+        let encrypted_1 = cell.encrypt(message).unwrap();
+        let encrypted_2 = cell.encrypt_with_context(message, []).unwrap();
 
         assert_eq!(cell.decrypt(&encrypted_1), Ok(message.to_vec()));
         assert_eq!(cell.decrypt(&encrypted_2), Ok(message.to_vec()));
 
         assert_eq!(
-            cell.decrypt_with_context(&encrypted_1, &[]),
+            cell.decrypt_with_context(&encrypted_1, []),
             Ok(message.to_vec())
         );
         assert_eq!(
-            cell.decrypt_with_context(&encrypted_2, &[]),
+            cell.decrypt_with_context(&encrypted_2, []),
             Ok(message.to_vec())
         );
     }
@@ -430,7 +430,7 @@ mod seal_with_passphrase {
             .seal();
         let message = b"Colorless green ideas sleep furiously".as_ref();
 
-        let encrypted = cell_a.encrypt(&message).unwrap();
+        let encrypted = cell_a.encrypt(message).unwrap();
 
         // You cannot use a different passphrase to decrypt data.
         assert!(cell_b.decrypt(&encrypted).is_err());
@@ -449,13 +449,13 @@ mod seal_with_passphrase {
         let context_a = b"The jaws that bite, the claws that catch!".as_ref();
         let context_b = b"One, two! One, two! And through and through".as_ref();
 
-        let encrypted = cell.encrypt_with_context(&message, &context_a).unwrap();
+        let encrypted = cell.encrypt_with_context(message, context_a).unwrap();
 
         // You cannot use a different context to decrypt data.
-        assert!(cell.decrypt_with_context(&encrypted, &context_b).is_err());
+        assert!(cell.decrypt_with_context(&encrypted, context_b).is_err());
 
         // Only the correct context will work.
-        let decrypted = cell.decrypt_with_context(&encrypted, &context_a).unwrap();
+        let decrypted = cell.decrypt_with_context(&encrypted, context_a).unwrap();
         assert_eq!(decrypted, message);
     }
 
@@ -466,7 +466,7 @@ mod seal_with_passphrase {
             .seal();
         let message = b"Colorless green ideas sleep furiously".as_ref();
 
-        let encrypted = cell.encrypt(&message).unwrap();
+        let encrypted = cell.encrypt(message).unwrap();
 
         // Invert every odd byte, this will surely break the message.
         let mut corrupted = encrypted;
@@ -486,7 +486,7 @@ mod seal_with_passphrase {
             .seal();
         let message = b"Colorless green ideas sleep furiously".as_ref();
 
-        let encrypted = cell.encrypt(&message).unwrap();
+        let encrypted = cell.encrypt(message).unwrap();
 
         let truncated = &encrypted[..encrypted.len() - 1];
 
@@ -500,7 +500,7 @@ mod seal_with_passphrase {
             .seal();
         let message = b"Colorless green ideas sleep furiously".as_ref();
 
-        let encrypted = cell.encrypt(&message).unwrap();
+        let encrypted = cell.encrypt(message).unwrap();
 
         let mut extended = encrypted;
         extended.push(0);
@@ -514,8 +514,8 @@ mod seal_with_passphrase {
             .unwrap()
             .seal();
 
-        assert!(cell.encrypt(&[]).is_err());
-        assert!(cell.decrypt(&[]).is_err());
+        assert!(cell.encrypt([]).is_err());
+        assert!(cell.decrypt([]).is_err());
     }
 
     #[test]
@@ -526,11 +526,11 @@ mod seal_with_passphrase {
         let message = b"Colorless green ideas sleep furiously".as_ref();
 
         // Passphrases are not keys, keys are not passphrases.
-        let encrypted_mk = cell_mk.encrypt(&message).unwrap();
-        assert!(cell_pw.decrypt(&encrypted_mk).is_err());
+        let encrypted_mk = cell_mk.encrypt(message).unwrap();
+        assert!(cell_pw.decrypt(encrypted_mk).is_err());
 
-        let encrypted_pw = cell_pw.encrypt(&message).unwrap();
-        assert!(cell_mk.decrypt(&encrypted_pw).is_err());
+        let encrypted_pw = cell_pw.encrypt(message).unwrap();
+        assert!(cell_mk.decrypt(encrypted_pw).is_err());
     }
 
     #[test]
@@ -542,8 +542,8 @@ mod seal_with_passphrase {
             .seal();
         let message = b"Colorless green ideas sleep furiously".as_ref();
 
-        let encrypted = cell_a.encrypt(&message).unwrap();
-        let decrypted = cell_b.decrypt(&encrypted).unwrap();
+        let encrypted = cell_a.encrypt(message).unwrap();
+        let decrypted = cell_b.decrypt(encrypted).unwrap();
 
         assert_eq!(decrypted, message);
     }
@@ -558,7 +558,7 @@ mod seal_with_passphrase {
 
         // Message encrypted by PyThemis
         let encrypted = b"\x00\x01\x01\x41\x0C\x00\x00\x00\x10\x00\x00\x00\x25\x00\x00\x00\x16\x00\x00\x00\x78\x98\x93\x12\xC9\x60\x1E\x22\xD7\xCB\x47\x06\xC9\xEC\x46\xB5\xB5\x9A\xFC\xC8\x3F\x06\x8F\x5B\xBE\x9F\x66\xA6\x40\x0D\x03\x00\x10\x00\x1C\x6D\x16\xFF\x39\xB9\x13\xDF\xC4\x41\x56\x31\x17\xF3\xC4\x05\x28\x15\x13\xA6\x74\x29\x0B\xF0\x5A\xFB\xAC\xD9\x79\x35\x7E\xBA\xD0\x8F\x8C\xA6\x9E\x4E\x83\x2A\x12\xBA\xC7\x59\xAA\xF6\xDF\x62\x8E\xCE\x31\x7C\xCF".as_ref();
-        let decrypted = cell.decrypt(&encrypted).unwrap();
+        let decrypted = cell.decrypt(encrypted).unwrap();
 
         assert_eq!(decrypted, message);
     }
@@ -570,7 +570,7 @@ mod token_protect {
     #[test]
     fn initialization() {
         assert!(SecureCell::with_key(SymmetricKey::new()).is_ok());
-        assert!(SecureCell::with_key(&[]).is_err());
+        assert!(SecureCell::with_key([]).is_err());
     }
 
     #[test]
@@ -581,9 +581,9 @@ mod token_protect {
         let message = b"Colorless green ideas sleep furiously".as_ref();
         let context = b"...and a toilet seat cover!".as_ref();
 
-        let (encrypted, token) = cell.encrypt_with_context(&message, &context).unwrap();
+        let (encrypted, token) = cell.encrypt_with_context(message, context).unwrap();
         let decrypted = cell
-            .decrypt_with_context(&encrypted, &token, &context)
+            .decrypt_with_context(encrypted, token, context)
             .unwrap();
 
         assert_eq!(decrypted, message);
@@ -596,7 +596,7 @@ mod token_protect {
             .token_protect();
         let message = b"Colorless green ideas sleep furiously".as_ref();
 
-        let (encrypted, token) = cell.encrypt(&message).unwrap();
+        let (encrypted, token) = cell.encrypt(message).unwrap();
 
         assert_eq!(encrypted.len(), message.len());
         assert!(!token.is_empty());
@@ -613,9 +613,9 @@ mod token_protect {
             b"Buffalo buffalo Buffalo buffalo buffalo buffalo Buffalo buffalo".as_ref();
 
         let (encrypted_short, token_short) =
-            cell.encrypt_with_context(&message, &context_short).unwrap();
+            cell.encrypt_with_context(message, context_short).unwrap();
         let (encrypted_long, token_long) =
-            cell.encrypt_with_context(&message, &context_long).unwrap();
+            cell.encrypt_with_context(message, context_long).unwrap();
 
         // Context is not (directly) included into encrypted message.
         assert_eq!(encrypted_short.len(), encrypted_long.len());
@@ -630,18 +630,18 @@ mod token_protect {
         let message = b"Colorless green ideas sleep furiously".as_ref();
 
         // encrypt(...) is encrypt_with_context(..., &[])
-        let (encrypted_1, token_1) = cell.encrypt(&message).unwrap();
-        let (encrypted_2, token_2) = cell.encrypt_with_context(&message, &[]).unwrap();
+        let (encrypted_1, token_1) = cell.encrypt(message).unwrap();
+        let (encrypted_2, token_2) = cell.encrypt_with_context(message, []).unwrap();
 
         assert_eq!(cell.decrypt(&encrypted_1, &token_1), Ok(message.to_vec()));
         assert_eq!(cell.decrypt(&encrypted_2, &token_2), Ok(message.to_vec()));
 
         assert_eq!(
-            cell.decrypt_with_context(&encrypted_1, &token_1, &[]),
+            cell.decrypt_with_context(&encrypted_1, &token_1, []),
             Ok(message.to_vec())
         );
         assert_eq!(
-            cell.decrypt_with_context(&encrypted_2, &token_2, &[]),
+            cell.decrypt_with_context(&encrypted_2, &token_2, []),
             Ok(message.to_vec())
         );
     }
@@ -656,7 +656,7 @@ mod token_protect {
             .token_protect();
         let message = b"Colorless green ideas sleep furiously".as_ref();
 
-        let (encrypted, token) = cell_a.encrypt(&message).unwrap();
+        let (encrypted, token) = cell_a.encrypt(message).unwrap();
 
         // You cannot use a different key to decrypt data.
         assert!(cell_b.decrypt(&encrypted, &token).is_err());
@@ -673,8 +673,8 @@ mod token_protect {
             .token_protect();
         let message = b"Colorless green ideas sleep furiously".as_ref();
 
-        let (encrypted_1, token_1) = cell.encrypt(&message).unwrap();
-        let (encrypted_2, token_2) = cell.encrypt(&message).unwrap();
+        let (encrypted_1, token_1) = cell.encrypt(message).unwrap();
+        let (encrypted_2, token_2) = cell.encrypt(message).unwrap();
 
         // You cannot use a different token to decrypt data, even the same original data.
         assert!(cell.decrypt(&encrypted_1, &token_2).is_err());
@@ -696,16 +696,16 @@ mod token_protect {
         let context_a = b"The jaws that bite, the claws that catch!".as_ref();
         let context_b = b"One, two! One, two! And through and through".as_ref();
 
-        let (encrypted, token) = cell.encrypt_with_context(&message, &context_a).unwrap();
+        let (encrypted, token) = cell.encrypt_with_context(message, context_a).unwrap();
 
         // You cannot use a different context to decrypt data.
         assert!(cell
-            .decrypt_with_context(&encrypted, &token, &context_b)
+            .decrypt_with_context(&encrypted, &token, context_b)
             .is_err());
 
         // Only the correct context will work.
         let decrypted = cell
-            .decrypt_with_context(&encrypted, &token, &context_a)
+            .decrypt_with_context(&encrypted, &token, context_a)
             .unwrap();
         assert_eq!(decrypted, message);
     }
@@ -717,7 +717,7 @@ mod token_protect {
             .token_protect();
         let message = b"Colorless green ideas sleep furiously".as_ref();
 
-        let (encrypted, token) = cell.encrypt(&message).unwrap();
+        let (encrypted, token) = cell.encrypt(message).unwrap();
 
         // Invert every odd byte, this will surely break the message.
         let mut corrupted_data = encrypted;
@@ -727,7 +727,7 @@ mod token_protect {
             }
         }
 
-        assert!(cell.decrypt(&corrupted_data, &token).is_err());
+        assert!(cell.decrypt(&corrupted_data, token).is_err());
     }
 
     #[test]
@@ -737,11 +737,11 @@ mod token_protect {
             .token_protect();
         let message = b"Colorless green ideas sleep furiously".as_ref();
 
-        let (encrypted, token) = cell.encrypt(&message).unwrap();
+        let (encrypted, token) = cell.encrypt(message).unwrap();
 
         let truncated_data = &encrypted[..encrypted.len() - 1];
 
-        assert!(cell.decrypt(&truncated_data, &token).is_err());
+        assert!(cell.decrypt(truncated_data, token).is_err());
     }
 
     #[test]
@@ -751,12 +751,12 @@ mod token_protect {
             .token_protect();
         let message = b"Colorless green ideas sleep furiously".as_ref();
 
-        let (encrypted, token) = cell.encrypt(&message).unwrap();
+        let (encrypted, token) = cell.encrypt(message).unwrap();
 
         let mut extended_data = encrypted;
         extended_data.push(0);
 
-        assert!(cell.decrypt(&extended_data, &token).is_err());
+        assert!(cell.decrypt(&extended_data, token).is_err());
     }
 
     #[test]
@@ -771,7 +771,7 @@ mod token_protect {
             .token_protect();
         let message = b"Colorless green ideas sleep furiously".as_ref();
 
-        let (encrypted, token) = cell.encrypt(&message).unwrap();
+        let (encrypted, token) = cell.encrypt(message).unwrap();
 
         // Invert every odd byte, this will surely break the token.
         let mut corrupted_token = token;
@@ -781,7 +781,7 @@ mod token_protect {
             }
         }
 
-        assert!(cell.decrypt(&encrypted, &corrupted_token).is_err());
+        assert!(cell.decrypt(encrypted, &corrupted_token).is_err());
     }
 
     #[test]
@@ -791,11 +791,11 @@ mod token_protect {
             .token_protect();
         let message = b"Colorless green ideas sleep furiously".as_ref();
 
-        let (encrypted, token) = cell.encrypt(&message).unwrap();
+        let (encrypted, token) = cell.encrypt(message).unwrap();
 
         let truncated_token = &token[..token.len() - 1];
 
-        assert!(cell.decrypt(&encrypted, &truncated_token).is_err());
+        assert!(cell.decrypt(encrypted, truncated_token).is_err());
     }
 
     #[test]
@@ -805,14 +805,14 @@ mod token_protect {
             .token_protect();
         let message = b"Colorless green ideas sleep furiously".as_ref();
 
-        let (encrypted, token) = cell.encrypt(&message).unwrap();
+        let (encrypted, token) = cell.encrypt(message).unwrap();
 
         let mut extended_token = token;
         extended_token.push(0);
 
         // Current implementation of Secure Cell allows the token to be overlong.
         // Extra data is simply ignored.
-        let decrypted = cell.decrypt(&encrypted, &extended_token).unwrap();
+        let decrypted = cell.decrypt(encrypted, &extended_token).unwrap();
         assert_eq!(decrypted, message);
     }
 
@@ -828,9 +828,9 @@ mod token_protect {
             .token_protect();
         let message = b"Colorless green ideas sleep furiously".as_ref();
 
-        let (encrypted, token) = cell.encrypt(&message).unwrap();
+        let (encrypted, token) = cell.encrypt(message).unwrap();
 
-        assert!(cell.decrypt(&token, &encrypted).is_err());
+        assert!(cell.decrypt(token, encrypted).is_err());
     }
 
     #[test]
@@ -839,12 +839,12 @@ mod token_protect {
             .unwrap()
             .token_protect();
 
-        assert!(cell.encrypt(&[]).is_err());
+        assert!(cell.encrypt([]).is_err());
 
         let message = b"Colorless green ideas sleep furiously".as_ref();
-        let (encrypted, token) = cell.encrypt(&message).unwrap();
+        let (encrypted, token) = cell.encrypt(message).unwrap();
 
-        assert!(cell.decrypt(&encrypted, &[]).is_err());
-        assert!(cell.decrypt(&[], &token).is_err());
+        assert!(cell.decrypt(encrypted, []).is_err());
+        assert!(cell.decrypt([], token).is_err());
     }
 }

--- a/tests/rust/secure_message.rs
+++ b/tests/rust/secure_message.rs
@@ -23,8 +23,8 @@ fn mode_encrypt_decrypt() {
     let secure = SecureMessage::new(gen_rsa_key_pair());
 
     let plaintext = b"test message please ignore";
-    let encrypted = secure.encrypt(&plaintext).expect("encryption");
-    let recovered_message = secure.decrypt(&encrypted).expect("decryption");
+    let encrypted = secure.encrypt(plaintext).expect("encryption");
+    let recovered_message = secure.decrypt(encrypted).expect("decryption");
 
     assert_eq!(recovered_message, plaintext);
 }
@@ -36,8 +36,8 @@ fn mode_sign_verify() {
     let verify = SecureVerify::new(public);
 
     let plaintext = b"test message please ignore";
-    let signed_message = sign.sign(&plaintext).unwrap();
-    let recovered_message = verify.verify(&signed_message).unwrap();
+    let signed_message = sign.sign(plaintext).unwrap();
+    let recovered_message = verify.verify(signed_message).unwrap();
 
     assert_eq!(recovered_message, plaintext);
 }
@@ -48,8 +48,8 @@ fn invalid_key() {
     let secure2 = SecureMessage::new(gen_ec_key_pair());
 
     let plaintext = b"test message please ignore";
-    let encrypted = secure1.encrypt(&plaintext).expect("encryption");
-    let error = secure2.decrypt(&encrypted).expect_err("decryption error");
+    let encrypted = secure1.encrypt(plaintext).expect("encryption");
+    let error = secure2.decrypt(encrypted).expect_err("decryption error");
 
     assert_eq!(error.kind(), ErrorKind::Fail);
 }
@@ -62,7 +62,7 @@ fn corrupted_data() {
     // Using index "10" for example leads to a crash with SIGBUS, so Themis definitely
     // could use some audit because it does not really handle corrupted messages well.
     let plaintext = b"test message please ignore";
-    let mut encrypted = secure.encrypt(&plaintext).expect("encryption");
+    let mut encrypted = secure.encrypt(plaintext).expect("encryption");
     encrypted[5] = !encrypted[5];
     let error = secure.decrypt(&encrypted).expect_err("decryption error");
 

--- a/tests/rust/secure_session.rs
+++ b/tests/rust/secure_session.rs
@@ -28,8 +28,8 @@ fn invalid_client_id() {
     let (private, _) = gen_ec_key_pair().split();
     let transport = MockTransport::new();
 
-    let error = SecureSession::new(&[], &private, transport)
-        .expect_err("construction with empty client ID");
+    let error =
+        SecureSession::new([], &private, transport).expect_err("construction with empty client ID");
 
     assert_eq!(error.kind(), ErrorKind::InvalidParameter);
 }
@@ -43,8 +43,8 @@ fn no_transport() {
     let mut transport_client = MockTransport::new();
     let mut transport_server = MockTransport::new();
 
-    expect_peer(&mut transport_client, &name_server, &public_server);
-    expect_peer(&mut transport_server, &name_client, &public_client);
+    expect_peer(&mut transport_client, name_server, &public_server);
+    expect_peer(&mut transport_server, name_client, &public_client);
 
     // The client and the server.
     let mut client = SecureSession::new(name_client, &private_client, transport_client)
@@ -85,11 +85,11 @@ fn no_transport() {
     // Try sending a message back and forth.
     let plaintext = b"test message please ignore";
 
-    let wrapped = client.wrap(&plaintext).expect("wrap 1 -> 2 message");
+    let wrapped = client.wrap(plaintext).expect("wrap 1 -> 2 message");
     let unwrapped = server.unwrap(&wrapped).expect("unwrap 1 -> 2 message");
     assert_eq!(unwrapped, plaintext);
 
-    let wrapped = server.wrap(&plaintext).expect("wrap 2 -> 1 message");
+    let wrapped = server.wrap(plaintext).expect("wrap 2 -> 1 message");
     let unwrapped = client.unwrap(&wrapped).expect("unwrap 2 -> 1 message");
     assert_eq!(unwrapped, plaintext);
 
@@ -115,8 +115,8 @@ fn with_transport() {
     let mut transport_client = MockTransport::new();
     let mut transport_server = MockTransport::new();
 
-    expect_peer(&mut transport_client, &name_server, &public_server);
-    expect_peer(&mut transport_server, &name_client, &public_client);
+    expect_peer(&mut transport_client, name_server, &public_server);
+    expect_peer(&mut transport_server, name_client, &public_client);
 
     connect_with_channels(&mut transport_client, &mut transport_server);
 
@@ -140,7 +140,7 @@ fn with_transport() {
 
     // Try sending a message back and forth.
     let message = b"test message please ignore";
-    client.send(&message).expect("send message");
+    client.send(message).expect("send message");
 
     let received = server.receive(1024).expect("receive message");
 
@@ -156,8 +156,8 @@ fn connection_state_reporting() {
     let mut transport_client = MockTransport::new();
     let mut transport_server = MockTransport::new();
 
-    expect_peer(&mut transport_server, &name_client, &public_client);
-    expect_peer(&mut transport_client, &name_server, &public_server);
+    expect_peer(&mut transport_server, name_client, &public_client);
+    expect_peer(&mut transport_client, name_server, &public_server);
 
     let state_client = monitor_state_changes(&mut transport_client);
     let state_server = monitor_state_changes(&mut transport_server);
@@ -202,9 +202,9 @@ fn server_does_not_identify_client() {
     let mut transport_server = MockTransport::new();
     expect_no_peers(&mut transport_server);
 
-    let mut client = SecureSession::new(&name_client, &private_client, transport_client)
+    let mut client = SecureSession::new(name_client, &private_client, transport_client)
         .expect("Secure Session client");
-    let mut server = SecureSession::new(&name_server, &private_server, transport_server)
+    let mut server = SecureSession::new(name_server, &private_server, transport_server)
         .expect("Secure Session server");
 
     let connect_request = client.connect_request().expect("connect request");
@@ -229,11 +229,11 @@ fn client_does_not_identify_server() {
     expect_no_peers(&mut transport_client);
 
     let mut transport_server = MockTransport::new();
-    expect_peer(&mut transport_server, &name_client, &public_client);
+    expect_peer(&mut transport_server, name_client, &public_client);
 
-    let mut client = SecureSession::new(&name_client, &private_client, transport_client)
+    let mut client = SecureSession::new(name_client, &private_client, transport_client)
         .expect("Secure Session client");
-    let mut server = SecureSession::new(&name_server, &private_server, transport_server)
+    let mut server = SecureSession::new(name_server, &private_server, transport_server)
         .expect("Secure Session server");
 
     let connect_request = client.connect_request().expect("connect request");
@@ -282,8 +282,8 @@ fn forward_error_receive_at_connection() {
     let mut transport_client = MockTransport::new();
     let mut transport_server = MockTransport::new();
 
-    expect_peer(&mut transport_client, &name_server, &public_server);
-    expect_peer(&mut transport_server, &name_client, &public_client);
+    expect_peer(&mut transport_client, name_server, &public_server);
+    expect_peer(&mut transport_server, name_client, &public_client);
 
     connect_with_channels(&mut transport_client, &mut transport_server);
 
@@ -318,8 +318,8 @@ fn forward_error_send_at_negotiation() {
     let mut transport_client = MockTransport::new();
     let mut transport_server = MockTransport::new();
 
-    expect_peer(&mut transport_client, &name_server, &public_server);
-    expect_peer(&mut transport_server, &name_client, &public_client);
+    expect_peer(&mut transport_client, name_server, &public_server);
+    expect_peer(&mut transport_server, name_client, &public_client);
 
     connect_with_channels(&mut transport_client, &mut transport_server);
 
@@ -355,8 +355,8 @@ fn forward_error_receive_at_negotiation() {
     let mut transport_client = MockTransport::new();
     let mut transport_server = MockTransport::new();
 
-    expect_peer(&mut transport_client, &name_server, &public_server);
-    expect_peer(&mut transport_server, &name_client, &public_client);
+    expect_peer(&mut transport_client, name_server, &public_server);
+    expect_peer(&mut transport_server, name_client, &public_client);
 
     connect_with_channels(&mut transport_client, &mut transport_server);
 
@@ -391,8 +391,8 @@ fn forward_error_send_at_exchange() {
     let mut transport_client = MockTransport::new();
     let mut transport_server = MockTransport::new();
 
-    expect_peer(&mut transport_client, &name_server, &public_server);
-    expect_peer(&mut transport_server, &name_client, &public_client);
+    expect_peer(&mut transport_client, name_server, &public_server);
+    expect_peer(&mut transport_server, name_client, &public_client);
 
     connect_with_channels(&mut transport_client, &mut transport_server);
 
@@ -433,8 +433,8 @@ fn forward_error_receive_at_exchange() {
     let mut transport_client = MockTransport::new();
     let mut transport_server = MockTransport::new();
 
-    expect_peer(&mut transport_client, &name_server, &public_server);
-    expect_peer(&mut transport_server, &name_client, &public_client);
+    expect_peer(&mut transport_client, name_server, &public_server);
+    expect_peer(&mut transport_server, name_client, &public_client);
 
     connect_with_channels(&mut transport_client, &mut transport_server);
 
@@ -477,8 +477,8 @@ fn cannot_send_empty_message() {
     let mut transport_client = MockTransport::new();
     let mut transport_server = MockTransport::new();
 
-    expect_peer(&mut transport_client, &name_server, &public_server);
-    expect_peer(&mut transport_server, &name_client, &public_client);
+    expect_peer(&mut transport_client, name_server, &public_server);
+    expect_peer(&mut transport_server, name_client, &public_client);
 
     connect_with_channels(&mut transport_client, &mut transport_server);
 
@@ -510,8 +510,8 @@ fn cannot_receive_empty_message() {
     let mut transport_client = MockTransport::new();
     let mut transport_server = MockTransport::new();
 
-    expect_peer(&mut transport_client, &name_server, &public_server);
-    expect_peer(&mut transport_server, &name_client, &public_client);
+    expect_peer(&mut transport_client, name_server, &public_server);
+    expect_peer(&mut transport_server, name_client, &public_client);
 
     connect_with_channels(&mut transport_client, &mut transport_server);
 
@@ -548,7 +548,7 @@ fn panic_in_get_pubkey_by_id_client() {
     let mut transport_server = MockTransport::new();
 
     transport_client.when_get_public_key_for_id(|_| panic!());
-    expect_peer(&mut transport_server, &name_client, &public_client);
+    expect_peer(&mut transport_server, name_client, &public_client);
 
     connect_with_channels(&mut transport_client, &mut transport_server);
 
@@ -573,7 +573,7 @@ fn panic_in_get_pubkey_by_id_server() {
     let mut transport_client = MockTransport::new();
     let mut transport_server = MockTransport::new();
 
-    expect_peer(&mut transport_client, &name_server, &public_server);
+    expect_peer(&mut transport_client, name_server, &public_server);
     transport_server.when_get_public_key_for_id(|_| panic!());
 
     connect_with_channels(&mut transport_client, &mut transport_server);
@@ -634,8 +634,8 @@ fn panic_in_status_change() {
     let mut transport_client = MockTransport::new();
     let mut transport_server = MockTransport::new();
 
-    expect_peer(&mut transport_client, &name_server, &public_server);
-    expect_peer(&mut transport_server, &name_client, &public_client);
+    expect_peer(&mut transport_client, name_server, &public_server);
+    expect_peer(&mut transport_server, name_client, &public_client);
 
     connect_with_channels(&mut transport_client, &mut transport_server);
 

--- a/tools/rust/scell_context_string_echo.rs
+++ b/tools/rust/scell_context_string_echo.rs
@@ -35,7 +35,7 @@ fn main() {
     let message = matches.value_of("message").unwrap();
     let context = matches.value_of("context").unwrap();
 
-    let cell = SecureCell::with_key(&key)
+    let cell = SecureCell::with_key(key)
         .unwrap_or_else(|_| {
             eprintln!("invalid parameters: empty master key");
             exit(1);
@@ -45,7 +45,7 @@ fn main() {
     match mode {
         "enc" => {
             let encrypted = cell
-                .encrypt_with_context(&message, &context)
+                .encrypt_with_context(message, context)
                 .unwrap_or_else(|error| {
                     eprintln!("failed to encrypt message: {error}");
                     exit(1);
@@ -58,7 +58,7 @@ fn main() {
                 exit(1);
             });
             let decrypted = cell
-                .decrypt_with_context(&decoded_message, &context)
+                .decrypt_with_context(decoded_message, context)
                 .unwrap_or_else(|error| {
                     eprintln!("failed to decrypt message: {error}");
                     exit(1);

--- a/tools/rust/scell_seal_string_echo.rs
+++ b/tools/rust/scell_seal_string_echo.rs
@@ -35,7 +35,7 @@ fn main() {
     let message = matches.value_of("message").unwrap();
     let context = matches.value_of("context").unwrap_or_default();
 
-    let cell = SecureCell::with_key(&key)
+    let cell = SecureCell::with_key(key)
         .unwrap_or_else(|_| {
             eprintln!("invalid parameters: empty master key");
             exit(1);
@@ -45,7 +45,7 @@ fn main() {
     match mode {
         "enc" => {
             let encrypted = cell
-                .encrypt_with_context(&message, &context)
+                .encrypt_with_context(message, context)
                 .unwrap_or_else(|error| {
                     eprintln!("failed to encrypt message: {error}");
                     exit(1);
@@ -58,7 +58,7 @@ fn main() {
                 exit(1);
             });
             let decrypted = cell
-                .decrypt_with_context(&decoded_message, &context)
+                .decrypt_with_context(decoded_message, context)
                 .unwrap_or_else(|error| {
                     eprintln!("failed to decrypt message: {error}");
                     exit(1);

--- a/tools/rust/scell_seal_string_echo_pw.rs
+++ b/tools/rust/scell_seal_string_echo_pw.rs
@@ -35,7 +35,7 @@ fn main() {
     let message = matches.value_of("message").unwrap();
     let context = matches.value_of("context").unwrap_or_default();
 
-    let cell = SecureCell::with_passphrase(&passphrase)
+    let cell = SecureCell::with_passphrase(passphrase)
         .unwrap_or_else(|_| {
             eprintln!("invalid parameters: empty passphrase");
             exit(1);
@@ -45,7 +45,7 @@ fn main() {
     match command {
         "enc" => {
             let encrypted = cell
-                .encrypt_with_context(&message, &context)
+                .encrypt_with_context(message, context)
                 .unwrap_or_else(|error| {
                     eprintln!("failed to encrypt message: {error}");
                     exit(1);
@@ -58,7 +58,7 @@ fn main() {
                 exit(1);
             });
             let decrypted = cell
-                .decrypt_with_context(&decoded_message, &context)
+                .decrypt_with_context(decoded_message, context)
                 .unwrap_or_else(|error| {
                     eprintln!("failed to decrypt message: {error}");
                     exit(1);

--- a/tools/rust/scell_token_string_echo.rs
+++ b/tools/rust/scell_token_string_echo.rs
@@ -39,7 +39,7 @@ fn main() {
     let message = parts.next().unwrap();
     let token = parts.next().unwrap_or("");
 
-    let cell = SecureCell::with_key(&key)
+    let cell = SecureCell::with_key(key)
         .unwrap_or_else(|_| {
             eprintln!("invalid parameters: empty master key");
             exit(1);
@@ -48,12 +48,12 @@ fn main() {
 
     match mode {
         "enc" => {
-            let (encrypted, token) = cell
-                .encrypt_with_context(&message, &context)
-                .unwrap_or_else(|error| {
-                    eprintln!("failed to encrypt message: {error}");
-                    exit(1);
-                });
+            let (encrypted, token) =
+                cell.encrypt_with_context(message, context)
+                    .unwrap_or_else(|error| {
+                        eprintln!("failed to encrypt message: {error}");
+                        exit(1);
+                    });
             println!("{},{}", base64::encode(&encrypted), base64::encode(&token));
         }
         "dec" => {
@@ -66,7 +66,7 @@ fn main() {
                 exit(1);
             });
             let decrypted = cell
-                .decrypt_with_context(&decoded_message, &decoded_token, &context)
+                .decrypt_with_context(decoded_message, decoded_token, context)
                 .unwrap_or_else(|error| {
                     eprintln!("failed to decrypt message: {error}");
                     exit(1);

--- a/tools/rust/smessage_encryption.rs
+++ b/tools/rust/smessage_encryption.rs
@@ -48,7 +48,7 @@ fn main() {
             let key_pair = KeyPair::try_join(private_key, public_key).expect("matching keys");
             let encrypter = SecureMessage::new(key_pair);
 
-            let encrypted = encrypter.encrypt(&message).unwrap_or_else(|error| {
+            let encrypted = encrypter.encrypt(message).unwrap_or_else(|error| {
                 eprintln!("failed to encrypt message: {error}");
                 exit(1);
             });
@@ -63,7 +63,7 @@ fn main() {
                 eprintln!("failed to decode message: {error}");
                 exit(1);
             });
-            let decrypted = encrypter.decrypt(&decoded_message).unwrap_or_else(|error| {
+            let decrypted = encrypter.decrypt(decoded_message).unwrap_or_else(|error| {
                 eprintln!("failed to decrypt message: {error}");
                 exit(1);
             });
@@ -73,7 +73,7 @@ fn main() {
         "sign" => {
             let signer = SecureSign::new(private_key);
 
-            let signed = signer.sign(&message).unwrap_or_else(|error| {
+            let signed = signer.sign(message).unwrap_or_else(|error| {
                 eprintln!("failed to sign message: {error}");
                 exit(1);
             });
@@ -87,7 +87,7 @@ fn main() {
                 eprintln!("failed to decode message: {error}");
                 exit(1);
             });
-            let verified = signer.verify(&decoded_message).unwrap_or_else(|error| {
+            let verified = signer.verify(decoded_message).unwrap_or_else(|error| {
                 eprintln!("failed to verify message: {error}");
                 exit(1);
             });


### PR DESCRIPTION
New clippy, new issues that make working code fail CI checks. Again.

Fixed clippy issues with `cargo clippy --fix --all-targets`, the formatted with `cargo fmt`.

Only cosmetic changes, most of them are outside of wrapper, i.e. in tests and benchmarks.

Update MSRV to 1.60 since our dependency `zeroize` now requires it.

Freeze two more dev deps `regex` and `memchr`, dependencies of `env_logger` used in Rust Themis tests.

## Checklist

- [x] Change is covered by automated tests
- [x] ~Benchmark results are attached (if applicable)~
- [x] The [coding guidelines] are followed
- [x] ~Public API has proper documentation~
- [x] ~Example projects and code samples are up-to-date (in case of API changes)~
- [x] ~Changelog is updated (in case of notable or breaking changes)~

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
