### PR TITLE
themis-android: add support for devices that are configured to use a page size of 16 KB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Changes that are currently in development and have not been released yet.
 
+### Android wrapper
+- Add support for Android devices that are configured to use a page size of 16 KB (Android 15+)
 
 ## [0.15.4](https://github.com/cossacklabs/themis/releases/tag/0.15.4), May 23 2024
 

--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -64,3 +64,4 @@ target_include_directories(themis_jni
         ../third_party/boringssl/src/include
 )
 target_link_libraries(themis_jni PRIVATE themis soter crypto decrepit)
+target_link_options(themis_jni PRIVATE "-Wl,-z,max-page-size=16384")


### PR DESCRIPTION
Adding support for android devices that run with Android 15+ and are configured to use a page size of 16 KB
see: https://developer.android.com/guide/practices/page-sizes

## Checklist

- [x] The [coding guidelines] are followed
- [x] Changelog is updated

[coding guidelines]: https://github.com/cossacklabs/themis/blob/master/CONTRIBUTING.md
