### PR TITLE
improve android example: remove second launcher and fix the manifest

### DIFF
--- a/docs/examples/android/app/src/main/AndroidManifest.xml
+++ b/docs/examples/android/app/src/main/AndroidManifest.xml
@@ -10,26 +10,26 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:extractNativeLibs="true"
         android:theme="@style/AppTheme">
+
+        <!-- Main launcher activity -->
         <activity android:name=".MainActivitySecureCell"
             android:label="@string/app_name"
-            android:exported="true"> <!-- Specify android:exported attribute with an explicit value -->
-
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-        </activity>
-        <activity android:name=".MainActivitySecureMessage"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+        </activity>
+
+        <!-- Secondary activity -->
+        <activity android:name=".MainActivitySecureMessage"
+            android:exported="true">
+            <!-- No launcher intent filter here -->
         </activity>
 
     </application>
 
 </manifest>
+

--- a/docs/examples/android/app/src/main/java/com/cossacklabs/themis/android/example/MainActivitySecureCell.kt
+++ b/docs/examples/android/app/src/main/java/com/cossacklabs/themis/android/example/MainActivitySecureCell.kt
@@ -1,5 +1,6 @@
 package com.cossacklabs.themis.android.example
 
+import android.content.Intent
 import android.os.Bundle
 import android.util.Base64
 import android.util.Log
@@ -18,6 +19,9 @@ class MainActivitySecureCell : AppCompatActivity() {
         } catch (e: Exception) {
             e.printStackTrace()
         }
+
+        // Call the second activity
+        openSecondActivity()
     }
 
     private fun encryptDataForStoring() {
@@ -32,5 +36,10 @@ class MainActivitySecureCell : AppCompatActivity() {
         val unprotected = sc.decrypt(decodedString)
         val decryptedData = String(unprotected, charset)
         Log.d("SMC", "decrypted data = $decryptedData")
+    }
+
+    private fun openSecondActivity() {
+        val intent = Intent(this, MainActivitySecureMessage::class.java)
+        startActivity(intent)
     }
 }


### PR DESCRIPTION
During the example test, I found the following deficiencies: 
1. Two application icons instead of one.
2. SecureMessage test was not happening. 
3. The app was not loading on the API 35 + 16k page memory platform. 

Fixed: 
1. fixed manifest. Now there is one icon. And the application loads adequately. 
2. Added code to start SecureMessage activity. 

The example application was tested on:
1. Android 10 phone 
2. API 33 Simulator 
3. API 34 Simulator 
4. API 35 Simulator 
5. API 35+16k Simulator 

Also, I think we should accept the PR https://github.com/cossacklabs/themis/pull/1051 
It works on 35+ Simulators and does not crash the test application. 


## Checklist

- [x] The [coding guidelines] are followed

