### PR TITLE
Release 0.15.5 android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,17 @@
 
 Changes that are currently in development and have not been released yet.
 
+
+## [0.15.5](https://github.com/cossacklabs/themis/releases/tag/0.15.5), Aug 20 2024
+
 ### Android wrapper
 - Add support for Android devices that are configured to use a page size of 16 KB (Android 15+)
+
+### Android example 
+- Remove second launcher 
+- Added extractNativeLibs="true" to the manifest 
+- Made example compatible with Android 15+ (API 35) 
+
 
 ## [0.15.4](https://github.com/cossacklabs/themis/releases/tag/0.15.4), May 23 2024
 

--- a/docs/examples/android/app/build.gradle
+++ b/docs/examples/android/app/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     testImplementation 'junit:junit:4.12'
-    implementation 'com.cossacklabs.com:themis:0.15.2'
+    implementation 'com.cossacklabs.com:themis:0.15.5'
     implementation "androidx.core:core-ktx:1.3.2"
     //noinspection GradleDependency: we use slightly outdated "kotlin_version" on purpose
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@
 org.gradle.configureondemand=true
 
 # Versions of AndroidThemis and JavaThemis packages.
-androidThemisVersion=0.15.2
+androidThemisVersion=0.15.5
 javaThemisVersion=0.15.2
 
 # Android Studio insists that this is set to use JUnit test runner.

--- a/src/wrappers/themis/android/AndroidManifest.xml
+++ b/src/wrappers/themis/android/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.cossacklabs.themis" android:versionCode="1" android:versionName="0.15.2">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.cossacklabs.themis" android:versionCode="1" android:versionName="0.15.5">
 </manifest>


### PR DESCRIPTION
Increased versions of Android wrapper release 

- Changelog 
- src/wrappers/themis/android/AndroidManifest.xml
- gradle.properties 

## Checklist

- [x] Changelog is updated (in case of notable or breaking changes)

