### PR TITLE
Remove pythemis_{make,install}_wheel

### DIFF
--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -58,7 +58,7 @@ jobs:
           sudo sh -c 'echo "DEBIAN_FRONTEND=noninteractive" >> /etc/environment'
           sudo apt update
           sudo apt install --yes gcc make libssl-dev \
-            python3 python3-setuptools python3-pip python3-venv
+            python3 python3-pip python3-venv
       - name: Check out code
         uses: actions/checkout@v2
       - name: Prepare Themis Core
@@ -70,8 +70,7 @@ jobs:
         run: mkdir /tmp/test_venv && python3 -m venv /tmp/test_venv
       - name: Install PyThemis into virtualenv
         run: |
-          make pythemis_make_wheel
-          source /tmp/test_venv/bin/activate && make pythemis_install_wheel
+          source /tmp/test_venv/bin/activate && make pythemis_install
       - name: Run test suite
         run: source /tmp/test_venv/bin/activate && make test_python
       - name: Uninstall PyThemis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,12 +50,8 @@ _Code:_
   - `pythemis.scomparator` and `pythemis.skeygen` are now imported with `from pythemis import *` ([#914](https://github.com/cossacklabs/themis/pull/914)).
   - Pythemis supports `pyproject.toml` as a main way of building packages. The old `setup.py` is preserved for backwards compatibility ([#1006](https://github.com/cossacklabs/themis/pull/1006)).
 
-  - New installation methods, accessible with make ([#1023](https://github.com/cossacklabs/themis/pull/1023)).
-    - create/install `.whl` package for virtualenv
-    - create/install `.deb` or `.rpm` package for system-wide installation
-
-  - New installation methods, accessible with make ([#1023](https://github.com/cossacklabs/themis/pull/1023)).
-    - create/install `.whl` package for virtualenv
+  - New installation methods, accessible with make ([#1023](https://github.com/cossacklabs/themis/pull/1023), [#1042](https://github.com/cossacklabs/themis/pull/1042)).
+    - install package into virtualenv
     - create/install `.deb` or `.rpm` package for system-wide installation
 
 - **Ruby**

--- a/Makefile
+++ b/Makefile
@@ -629,25 +629,6 @@ endif
 	@echo -n "pythemis install "
 	@$(BUILD_CMD_)
 
-pythemis_make_wheel: CMD = cd src/wrappers/themis/python/ && python3 setup.py bdist_wheel
-pythemis_make_wheel:
-ifeq ($(PYTHON3_VERSION),)
-	@echo "python3 not found"
-	@exit 1
-endif
-	@echo -n "pythemis make wheel "
-	@$(BUILD_CMD_)
-	@echo Result: src/wrappers/themis/python/dist/pythemis-$(VERSION_SHORT)-py2.py3-none-any.whl
-
-pythemis_install_wheel: CMD = pip install src/wrappers/themis/python/dist/pythemis-$(VERSION_SHORT)-py2.py3-none-any.whl
-pythemis_install_wheel:
-ifeq ($(PYTHON3_VERSION),)
-	@echo "python3 not found"
-	@exit 1
-endif
-	@echo -n "pythemis install wheel "
-	@$(BUILD_CMD_)
-
 ########################################################################
 #
 # Packaging Themis Core: Linux distributions


### PR DESCRIPTION
After stable was merged into master, wheel generation is no longer needed since `make pythemis_install` just works when virtualenv is activated.

Also, previous command for .whl generation is no longer working, would need some changes to make it work with pyproject.toml

<!-- Describe your changes here -->

## Checklist

- [x] Change is covered by automated tests
- [x] ~Benchmark results are attached (if applicable)~
- [x] The [coding guidelines] are followed
- [x] ~Public API has proper documentation~
- [x] ~Example projects and code samples are up-to-date (in case of API changes)~
- [x] Changelog is updated (in case of notable or breaking changes)

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
