### PR TITLE
Using the -y option to archive themis.xcframework.zip 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,24 +4,32 @@
 
 Changes that are currently in development and have not been released yet.
 
+
+
+## [0.15.3](https://github.com/cossacklabs/themis/releases/tag/0.15.3), April 30 2024
+
+### Swift, Objective-C wrappers
+- Added the '-y' option for the zip program when archiving themis.xcframework to follow symlinks.
+
+
 ## [0.15.2](https://github.com/cossacklabs/themis/releases/tag/0.15.2), November 24 2023
 
-### JsThemis wrapper 
-- Added the ability to use the `import` syntax for the jsthemis module. 
-- Added a declaration file for TypeScript. 
+### JsThemis wrapper
+- Added the ability to use the `import` syntax for the jsthemis module.
+- Added a declaration file for TypeScript.
 
 ### Android, ReactNative wrappers
 Updated versions of dependencies. New minimum versions of iOS, Android are set.
-- Target API level 33 
-- Minimum API level 21 
-- Minumum iOS set to 12.4 due to ReactNative requirements 
+- Target API level 33
+- Minimum API level 21
+- Minumum iOS set to 12.4 due to ReactNative requirements
 
 ## [0.15.1](https://github.com/cossacklabs/themis/releases/tag/0.15.1), September 13 2023
 
-### Swift, Objective-C wrappers 
-- Updated OpenSSL to 1.1.1v 
-- Removed support of 32-bit platforms 
-- Minimum iOS: 11, macOS: 10.13, Catalyst: 14 
+### Swift, Objective-C wrappers
+- Updated OpenSSL to 1.1.1v
+- Removed support of 32-bit platforms
+- Minimum iOS: 11, macOS: 10.13, Catalyst: 14
 
 ## [0.15.0](https://github.com/cossacklabs/themis/releases/tag/0.15.0), June 21st 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Changes that are currently in development and have not been released yet.
 ## [0.15.3](https://github.com/cossacklabs/themis/releases/tag/0.15.3), April 30 2024
 
 ### Swift, Objective-C wrappers
-- Added the '-y' option for the zip program when archiving themis.xcframework to follow symlinks.
+- Added the '-y' option for the zip program when archiving `themis.xcframework` to follow symlinks. It will fix macOS distribution with Themis added via SPM.
 
 
 ## [0.15.2](https://github.com/cossacklabs/themis/releases/tag/0.15.2), November 24 2023

--- a/Package.swift
+++ b/Package.swift
@@ -15,11 +15,11 @@ let package = Package(
     targets: [
         .binaryTarget(name: "themis",
                       // update version in URL path
-                      url: "https://github.com/cossacklabs/themis/releases/download/0.15.1/themis.xcframework.zip",
+                      url: "https://github.com/cossacklabs/themis/releases/download/0.15.3/themis.xcframework.zip",
                       // The scripts/create_xcframework.sh calculates the checksum when generating the XCF.
                       // Alternatively, run from package directory:
                       // swift package compute-checksum build/xcf_output/themis.xcframework.zip
-                      checksum: "2d5bfbba7d5d3ecd0d40acdaee65d1b5d42dee5df5ae9d99faec4119087238c5"),
+                      checksum: "7166aaef8de590416cb17f97ae630b63c16d4240f07ac0f6b17e0044349115aa"),
 
     ]
 )

--- a/scripts/create_xcframeworks.sh
+++ b/scripts/create_xcframeworks.sh
@@ -61,7 +61,7 @@ rm -rf $output_dir/macosx
 # zip the xcodeframework
 # SPM accepts binary targets only in zip format
 cd $output_dir
-zip -r themis.xcframework.zip themis.xcframework
+zip -y -r themis.xcframework.zip themis.xcframework
 
 rm -rf themis.xcframework
 


### PR DESCRIPTION
I added option -y for zip program. It follows the symlinks. It fixed the issue of the SPM package for macOS applications. 

## Checklist

- [x] Changelog is updated (in case of notable or breaking changes)

